### PR TITLE
build(accounts): add export_allauth_schema --check pre-commit drift guard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,37 @@ jobs:
 
       - run: uv run pre-commit run --all-files
         env:
-          SKIP: ruff,eslint,missing-migrations,backend-schema
+          SKIP: ruff,eslint,missing-migrations,backend-schema,backend-auth-schema
+      - run: uv run python manage.py export_allauth_schema --check
+        env:
+          DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.production"
+          SECRET_KEY: ${{ steps.secret_id_generator.outputs.SECRET_KEY }}
+          DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/vinta_schedule_test"
+          ALLOWED_HOSTS: ".example.org"
+          SMTP_HOST: 'example.org'
+          SMTP_USERNAME: "test"
+          SMTP_PASSWORD: "test"
+          REDIS_URL: "redis://localhost:6379"
+          SITE_DOMAIN: 'example.com'
+          API_DOMAIN: 'api.example.com'
+          DEFAULT_BCC_EMAILS: 'hugo@example.com'
+          AWS_STATIC_BUCKET_NAME: 'example-static'
+          AWS_ACCESS_KEY_ID: 'test'
+          AWS_SECRET_ACCESS_KEY: 'test'
+          AWS_S3_ACCESS_KEY_ID: 'test'
+          AWS_S3_SECRET_ACCESS_KEY: 'test'
+          AWS_MEDIA_BUCKET_NAME: 'example-media'
+          AWS_MEDIA_LOCATION: 'media'
+          AWS_MEDIA_S3_CUSTOM_DOMAIN: 'example.com'
+          AWS_MEDIA_S3_ENDPOINT_URL: 'https://example.com'
+          AWS_S3_REGION_NAME: 'us-east-1'
+          AWS_CLOUDFRONT_KEY_ID: 'test'
+          AWS_CLOUDFRONT_KEY: 'test'
+          SALT_KEY: 'test_salt_key_123'
+          TWILIO_ACCOUNT_SID: 'FAKE_ACCOUNT_SID'
+          TWILIO_AUTH_TOKEN: 'FAKE_ACCOUNT_SID'
+          TWILIO_NUMBER: '+12345678901'
+          TWILIO_DEFAULT_BROADCAST_NUMBERS: '+12345678901,+10987654321'
       - run: uv run python manage.py makemigrations --check --dry-run
         env:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.production"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,3 +71,5 @@ repos:
         # Allauth headless spec depends on auth settings + the signup form/adapters.
         files: (.*/?settings/.+|.+base_forms\.py|.+account_adapters\.py|.+pyproject\.toml|^schema-auth\.yml$)
         pass_filenames: false
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,5 +71,3 @@ repos:
         # Allauth headless spec depends on auth settings + the signup form/adapters.
         files: (.*/?settings/.+|.+base_forms\.py|.+account_adapters\.py|.+pyproject\.toml|^schema-auth\.yml$)
         pass_filenames: false
-        env:
-          DJANGO_SETTINGS_MODULE: config.settings.local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,10 @@ repos:
         language: system
         files: ^
         pass_filenames: false
+      - id: backend-auth-schema
+        name: backend-auth-schema-local
+        entry: uv run python manage.py export_allauth_schema --check
+        language: system
+        # Allauth headless spec depends on auth settings + the signup form/adapters.
+        files: (.*/?settings/.+|.+base_forms\.py|.+account_adapters\.py|.+pyproject\.toml|^schema-auth\.yml$)
+        pass_filenames: false

--- a/accounts/management/commands/export_allauth_schema.py
+++ b/accounts/management/commands/export_allauth_schema.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
@@ -18,6 +18,14 @@ class Command(BaseCommand):
             default="schema-auth.yml",
             help="Output path (.json, .yaml or .yml). Defaults to ./schema-auth.yml",
         )
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help=(
+                "Exit with a non-zero status if the file on disk is out of date "
+                "instead of writing it. Use as a CI / pre-commit drift guard."
+            ),
+        )
 
     def handle(self, *args, **options):
         # Imported lazily so the command only pulls allauth in when actually run.
@@ -26,13 +34,17 @@ class Command(BaseCommand):
         spec = get_schema()
         self._patch_refresh_token_meta(spec)
         output = Path(options["output"])
+        content = self._render(spec, output.suffix)
 
-        if output.suffix in {".yaml", ".yml"}:
-            import yaml
-
-            content = yaml.dump(spec, Dumper=yaml.Dumper, sort_keys=True)
-        else:
-            content = json.dumps(spec, indent=2, sort_keys=True)
+        if options["check"]:
+            current = output.read_text() if output.exists() else None
+            if current != content:
+                raise CommandError(
+                    f"{output} is out of date. Regenerate it with:\n"
+                    f"    python manage.py export_allauth_schema -o {output}"
+                )
+            self.stdout.write(self.style.SUCCESS(f"{output} is up to date."))
+            return
 
         output.write_text(content)
 
@@ -42,6 +54,15 @@ class Command(BaseCommand):
                 f"({spec['info']['title']} {spec['info'].get('version', '')})".strip()
             )
         )
+
+    @staticmethod
+    def _render(spec: dict, suffix: str) -> str:
+        """Serialize the spec to YAML or JSON, deterministically (sorted keys)."""
+        if suffix in {".yaml", ".yml"}:
+            import yaml
+
+            return yaml.dump(spec, Dumper=yaml.Dumper, sort_keys=True)
+        return json.dumps(spec, indent=2, sort_keys=True)
 
     @staticmethod
     def _patch_refresh_token_meta(spec: dict) -> None:

--- a/schema-auth.yml
+++ b/schema-auth.yml
@@ -15,7 +15,6 @@ components:
             email: email@domain.org
             has_usable_password: true
             id: 123
-            username: wizard
         meta:
           access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdW
           is_authenticated: true
@@ -2120,14 +2119,9 @@ components:
           description: The user ID.
           example: 123
           type: integer
-        username:
-          description: The username.
-          example: wizard
-          type: string
       required:
       - display
       - has_usable_password
-      - username
       type: object
     UserSessionsConfiguration:
       description: 'Configuration of the Django `allauth.usersessions` app.


### PR DESCRIPTION
## Summary
`schema-auth.yml` is generated by `python manage.py export_allauth_schema` (it introspects the allauth config + the signup form), but — unlike `schema.yml` — nothing regenerated or verified it on commit. It drifted silently: the stale `username` field lingered after `ACCOUNT_USER_MODEL_USERNAME_FIELD = None`, and the Auth–Tenant Provisioning work added `organization_name` to the signup form without re-exporting. This adds a guard so that can't happen again.

## Changes
- `export_allauth_schema` gains a **`--check`** mode: regenerate the spec in memory, diff against the file on disk, exit non-zero on drift (no write). Mirrors `makemigrations --check`.
- New **`backend-auth-schema-local`** pre-commit hook runs `export_allauth_schema --check`, scoped to auth-relevant inputs (`settings/`, `base_forms.py`, `account_adapters.py`, `pyproject.toml`, `schema-auth.yml`) so it doesn't run on every commit.
- Regenerated `schema-auth.yml` to drop the stale `username` field, so the guard passes on `main`.

## Note on the feature stack
The Auth–Tenant Provisioning feature (PRs #32–#39) carries its own regenerated `schema-auth.yml` (adds `organization_name`, also drops `username`). When both this guard and that feature land, `schema-auth.yml` will be current either merge order — both regenerations agree on the `username` removal; the feature additionally adds `organization_name`. A `schema-auth.yml` merge conflict, if any, resolves to "drop username + add organization_name".

## Test plan
- `uv run python manage.py export_allauth_schema --check` → exits 0 ("up to date") on this branch.
- Dirty the file → `--check` exits 1. Verified.
- `uv run pytest -n auto` (unaffected; command-only change).