### PR TITLE
feat(organizations): add admin organization members list endpoint

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -30,11 +30,25 @@
 - **Key**: `is_active` field (default+db_default True, indexed). New `get_active_organization_membership(user)` helper = single source of truth (None for missing OR inactive). Gate closed across get_queryset, all relevant permissions, serializer create/save WRITE paths, OrganizationViewSet.current, public GraphQL users query, User.is_organization_admin. Design note: inactive membership blocks re-provisioning; reactivation (Phase 3) is the un-disable path. Outer gate green (1262 passed); mypy adds no new errors (8 pre-existing in serializers.py).
 - **Deviations**: extended gating to OrganizationInvitationPermission (consistency).
 
+### Phase 2 — List organization members (admin) ✅
+- **Status**: done, reviewed (3 layers; Layer 3 confirmed the IsOrganizationAdmin collection-level flaw the implementer flagged → fixer), pushed, PR opened.
+- **Model**: claude-haiku-4-5 (tier 2); fixer: haiku.
+- **Branch**: plan/rest-api-frontend-gaps/phase-2 (base: phase-1)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/44
+- **PR-context**: .vinta-ai-workflows/prs-context/rest-api-frontend-gaps/phase-2.md (published)
+- **Key**: `OrganizationMembershipViewSet` (ReadOnly, IsOrganizationAdmin), `OrganizationMembershipSerializer` (read-only, flattened user email + profile name, select_related no-N+1, no PII leak), route `organization-members`, schema regen. List returns active+inactive. IMPORTANT FIX: `IsOrganizationAdmin.has_permission` now requires `membership.is_admin` (was membership-only) — gates collection actions; reusable by all future admin endpoints with no per-view override. Outer gate green (1272).
+- **Deviations**: none (the permission fix is reused infra, benefits later phases).
+
 ## Current Phase
-Phase 2 — List organization members (admin) (next).
+Phase 3 — Deactivate/reactivate a member (admin) (next).
 
 ## Remaining Phases
-3 (deactivate/reactivate member), 4 (request own import), 5 (request own sync), 6 (admin sync other), 7 (rooms sync trigger), 8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+4 (request own import), 5 (request own sync), 6 (admin sync other), 7 (rooms sync trigger), 8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+
+## Reusable infra notes (for later phases)
+- `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.
+- `get_active_organization_membership(user)` (organizations/models.py) — canonical active-membership resolver (None for missing OR inactive).
+- DI in actions: `@inject` + `Annotated[Service, Provide["service_name"]]`; authenticate CalendarService with the user's SocialAccount (see CalendarViewSet.available_windows).
 
 ## Deferred Phases
 None (no cross-repo, no flag-removal phases in this plan).

--- a/organizations/permissions.py
+++ b/organizations/permissions.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import BasePermission
 from organizations.models import (
     Organization,
     OrganizationInvitation,
+    OrganizationMembership,
     OrganizationModel,
     get_active_organization_membership,
 )
@@ -105,6 +106,8 @@ class IsOrganizationAdmin(BasePermission):
         # Determine the object's organization_id
         if isinstance(obj, Organization):
             obj_organization_id = obj.id
+        elif isinstance(obj, OrganizationMembership):
+            obj_organization_id = obj.organization_id
         elif isinstance(obj, OrganizationModel):
             obj_organization_id = obj.organization_id
         else:

--- a/organizations/permissions.py
+++ b/organizations/permissions.py
@@ -84,9 +84,10 @@ class IsOrganizationAdmin(BasePermission):
     """
     Permission for admin-only endpoints within an organization.
 
-    - `has_permission`: requires an authenticated user with an active
-      organization membership (using safe `getattr` to handle membership-less users).
-    - `has_object_permission`: delegates the "is this user an admin of this object's org"
+    - `has_permission`: requires an authenticated user with an active ADMIN organization
+      membership. This gate enforces the admin role at the collection level (list, create).
+    - `has_object_permission`: additionally enforces that the object's organization matches
+      the membership organization and delegates the "is this user an admin of this object's org"
       decision to `User.is_organization_admin(organization_id)` so the rule has a single
       implementation. Handles both Organization instances and OrganizationModel subclasses.
     """
@@ -95,7 +96,8 @@ class IsOrganizationAdmin(BasePermission):
         user: User = request.user
         if not user or not user.is_authenticated:
             return False
-        return get_active_organization_membership(user) is not None
+        membership = get_active_organization_membership(user)
+        return membership is not None and membership.is_admin
 
     def has_object_permission(self, request, view, obj) -> bool:
         user: User = request.user

--- a/organizations/routes.py
+++ b/organizations/routes.py
@@ -1,6 +1,10 @@
 from common.types import RouteDict
 
-from .views import OrganizationInvitationViewSet, OrganizationViewSet
+from .views import (
+    OrganizationInvitationViewSet,
+    OrganizationMembershipViewSet,
+    OrganizationViewSet,
+)
 
 
 routes: list[RouteDict] = [
@@ -8,6 +12,11 @@ routes: list[RouteDict] = [
         "regex": r"organizations",
         "viewset": OrganizationViewSet,
         "basename": "Organizations",
+    },
+    {
+        "regex": r"organization-members",
+        "viewset": OrganizationMembershipViewSet,
+        "basename": "OrganizationMembers",
     },
     {
         "regex": r"invitations",

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -132,6 +132,31 @@ class CurrentMembershipSerializer(serializers.ModelSerializer):
         return OrganizationSerializer(obj.organization, context=self.context).data  # type: ignore[call-arg]
 
 
+class OrganizationMembershipSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for listing and retrieving organization members.
+
+    Exposes membership role, active status, and flattened user information
+    (email, first_name, last_name) for the admin datatable.
+    """
+
+    user_email = serializers.EmailField(source="user.email", read_only=True)
+    user_first_name = serializers.CharField(source="user.profile.first_name", read_only=True)
+    user_last_name = serializers.CharField(source="user.profile.last_name", read_only=True)
+
+    class Meta:
+        model = OrganizationMembership
+        fields = (
+            "id",
+            "role",
+            "is_active",
+            "user_email",
+            "user_first_name",
+            "user_last_name",
+        )
+        read_only_fields = fields
+
+
 class AcceptInvitationSerializer(serializers.Serializer):
     """
     Serializer for accepting invitations via public endpoint.

--- a/organizations/tests/test_permissions.py
+++ b/organizations/tests/test_permissions.py
@@ -83,10 +83,10 @@ class TestIsOrganizationAdminPermission:
         assert permission.has_permission(request, view_mock) is True
 
     def test_has_permission_member_user(self, factory, member_user, permission, view_mock):
-        """Member user with membership should have permission."""
+        """Member user without admin role should not have permission."""
         request = factory.get("/")
         request.user = member_user
-        assert permission.has_permission(request, view_mock) is True
+        assert permission.has_permission(request, view_mock) is False
 
     def test_has_permission_membership_less_user(
         self, factory, membership_less_user, permission, view_mock
@@ -212,6 +212,21 @@ class TestIsOrganizationAdminPermission:
             organization=org,
             role=OrganizationRole.MEMBER,
             is_active=False,
+        )
+        request = factory.get("/")
+        request.user = user
+        assert permission.has_permission(request, view_mock) is False
+
+    def test_has_permission_active_member_denied(self, factory, permission, view_mock):
+        """Active member without admin role is denied at has_permission level."""
+        user = baker.make(User)
+        org = baker.make(Organization)
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
         )
         request = factory.get("/")
         request.user = user

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -1132,3 +1132,241 @@ class TestOrganizationInvitationPermissions:
         url = reverse("api:OrganizationInvitations-list")
         response = anonymous_client.get(url)
         assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+
+@pytest.mark.django_db
+class TestOrganizationMembershipViewSet:
+    """Test suite for OrganizationMembershipViewSet"""
+
+    def test_list_members_admin_sees_all(self, auth_client, user):
+        """Test that admin can list all members (active and inactive) of their organization"""
+        # Create organization with admin membership for the user
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        admin_membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        # Create some other members (active and inactive)
+        baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        inactive_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        url = reverse("api:OrganizationMembers-list")
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        results = response.json()["results"]
+        assert len(results) == 3  # admin + active_member + inactive_member
+
+        # Verify that response includes expected fields
+        for result in results:
+            assert "id" in result
+            assert "role" in result
+            assert "is_active" in result
+            assert "user_email" in result
+            assert "user_first_name" in result
+            assert "user_last_name" in result
+
+        # Verify admin membership is present
+        admin_ids = [r["id"] for r in results if r["id"] == admin_membership.id]
+        assert len(admin_ids) == 1
+
+        # Verify inactive member is present
+        inactive_ids = [r["id"] for r in results if r["id"] == inactive_member.id]
+        assert len(inactive_ids) == 1
+
+    def test_list_members_non_admin_forbidden(self, auth_client, user):
+        """Test that non-admin members get 403 when listing organization members"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        # Create user with member (not admin) role
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-list")
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_list_members_membership_less_user_forbidden(self, auth_client):
+        """Test that membership-less users get 403 when listing organization members"""
+        # auth_client is already authenticated but has no membership
+        url = reverse("api:OrganizationMembers-list")
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_list_members_inactive_membership_forbidden(self, auth_client, user):
+        """Test that users with inactive membership get 403"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        # Create inactive admin membership
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=False,
+        )
+
+        url = reverse("api:OrganizationMembers-list")
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_list_members_cross_org_exclusion(self, auth_client, user):
+        """Test that admin only sees members of their own organization"""
+        # Create org1 with admin membership for the user
+        org1 = OrganizationTestFactory.create_organization(name="Org 1")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org1,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        # Create org2 with some members
+        org2 = OrganizationTestFactory.create_organization(name="Org 2")
+        baker.make(
+            OrganizationMembership,
+            organization=org2,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-list")
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        results = response.json()["results"]
+        # Should only see 1 member (the admin from org1)
+        assert len(results) == 1
+        assert results[0]["id"] == user.organization_membership.id
+
+    def test_retrieve_member_admin_success(self, auth_client, user):
+        """Test that admin can retrieve a specific member"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-detail", kwargs={"pk": member.pk})
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        result = response.json()
+        assert result["id"] == member.id
+        assert result["role"] == OrganizationRole.MEMBER
+        assert result["is_active"] is True
+        assert result["user_email"] == member.user.email
+
+    def test_retrieve_member_cross_org_not_found(self, auth_client, user):
+        """Test that admin cannot retrieve a member from a different organization"""
+        org1 = OrganizationTestFactory.create_organization(name="Org 1")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org1,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        org2 = OrganizationTestFactory.create_organization(name="Org 2")
+        member_in_org2 = baker.make(
+            OrganizationMembership,
+            organization=org2,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-detail", kwargs={"pk": member_in_org2.pk})
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_member_non_admin_forbidden(self, auth_client, user):
+        """Test that non-admin members cannot retrieve other members"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        other_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-detail", kwargs={"pk": other_member.pk})
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_retrieve_member_includes_profile_info(self, auth_client, user):
+        """Test that member serialization includes user profile information"""
+        from users.factories import UserFactory
+
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        # Create a member with profile info
+        member_user = UserFactory().create_user()
+        member_user.profile.first_name = "John"
+        member_user.profile.last_name = "Doe"
+        member_user.profile.save()
+
+        member = baker.make(
+            OrganizationMembership,
+            user=member_user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-detail", kwargs={"pk": member.pk})
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        result = response.json()
+        assert result["user_email"] == member_user.email
+        assert result["user_first_name"] == "John"
+        assert result["user_last_name"] == "Doe"

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -133,18 +133,6 @@ class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
     serializer_class = OrganizationMembershipSerializer
     permission_classes = (IsOrganizationAdmin,)
 
-    def check_permissions(self, request):
-        """Override to enforce admin check at the view level (both has_permission and admin role)."""
-        super().check_permissions(request)
-        # has_permission checks authenticated + active membership
-        # Now verify the user is actually an admin
-        membership = get_active_organization_membership(request.user)
-        if membership and not membership.is_admin:
-            self.permission_denied(
-                request,
-                message="You must be an admin to access this resource.",
-            )
-
     def get_queryset(self):
         """Org-scoped queryset: return members of the caller's organization only."""
         user = self.request.user

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from common.utils.view_utils import (
     NoListVintaScheduleModelViewSet,
     NoUpdateVintaScheduleModelViewSet,
+    ReadOnlyVintaScheduleModelViewSet,
 )
 from organizations.exceptions import (
     DuplicateInvitationError,
@@ -22,9 +23,11 @@ from organizations.filtersets import OrganizationInvitationFilterSet
 from organizations.models import (
     Organization,
     OrganizationInvitation,
+    OrganizationMembership,
     get_active_organization_membership,
 )
 from organizations.permissions import (
+    IsOrganizationAdmin,
     OrganizationInvitationPermission,
     OrganizationManagementPermission,
 )
@@ -32,6 +35,7 @@ from organizations.serializers import (
     AcceptInvitationSerializer,
     CurrentMembershipSerializer,
     OrganizationInvitationSerializer,
+    OrganizationMembershipSerializer,
     OrganizationSerializer,
 )
 from organizations.services import OrganizationService
@@ -115,6 +119,43 @@ class OrganizationInvitationViewSet(NoUpdateVintaScheduleModelViewSet):
     def perform_destroy(self, instance):
         """Revoke invitation by calling the service method."""
         self.organization_service.revoke_invitation(str(instance.id))
+
+
+class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
+    """
+    A viewset for listing and retrieving organization members.
+
+    Admin-only endpoint — lists both active and inactive members of the caller's
+    organization, suitable for a datatable view. Non-admin members get 403.
+    """
+
+    queryset = OrganizationMembership.objects.select_related("user", "user__profile")
+    serializer_class = OrganizationMembershipSerializer
+    permission_classes = (IsOrganizationAdmin,)
+
+    def check_permissions(self, request):
+        """Override to enforce admin check at the view level (both has_permission and admin role)."""
+        super().check_permissions(request)
+        # has_permission checks authenticated + active membership
+        # Now verify the user is actually an admin
+        membership = get_active_organization_membership(request.user)
+        if membership and not membership.is_admin:
+            self.permission_denied(
+                request,
+                message="You must be an admin to access this resource.",
+            )
+
+    def get_queryset(self):
+        """Org-scoped queryset: return members of the caller's organization only."""
+        user = self.request.user
+        membership = get_active_organization_membership(user)
+        if membership:
+            return (
+                OrganizationMembership.objects.filter(organization_id=membership.organization_id)
+                .select_related("user", "user__profile")
+                .order_by("id")
+            )
+        return OrganizationMembership.objects.none()
 
 
 class AcceptInvitationView(generics.CreateAPIView):

--- a/schema.yml
+++ b/schema.yml
@@ -4206,6 +4206,138 @@ paths:
               schema:
                 $ref: '#/components/schemas/AcceptInvitation'
           description: ''
+  /organization-members/:
+    get:
+      operationId: organization_members_list
+      description: |-
+        A viewset for listing and retrieving organization members.
+
+        Admin-only endpoint — lists both active and inactive members of the caller's
+        organization, suitable for a datatable view. Non-admin members get 403.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - organization-members
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedOrganizationMembershipList'
+          description: ''
+  /organization-members{format}:
+    get:
+      operationId: organization_members_formatted_list
+      description: |-
+        A viewset for listing and retrieving organization members.
+
+        Admin-only endpoint — lists both active and inactive members of the caller's
+        organization, suitable for a datatable view. Non-admin members get 403.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - organization-members
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedOrganizationMembershipList'
+          description: ''
+  /organization-members/{id}/:
+    get:
+      operationId: organization_members_retrieve
+      description: |-
+        A viewset for listing and retrieving organization members.
+
+        Admin-only endpoint — lists both active and inactive members of the caller's
+        organization, suitable for a datatable view. Non-admin members get 403.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organization-members
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationMembership'
+          description: ''
+  /organization-members/{id}{format}:
+    get:
+      operationId: organization_members_formatted_retrieve
+      description: |-
+        A viewset for listing and retrieving organization members.
+
+        Admin-only endpoint — lists both active and inactive members of the caller's
+        organization, suitable for a datatable view. Non-admin members get 403.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organization-members
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationMembership'
+          description: ''
   /organizations/:
     post:
       operationId: organizations_create
@@ -6655,6 +6787,51 @@ components:
       - invited_by
       - modified
       - organization
+    OrganizationMembership:
+      type: object
+      description: |-
+        Read-only serializer for listing and retrieving organization members.
+
+        Exposes membership role, active status, and flattened user information
+        (email, first_name, last_name) for the admin datatable.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          readOnly: true
+          description: |-
+            Role the user holds in this organization. Admins can manage organization-scoped resources (e.g. CalendarGroups) regardless of direct ownership.
+
+            * `member` - Member
+            * `admin` - Admin
+        is_active:
+          type: boolean
+          readOnly: true
+          description: 'Whether this membership is active. Inactive memberships are
+            treated as gated: the user still has a row but loses all tenant-scoped
+            access until reactivated. Use this to disable a user without deleting
+            their membership record (which would lose role/history). Default True
+            keeps every existing read unchanged.'
+        user_email:
+          type: string
+          format: email
+          readOnly: true
+        user_first_name:
+          type: string
+          readOnly: true
+        user_last_name:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - is_active
+      - role
+      - user_email
+      - user_first_name
+      - user_last_name
     PaginatedAvailableTimeList:
       type: object
       required:
@@ -6862,6 +7039,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OrganizationInvitation'
+    PaginatedOrganizationMembershipList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationMembership'
     PaginatedUnavailableTimeWindowList:
       type: object
       required:


### PR DESCRIPTION
## Summary
Phase 2 of the **REST API Frontend Gaps** plan. Adds `GET /organization-members/` (list) and `GET /organization-members/{id}/` (retrieve), admin-only, for the team datatable. Lists **both active and inactive** members so admins can see (and later re-enable) disabled users.

Also hardens the shared `IsOrganizationAdmin` permission: its `has_permission` now requires an active **admin** membership (previously only required membership), so the permission correctly gates collection actions (list/create) — not just object actions. This makes it genuinely reusable by every later admin endpoint without per-view workarounds.

## What changed
- `OrganizationMembershipViewSet` (`ReadOnlyVintaScheduleModelViewSet`, `IsOrganizationAdmin`), org-scoped queryset.
- `OrganizationMembershipSerializer` — read-only, exposes id/role/is_active + flattened user email + profile name.
- `IsOrganizationAdmin.has_permission` tightened to require `membership.is_admin`.
- Route `organization-members`; `schema.yml` regenerated.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 2 + API Design 4.1.

## Review history
Layer-3 review confirmed the permission flaw the implementer flagged: a list endpoint only triggers `has_permission`, so `IsOrganizationAdmin` was letting any active member list members. Fixed in the second commit (admin check moved into `has_permission`; per-view `check_permissions` override removed); regression test added asserting a non-admin member gets 403 on the list action.

## Test plan
- `uv run pytest organizations/tests/ -n auto`
- Asserts: admin list 200 with user fields (active+inactive); non-admin 403 on list; membership-less 403; inactive 403; cross-org members excluded; retrieve cross-org id 404.
- Outer gate green: ruff, format --check, mypy (no new errors), makemigrations --check, check --deploy, `pytest -n auto` (1272 passed).