### PR TITLE
feat: Add CalendarGroup to our REST API

### DIFF
--- a/calendar_integration/filtersets.py
+++ b/calendar_integration/filtersets.py
@@ -1,6 +1,12 @@
 from django_filters import rest_framework as filters
 
-from calendar_integration.models import AvailableTime, BlockedTime, Calendar, CalendarEvent
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+)
 
 
 class CalendarEventFilterSet(filters.FilterSet):
@@ -93,6 +99,35 @@ class BlockedTimeFilterSet(filters.FilterSet):
         self.filters["calendar"] = filters.ModelChoiceFilter(
             field_name="calendar_fk_id",
             label="Filter by calendar ID",
+            queryset=(
+                Calendar.objects.filter_by_organization(
+                    self.request.user.organization_membership.organization_id
+                )
+                if self.request.user and self.request.user.is_authenticated
+                else Calendar.objects.none()
+            ),
+        )
+
+
+class CalendarGroupFilterSet(filters.FilterSet):
+    """FilterSet for CalendarGroup."""
+
+    name = filters.CharFilter(
+        field_name="name",
+        lookup_expr="icontains",
+        label="Filter by partial name match",
+    )
+
+    class Meta:
+        model = CalendarGroup
+        fields = ("name",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.filters["calendar"] = filters.ModelChoiceFilter(
+            field_name="slots__memberships__calendar_fk_id",
+            label="Filter to groups whose slot pools include this calendar",
             queryset=(
                 Calendar.objects.filter_by_organization(
                     self.request.user.organization_membership.organization_id

--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -36,3 +36,34 @@ class CalendarAvailabilityPermission(BasePermission):
     def has_permission(self, request, view):
         # Only authenticated users can check availability
         return request.user.is_authenticated
+
+
+class CalendarGroupPermission(BasePermission):
+    """
+    Permission for CalendarGroup REST endpoints.
+
+    - `has_permission` requires an authenticated user with an active
+      organization membership; list/create are org-scoped by the viewset.
+    - `has_object_permission` additionally requires the user to own at least
+      one calendar inside the group's slots — matching the plan's "owns at
+      least one calendar in the group" heuristic. An org-admin override is a
+      follow-up.
+    """
+
+    def has_permission(self, request, view):
+        user = request.user
+        if not user.is_authenticated:
+            return False
+        return getattr(user, "organization_membership", None) is not None
+
+    def has_object_permission(self, request, view, obj):
+        if obj.organization_id != request.user.organization_membership.organization_id:
+            return False
+        return (
+            CalendarOwnership.objects.filter_by_organization(obj.organization_id)
+            .filter(
+                user=request.user,
+                calendar__group_slots__group_fk=obj,
+            )
+            .exists()
+        )

--- a/calendar_integration/routes.py
+++ b/calendar_integration/routes.py
@@ -4,6 +4,7 @@ from .views import (
     AvailableTimeViewSet,
     BlockedTimeViewSet,
     CalendarEventViewSet,
+    CalendarGroupViewSet,
     CalendarViewSet,
 )
 
@@ -13,6 +14,11 @@ routes: list[RouteDict] = [
         "regex": r"calendar-events",
         "viewset": CalendarEventViewSet,
         "basename": "CalendarEvents",
+    },
+    {
+        "regex": r"calendar-groups",
+        "viewset": CalendarGroupViewSet,
+        "basename": "CalendarGroups",
     },
     {
         "regex": r"calendar",

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -11,12 +11,16 @@ from dependency_injector.wiring import Provide, inject
 from rest_framework import serializers
 
 from calendar_integration.constants import CalendarProvider, CalendarType
-from calendar_integration.exceptions import CalendarServiceNotInjectedError
+from calendar_integration.exceptions import CalendarGroupError, CalendarServiceNotInjectedError
 from calendar_integration.models import (
     AvailableTime,
     BlockedTime,
     Calendar,
     CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
     CalendarOwnership,
     EventAttendance,
     EventExternalAttendance,
@@ -30,6 +34,10 @@ from calendar_integration.services.dataclasses import (
     BlockedTimeData,
     CalendarEventAdapterOutputData,
     CalendarEventInputData,
+    CalendarGroupEventInputData,
+    CalendarGroupInputData,
+    CalendarGroupSlotInputData,
+    CalendarGroupSlotSelectionInputData,
     EventAttendanceInputData,
     EventExternalAttendanceInputData,
     ExternalAttendeeInputData,
@@ -39,7 +47,11 @@ from calendar_integration.services.dataclasses import (
 from calendar_integration.virtual_models import (
     AvailableTimeVirtualModel,
     BlockedTimeVirtualModel,
+    CalendarEventGroupSelectionVirtualModel,
     CalendarEventVirtualModel,
+    CalendarGroupSlotMembershipVirtualModel,
+    CalendarGroupSlotVirtualModel,
+    CalendarGroupVirtualModel,
     CalendarOwnershipVirtualModel,
     CalendarVirtualModel,
     EventAttendanceVirtualModel,
@@ -56,6 +68,7 @@ from users.serializers import UserSerializer
 
 
 if TYPE_CHECKING:
+    from calendar_integration.services.calendar_group_service import CalendarGroupService
     from calendar_integration.services.calendar_service import CalendarService
 
 
@@ -2057,3 +2070,284 @@ class AvailableTimeBulkModificationSerializer(serializers.Serializer):
             modified_end_time_offset=self.validated_data.get("modified_end_time_offset"),
             modification_rrule_string=final_rrule_string,
         )
+
+
+# ---------------------------------------------------------------------------
+# CalendarGroup REST serializers
+# ---------------------------------------------------------------------------
+def _translate_group_error(exc: CalendarGroupError) -> serializers.ValidationError:
+    return serializers.ValidationError({"non_field_errors": [str(exc)]})
+
+
+class CalendarGroupSlotMembershipSerializer(VirtualModelSerializer):
+    calendar = CalendarSerializer(read_only=True)
+
+    class Meta:
+        model = CalendarGroupSlotMembership
+        virtual_model = CalendarGroupSlotMembershipVirtualModel
+        fields = ("id", "calendar")
+
+
+class CalendarGroupSlotSerializer(VirtualModelSerializer):
+    """Nested slot representation used inside CalendarGroupSerializer.
+
+    On write, accepts `calendar_ids: list[int]`; on read exposes the calendar
+    pool via `calendars` (the M2M). We deliberately keep slot writes to
+    payload-time data only — persistence happens through
+    `CalendarGroupSerializer` which delegates to `CalendarGroupService`.
+    """
+
+    calendars = CalendarSerializer(many=True, read_only=True)
+    calendar_ids = serializers.ListField(
+        child=serializers.IntegerField(), write_only=True, required=True
+    )
+
+    class Meta:
+        model = CalendarGroupSlot
+        virtual_model = CalendarGroupSlotVirtualModel
+        fields = (
+            "id",
+            "name",
+            "description",
+            "order",
+            "required_count",
+            "calendars",
+            "calendar_ids",
+        )
+        read_only_fields = ("id",)
+
+
+class CalendarGroupSerializer(VirtualModelSerializer):
+    slots = CalendarGroupSlotSerializer(many=True)
+
+    class Meta:
+        model = CalendarGroup
+        virtual_model = CalendarGroupVirtualModel
+        fields = (
+            "id",
+            "name",
+            "description",
+            "slots",
+            "created",
+            "modified",
+        )
+        read_only_fields = ("id", "created", "modified")
+
+    @inject
+    def __init__(
+        self,
+        *args,
+        calendar_group_service: Annotated[
+            "CalendarGroupService | None", Provide["calendar_group_service"]
+        ] = None,
+        **kwargs,
+    ):
+        self.calendar_group_service = calendar_group_service
+        super().__init__(*args, **kwargs)
+
+    def _organization(self) -> Organization:
+        request = self.context.get("request") if self.context else None
+        if not request or not getattr(request, "user", None):
+            raise serializers.ValidationError(
+                {"non_field_errors": ["Authenticated user with organization is required."]}
+            )
+        membership = getattr(request.user, "organization_membership", None)
+        if not membership:
+            raise serializers.ValidationError(
+                {"non_field_errors": ["User has no organization membership."]}
+            )
+        return membership.organization
+
+    def _to_input_data(self, validated_data: dict) -> CalendarGroupInputData:
+        return CalendarGroupInputData(
+            name=validated_data["name"],
+            description=validated_data.get("description", ""),
+            slots=[
+                CalendarGroupSlotInputData(
+                    name=slot["name"],
+                    calendar_ids=list(slot["calendar_ids"]),
+                    required_count=slot.get("required_count", 1),
+                    description=slot.get("description", ""),
+                    order=slot.get("order", 0),
+                )
+                for slot in validated_data.get("slots", [])
+            ],
+        )
+
+    def create(self, validated_data: dict) -> CalendarGroup:
+        if not self.calendar_group_service:
+            raise CalendarServiceNotInjectedError(
+                "calendar_group_service is not defined; configure the DI container."
+            )
+        organization = self._organization()
+        self.calendar_group_service.initialize(organization=organization)
+        try:
+            return self.calendar_group_service.create_group(self._to_input_data(validated_data))
+        except CalendarGroupError as e:
+            raise _translate_group_error(e) from e
+
+    def update(self, instance: CalendarGroup, validated_data: dict) -> CalendarGroup:
+        if not self.calendar_group_service:
+            raise CalendarServiceNotInjectedError(
+                "calendar_group_service is not defined; configure the DI container."
+            )
+        organization = self._organization()
+        self.calendar_group_service.initialize(organization=organization)
+        try:
+            return self.calendar_group_service.update_group(
+                group_id=instance.id, data=self._to_input_data(validated_data)
+            )
+        except CalendarGroupError as e:
+            raise _translate_group_error(e) from e
+
+
+class CalendarEventGroupSelectionSerializer(VirtualModelSerializer):
+    slot = CalendarGroupSlotSerializer(read_only=True)
+    calendar = CalendarSerializer(read_only=True)
+
+    class Meta:
+        model = CalendarEventGroupSelection
+        virtual_model = CalendarEventGroupSelectionVirtualModel
+        fields = ("id", "slot", "calendar")
+
+
+class _CalendarGroupSlotSelectionInputSerializer(serializers.Serializer):
+    slot_id = serializers.IntegerField()
+    calendar_ids = serializers.ListField(child=serializers.IntegerField())
+
+
+class CalendarGroupEventCreateSerializer(serializers.Serializer):
+    """Input for booking an event through a CalendarGroup.
+
+    On `save()` this delegates to `CalendarGroupService.create_grouped_event`
+    and returns the created `CalendarEvent`. The view is responsible for
+    serializing the result (typically with `CalendarEventSerializer`).
+    """
+
+    title = serializers.CharField()
+    description = serializers.CharField(allow_blank=True, required=False, default="")
+    start_time = serializers.DateTimeField()
+    end_time = serializers.DateTimeField()
+    timezone = serializers.CharField()
+    slot_selections = _CalendarGroupSlotSelectionInputSerializer(many=True)
+    attendances = serializers.ListField(child=serializers.DictField(), required=False, default=list)
+    external_attendances = serializers.ListField(
+        child=serializers.DictField(), required=False, default=list
+    )
+
+    @inject
+    def __init__(
+        self,
+        *args,
+        calendar_group_service: Annotated[
+            "CalendarGroupService | None", Provide["calendar_group_service"]
+        ] = None,
+        **kwargs,
+    ):
+        self.calendar_group_service = calendar_group_service
+        super().__init__(*args, **kwargs)
+
+    def validate_end_time(self, end_time: datetime.datetime) -> datetime.datetime:
+        start_time = self.initial_data.get("start_time") if self.initial_data else None
+        if start_time:
+            try:
+                start_time_parsed = (
+                    datetime.datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+                    if isinstance(start_time, str)
+                    else start_time
+                )
+            except ValueError:
+                start_time_parsed = None
+            if start_time_parsed and end_time <= start_time_parsed:
+                raise serializers.ValidationError("end_time must be after start_time.")
+        return end_time
+
+    def save(self, **kwargs):
+        if not self.calendar_group_service or not self.calendar_group_service.calendar_service:
+            raise CalendarServiceNotInjectedError(
+                "calendar_group_service / calendar_service not defined; configure the DI container."
+            )
+        group = kwargs.get("group")
+        if group is None:
+            raise serializers.ValidationError(
+                {"non_field_errors": ["group is required via serializer.save(group=…)"]}
+            )
+        request = self.context.get("request") if self.context else None
+        if not request or not getattr(request, "user", None):
+            raise serializers.ValidationError(
+                {"non_field_errors": ["Authenticated user with organization is required."]}
+            )
+        membership = getattr(request.user, "organization_membership", None)
+        if not membership:
+            raise serializers.ValidationError(
+                {"non_field_errors": ["User has no organization membership."]}
+            )
+        organization = membership.organization
+
+        # Initialize the nested CalendarService on the group service — the
+        # grouped-event flow delegates to `self.calendar_group_service.calendar_service.create_event`
+        # internally, so that exact instance needs to be initialized.
+        self.calendar_group_service.calendar_service.initialize_without_provider(
+            user_or_token=request.user, organization=organization
+        )
+        self.calendar_group_service.initialize(organization=organization)
+
+        data = CalendarGroupEventInputData(
+            title=self.validated_data["title"],
+            description=self.validated_data.get("description", ""),
+            start_time=self.validated_data["start_time"],
+            end_time=self.validated_data["end_time"],
+            timezone=self.validated_data["timezone"],
+            group_id=group.id,
+            slot_selections=[
+                CalendarGroupSlotSelectionInputData(
+                    slot_id=s["slot_id"], calendar_ids=list(s["calendar_ids"])
+                )
+                for s in self.validated_data["slot_selections"]
+            ],
+            attendances=[
+                EventAttendanceInputData(user_id=a["user_id"])
+                for a in self.validated_data.get("attendances", [])
+            ],
+            external_attendances=[
+                EventExternalAttendanceInputData(
+                    external_attendee=ExternalAttendeeInputData(
+                        email=e["external_attendee"]["email"],
+                        name=e["external_attendee"].get("name", ""),
+                        id=e["external_attendee"].get("id"),
+                    )
+                )
+                for e in self.validated_data.get("external_attendances", [])
+            ],
+        )
+        try:
+            return self.calendar_group_service.create_grouped_event(data)
+        except CalendarGroupError as e:
+            raise _translate_group_error(e) from e
+
+
+class CalendarGroupSlotAvailabilitySerializer(serializers.Serializer):
+    slot_id = serializers.IntegerField()
+    available_calendar_ids = serializers.ListField(child=serializers.IntegerField())
+
+
+class CalendarGroupRangeAvailabilitySerializer(serializers.Serializer):
+    start_time = serializers.DateTimeField()
+    end_time = serializers.DateTimeField()
+    slots = CalendarGroupSlotAvailabilitySerializer(many=True)
+
+
+class _RangeInputSerializer(serializers.Serializer):
+    start_time = serializers.DateTimeField()
+    end_time = serializers.DateTimeField()
+
+
+class CalendarGroupAvailabilityQuerySerializer(serializers.Serializer):
+    """Input for the availability action: list of [start, end] windows."""
+
+    ranges = _RangeInputSerializer(many=True)
+
+
+class BookableSlotProposalSerializer(serializers.Serializer):
+    start_time = serializers.DateTimeField()
+    end_time = serializers.DateTimeField()

--- a/calendar_integration/tests/test_views_calendar_group.py
+++ b/calendar_integration/tests/test_views_calendar_group.py
@@ -1,0 +1,435 @@
+"""Tests for the internal REST API exposing CalendarGroup endpoints."""
+
+import datetime
+import json
+import uuid
+from datetime import timedelta
+
+from django.urls import reverse
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+
+from calendar_integration.constants import (
+    CalendarProvider,
+    CalendarType,
+    EventManagementPermissions,
+)
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarManagementToken,
+    CalendarOwnership,
+)
+from organizations.models import Organization, OrganizationMembership
+
+
+def _grant_calendar_owner_token(user, calendar):
+    """Mirror `CalendarService._grant_calendar_owner_permissions` so the
+    permission service can resolve a token for the user+calendar pair."""
+    token = CalendarManagementToken.objects.create(
+        organization=calendar.organization,
+        calendar_fk=calendar,
+        user=user,
+        token_hash=f"test-{uuid.uuid4().hex}",
+    )
+    for perm in (
+        EventManagementPermissions.CREATE,
+        EventManagementPermissions.UPDATE_ATTENDEES,
+        EventManagementPermissions.UPDATE_DETAILS,
+        EventManagementPermissions.RESCHEDULE,
+        EventManagementPermissions.CANCEL,
+    ):
+        token.permissions.create(permission=perm, organization_id=calendar.organization_id)
+    return token
+
+
+def _assert_status(response, expected):
+    assert response.status_code == expected, (
+        f"{response.status_code} != {expected}\n"
+        f"Response: {json.dumps(response.json() if response.content else {}, indent=2, default=str)}"
+    )
+
+
+@pytest.fixture
+def organization(user):
+    org = baker.make(Organization, name=f"Org {uuid.uuid4().hex[:6]}")
+    baker.make(OrganizationMembership, user=user, organization=org)
+    return org
+
+
+@pytest.fixture
+def internal_calendars(organization):
+    calendars = {}
+    for name, external in (
+        ("Dr. A", "phys_a"),
+        ("Dr. B", "phys_b"),
+        ("Room 1", "room_1"),
+    ):
+        calendars[external] = Calendar.objects.create(
+            organization=organization,
+            name=name,
+            external_id=external,
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=(
+                CalendarType.PERSONAL if external.startswith("phys_") else CalendarType.RESOURCE
+            ),
+            manage_available_windows=True,
+            accepts_public_scheduling=True,
+        )
+    return calendars
+
+
+@pytest.fixture
+def owned_group(user, organization, internal_calendars):
+    """A group where `user` owns at least one of the pool calendars so the
+    CalendarGroupPermission passes object-level checks."""
+    CalendarOwnership.objects.create(
+        organization=organization, calendar=internal_calendars["phys_a"], user=user
+    )
+    group = CalendarGroup.objects.create(organization=organization, name="Clinic")
+    physicians = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Physicians", order=0
+    )
+    rooms = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Rooms", order=1
+    )
+    for cal in (internal_calendars["phys_a"], internal_calendars["phys_b"]):
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=physicians, calendar=cal
+        )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=rooms, calendar=internal_calendars["room_1"]
+    )
+    return group
+
+
+@pytest.mark.django_db
+class TestCalendarGroupCrud:
+    def test_list_requires_auth(self, anonymous_client):
+        url = reverse("api:CalendarGroups-list")
+        response = anonymous_client.get(url)
+        _assert_status(response, status.HTTP_401_UNAUTHORIZED)
+
+    def test_list_scoped_to_organization(self, auth_client, organization, owned_group):
+        other_org = baker.make(Organization)
+        CalendarGroup.objects.create(organization=other_org, name="Other")
+        url = reverse("api:CalendarGroups-list")
+        response = auth_client.get(url)
+        _assert_status(response, status.HTTP_200_OK)
+        ids = [g["id"] for g in response.data["results"]]
+        assert ids == [owned_group.id]
+
+    def test_retrieve(self, auth_client, owned_group):
+        url = reverse("api:CalendarGroups-detail", kwargs={"pk": owned_group.id})
+        response = auth_client.get(url)
+        _assert_status(response, status.HTTP_200_OK)
+        assert response.data["name"] == "Clinic"
+        assert {s["name"] for s in response.data["slots"]} == {"Physicians", "Rooms"}
+
+    def test_retrieve_forbidden_if_user_does_not_own_any_pool_calendar(
+        self, auth_client, organization, internal_calendars
+    ):
+        group = CalendarGroup.objects.create(organization=organization, name="Foreign")
+        slot = CalendarGroupSlot.objects.create(organization=organization, group=group, name="Slot")
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=slot, calendar=internal_calendars["phys_b"]
+        )
+        # user doesn't own phys_b → no permission
+        url = reverse("api:CalendarGroups-detail", kwargs={"pk": group.id})
+        response = auth_client.get(url)
+        _assert_status(response, status.HTTP_403_FORBIDDEN)
+
+    def test_create_group(self, auth_client, organization, internal_calendars, user):
+        # The create endpoint uses the serializer which delegates to
+        # CalendarGroupService; make sure the user owns one calendar so
+        # the subsequent object-level access on retrieve works too.
+        CalendarOwnership.objects.create(
+            organization=organization, calendar=internal_calendars["phys_a"], user=user
+        )
+        url = reverse("api:CalendarGroups-list")
+        payload = {
+            "name": "New Clinic",
+            "description": "",
+            "slots": [
+                {
+                    "name": "Physicians",
+                    "calendar_ids": [
+                        internal_calendars["phys_a"].id,
+                        internal_calendars["phys_b"].id,
+                    ],
+                    "required_count": 1,
+                    "order": 0,
+                },
+                {
+                    "name": "Rooms",
+                    "calendar_ids": [internal_calendars["room_1"].id],
+                    "required_count": 1,
+                    "order": 1,
+                },
+            ],
+        }
+        response = auth_client.post(url, payload, format="json")
+        _assert_status(response, status.HTTP_201_CREATED)
+        created = CalendarGroup.objects.filter_by_organization(organization.id).get(
+            name="New Clinic"
+        )
+        assert set(created.slots.values_list("name", flat=True)) == {"Physicians", "Rooms"}
+
+    def test_create_group_rejects_duplicate_slot_name(
+        self, auth_client, organization, internal_calendars, user
+    ):
+        CalendarOwnership.objects.create(
+            organization=organization, calendar=internal_calendars["phys_a"], user=user
+        )
+        url = reverse("api:CalendarGroups-list")
+        payload = {
+            "name": "Bad",
+            "slots": [
+                {"name": "Dup", "calendar_ids": [internal_calendars["phys_a"].id]},
+                {"name": "Dup", "calendar_ids": [internal_calendars["phys_b"].id]},
+            ],
+        }
+        response = auth_client.post(url, payload, format="json")
+        _assert_status(response, status.HTTP_400_BAD_REQUEST)
+        assert "duplicate" in json.dumps(response.data).lower()
+
+    def test_update_group(self, auth_client, owned_group, internal_calendars):
+        url = reverse("api:CalendarGroups-detail", kwargs={"pk": owned_group.id})
+        payload = {
+            "name": "Clinic Renamed",
+            "description": "New desc",
+            "slots": [
+                {
+                    "name": "Physicians",
+                    "calendar_ids": [internal_calendars["phys_a"].id],
+                    "required_count": 1,
+                    "order": 0,
+                },
+                {
+                    "name": "Rooms",
+                    "calendar_ids": [internal_calendars["room_1"].id],
+                    "required_count": 1,
+                    "order": 1,
+                },
+            ],
+        }
+        response = auth_client.put(url, payload, format="json")
+        _assert_status(response, status.HTTP_200_OK)
+        owned_group.refresh_from_db()
+        assert owned_group.name == "Clinic Renamed"
+        assert set(
+            owned_group.slots.get(name="Physicians").calendars.values_list("external_id", flat=True)
+        ) == {"phys_a"}
+
+    def test_destroy(self, auth_client, owned_group):
+        url = reverse("api:CalendarGroups-detail", kwargs={"pk": owned_group.id})
+        response = auth_client.delete(url)
+        _assert_status(response, status.HTTP_204_NO_CONTENT)
+        assert not CalendarGroup.objects.filter(id=owned_group.id).exists()
+
+    def test_destroy_refused_when_group_has_events(
+        self, auth_client, owned_group, internal_calendars, organization
+    ):
+        baker.make(
+            CalendarEvent,
+            organization=organization,
+            calendar_fk=internal_calendars["phys_a"],
+            calendar_group_fk=owned_group,
+            title="Pinned",
+            external_id="ev_pinned",
+            start_time_tz_unaware=datetime.datetime.now(datetime.UTC) + timedelta(hours=1),
+            end_time_tz_unaware=datetime.datetime.now(datetime.UTC) + timedelta(hours=2),
+            timezone="UTC",
+        )
+        url = reverse("api:CalendarGroups-detail", kwargs={"pk": owned_group.id})
+        response = auth_client.delete(url)
+        _assert_status(response, status.HTTP_400_BAD_REQUEST)
+
+
+@pytest.mark.django_db
+class TestCalendarGroupEventActions:
+    def _make_window_available(self, calendars, start, end):
+        for cal in calendars:
+            AvailableTime.objects.create(
+                organization=cal.organization,
+                calendar=cal,
+                start_time_tz_unaware=start,
+                end_time_tz_unaware=end,
+                timezone="UTC",
+            )
+
+    def test_create_event_action(
+        self, auth_client, user, owned_group, internal_calendars, organization
+    ):
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0)
+        start = now + timedelta(hours=1)
+        end = start + timedelta(hours=1)
+        self._make_window_available(internal_calendars.values(), start, end)
+        # The create_event flow needs a management token for the primary calendar.
+        _grant_calendar_owner_token(user, internal_calendars["phys_a"])
+        physicians = owned_group.slots.get(name="Physicians")
+        rooms = owned_group.slots.get(name="Rooms")
+
+        url = reverse("api:CalendarGroups-create-event", kwargs={"pk": owned_group.id})
+        payload = {
+            "title": "Follow-up",
+            "description": "",
+            "start_time": start.isoformat(),
+            "end_time": end.isoformat(),
+            "timezone": "UTC",
+            "slot_selections": [
+                {"slot_id": physicians.id, "calendar_ids": [internal_calendars["phys_a"].id]},
+                {"slot_id": rooms.id, "calendar_ids": [internal_calendars["room_1"].id]},
+            ],
+        }
+        response = auth_client.post(url, payload, format="json")
+        _assert_status(response, status.HTTP_201_CREATED)
+        event = CalendarEvent.objects.filter_by_organization(organization.id).get(title="Follow-up")
+        assert event.calendar_fk_id == internal_calendars["phys_a"].id
+        assert event.calendar_group_fk_id == owned_group.id
+        assert (
+            CalendarEventGroupSelection.objects.filter_by_organization(organization.id)
+            .filter(event_fk=event)
+            .count()
+            == 2
+        )
+
+    def test_create_event_action_rejects_unavailable_calendar(
+        self, auth_client, user, owned_group, internal_calendars
+    ):
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0)
+        start = now + timedelta(hours=1)
+        end = start + timedelta(hours=1)
+        # no AvailableTime — calendars aren't available
+        _grant_calendar_owner_token(user, internal_calendars["phys_a"])
+        physicians = owned_group.slots.get(name="Physicians")
+        rooms = owned_group.slots.get(name="Rooms")
+
+        url = reverse("api:CalendarGroups-create-event", kwargs={"pk": owned_group.id})
+        payload = {
+            "title": "Nope",
+            "description": "",
+            "start_time": start.isoformat(),
+            "end_time": end.isoformat(),
+            "timezone": "UTC",
+            "slot_selections": [
+                {"slot_id": physicians.id, "calendar_ids": [internal_calendars["phys_a"].id]},
+                {"slot_id": rooms.id, "calendar_ids": [internal_calendars["room_1"].id]},
+            ],
+        }
+        response = auth_client.post(url, payload, format="json")
+        _assert_status(response, status.HTTP_400_BAD_REQUEST)
+        assert "not available" in json.dumps(response.data).lower()
+
+    def test_list_events_action(self, auth_client, owned_group, internal_calendars, organization):
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0)
+        start = now + timedelta(hours=1)
+        end = start + timedelta(hours=1)
+        in_range = baker.make(
+            CalendarEvent,
+            organization=organization,
+            calendar_fk=internal_calendars["phys_a"],
+            calendar_group_fk=owned_group,
+            title="Grouped",
+            external_id="ev_grouped",
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=end,
+            timezone="UTC",
+        )
+        baker.make(
+            CalendarEvent,
+            organization=organization,
+            calendar_fk=internal_calendars["phys_a"],
+            title="Standalone",
+            external_id="ev_standalone",
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=end,
+            timezone="UTC",
+        )
+        url = reverse("api:CalendarGroups-list-events", kwargs={"pk": owned_group.id})
+        response = auth_client.get(
+            url,
+            {
+                "start_datetime": start.isoformat(),
+                "end_datetime": (end + timedelta(hours=1)).isoformat(),
+            },
+        )
+        _assert_status(response, status.HTTP_200_OK)
+        assert [e["id"] for e in response.data] == [in_range.id]
+
+    def test_availability_action(self, auth_client, owned_group, internal_calendars, organization):
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0)
+        start = now + timedelta(hours=1)
+        end = start + timedelta(hours=1)
+        self._make_window_available(internal_calendars.values(), start, end)
+        url = reverse("api:CalendarGroups-availability", kwargs={"pk": owned_group.id})
+        response = auth_client.post(
+            url,
+            {"ranges": [{"start_time": start.isoformat(), "end_time": end.isoformat()}]},
+            format="json",
+        )
+        _assert_status(response, status.HTTP_200_OK)
+        assert len(response.data) == 1
+        slot_ids_in_payload = {s["slot_id"] for s in response.data[0]["slots"]}
+        assert slot_ids_in_payload == set(owned_group.slots.values_list("id", flat=True))
+
+    def test_bookable_slots_action(
+        self, auth_client, owned_group, internal_calendars, organization
+    ):
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0)
+        start = now + timedelta(hours=1)
+        end = start + timedelta(hours=1)
+        self._make_window_available(internal_calendars.values(), start, end)
+        url = reverse("api:CalendarGroups-bookable-slots", kwargs={"pk": owned_group.id})
+        response = auth_client.get(
+            url,
+            {
+                "search_window_start": start.isoformat(),
+                "search_window_end": end.isoformat(),
+                "duration_seconds": str(60 * 60),
+                "slot_step_seconds": str(60 * 60),
+            },
+        )
+        _assert_status(response, status.HTTP_200_OK)
+        assert len(response.data) == 1
+
+    def test_bookable_slots_missing_params(self, auth_client, owned_group):
+        url = reverse("api:CalendarGroups-bookable-slots", kwargs={"pk": owned_group.id})
+        response = auth_client.get(url)
+        _assert_status(response, status.HTTP_400_BAD_REQUEST)
+
+
+@pytest.mark.django_db
+class TestPermissionBoundary:
+    def test_cannot_access_other_org_group(
+        self, auth_client, user, organization, internal_calendars
+    ):
+        other_org = baker.make(Organization)
+        other_cal = Calendar.objects.create(
+            organization=other_org,
+            name="Other",
+            external_id="other",
+            provider=CalendarProvider.INTERNAL,
+        )
+        # User owns a calendar in THEIR org, but other_group belongs to another org.
+        CalendarOwnership.objects.create(
+            organization=organization, calendar=internal_calendars["phys_a"], user=user
+        )
+        other_group = CalendarGroup.objects.create(organization=other_org, name="Other")
+        other_slot = CalendarGroupSlot.objects.create(
+            organization=other_org, group=other_group, name="Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=other_org, slot=other_slot, calendar=other_cal
+        )
+        url = reverse("api:CalendarGroups-detail", kwargs={"pk": other_group.id})
+        response = auth_client.get(url)
+        # Queryset is org-scoped, so it should 404 rather than 403.
+        _assert_status(response, status.HTTP_404_NOT_FOUND)

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -11,21 +11,27 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from calendar_integration.exceptions import CalendarIntegrationError
+from calendar_integration.exceptions import (
+    CalendarGroupError,
+    CalendarIntegrationError,
+)
 from calendar_integration.filtersets import (
     AvailableTimeFilterSet,
     BlockedTimeFilterSet,
     CalendarEventFilterSet,
+    CalendarGroupFilterSet,
 )
 from calendar_integration.models import (
     AvailableTime,
     BlockedTime,
     Calendar,
     CalendarEvent,
+    CalendarGroup,
 )
 from calendar_integration.permissions import (
     CalendarAvailabilityPermission,
     CalendarEventPermission,
+    CalendarGroupPermission,
 )
 from calendar_integration.serializers import (
     AvailableTimeBulkModificationSerializer,
@@ -35,15 +41,21 @@ from calendar_integration.serializers import (
     BlockedTimeBulkModificationSerializer,
     BlockedTimeRecurringExceptionSerializer,
     BlockedTimeSerializer,
+    BookableSlotProposalSerializer,
     BulkAvailableTimeSerializer,
     BulkBlockedTimeSerializer,
     CalendarBundleCreateSerializer,
     CalendarEventSerializer,
+    CalendarGroupAvailabilityQuerySerializer,
+    CalendarGroupEventCreateSerializer,
+    CalendarGroupRangeAvailabilitySerializer,
+    CalendarGroupSerializer,
     CalendarSerializer,
     EventBulkModificationSerializer,
     EventRecurringExceptionSerializer,
     UnavailableTimeWindowSerializer,
 )
+from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_service import CalendarService
 from common.utils.view_utils import VintaScheduleModelViewSet
 from organizations.models import OrganizationMembership
@@ -852,3 +864,251 @@ class AvailableTimeViewSet(VintaScheduleModelViewSet):
             )
         except ValueError as e:
             raise ValidationError({"non_field_errors": [str(e)]}) from e
+
+
+class CalendarGroupViewSet(VintaScheduleModelViewSet):
+    """
+    ViewSet for CalendarGroup CRUD and grouped event actions.
+    """
+
+    permission_classes = (CalendarGroupPermission,)
+    queryset = CalendarGroup.objects.all()
+    serializer_class = CalendarGroupSerializer
+    filterset_class = CalendarGroupFilterSet
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return CalendarGroup.objects.none()
+        try:
+            organization_id = user.organization_membership.organization_id
+        except OrganizationMembership.DoesNotExist:
+            return CalendarGroup.objects.none()
+        return super().get_queryset().filter_by_organization(organization_id)
+
+    @extend_schema(
+        summary="Delete calendar group",
+        description="Delete a CalendarGroup. Fails with 400 if the group has any bookings.",
+        responses={204: None},
+    )
+    @inject
+    def destroy(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        instance = self.get_object()
+        calendar_group_service.initialize(organization=instance.organization)
+        try:
+            calendar_group_service.delete_group(group_id=instance.id)
+        except CalendarGroupError as e:
+            raise ValidationError({"non_field_errors": [str(e)]}) from e
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        summary="Create grouped event",
+        request=CalendarGroupEventCreateSerializer,
+        responses={201: CalendarEventSerializer},
+    )
+    @action(
+        methods=["POST"],
+        detail=True,
+        url_path="events",
+        url_name="create-event",
+    )
+    def create_event(self, request, pk):
+        group = self.get_object()
+        serializer = CalendarGroupEventCreateSerializer(
+            data=request.data, context=self.get_serializer_context()
+        )
+        serializer.is_valid(raise_exception=True)
+        event = serializer.save(group=group)
+        return Response(
+            CalendarEventSerializer(event, context=self.get_serializer_context()).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @extend_schema(
+        summary="List events booked under this group",
+        parameters=[
+            OpenApiParameter(
+                name="start_datetime",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description="Start datetime in ISO format",
+                required=True,
+            ),
+            OpenApiParameter(
+                name="end_datetime",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description="End datetime in ISO format",
+                required=True,
+            ),
+        ],
+        responses={200: CalendarEventSerializer(many=True)},
+    )
+    @action(
+        methods=["GET"],
+        detail=True,
+        url_path="booked-events",
+        url_name="list-events",
+    )
+    @inject
+    def list_events(
+        self,
+        request,
+        pk,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+    ):
+        group = self.get_object()
+        start_raw = request.query_params.get("start_datetime")
+        end_raw = request.query_params.get("end_datetime")
+        if not start_raw or not end_raw:
+            raise ValidationError(
+                {"non_field_errors": ["start_datetime and end_datetime are required"]}
+            )
+        try:
+            start_dt = datetime.datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
+            end_dt = datetime.datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+        except ValueError as e:
+            raise ValidationError(
+                {"non_field_errors": ["Invalid datetime format; use ISO 8601."]}
+            ) from e
+
+        calendar_group_service.initialize(organization=group.organization)
+        events = calendar_group_service.get_group_events(
+            group_id=group.id, start=start_dt, end=end_dt
+        )
+        return Response(
+            CalendarEventSerializer(
+                list(events), many=True, context=self.get_serializer_context()
+            ).data
+        )
+
+    @extend_schema(
+        summary="Per-slot availability for requested ranges",
+        request=CalendarGroupAvailabilityQuerySerializer,
+        responses={200: CalendarGroupRangeAvailabilitySerializer(many=True)},
+    )
+    @action(
+        methods=["POST"],
+        detail=True,
+        url_path="availability",
+        url_name="availability",
+    )
+    @inject
+    def availability(
+        self,
+        request,
+        pk,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+    ):
+        group = self.get_object()
+        input_serializer = CalendarGroupAvailabilityQuerySerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+
+        calendar_group_service.initialize(organization=group.organization)
+        ranges = [
+            (r["start_time"], r["end_time"]) for r in input_serializer.validated_data["ranges"]
+        ]
+        result = calendar_group_service.check_group_availability(group_id=group.id, ranges=ranges)
+        payload = [
+            {
+                "start_time": r.start_time,
+                "end_time": r.end_time,
+                "slots": [
+                    {
+                        "slot_id": s.slot_id,
+                        "available_calendar_ids": s.available_calendar_ids,
+                    }
+                    for s in r.slots
+                ],
+            }
+            for r in result
+        ]
+        return Response(CalendarGroupRangeAvailabilitySerializer(payload, many=True).data)
+
+    @extend_schema(
+        summary="Bookable slot proposals for the group within a search window",
+        parameters=[
+            OpenApiParameter(
+                name="search_window_start",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description="Start of the search window (ISO 8601)",
+                required=True,
+            ),
+            OpenApiParameter(
+                name="search_window_end",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description="End of the search window (ISO 8601)",
+                required=True,
+            ),
+            OpenApiParameter(
+                name="duration_seconds",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                description="Desired event duration, in seconds",
+                required=True,
+            ),
+            OpenApiParameter(
+                name="slot_step_seconds",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                description="Search step, in seconds (default 900 = 15min)",
+                required=False,
+            ),
+        ],
+        responses={200: BookableSlotProposalSerializer(many=True)},
+    )
+    @action(
+        methods=["GET"],
+        detail=True,
+        url_path="bookable-slots",
+        url_name="bookable-slots",
+    )
+    @inject
+    def bookable_slots(
+        self,
+        request,
+        pk,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+    ):
+        group = self.get_object()
+        try:
+            start_dt = datetime.datetime.fromisoformat(
+                request.query_params["search_window_start"].replace("Z", "+00:00")
+            )
+            end_dt = datetime.datetime.fromisoformat(
+                request.query_params["search_window_end"].replace("Z", "+00:00")
+            )
+            duration_seconds = int(request.query_params["duration_seconds"])
+            slot_step_seconds = int(request.query_params.get("slot_step_seconds", 15 * 60))
+        except (KeyError, ValueError) as e:
+            raise ValidationError(
+                {
+                    "non_field_errors": [
+                        "search_window_start, search_window_end and duration_seconds are required "
+                        "ISO/integer values."
+                    ]
+                }
+            ) from e
+
+        calendar_group_service.initialize(organization=group.organization)
+        try:
+            proposals = calendar_group_service.find_bookable_slots(
+                group_id=group.id,
+                search_window_start=start_dt,
+                search_window_end=end_dt,
+                duration=datetime.timedelta(seconds=duration_seconds),
+                slot_step=datetime.timedelta(seconds=slot_step_seconds),
+            )
+        except CalendarGroupError as e:
+            raise ValidationError({"non_field_errors": [str(e)]}) from e
+
+        payload = [{"start_time": p.start_time, "end_time": p.end_time} for p in proposals]
+        return Response(BookableSlotProposalSerializer(payload, many=True).data)

--- a/calendar_integration/virtual_models.py
+++ b/calendar_integration/virtual_models.py
@@ -5,6 +5,10 @@ from calendar_integration.models import (
     BlockedTime,
     Calendar,
     CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
     CalendarOwnership,
     EventAttendance,
     EventExternalAttendance,
@@ -67,6 +71,36 @@ class NestedCalendarEventVirtualModel(v.VirtualModel):
         model = CalendarEvent
 
 
+class CalendarGroupSlotMembershipVirtualModel(v.VirtualModel):
+    calendar = CalendarVirtualModel()
+
+    class Meta:
+        model = CalendarGroupSlotMembership
+
+
+class CalendarGroupSlotVirtualModel(v.VirtualModel):
+    memberships = CalendarGroupSlotMembershipVirtualModel(many=True)
+    calendars = CalendarVirtualModel(many=True)
+
+    class Meta:
+        model = CalendarGroupSlot
+
+
+class CalendarGroupVirtualModel(v.VirtualModel):
+    slots = CalendarGroupSlotVirtualModel(many=True)
+
+    class Meta:
+        model = CalendarGroup
+
+
+class CalendarEventGroupSelectionVirtualModel(v.VirtualModel):
+    slot = CalendarGroupSlotVirtualModel()
+    calendar = CalendarVirtualModel()
+
+    class Meta:
+        model = CalendarEventGroupSelection
+
+
 class CalendarEventVirtualModel(v.VirtualModel):
     calendar = CalendarVirtualModel()
     external_attendances = EventExternalAttendanceVirtualModel(many=True)
@@ -74,6 +108,8 @@ class CalendarEventVirtualModel(v.VirtualModel):
     resource_allocations = ResourceAllocationVirtualModel(many=True)
     recurrence_rule = RecurrenceRuleVirtualModel()
     parent_recurring_object = NestedCalendarEventVirtualModel()
+    group_selections = CalendarEventGroupSelectionVirtualModel(many=True)
+    calendar_group = CalendarGroupVirtualModel()
 
     class Meta:
         model = CalendarEvent

--- a/dev-plans/2026-04-20-CALENDAR_GROUP_PLAN.md
+++ b/dev-plans/2026-04-20-CALENDAR_GROUP_PLAN.md
@@ -351,6 +351,65 @@ All mutations enforce permissions via `CalendarPermissionService` (extend it wit
 
 ---
 
+## API (Internal REST)
+
+The project also exposes a Django REST Framework viewset-based API for internal (session-authenticated) clients, under `calendar_integration/views.py`, `calendar_integration/serializers.py`, `calendar_integration/filtersets.py` and `calendar_integration/routes.py`. We add `CalendarGroup` endpoints here so internal UIs don't have to go through GraphQL.
+
+### Virtual models ([calendar_integration/virtual_models.py](calendar_integration/virtual_models.py))
+
+Add `CalendarGroupSlotMembershipVirtualModel`, `CalendarGroupSlotVirtualModel`, `CalendarGroupVirtualModel`, and `CalendarEventGroupSelectionVirtualModel` mirroring the existing pattern (so `VirtualModelSerializer` can prefetch efficiently). Extend `CalendarEventVirtualModel` with `group_selections` and `calendar_group` relations.
+
+### Serializers ([calendar_integration/serializers.py](calendar_integration/serializers.py))
+
+- `CalendarGroupSlotMembershipSerializer` — read-only nested representation (`id`, `calendar`).
+- `CalendarGroupSlotSerializer` — nested slot representation with `id`, `name`, `description`, `order`, `required_count`, and a writable `calendar_ids: list[int]` alongside the read-only `calendars` field.
+- `CalendarGroupSerializer` — `id`, `name`, `description`, nested `slots`, timestamps. On `create`/`update`, delegates to `CalendarGroupService.create_group` / `update_group`, converting nested slot payloads to `CalendarGroupInputData`.
+- `CalendarEventGroupSelectionSerializer` — read-only, `id`, `slot`, `calendar`.
+- `CalendarGroupEventCreateSerializer` — write-only input for creating a grouped event. Fields: `group_id`, `title`, `description`, `start_time`, `end_time`, `timezone`, `slot_selections: list[{slot_id, calendar_ids: list[int]}]`, `attendances`, `external_attendances`. On `save()`, delegates to `CalendarGroupService.create_grouped_event` and returns the full `CalendarEvent`. The response is serialized with `CalendarEventSerializer`.
+- `CalendarGroupAvailabilityRangeSerializer` / `CalendarGroupSlotAvailabilitySerializer` — output for the availability action.
+- `BookableSlotProposalSerializer` — output for the bookable-slots action.
+
+Service errors (`CalendarGroupValidationError`, `CalendarGroupSlotInUseError`, `CalendarGroupHasFutureEventsError`) are translated to DRF `ValidationError` with a per-exception `non_field_errors` payload.
+
+### Permissions ([calendar_integration/permissions.py](calendar_integration/permissions.py))
+
+Add `CalendarGroupPermission`: authenticated user with an active `OrganizationMembership` matching the group's organization. For object-level access we check that the user owns at least one calendar in the group (via `CalendarOwnership`) — mirroring the "likely permission model" noted above. Org-admin override is a follow-up.
+
+### FilterSet ([calendar_integration/filtersets.py](calendar_integration/filtersets.py))
+
+`CalendarGroupFilterSet` — `name` (icontains), `calendar` (ModelChoiceFilter — returns groups whose slots include that calendar).
+
+### ViewSet ([calendar_integration/views.py](calendar_integration/views.py))
+
+`CalendarGroupViewSet(VintaScheduleModelViewSet)`:
+
+- Standard CRUD: `list`, `retrieve`, `create`, `update`, `partial_update`, `destroy`. CRUD methods mirror the webhook-mutations pattern — the serializer delegates to `CalendarGroupService`. `destroy` raises `ValidationError` when the service raises `CalendarGroupHasFutureEventsError`.
+- Custom actions:
+  - `POST /calendar-groups/{id}/events/` (`url_path="events"`, `url_name="create-event"`) — accepts `CalendarGroupEventCreateSerializer`; returns the created `CalendarEvent`.
+  - `GET /calendar-groups/{id}/events/?start_datetime=…&end_datetime=…` (`url_path="events"`, `url_name="list-events"`, `methods=["GET"]`) — lists grouped events in range. Note that a single `@action` can accept both `GET` and `POST`; we'll keep them split for clarity.
+  - `POST /calendar-groups/{id}/availability/` — body is `{ "ranges": [{"start_time", "end_time"}, ...] }`, returns per-range, per-slot availability. `POST` to avoid long query-string range payloads.
+  - `GET /calendar-groups/{id}/bookable-slots/?search_window_start&search_window_end&duration_seconds&slot_step_seconds` — returns `[BookableSlotProposal]`.
+
+Each action authenticates the underlying `CalendarService`/`CalendarGroupService` via `initialize_without_provider(organization=user.organization_membership.organization)` — the grouped-event flow needs provider adapters when the primary calendar is Google/Microsoft, so the viewset uses `authenticate(account=social_account, organization=…)` when a matching `SocialAccount` exists for the primary calendar's provider.
+
+### Routes ([calendar_integration/routes.py](calendar_integration/routes.py))
+
+Register `CalendarGroupViewSet` under `r"calendar-groups"` with basename `CalendarGroups`.
+
+### Testing
+
+- `calendar_integration/tests/test_views_calendar_group.py`:
+  - CRUD happy paths (`list`, `retrieve`, `create`, `update`, `destroy`).
+  - `create` validation surfaces from the service (duplicate slot name, cross-org calendar, empty pool).
+  - `destroy` blocked by `CalendarGroupHasFutureEventsError`.
+  - `events` POST: creates grouped event, returns `CalendarEvent` payload, persists `CalendarEventGroupSelection` rows.
+  - `events` GET: returns events scoped to the group within the range.
+  - `availability` POST returns per-range slot availability.
+  - `bookable-slots` GET returns proposals.
+  - Object-level permission blocks users who don't own any of the group's calendars.
+
+---
+
 ## Migrations
 
 Single new migration `calendar_integration/migrations/00XX_calendar_group.py` containing:
@@ -426,10 +485,16 @@ Land in this order; each step is independently mergeable.
    - Types, queries, mutations, permission checks.
    - Schema snapshot test (if the project has one).
 
-5. **PR 5 — follow-ups (separate tickets)**
+5. **PR 5 — Internal REST API**
+   - Virtual models, serializers, filterset, permission class, viewset with CRUD + `events` (GET/POST), `availability` (POST), `bookable-slots` (GET) actions.
+   - Route registration.
+   - Full viewset test suite.
+
+6. **PR 6 — follow-ups (separate tickets)**
    - `*_with_bulk_modifications` parity for groups.
    - Bundle-based persistence for non-primary selections (Option A) if Option B proves insufficient.
    - Performance: replace Python-loop `find_bookable_slots` with a SQL `generate_series`-based approach for large windows.
+   - `CalendarPermissionService.can_manage_calendar_group` + org-admin override for the REST permission class.
 
 ---
 

--- a/schema.yml
+++ b/schema.yml
@@ -2606,6 +2606,813 @@ paths:
           description: ''
         '204':
           description: No response body
+  /calendar-groups/:
+    get:
+      operationId: calendar_groups_list
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCalendarGroupList'
+          description: ''
+    post:
+      operationId: calendar_groups_create
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+  /calendar-groups{format}:
+    get:
+      operationId: calendar_groups_formatted_list
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCalendarGroupList'
+          description: ''
+    post:
+      operationId: calendar_groups_formatted_create
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+  /calendar-groups/{id}/:
+    get:
+      operationId: calendar_groups_retrieve
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+    put:
+      operationId: calendar_groups_update
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+    patch:
+      operationId: calendar_groups_partial_update
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarGroup'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarGroup'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarGroup'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+    delete:
+      operationId: calendar_groups_destroy
+      description: Delete a CalendarGroup. Fails with 400 if the group has any bookings.
+      summary: Delete calendar group
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /calendar-groups/{id}{format}:
+    get:
+      operationId: calendar_groups_formatted_retrieve
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+    put:
+      operationId: calendar_groups_formatted_update
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroup'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+    patch:
+      operationId: calendar_groups_formatted_partial_update
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarGroup'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarGroup'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarGroup'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarGroup'
+          description: ''
+    delete:
+      operationId: calendar_groups_formatted_destroy
+      description: Delete a CalendarGroup. Fails with 400 if the group has any bookings.
+      summary: Delete calendar group
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /calendar-groups/{id}/availability/:
+    post:
+      operationId: calendar_groups_availability_create
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: Per-slot availability for requested ranges
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupAvailabilityQuery'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupAvailabilityQuery'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupAvailabilityQuery'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCalendarGroupRangeAvailabilityList'
+          description: ''
+  /calendar-groups/{id}/availability{format}:
+    post:
+      operationId: calendar_groups_availability_formatted_create
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: Per-slot availability for requested ranges
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupAvailabilityQuery'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupAvailabilityQuery'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupAvailabilityQuery'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCalendarGroupRangeAvailabilityList'
+          description: ''
+  /calendar-groups/{id}/bookable-slots/:
+    get:
+      operationId: calendar_groups_bookable_slots_list
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: Bookable slot proposals for the group within a search window
+      parameters:
+      - in: query
+        name: duration_seconds
+        schema:
+          type: integer
+        description: Desired event duration, in seconds
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: search_window_end
+        schema:
+          type: string
+        description: End of the search window (ISO 8601)
+        required: true
+      - in: query
+        name: search_window_start
+        schema:
+          type: string
+        description: Start of the search window (ISO 8601)
+        required: true
+      - in: query
+        name: slot_step_seconds
+        schema:
+          type: integer
+        description: Search step, in seconds (default 900 = 15min)
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBookableSlotProposalList'
+          description: ''
+  /calendar-groups/{id}/bookable-slots{format}:
+    get:
+      operationId: calendar_groups_bookable_slots_formatted_list
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: Bookable slot proposals for the group within a search window
+      parameters:
+      - in: query
+        name: duration_seconds
+        schema:
+          type: integer
+        description: Desired event duration, in seconds
+        required: true
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: search_window_end
+        schema:
+          type: string
+        description: End of the search window (ISO 8601)
+        required: true
+      - in: query
+        name: search_window_start
+        schema:
+          type: string
+        description: Start of the search window (ISO 8601)
+        required: true
+      - in: query
+        name: slot_step_seconds
+        schema:
+          type: integer
+        description: Search step, in seconds (default 900 = 15min)
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBookableSlotProposalList'
+          description: ''
+  /calendar-groups/{id}/booked-events/:
+    get:
+      operationId: calendar_groups_booked_events_list
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: List events booked under this group
+      parameters:
+      - in: query
+        name: end_datetime
+        schema:
+          type: string
+        description: End datetime in ISO format
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: start_datetime
+        schema:
+          type: string
+        description: Start datetime in ISO format
+        required: true
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCalendarEventList'
+          description: ''
+  /calendar-groups/{id}/booked-events{format}:
+    get:
+      operationId: calendar_groups_booked_events_formatted_list
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: List events booked under this group
+      parameters:
+      - in: query
+        name: end_datetime
+        schema:
+          type: string
+        description: End datetime in ISO format
+        required: true
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Filter by partial name match
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: start_datetime
+        schema:
+          type: string
+        description: Start datetime in ISO format
+        required: true
+      tags:
+      - calendar-groups
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCalendarEventList'
+          description: ''
+  /calendar-groups/{id}/events/:
+    post:
+      operationId: calendar_groups_events_create
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: Create grouped event
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupEventCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupEventCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupEventCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+  /calendar-groups/{id}/events{format}:
+    post:
+      operationId: calendar_groups_events_formatted_create
+      description: ViewSet for CalendarGroup CRUD and grouped event actions.
+      summary: Create grouped event
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupEventCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupEventCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarGroupEventCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
   /calendar/{id}/:
     get:
       operationId: calendar_retrieve
@@ -5148,6 +5955,18 @@ components:
           description: True if cancelling the occurrence, False if modifying
       required:
       - exception_date
+    BookableSlotProposal:
+      type: object
+      properties:
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+      required:
+      - end_time
+      - start_time
     BulkAvailableTime:
       type: object
       description: Serializer for creating multiple available times.
@@ -5338,6 +6157,160 @@ components:
       - start_time
       - timezone
       - title
+    CalendarGroup:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        slots:
+          type: array
+          items:
+            $ref: '#/components/schemas/CalendarGroupSlot'
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created
+      - id
+      - modified
+      - name
+      - slots
+    CalendarGroupAvailabilityQuery:
+      type: object
+      description: 'Input for the availability action: list of [start, end] windows.'
+      properties:
+        ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/_RangeInput'
+      required:
+      - ranges
+    CalendarGroupEventCreate:
+      type: object
+      description: |-
+        Input for booking an event through a CalendarGroup.
+
+        On `save()` this delegates to `CalendarGroupService.create_grouped_event`
+        and returns the created `CalendarEvent`. The view is responsible for
+        serializing the result (typically with `CalendarEventSerializer`).
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+          default: ''
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        timezone:
+          type: string
+        slot_selections:
+          type: array
+          items:
+            $ref: '#/components/schemas/_CalendarGroupSlotSelectionInput'
+        attendances:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        external_attendances:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+      - end_time
+      - slot_selections
+      - start_time
+      - timezone
+      - title
+    CalendarGroupRangeAvailability:
+      type: object
+      properties:
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        slots:
+          type: array
+          items:
+            $ref: '#/components/schemas/CalendarGroupSlotAvailability'
+      required:
+      - end_time
+      - slots
+      - start_time
+    CalendarGroupSlot:
+      type: object
+      description: |-
+        Nested slot representation used inside CalendarGroupSerializer.
+
+        On write, accepts `calendar_ids: list[int]`; on read exposes the calendar
+        pool via `calendars` (the M2M). We deliberately keep slot writes to
+        payload-time data only — persistence happens through
+        `CalendarGroupSerializer` which delegates to `CalendarGroupService`.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        order:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        required_count:
+          type: integer
+          maximum: 32767
+          minimum: 0
+          description: How many calendars from the pool must be selected when booking.
+            Default 1; use larger values when a slot needs multiple calendars (e.g.
+            two nurses).
+        calendars:
+          type: array
+          items:
+            $ref: '#/components/schemas/Calendar'
+          readOnly: true
+        calendar_ids:
+          type: array
+          items:
+            type: integer
+          writeOnly: true
+      required:
+      - calendar_ids
+      - calendars
+      - id
+      - name
+    CalendarGroupSlotAvailability:
+      type: object
+      properties:
+        slot_id:
+          type: integer
+        available_calendar_ids:
+          type: array
+          items:
+            type: integer
+      required:
+      - available_calendar_ids
+      - slot_id
     CalendarTypeEnum:
       enum:
       - personal
@@ -5672,6 +6645,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BlockedTime'
+    PaginatedBookableSlotProposalList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookableSlotProposal'
     PaginatedCalendarEventList:
       type: object
       required:
@@ -5695,6 +6691,52 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CalendarEvent'
+    PaginatedCalendarGroupList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CalendarGroup'
+    PaginatedCalendarGroupRangeAvailabilityList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CalendarGroupRangeAvailability'
     PaginatedCalendarList:
       type: object
       required:
@@ -6122,6 +7164,29 @@ components:
         calendar:
           type: integer
           writeOnly: true
+    PatchedCalendarGroup:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        slots:
+          type: array
+          items:
+            $ref: '#/components/schemas/CalendarGroupSlot'
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
     PatchedOrganization:
       type: object
       properties:
@@ -6517,6 +7582,30 @@ components:
         * `FR` - Friday
         * `SA` - Saturday
         * `SU` - Sunday
+    _CalendarGroupSlotSelectionInput:
+      type: object
+      properties:
+        slot_id:
+          type: integer
+        calendar_ids:
+          type: array
+          items:
+            type: integer
+      required:
+      - calendar_ids
+      - slot_id
+    _RangeInput:
+      type: object
+      properties:
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+      required:
+      - end_time
+      - start_time
   securitySchemes:
     cookieAuth:
       type: apiKey


### PR DESCRIPTION
- Implemented CalendarGroupViewSet for managing calendar groups, including list, retrieve, create, update, and delete operations.
- Added serializers for CalendarGroup, CalendarGroupSlot, and CalendarEventGroupSelection to handle nested data structures.
- Introduced virtual models for efficient data retrieval and representation in the API.
- Created actions for creating grouped events, listing events within a group, checking availability, and retrieving bookable slots.
- Integrated permission checks to ensure users can only access groups they own.
- Developed comprehensive tests for all new functionalities, covering CRUD operations, event creation, and availability checks.