### PR TITLE
Remove username field

### DIFF
--- a/accounts/account_adapters.py
+++ b/accounts/account_adapters.py
@@ -37,7 +37,6 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             # If the instance is a User, use the UserSerializer to serialize it
             return {
                 "id": instance.id,
-                "username": instance.username,
                 "email": instance.email,
                 "phone_number": instance.phone_number,
                 "is_active": instance.is_active,
@@ -205,7 +204,6 @@ class AccountAdapter(DefaultAccountAdapter):
             "Sending verification code %s to %s for user %s.",
             code,
             phone,
-            user.username,
         )
         self.notification_service.create_notification(
             user_id=user.id,

--- a/accounts/tests/test_account_adapters.py
+++ b/accounts/tests/test_account_adapters.py
@@ -28,7 +28,6 @@ class TestSocialAccountAdapter:
         adapter = SocialAccountAdapter()
         data = adapter.serialize_instance(user)
         assert data["id"] == user.id
-        assert data["username"] == user.username
         assert data["profile"]["first_name"] == user.profile.first_name
 
     def test_serialize_instance_sociallogin(self, user):
@@ -74,7 +73,7 @@ class TestSocialAccountAdapter:
 
     def test_deserialize_instance_user_without_id(self):
         adapter = SocialAccountAdapter()
-        data = {"username": "foo", "profile": {"first_name": "Bar", "last_name": "Baz"}}
+        data = {"profile": {"first_name": "Bar", "last_name": "Baz"}}
         result = adapter.deserialize_instance(User, data)
         assert isinstance(result, User)
         assert isinstance(result.profile, Profile)
@@ -178,7 +177,6 @@ class TestAccountAdapter:
         assert found is None
 
     def test_send_verification_code_sms_success(self, adapter, user):
-        user.username = "foo"
         with patch("accounts.account_adapters.logger.info") as log_info:
             adapter.send_verification_code_sms(user, "+123456789", "1234")
             log_info.assert_called()

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -1048,7 +1048,7 @@ class CalendarService(BaseCalendarService):
                                 and hasattr(users_by_id[a.user_id].profile, "__str__")
                                 else None
                             )
-                            or users_by_id[a.user_id].username,
+                            or users_by_id[a.user_id].email,
                             status="pending",
                         )
                         for a in event_data.attendances
@@ -1316,7 +1316,7 @@ class CalendarService(BaseCalendarService):
                                 and hasattr(users_by_id[a.user_id].profile, "__str__")
                                 else None
                             )
-                            or users_by_id[a.user_id].username,
+                            or users_by_id[a.user_id].email,
                             status=(
                                 attendance_by_user_id[a.user_id].status
                                 if a.user_id in attendance_by_user_id

--- a/calendar_integration/tests/services/test_calendar_permission_service.py
+++ b/calendar_integration/tests/services/test_calendar_permission_service.py
@@ -1,4 +1,5 @@
 import base64
+import uuid
 from datetime import timedelta
 
 from django.utils import timezone
@@ -48,10 +49,8 @@ def user(db):
 @pytest.fixture
 def another_user(db):
     """Create another test user."""
-    import uuid
-
     unique_email = f"another+{uuid.uuid4().hex[:8]}@example.com"
-    user = User.objects.create(email=unique_email, username=unique_email)
+    user = User.objects.create(email=unique_email)
     Profile.objects.create(user=user)
     return user
 

--- a/calendar_integration/tests/services/test_calendar_service.py
+++ b/calendar_integration/tests/services/test_calendar_service.py
@@ -191,9 +191,7 @@ def mock_ms_adapter():
 @pytest.fixture
 def social_account(db):
     """Create a social account for testing."""
-    user = User.objects.create_user(
-        username="testuser", email="test@example.com", password="testpass123"
-    )
+    user = User.objects.create_user(email="test@example.com", password="testpass123")
     # Create a profile for the user to avoid RelatedObjectDoesNotExist errors
     Profile.objects.create(user=user)
     account = SocialAccount.objects.create(user=user, provider=CalendarProvider.GOOGLE, uid="12345")
@@ -365,8 +363,8 @@ def sample_event_input_data():
 @pytest.fixture
 def sample_event_input_data_with_attendances(db):
     """Sample event input data with attendances for testing."""
-    user1 = User.objects.create_user(username="user1", email="user1@example.com")
-    user2 = User.objects.create_user(username="user2", email="user2@example.com")
+    user1 = User.objects.create_user(email="user1@example.com")
+    user2 = User.objects.create_user(email="user2@example.com")
 
     return CalendarEventInputData(
         title="Event with Attendances",
@@ -1364,9 +1362,7 @@ def test_create_recurring_exception_on_master_preserves_attendances_and_resource
     mock_google_adapter.provider = CalendarProvider.GOOGLE
 
     # Create additional user and resource for testing
-    additional_user = User.objects.create_user(
-        username="attendee", email="attendee@example.com", password="testpass123"
-    )
+    additional_user = User.objects.create_user(email="attendee@example.com", password="testpass123")
     resource_calendar = Calendar.objects.create(
         name="Test Resource",
         external_id="resource_123",
@@ -2859,7 +2855,7 @@ def test_update_event_with_attendances(
 ):
     """Test updating an event with attendances and external attendances."""
     # Create initial attendances
-    user1 = User.objects.create_user(username="initial_user1", email="initial1@example.com")
+    user1 = User.objects.create_user(email="initial1@example.com")
     Profile.objects.create(user=user1, first_name="Initial", last_name="User")
 
     EventAttendance.objects.create(
@@ -2879,8 +2875,8 @@ def test_update_event_with_attendances(
     )
 
     # Create new users for updated attendances
-    new_user1 = User.objects.create_user(username="new_user1", email="new1@example.com")
-    new_user2 = User.objects.create_user(username="new_user2", email="new2@example.com")
+    new_user1 = User.objects.create_user(email="new1@example.com")
+    new_user2 = User.objects.create_user(email="new2@example.com")
     Profile.objects.create(user=new_user1, first_name="New", last_name="User 1")
     Profile.objects.create(user=new_user2, first_name="New", last_name="User 2")
 
@@ -3618,9 +3614,7 @@ def test_process_event_attendees_new_user(
 ):
     """Test processing event attendees with a new user."""
     # Create a user that matches the attendee email
-    User.objects.create_user(
-        username="attendee", email="attendee@example.com", password="testpass123"
-    )
+    User.objects.create_user(email="attendee@example.com", password="testpass123")
 
     event_data = CalendarEventAdapterOutputData(
         calendar_external_id="cal_123",
@@ -5160,9 +5154,7 @@ def test_apply_sync_changes_attendances_to_create(
     )
 
     # Create user for attendance
-    user = User.objects.create_user(
-        username="attendee", email="attendee@example.com", password="testpass123"
-    )
+    user = User.objects.create_user(email="attendee@example.com", password="testpass123")
 
     changes = EventsSyncChanges()
 
@@ -7235,9 +7227,7 @@ def test_delete_event_calls_side_effects(
 @pytest.fixture
 def calendar_owner_user(db):
     """Create a calendar owner user for testing."""
-    return User.objects.create_user(
-        username="calendar_owner", email="owner@example.com", password="testpass123"
-    )
+    return User.objects.create_user(email="owner@example.com", password="testpass123")
 
 
 @pytest.fixture
@@ -7292,9 +7282,7 @@ def owned_calendar(db, organization, calendar_owner_user):
 @pytest.fixture
 def unrelated_user(db):
     """Create an unrelated user for testing."""
-    user = User.objects.create_user(
-        username="unrelated_user", email="unrelated@example.com", password="testpass123"
-    )
+    user = User.objects.create_user(email="unrelated@example.com", password="testpass123")
     Profile.objects.create(user=user)
     return user
 
@@ -7379,9 +7367,7 @@ def test_get_write_adapter_prefers_default_owner(
 ):
     """Test that _get_write_adapter_for_calendar prefers owners with is_default=True."""
     # Create another user who also owns the calendar but is not default
-    other_owner = User.objects.create_user(
-        username="other_owner", email="other@example.com", password="testpass123"
-    )
+    other_owner = User.objects.create_user(email="other@example.com", password="testpass123")
     other_social_account = SocialAccount.objects.create(
         user=other_owner, provider=CalendarProvider.GOOGLE, uid="other123"
     )
@@ -7439,9 +7425,7 @@ def test_get_write_adapter_returns_self_adapter_when_no_valid_owner(
     )
 
     # Create user without social account
-    user_no_social = User.objects.create_user(
-        username="user_no_social", email="nosocial@example.com", password="testpass123"
-    )
+    user_no_social = User.objects.create_user(email="nosocial@example.com", password="testpass123")
     CalendarOwnership.objects.create(
         organization=organization,
         calendar=calendar_no_owner,

--- a/calendar_integration/tests/tasks/test_calendar_sync_tasks.py
+++ b/calendar_integration/tests/tasks/test_calendar_sync_tasks.py
@@ -24,9 +24,7 @@ from users.models import User
 @pytest.fixture
 def social_account(db):
     """Create a social account for testing."""
-    user = User.objects.create_user(
-        username="testuser", email="test@example.com", password="testpass123"
-    )
+    user = User.objects.create_user(email="test@example.com", password="testpass123")
     account = SocialAccount.objects.create(user=user, provider=CalendarProvider.GOOGLE, uid="12345")
     return account
 

--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,7 @@ def user(user_password):
 @pytest.fixture
 def auth_client(user, user_password):
     client = APIClient()
-    client.login(username=user.username, password=user_password)
+    client.login(email=user.email, password=user_password)
     return client
 
 

--- a/public_api/tests/test_queries.py
+++ b/public_api/tests/test_queries.py
@@ -631,8 +631,8 @@ class TestGraphQLQueries:
         mock_rate_limiter.return_value = iter([None])
 
         user_model = get_user_model()
-        # Create user with profile first and last name
-        user = baker.make(user_model, email="alice@example.com", username="alice1")
+        # Create user with profile first and last nam
+        user = baker.make(user_model, email="alice@example.com")
         baker.make(OrganizationMembership, user=user, organization=organization)
         # Create profile for the user with given names
         baker.make(
@@ -643,7 +643,7 @@ class TestGraphQLQueries:
         )
 
         # Create another user that should not match
-        other = baker.make(user_model, email="bob@example.com", username="bob1")
+        other = baker.make(user_model, email="bob@example.com")
         baker.make(OrganizationMembership, user=other, organization=organization)
         baker.make(
             "users.Profile",
@@ -680,10 +680,10 @@ class TestGraphQLQueries:
         mock_rate_limiter.return_value = iter([None])
 
         user_model = get_user_model()
-        user = baker.make(user_model, email="carol@example.com", username="carol1")
+        user = baker.make(user_model, email="carol@example.com")
         baker.make(OrganizationMembership, user=user, organization=organization)
 
-        baker.make(user_model, email="dave@other.com", username="dave1")
+        baker.make(user_model, email="dave@other.com")
 
         query = """
             query GetUsers($email: String) {
@@ -1464,7 +1464,7 @@ class TestGraphQLQueries:
 
         # Create another user in the same organization to ensure filtering works
         user_model = get_user_model()
-        other_user = baker.make(user_model, email="other@example.com", username="otheruser")
+        other_user = baker.make(user_model, email="other@example.com")
         baker.make(
             OrganizationMembership,
             user=other_user,
@@ -1476,7 +1476,6 @@ class TestGraphQLQueries:
                 users(userId: $userId, offset: $offset, limit: $limit) {
                     id
                     email
-                    username
                 }
             }
         """
@@ -1709,7 +1708,7 @@ class TestGraphQLQueries:
 
         # Create multiple users
         for i in range(5):
-            user = baker.make(user_model, email=f"user{i}@test.com", username=f"user{i}")
+            user = baker.make(user_model, email=f"user{i}@test.com")
             baker.make(OrganizationMembership, user=user, organization=organization)
             users.append(user)
 
@@ -1718,7 +1717,6 @@ class TestGraphQLQueries:
                 users {
                     id
                     email
-                    username
                 }
             }
         """
@@ -1747,7 +1745,7 @@ class TestGraphQLQueries:
 
         # Create multiple users
         for i in range(10):
-            user = baker.make(user_model, email=f"user{i}@test.com", username=f"user{i}")
+            user = baker.make(user_model, email=f"user{i}@test.com")
             baker.make(OrganizationMembership, user=user, organization=organization)
             users.append(user)
 
@@ -1756,7 +1754,6 @@ class TestGraphQLQueries:
                 users(offset: $offset, limit: $limit) {
                     id
                     email
-                    username
                 }
             }
         """

--- a/schema.yml
+++ b/schema.yml
@@ -5474,13 +5474,6 @@ components:
         phone_number:
           type: string
           readOnly: true
-        username:
-          type: string
-          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
-            only.
-          pattern: ^[\w.-]+$
-          maxLength: 150
-          minLength: 3
         profile:
           $ref: '#/components/schemas/Profile'
         is_active:
@@ -5522,7 +5515,6 @@ components:
       - modified
       - phone_number
       - profile
-      - username
     WebhookConfiguration:
       type: object
       properties:

--- a/templates/accounts/notifications/emails/password_reset_request.body.html
+++ b/templates/accounts/notifications/emails/password_reset_request.body.html
@@ -12,7 +12,7 @@ It can be safely ignored if you did not request a password reset. Click the link
   <a href="{{ password_reset_url }}">{{ password_reset_url }}</a>
 </p>
 
-{% blocktrans %}In case you forgot, your username is {{ user.username }}.{% endblocktrans %}{% endif %}
+{% blocktrans %}In case you forgot, your username is {{ user.email }}.{% endblocktrans %}{% endif %}
 {% endblock %}
 
 {% block email_footer %}

--- a/users/graphql.py
+++ b/users/graphql.py
@@ -18,7 +18,6 @@ class ProfileGraphQLType:
 @strawberry_django.type(User)
 class UserGraphQLType:
     id: strawberry.auto  # noqa: A003
-    username: strawberry.auto
     email: strawberry.auto
     phone_number: strawberry.auto
     is_active: strawberry.auto

--- a/users/migrations/0001_initial.py
+++ b/users/migrations/0001_initial.py
@@ -28,7 +28,6 @@ class Migration(migrations.Migration):
                 ('created', model_utils.fields.AutoCreatedField(db_index=True, default=django.utils.timezone.now, editable=False, verbose_name='created')),
                 ('modified', model_utils.fields.AutoLastModifiedField(db_index=True, default=django.utils.timezone.now, editable=False, verbose_name='modified')),
                 ('meta', models.JSONField(blank=True, default=dict, verbose_name='meta')),
-                ('username', models.CharField(db_index=True, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.core.validators.RegexValidator(message='Enter a valid username. This value may contain only letters, numbers and ./-/_ characters.', regex='^[\\w.-]+$'), django.core.validators.MinLengthValidator(limit_value=3, message='Username must be at least 3 characters long.')])),
                 ('email', models.EmailField(max_length=255, unique=True)),
                 ('phone_number', models.CharField(max_length=20)),
                 ('phone_verified_date', models.DateTimeField(blank=True, null=True)),

--- a/users/models.py
+++ b/users/models.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
-from django.core.validators import MinLengthValidator, RegexValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -16,24 +15,6 @@ if TYPE_CHECKING:
 
 
 class User(AbstractBaseUser, PermissionsMixin, BaseModel):
-    username = models.CharField(
-        max_length=150,
-        unique=True,
-        help_text=_("Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."),
-        validators=[
-            RegexValidator(
-                regex=r"^[\w.-]+$",
-                message=_(
-                    "Enter a valid username. This value may contain only letters, numbers and ./-/_ characters."
-                ),
-            ),
-            MinLengthValidator(
-                limit_value=3,
-                message=_("Username must be at least 3 characters long."),
-            ),
-        ],
-        db_index=True,
-    )
     email = models.EmailField(max_length=255, unique=True)
     phone_number = models.CharField(max_length=20)
 
@@ -54,7 +35,7 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel):
     profile: "Profile"
     billing_profile: "BillingProfile"
 
-    USERNAME_FIELD = "username"
+    USERNAME_FIELD = "email"
 
     def get_full_name(self):
         return str(self.profile)

--- a/users/notification_contexts.py
+++ b/users/notification_contexts.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 from vintasend.services.notification_service import register_context
 
 from users.models import User
 
 
 @register_context("user_context")
-def user_context(user_id: str) -> dict[str, str]:
+def user_context(user_id: str) -> dict[str, Any]:
     """
     Provides a context for user-related notifications.
     """
@@ -13,7 +15,6 @@ def user_context(user_id: str) -> dict[str, str]:
     return {
         "user": {
             "id": user.id,
-            "username": user.username,
             "email": user.email,
             "first_name": user.profile.first_name if user.profile else "",
             "last_name": user.profile.last_name if user.profile else "",

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -38,7 +38,6 @@ class UserSerializer(VirtualModelSerializer):
             "id",
             "email",
             "phone_number",
-            "username",
             "profile",
             "is_active",
             "is_staff",

--- a/vinta_schedule_api/settings/base.py
+++ b/vinta_schedule_api/settings/base.py
@@ -294,10 +294,9 @@ CORS_ALLOW_HEADERS = (
 )
 CORS_ALLOW_CREDENTIALS = True
 HEADLESS_ONLY = True
-ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
-ACCOUNT_LOGIN_METHODS = {"email", "username", "phone"}
+ACCOUNT_USER_MODEL_USERNAME_FIELD = "email"
+ACCOUNT_LOGIN_METHODS = {"email", "phone"}
 ACCOUNT_SIGNUP_FIELDS = [
-    "username*",
     "email*",
     "phone*",
     "password1",
@@ -326,7 +325,7 @@ HEADLESS_ADAPTER = "accounts.account_adapters.HeadlessAdapter"
 HEADLESS_TOKEN_STRATEGY = "accounts.token_strategies.AccessAndRefreshTokenStrategy"  # noqa: S105
 ACCESS_TOKEN_EXPIRY_MINUTES = config("ACCESS_TOKEN_EXPIRY_MINUTES", cast=int, default=15)
 REFRESH_TOKEN_EXPIRY_DAYS = config("REFRESH_TOKEN_EXPIRY_DAYS", cast=int, default=30)
-ACCOUNT_LOGIN_METHODS = {"phone", "email", "username"}
+ACCOUNT_LOGIN_METHODS = {"phone", "email"}
 ACCOUNT_PHONE_VERIFICATION_ENABLED = True
 ACCOUNT_PHONE_VERIFICATION_MAX_ATTEMPTS = 3
 ACCOUNT_PHONE_VERIFICATION_SUPPORTS_RESEND = True


### PR DESCRIPTION
## Summary by Sourcery

Remove the username field from the User model and migrate to using email as the primary identifier across the codebase.

Enhancements:
- Drop the username field and set USERNAME_FIELD to email in the User model and migration.
- Update authentication settings to use email (and phone) only, adjusting login methods and signup fields.
- Replace username with email in login flows, fixtures, and conftest setup.

Documentation:
- Remove username property from the OpenAPI schema.

Tests:
- Remove username creation and assertions in tests, updating fixtures to create users with email only.

Chores:
- Remove username references from serializers, GraphQL types, account adapters, notification contexts, and email templates.