### PR TITLE
Allow any user to schedule events on any calendar

### DIFF
--- a/calendar_integration/services/protocols/initializer_or_authenticated_calendar_service.py
+++ b/calendar_integration/services/protocols/initializer_or_authenticated_calendar_service.py
@@ -37,6 +37,9 @@ class InitializedOrAuthenticatedCalendarService(Protocol):
     ) -> CalendarEvent:
         ...
 
+    def _get_write_adapter_for_calendar(self, calendar: Calendar) -> CalendarAdapter | None:
+        ...
+
     def create_event(self, calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
         ...
 


### PR DESCRIPTION
## Summary by Sourcery

Implement adapter delegation in CalendarService to allow non-owner users to schedule events by resolving and using the calendar owner's social account adapter, updating create/update/delete methods accordingly and adding tests to cover ownership and fallback scenarios

New Features:
- Add logic to select a write adapter based on calendar ownership or service account ownership
- Enable non-owner users to perform create, update, and delete operations by delegating to the calendar owner’s adapter

Enhancements:
- Restrict write adapter delegation to PERSONAL and RESOURCE calendar types
- Fall back to the authenticated user's adapter when no valid owner or matching provider is found

Tests:
- Introduce fixtures and tests to verify write adapter resolution for owned, non-owned, and service account calendars
- Add tests to ensure correct adapter is chosen among multiple owners, filtered by provider, and to validate fallback behavior
- Extend create_event, update_event, and delete_event tests to confirm delegation to the appropriate adapter or fallback