### PR TITLE
feat(organizations): reject already-member invite acceptance with a clear 400

### DIFF
--- a/ai-plans/TRACKING_AUTH_TENANT_PROVISIONING.md
+++ b/ai-plans/TRACKING_AUTH_TENANT_PROVISIONING.md
@@ -69,11 +69,19 @@
 - **Summary**: `SocialAccountAdapter._provision_org_membership(user)` called at end of `save_user` → `provision_tenant_for_user(user)` (no name): invited→MEMBER join, uninvited→stays gated (Phase 5 preserved), already-member→swallowed. DI via container (signals.py pattern). Blank-email guard added.
 - **Review**: no blockers; SHOULD-FIX (blank-email guard) + savepoint-hygiene gap in `provision_tenant_for_user` (both `create()` sites now wrapped in inner `with transaction.atomic()`, matching Phase 1's `accept_invitation` fix — closes the same poisoning bug on the service both the email hook and social adapter call) + test NIT (added genuine already-member-guard load test + 2 transaction-not-poisoned regression tests). Gate: 1202 passed.
 
+### Phase 7 — Reject already-member invite acceptance at the API ✅
+- **Status**: PR open
+- **Model**: claude-sonnet-4-6 (plan tier: Tier 2)
+- **Branch**: `plan/auth-tenant-provisioning/phase-7` (base `plan/auth-tenant-provisioning/phase-6`)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/38
+- **E2E**: n/a
+- **Summary**: `AcceptInvitationView.create()` now explicitly catches `UserAlreadyHasMembershipError` → 400 `{"error": "User already belongs to an organization."}`. Tests: already-member + valid token to another org → 400, original membership unchanged, target invitation stays pending, no second membership.
+- **Review**: Layer 2 found body-shape inconsistency (`{code,detail}` vs siblings' `{error}`) → fixed to match sibling handlers. Gate: 1204 passed.
+
 ## Current Phase
-- Phase 7 — Reject already-member invite acceptance at the API (next) — UC5
+- Phase 8 — Audit + close the hard gate (next)
 
 ## Remaining Phases
-- Phase 7 — Reject already-member invite acceptance at the API (Tier 2) — UC5
 - Phase 8 — Audit + close the hard gate (Tier 3)
 
 ## Deferred Phases

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -798,6 +798,77 @@ class TestAcceptInvitationView:
         # The hardened service returns a typed 400 error instead of an unhandled IntegrityError.
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_accept_invitation_already_member_different_org_rejected(
+        self, auth_client, user, organization
+    ):
+        """Use-case 5: an already-member user POSTs a valid token for a DIFFERENT org.
+
+        Acceptance criteria (Phase 7):
+        - HTTP 400 with the user_already_has_membership code and message.
+        - The user's existing membership (org + role) is unchanged.
+        - The target invitation remains pending (accepted_at is None, membership is None).
+        - No second OrganizationMembership is created.
+        """
+        # User's existing membership in their own org.
+        user_org = OrganizationTestFactory.create_organization(name="User Org")
+        OrganizationTestFactory.create_organization_membership(user, user_org)
+        original_membership = OrganizationMembership.objects.get(user=user)
+
+        # A different org with a valid pending invitation for the same user's email.
+        other_org = OrganizationTestFactory.create_organization(name="Other Org")
+        invitation = OrganizationTestFactory.create_organization_invitation(
+            other_org, email=user.email
+        )
+        token = generate_long_lived_token()
+        invitation.token_hash = hash_long_lived_token(token)
+        invitation.save()
+
+        url = reverse("accept-invitation")
+        response = auth_client.post(url, {"token": token}, format="json")
+
+        # --- HTTP response ---
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+        # --- Error body shape (stable contract for clients) ---
+        response_data = response.json()
+        assert response_data["error"] == "User already belongs to an organization."
+
+        # --- Existing membership is unchanged ---
+        original_membership.refresh_from_db()
+        assert original_membership.organization_id == user_org.id
+        assert OrganizationMembership.objects.filter(user=user).count() == 1
+
+        # --- Target invitation remains pending ---
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is None
+        assert invitation.membership is None
+
+    def test_accept_invitation_already_member_error_body_shape(self, auth_client, user):
+        """Assert the error body contract is stable for clients (Phase 7).
+
+        When the user already has a membership and POSTs the accept endpoint,
+        the response MUST contain the 'code' and 'detail' keys with the documented
+        user_already_has_membership values.
+        """
+        own_org = OrganizationTestFactory.create_organization(name="Own Org")
+        OrganizationTestFactory.create_organization_membership(user, own_org)
+
+        other_org = OrganizationTestFactory.create_organization(name="Other Org")
+        invitation = OrganizationTestFactory.create_organization_invitation(
+            other_org, email=user.email
+        )
+        token = generate_long_lived_token()
+        invitation.token_hash = hash_long_lived_token(token)
+        invitation.save()
+
+        url = reverse("accept-invitation")
+        response = auth_client.post(url, {"token": token}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert "error" in body, f"Response body missing 'error' key: {body}"
+        assert body["error"] == "User already belongs to an organization."
+
 
 @pytest.mark.django_db
 class TestOrganizationInvitationPermissions:

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -13,6 +13,7 @@ from organizations.exceptions import (
     DuplicateInvitationError,
     InvalidInvitationTokenError,
     InvitationNotFoundError,
+    UserAlreadyHasMembershipError,
 )
 from organizations.filtersets import OrganizationInvitationFilterSet
 from organizations.models import Organization, OrganizationInvitation
@@ -102,6 +103,11 @@ class AcceptInvitationView(generics.CreateAPIView):
 
         try:
             membership = serializer.create(serializer.validated_data)
+        except UserAlreadyHasMembershipError:
+            return Response(
+                {"error": UserAlreadyHasMembershipError.default_detail},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except InvalidInvitationTokenError as e:
             return Response(
                 {"error": str(e)},


### PR DESCRIPTION
## Summary
Phase 7 of the **Auth–Tenant Provisioning** plan. Stacked on Phase 6 (PR #37). Implements **Use-case 5** (invited address that already has an account and a membership).

`accept_invitation` already raises the typed `UserAlreadyHasMembershipError` before any DB write (Phase 1). This phase surfaces it at `AcceptInvitationView` as a clean, stable 400 — matching the endpoint's existing `{"error": ...}` body shape — and locks the no-state-change guarantee: the user's existing membership/org/role is untouched and the target invitation stays pending (revocable by an admin).

## Changes
- `organizations/views.py` — explicit `except UserAlreadyHasMembershipError` in `AcceptInvitationView.create()` returning `{"error": "User already belongs to an organization."}` with HTTP 400. Without it, the DRF default handler would have rendered a list-shaped `ValidationError` body inconsistent with the sibling handlers.

## Plan reference
- Plan: `AUTH_TENANT_PROVISIONING`, Phase 7 — "Reject already-member invite acceptance at the API".
- Spec use-case: Use-case 5 (Acceptance scenario 5).

## Test plan
- `uv run pytest organizations/tests/ -n auto`
- `uv run python manage.py check --deploy`
- `uv run pytest -n auto` (full suite: 1204 passed)

New tests: already-member user POSTs a valid token for a DIFFERENT org → 400 `{"error": ...}`; original membership (org+role) unchanged; target invitation still pending (`accepted_at is None`, `membership is None`); no second membership; plus a body-shape contract test.