### PR TITLE
feat(organizations): add guarded tenant-provisioning service

### DIFF
--- a/ai-plans/TRACKING_AUTH_TENANT_PROVISIONING.md
+++ b/ai-plans/TRACKING_AUTH_TENANT_PROVISIONING.md
@@ -1,0 +1,37 @@
+# Tracking — AUTH_TENANT_PROVISIONING
+
+- **Feature**: Auth–Tenant Provisioning (wire signup → organization/tenant)
+- **Plan**: [ai-plans/2026-06-04-AUTH_TENANT_PROVISIONING_IMPLEMENTATION_PLAN.md](2026-06-04-AUTH_TENANT_PROVISIONING_IMPLEMENTATION_PLAN.md)
+- **Spec**: [ai-plans/2026-06-04-AUTH_TENANT_PROVISIONING_SPEC.md](2026-06-04-AUTH_TENANT_PROVISIONING_SPEC.md)
+- **Started**: 2026-06-04
+- **Last updated**: 2026-06-04
+- **Feature flag**: none (shipped unflagged — known-requirement fix)
+- **Run options**: auto-flow (no per-phase pause), inline PR comments ON
+- **Branch pattern**: `plan/auth-tenant-provisioning/phase-{id}`, stacked
+
+## Completed Phases
+
+### Phase 1 — Central tenant-provisioning service ✅
+- **Status**: merged-ready (PR open)
+- **Model**: claude-sonnet-4-6 (plan tier: Tier 3)
+- **Branch**: `plan/auth-tenant-provisioning/phase-1` (base `main`)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/32
+- **E2E**: n/a (backend-only)
+- **Summary**: Added `UserAlreadyHasMembershipError` (DRF `ValidationError` → 400) and `OrganizationService.provision_tenant_for_user(user, organization_name=None)` — the single guarded entry point: already-member → raise; non-expired/unaccepted invitation matching `user.email` → MEMBER join + mark invitation accepted; else `organization_name` → `create_organization` (ADMIN); else `None` (gated onboarding). Hardened `accept_invitation` to raise the typed error before the DB write and wrap the insert in a savepoint (avoids `ATOMIC_REQUESTS` transaction-poison). Fixed the `IntegrityError` import to Django's class so the concurrency backstop actually catches `.create()` violations.
+- **Review**: 3 BLOCKERs found + fixed (wrong `IntegrityError` class; concurrency test never exercised the backstop; missing savepoint in `accept_invitation`) + 1 should-fix (unguarded `create_organization` delegation) + 1 nit. Final gate: `check --deploy` clean, `pytest -n auto` = 1170 passed.
+- **Key API for later phases**: `OrganizationService.provision_tenant_for_user(user, organization_name=None)` — invite-first; returns the membership or `None`. Phases 3/4/6 call this; Phase 7 surfaces `UserAlreadyHasMembershipError` at the accept endpoint.
+
+## Current Phase
+- Phase 2 — Capture intended org name at signup (next)
+
+## Remaining Phases
+- Phase 2 — Capture intended org name at signup (Tier 2)
+- Phase 3 — Create own org on email verification, no invite (Tier 3) — UC1
+- Phase 4 — Auto-join invited org on email verification (Tier 2) — UC2
+- Phase 5 — Gated onboarding for uninvited social signup (Tier 2) — UC3
+- Phase 6 — Auto-join invited org on social signup (Tier 3) — UC4
+- Phase 7 — Reject already-member invite acceptance at the API (Tier 2) — UC5
+- Phase 8 — Audit + close the hard gate (Tier 3)
+
+## Deferred Phases
+- none (no cross-repo, no flag-removal)

--- a/organizations/exceptions.py
+++ b/organizations/exceptions.py
@@ -14,3 +14,8 @@ class InvalidInvitationTokenError(ValidationError):
 class InvitationNotFoundError(ValidationError):
     default_detail = "Invitation does not exist"
     default_code = "invitation_not_found"
+
+
+class UserAlreadyHasMembershipError(ValidationError):
+    default_detail = "User already belongs to an organization."
+    default_code = "user_already_has_membership"

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -1,12 +1,11 @@
 import datetime
 from typing import Annotated
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.urls import reverse
 
 from allauth.utils import build_absolute_uri
 from dependency_injector.wiring import Provide, inject
-from psycopg import IntegrityError
 from vintasend.services.notification_service import (
     NotificationContextDict,
     NotificationService,
@@ -23,6 +22,7 @@ from organizations.exceptions import (
     DuplicateInvitationError,
     InvalidInvitationTokenError,
     InvitationNotFoundError,
+    UserAlreadyHasMembershipError,
 )
 from organizations.models import (
     Organization,
@@ -147,23 +147,98 @@ class OrganizationService:
     def accept_invitation(self, token: str, user: User) -> OrganizationMembership:
         """
         Accept an invitation to join an organization.
+
+        Raises UserAlreadyHasMembershipError if the user is already a member of any
+        organization before the membership create is attempted, preventing an IntegrityError
+        from the OneToOne constraint on OrganizationMembership.user.
+
         :param token: Invitation token.
         :param user: User who is accepting the invitation.
         :return: Created OrganizationMembership instance.
         """
+        if hasattr(user, "organization_membership"):
+            raise UserAlreadyHasMembershipError()
+
         now = datetime.datetime.now(tz=datetime.UTC)
         invitations = OrganizationInvitation.objects.filter(email=user.email, expires_at__gt=now)
         for invitation in invitations:
             if verify_long_lived_token(token, invitation.token_hash):
-                membership = OrganizationMembership.objects.create(
-                    user=user, organization=invitation.organization
-                )
+                try:
+                    with transaction.atomic():
+                        membership = OrganizationMembership.objects.create(
+                            user=user, organization=invitation.organization
+                        )
+                except IntegrityError as e:
+                    raise UserAlreadyHasMembershipError() from e
                 invitation.accepted_at = now
                 invitation.membership = membership
                 invitation.save()
                 return membership
 
         raise InvalidInvitationTokenError()
+
+    @transaction.atomic()
+    def provision_tenant_for_user(
+        self, user: User, organization_name: str | None = None
+    ) -> OrganizationMembership | None:
+        """
+        Provision a tenant for a user who does not yet have a membership.
+
+        This is the single guarded entry point for turning a membership-less user into a
+        member. It is called by every signup path (email confirmation, social adapter,
+        explicit invite accept) so the provisioning decision is centralised and can never
+        silently create a second membership.
+
+        Logic (in order):
+        1. If the user already has a membership → raise UserAlreadyHasMembershipError.
+        2. Else if a non-expired, unaccepted OrganizationInvitation exists for user.email
+           → create a MEMBER membership in the inviting org and mark the invitation
+           accepted.
+        3. Else if organization_name is truthy → delegate to create_organization (user
+           becomes ADMIN of a new org).
+        4. Else → return None (caller decides — gated onboarding).
+
+        :param user: The user to provision a tenant for.
+        :param organization_name: Optional name of the new organization to create when no
+            pending invitation is found.
+        :return: The created OrganizationMembership on the join/create branches; None on
+            the no-op branch.
+        :raises UserAlreadyHasMembershipError: When the user already belongs to an
+            organization.
+        """
+        if hasattr(user, "organization_membership"):
+            raise UserAlreadyHasMembershipError()
+
+        now = datetime.datetime.now(tz=datetime.UTC)
+        pending_invitation = OrganizationInvitation.objects.filter(
+            email=user.email,
+            expires_at__gt=now,
+            accepted_at__isnull=True,
+            membership__isnull=True,
+        ).first()
+
+        if pending_invitation is not None:
+            try:
+                membership = OrganizationMembership.objects.create(
+                    user=user,
+                    organization=pending_invitation.organization,
+                    role=OrganizationRole.MEMBER,
+                )
+            except IntegrityError as e:
+                raise UserAlreadyHasMembershipError() from e
+            pending_invitation.accepted_at = now
+            pending_invitation.membership = membership
+            pending_invitation.save()
+            return membership
+
+        if organization_name:
+            try:
+                organization = self.create_organization(creator=user, name=organization_name)
+            except IntegrityError as e:
+                raise UserAlreadyHasMembershipError() from e
+            return organization.memberships.get(user=user)
+
+        return None
 
     def revoke_invitation(self, invitation_id: str) -> None:
         """

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -6,8 +6,17 @@ from django.db.utils import IntegrityError
 import pytest
 from model_bakery import baker
 
-from organizations.exceptions import InvalidInvitationTokenError, InvitationNotFoundError
-from organizations.models import Organization
+from organizations.exceptions import (
+    InvalidInvitationTokenError,
+    InvitationNotFoundError,
+    UserAlreadyHasMembershipError,
+)
+from organizations.models import (
+    Organization,
+    OrganizationInvitation,
+    OrganizationMembership,
+    OrganizationRole,
+)
 from organizations.services import OrganizationService
 from users.models import User
 
@@ -468,12 +477,15 @@ class TestOrganizationService:
             organization_service.revoke_invitation(invitation_id=fake_id)
 
     def test_accept_invitation_already_accepted(self, organization_service, organization):
-        """Test accepting an invitation that was already accepted."""
+        """Test accepting an invitation for a user who already has a membership.
+
+        The hardened accept_invitation raises UserAlreadyHasMembershipError before
+        attempting the DB create, so we get a typed error instead of a raw IntegrityError.
+        """
         from common.utils.authentication_utils import (
             generate_long_lived_token,
             hash_long_lived_token,
         )
-        from organizations.models import OrganizationInvitation, OrganizationMembership
 
         # Create a unique user for this test to avoid membership conflicts
         test_user = baker.make(User, email="unique_accepted@example.com")
@@ -492,7 +504,251 @@ class TestOrganizationService:
             membership=membership,
         )
 
-        # Try to accept again - should fail with IntegrityError due to unique constraint
-        # The service should handle this case better, but currently it doesn't
-        with pytest.raises(IntegrityError):
+        # The hardened path now raises UserAlreadyHasMembershipError, not IntegrityError.
+        with pytest.raises(UserAlreadyHasMembershipError):
             organization_service.accept_invitation(token=token, user=test_user)
+
+    # -----------------------------------------------------------------------
+    # Tests for provision_tenant_for_user
+    # -----------------------------------------------------------------------
+
+    def _make_invitation(
+        self,
+        *,
+        email: str,
+        organization: Organization,
+        invited_by: User,
+        expired: bool = False,
+        accepted: bool = False,
+    ) -> OrganizationInvitation:
+        """Helper: create an OrganizationInvitation for the given parameters."""
+        now = datetime.datetime.now(tz=datetime.UTC)
+        expires_at = (
+            now - datetime.timedelta(hours=1) if expired else now + datetime.timedelta(days=7)
+        )
+        membership = (
+            baker.make(OrganizationMembership, organization=organization) if accepted else None
+        )
+        return baker.make(
+            OrganizationInvitation,
+            email=email,
+            organization=organization,
+            invited_by=invited_by,
+            expires_at=expires_at,
+            accepted_at=now if accepted else None,
+            membership=membership,
+        )
+
+    def test_provision_tenant_for_user_with_pending_invite(
+        self, organization_service, organization
+    ):
+        """Branch (a): pending invite → MEMBER membership in inviting org, invitation marked accepted."""
+        inviter = baker.make(User, email="inviter@example.com")
+        invitee = baker.make(User, email="invitee@example.com")
+        invitation = self._make_invitation(
+            email=invitee.email, organization=organization, invited_by=inviter
+        )
+
+        membership = organization_service.provision_tenant_for_user(invitee)
+
+        assert membership is not None
+        assert membership.user == invitee
+        assert membership.organization == organization
+        assert membership.role == OrganizationRole.MEMBER
+
+        # Invitation must be marked accepted and linked.
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is not None
+        assert invitation.membership == membership
+
+        # No new org should have been created.
+        assert Organization.objects.count() == 1
+
+    def test_provision_tenant_for_user_name_only_no_invite(self, organization_service):
+        """Branch (b): no invite, name supplied → new org created with user as ADMIN."""
+        user = baker.make(User, email="creator@example.com")
+
+        membership = organization_service.provision_tenant_for_user(
+            user, organization_name="My Org"
+        )
+
+        assert membership is not None
+        assert membership.user == user
+        assert membership.role == OrganizationRole.ADMIN
+        assert membership.organization.name == "My Org"
+
+    def test_provision_tenant_for_user_already_has_membership(
+        self, organization_service, organization
+    ):
+        """Branch (c): user already has a membership → raises UserAlreadyHasMembershipError."""
+        user = baker.make(User, email="member@example.com")
+        baker.make(OrganizationMembership, user=user, organization=organization)
+
+        # Reload user from DB so the related manager cache is warm.
+        user.refresh_from_db()
+
+        with pytest.raises(UserAlreadyHasMembershipError):
+            organization_service.provision_tenant_for_user(user)
+
+    def test_provision_tenant_for_user_no_invite_no_name_returns_none(self, organization_service):
+        """Branch (d): no invite, no name → returns None, no membership created."""
+        user = baker.make(User, email="nobody@example.com")
+
+        result = organization_service.provision_tenant_for_user(user)
+
+        assert result is None
+        assert not OrganizationMembership.objects.filter(user=user).exists()
+
+    def test_provision_tenant_for_user_expired_invite_ignored(
+        self, organization_service, organization
+    ):
+        """Branch (e): expired invitation is ignored; falls through to name/None branch."""
+        inviter = baker.make(User, email="inviter2@example.com")
+        invitee = baker.make(User, email="invitee2@example.com")
+        self._make_invitation(
+            email=invitee.email, organization=organization, invited_by=inviter, expired=True
+        )
+
+        # No name → should return None (not join via the expired invite).
+        result = organization_service.provision_tenant_for_user(invitee)
+        assert result is None
+        assert not OrganizationMembership.objects.filter(user=invitee).exists()
+
+    def test_accept_invitation_raises_for_user_with_existing_membership(
+        self, organization_service, organization
+    ):
+        """accept_invitation raises UserAlreadyHasMembershipError when user already has a membership."""
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        user = baker.make(User, email="already_member@example.com")
+        baker.make(OrganizationMembership, user=user, organization=organization)
+        user.refresh_from_db()
+
+        # Create a valid (non-expired) invitation for the same user.
+        token = generate_long_lived_token()
+        token_hash = hash_long_lived_token(token)
+        other_org = baker.make(Organization, name="Other Org")
+        baker.make(
+            OrganizationInvitation,
+            email=user.email,
+            organization=other_org,
+            token_hash=token_hash,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership=None,
+        )
+
+        with pytest.raises(UserAlreadyHasMembershipError):
+            organization_service.accept_invitation(token=token, user=user)
+
+    def test_provision_tenant_for_user_already_member_guard(
+        self, organization_service, organization
+    ):
+        """Integration: the hasattr guard fires on the second sequential call.
+
+        Two sequential calls on the same user verify that the upfront hasattr check
+        raises UserAlreadyHasMembershipError before any DB write on the second attempt.
+        This exercises the guard path but NOT the except-IntegrityError backstop — see
+        the dedicated backstop tests below.
+        """
+        user = baker.make(User, email="concurrent@example.com")
+
+        first_membership = organization_service.provision_tenant_for_user(
+            user, organization_name="Concurrent Org"
+        )
+        assert first_membership is not None
+
+        # Reload user so the related-manager attribute is fresh.
+        user.refresh_from_db()
+
+        with pytest.raises(UserAlreadyHasMembershipError):
+            organization_service.provision_tenant_for_user(user, organization_name="Second Org")
+
+        # Exactly one membership in the DB.
+        assert OrganizationMembership.objects.filter(user=user).count() == 1
+
+    # -----------------------------------------------------------------------
+    # Backstop tests: IntegrityError → UserAlreadyHasMembershipError
+    # These tests genuinely exercise the except IntegrityError path by mocking
+    # OrganizationMembership.objects.create to raise django.db.IntegrityError.
+    # They would FAIL if the import were psycopg.IntegrityError instead of the
+    # Django one, proving that the correct class is caught.
+    # -----------------------------------------------------------------------
+
+    def test_provision_tenant_for_user_invite_branch_integrity_error_backstop(
+        self, organization_service, organization
+    ):
+        """Backstop: IntegrityError from create() on the invite branch → UserAlreadyHasMembershipError.
+
+        Simulates a race-condition duplicate-key error that bypasses the upfront hasattr guard
+        (e.g. concurrent requests both passed the guard before either committed).
+        """
+        from django.db import IntegrityError as DjangoIntegrityError
+
+        inviter = baker.make(User, email="inviter_backstop@example.com")
+        invitee = baker.make(User, email="invitee_backstop@example.com")
+        self._make_invitation(email=invitee.email, organization=organization, invited_by=inviter)
+
+        with patch.object(
+            OrganizationMembership.objects,
+            "create",
+            side_effect=DjangoIntegrityError("duplicate key"),
+        ):
+            with pytest.raises(UserAlreadyHasMembershipError):
+                organization_service.provision_tenant_for_user(invitee)
+
+    def test_provision_tenant_for_user_name_branch_integrity_error_backstop(
+        self, organization_service
+    ):
+        """Backstop: IntegrityError from create() on the name-only branch → UserAlreadyHasMembershipError.
+
+        Simulates a race where create_organization raises IntegrityError (duplicate membership).
+        """
+        from django.db import IntegrityError as DjangoIntegrityError
+
+        user = baker.make(User, email="race_org_creator@example.com")
+
+        with patch.object(
+            OrganizationMembership.objects,
+            "create",
+            side_effect=DjangoIntegrityError("duplicate key"),
+        ):
+            with pytest.raises(UserAlreadyHasMembershipError):
+                organization_service.provision_tenant_for_user(user, organization_name="Race Org")
+
+    def test_accept_invitation_integrity_error_backstop(self, organization_service, organization):
+        """Backstop: IntegrityError from create() in accept_invitation → UserAlreadyHasMembershipError.
+
+        Simulates a race where the user gets a membership between the hasattr check and the
+        DB create call. Under ATOMIC_REQUESTS the savepoint protects the outer transaction.
+        """
+        from django.db import IntegrityError as DjangoIntegrityError
+
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        user = baker.make(User, email="accept_race@example.com")
+        token = generate_long_lived_token()
+        token_hash = hash_long_lived_token(token)
+        baker.make(
+            OrganizationInvitation,
+            email=user.email,
+            organization=organization,
+            token_hash=token_hash,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership=None,
+        )
+
+        with patch.object(
+            OrganizationMembership.objects,
+            "create",
+            side_effect=DjangoIntegrityError("duplicate key"),
+        ):
+            with pytest.raises(UserAlreadyHasMembershipError):
+                organization_service.accept_invitation(token=token, user=user)

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -769,9 +769,12 @@ class TestAcceptInvitationView:
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
 
     def test_accept_invitation_already_accepted(self, auth_client, user, organization):
-        """Test accepting an invitation for a user who is already a member."""
-        from django.db.utils import IntegrityError
+        """Test accepting an invitation for a user who is already a member.
 
+        Since accept_invitation now raises UserAlreadyHasMembershipError (a DRF
+        ValidationError) before touching the DB, the view returns a 400 response
+        with a typed error rather than an unhandled IntegrityError.
+        """
         # Create a membership for the user in the organization
         OrganizationTestFactory.create_organization_membership(user, organization)
 
@@ -790,10 +793,10 @@ class TestAcceptInvitationView:
             "token": token,
         }
 
-        # This should fail with an IntegrityError because the user already has a membership
-        # In Django tests, unhandled exceptions are re-raised instead of becoming HTTP 500s
-        with pytest.raises(IntegrityError, match="duplicate key value violates unique constraint"):
-            auth_client.post(url, data, format="json")
+        response = auth_client.post(url, data, format="json")
+
+        # The hardened service returns a typed 400 error instead of an unhandled IntegrityError.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
Phase 1 of the **Auth–Tenant Provisioning** plan ([ai-plans/2026-06-04-AUTH_TENANT_PROVISIONING_IMPLEMENTATION_PLAN.md](../ai-plans/2026-06-04-AUTH_TENANT_PROVISIONING_IMPLEMENTATION_PLAN.md)).

Adds the single guarded entry point that turns a membership-less user into an organization member, so every signup path (email-confirmation hook, social adapter, explicit invite-accept) routes the same decision through one place and can never silently create a second membership. No user-visible behavior on its own — this is the scaffolding Phases 3–7 consume.

## Changes
- New `UserAlreadyHasMembershipError` (DRF `ValidationError` → renders as 400) in `organizations/exceptions.py`.
- New `OrganizationService.provision_tenant_for_user(user, organization_name=None)` with ordered branches: already-member → raise; non-expired/unaccepted invitation matching `user.email` → MEMBER join + mark invitation accepted; else `organization_name` → `create_organization` (ADMIN); else `None` (gated onboarding).
- Hardened `accept_invitation`: raises the typed error before the DB write when the user already has a membership, and wraps the membership insert in a savepoint so a concurrent unique-violation rolls back cleanly under `ATOMIC_REQUESTS` instead of poisoning the request transaction.
- Switched the `IntegrityError` import to Django's (`from django.db import IntegrityError`) so the concurrency backstop catches what the ORM actually raises.

## Plan reference
- Plan: `AUTH_TENANT_PROVISIONING`, Phase 1 — "Central tenant-provisioning service".
- Spec use-case: shared scaffolding (no use-case yet); underpins Use-cases 1, 2, 4, 5.

## Test plan
- `uv run pytest organizations/tests/ -n auto`
- `uv run python manage.py check --deploy`
- `uv run pytest -n auto` (full suite: 1170 passed)

Covers all four provisioning branches, the expired-invite fall-through, the hardened `accept_invitation`, and three backstop tests that mock `OrganizationMembership.objects.create` to raise `django.db.IntegrityError` and assert the typed error surfaces.