### PR TITLE
feat(organizations): add member deactivate/reactivate actions

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -39,11 +39,19 @@
 - **Key**: `OrganizationMembershipViewSet` (ReadOnly, IsOrganizationAdmin), `OrganizationMembershipSerializer` (read-only, flattened user email + profile name, select_related no-N+1, no PII leak), route `organization-members`, schema regen. List returns active+inactive. IMPORTANT FIX: `IsOrganizationAdmin.has_permission` now requires `membership.is_admin` (was membership-only) — gates collection actions; reusable by all future admin endpoints with no per-view override. Outer gate green (1272).
 - **Deviations**: none (the permission fix is reused infra, benefits later phases).
 
+### Phase 3 — Deactivate/reactivate a member (admin) ✅
+- **Status**: done, reviewed (3 layers; Layer 3 surfaced that the last-admin 400 is unreachable → documented + sole-admin self-deactivate test), pushed, PR opened.
+- **Model**: haiku (tier 2); fixer: haiku.
+- **Branch**: plan/rest-api-frontend-gaps/phase-3 (base: phase-2) — **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/45
+- **PR-context**: phase-3.md (published)
+- **Key**: `deactivate`/`reactivate` detail @actions on OrganizationMembershipViewSet; self-lockout guard (403) enforces the org-keeps-an-admin invariant; last-admin guard kept as documented defense-in-depth (unreachable via HTTP). Idempotent. Outer gate green (1285). mypy baseline = 108 full-project errors (pre-existing, test files); confirmed zero new across phases.
+- **Deviations**: none.
+
 ## Current Phase
-Phase 3 — Deactivate/reactivate a member (admin) (next).
+Phase 4 — Request own calendar import (next).
 
 ## Remaining Phases
-4 (request own import), 5 (request own sync), 6 (admin sync other), 7 (rooms sync trigger), 8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+5 (request own sync), 6 (admin sync other), 7 (rooms sync trigger), 8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -1462,6 +1462,32 @@ class TestOrganizationMembershipViewSet:
         admin_membership.refresh_from_db()
         assert admin_membership.is_active is True
 
+    def test_sole_admin_cannot_self_deactivate(self, auth_client, user):
+        """Test that sole admin cannot deactivate themselves, preserving org invariant.
+
+        This documents the real protection: even if an admin is the sole admin of the org,
+        the self-lockout guard (target.user_id == request.user.id) returns 403 before
+        the last-admin guard can fire. The org always keeps at least one admin via this path.
+        """
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        sole_admin_membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": sole_admin_membership.pk})
+        response = auth_client.post(url)
+
+        # Self-deactivation is forbidden, even for sole admin
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+        # Membership remains active in DB
+        sole_admin_membership.refresh_from_db()
+        assert sole_admin_membership.is_active is True
+
     def test_deactivate_last_active_admin_succeeds_with_other_admins(self, auth_client, user):
         """Test that deactivating an admin succeeds when other admins remain.
 

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -1370,3 +1370,358 @@ class TestOrganizationMembershipViewSet:
         assert result["user_email"] == member_user.email
         assert result["user_first_name"] == "John"
         assert result["user_last_name"] == "Doe"
+
+    def test_deactivate_member_admin_success(self, auth_client, user):
+        """Test that admin can deactivate another active member"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        # Create another admin so we can safely deactivate without triggering last-admin guard
+        baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        target_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        result = response.json()
+        assert result["is_active"] is False
+        assert result["id"] == target_member.id
+
+        # Verify in DB
+        target_member.refresh_from_db()
+        assert target_member.is_active is False
+
+    def test_deactivate_member_idempotent(self, auth_client, user):
+        """Test that deactivating an already-inactive member is a no-op success"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        target_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        result = response.json()
+        assert result["is_active"] is False
+
+    def test_deactivate_self_forbidden(self, auth_client, user):
+        """Test that admin cannot deactivate their own membership"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        admin_membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        # Create another admin to prevent last-admin guard interference
+        baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": admin_membership.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+        # Verify unchanged
+        admin_membership.refresh_from_db()
+        assert admin_membership.is_active is True
+
+    def test_deactivate_last_active_admin_succeeds_with_other_admins(self, auth_client, user):
+        """Test that deactivating an admin succeeds when other admins remain.
+
+        The last-admin guard (other_active_admin_count == 0) only fires if the target
+        is the ONLY admin. When there are multiple admins, deactivating one is allowed.
+        """
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        # Create another admin so we can safely deactivate without hitting the last-admin guard
+        other_admin = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": other_admin.pk})
+        response = auth_client.post(url)
+
+        # Should succeed because there's still one admin (the requester)
+        assert_response_status_code(response, status.HTTP_200_OK)
+        other_admin.refresh_from_db()
+        assert other_admin.is_active is False
+
+    def test_deactivate_non_admin_forbidden(self, auth_client, user):
+        """Test that non-admin member cannot deactivate another member"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        target_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_deactivate_cross_org_not_found(self, auth_client, user):
+        """Test that admin cannot deactivate a member from a different organization"""
+        org1 = OrganizationTestFactory.create_organization(name="Org 1")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org1,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        org2 = OrganizationTestFactory.create_organization(name="Org 2")
+        member_in_org2 = baker.make(
+            OrganizationMembership,
+            organization=org2,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": member_in_org2.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_deactivate_gates_access(self, auth_client, user):
+        """Test that a deactivated member loses access to tenant endpoints.
+
+        When a member is deactivated, the hard-gate treats their membership as
+        inactive and returns 404 (membership-less) for tenant-scoped endpoints.
+        """
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        target_user = baker.make("users.User")
+        target_member = baker.make(
+            OrganizationMembership,
+            user=target_user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        # Deactivate the target member
+        url = reverse("api:OrganizationMembers-deactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        # Now authenticate as the target user and verify they're gated
+        target_client = APIClient()
+        target_client.force_authenticate(user=target_user)
+
+        # Refresh the user's membership from DB to pick up the deactivation
+        target_user.refresh_from_db()
+
+        # Try to access /organizations/current/ — should get 404 (membership inactive = gated)
+        current_url = reverse("api:Organizations-current")
+        response = target_client.get(current_url)
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_reactivate_member_admin_success(self, auth_client, user):
+        """Test that admin can reactivate an inactive member"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        target_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        url = reverse("api:OrganizationMembers-reactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        result = response.json()
+        assert result["is_active"] is True
+        assert result["id"] == target_member.id
+
+        # Verify in DB
+        target_member.refresh_from_db()
+        assert target_member.is_active is True
+
+    def test_reactivate_member_idempotent(self, auth_client, user):
+        """Test that reactivating an already-active member is a no-op success"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        target_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        url = reverse("api:OrganizationMembers-reactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        result = response.json()
+        assert result["is_active"] is True
+
+    def test_reactivate_non_admin_forbidden(self, auth_client, user):
+        """Test that non-admin member cannot reactivate another member"""
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        target_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        url = reverse("api:OrganizationMembers-reactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_reactivate_cross_org_not_found(self, auth_client, user):
+        """Test that admin cannot reactivate a member from a different organization"""
+        org1 = OrganizationTestFactory.create_organization(name="Org 1")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org1,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        org2 = OrganizationTestFactory.create_organization(name="Org 2")
+        member_in_org2 = baker.make(
+            OrganizationMembership,
+            organization=org2,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        url = reverse("api:OrganizationMembers-reactivate", kwargs={"pk": member_in_org2.pk})
+        response = auth_client.post(url)
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_reactivate_restores_access(self, auth_client, user):
+        """Test that a reactivated member regains access to tenant endpoints.
+
+        When a member is reactivated, the hard-gate treats their membership as
+        active and returns 200 with org data for tenant-scoped endpoints.
+        """
+        organization = OrganizationTestFactory.create_organization(name="Test Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        target_user = baker.make("users.User")
+        target_member = baker.make(
+            OrganizationMembership,
+            user=target_user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        # Reactivate the target member
+        url = reverse("api:OrganizationMembers-reactivate", kwargs={"pk": target_member.pk})
+        response = auth_client.post(url)
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        # Now authenticate as the target user and verify they're no longer gated
+        target_client = APIClient()
+        target_client.force_authenticate(user=target_user)
+
+        # Refresh the user's membership from DB to pick up the reactivation
+        target_user.refresh_from_db()
+
+        # Try to access /organizations/current/ — should now work
+        current_url = reverse("api:Organizations-current")
+        response = target_client.get(current_url)
+        assert_response_status_code(response, status.HTTP_200_OK)
+        result = response.json()
+        assert result["organization"]["id"] == organization.id

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -4,7 +4,7 @@ from dependency_injector.wiring import Provide, inject
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import generics, status
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -123,10 +123,15 @@ class OrganizationInvitationViewSet(NoUpdateVintaScheduleModelViewSet):
 
 class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
     """
-    A viewset for listing and retrieving organization members.
+    A viewset for listing, retrieving, and managing organization members.
 
     Admin-only endpoint — lists both active and inactive members of the caller's
     organization, suitable for a datatable view. Non-admin members get 403.
+
+    Actions:
+    - `deactivate`: POST to disable a member (prevent self-deactivation and
+      protect the last active admin).
+    - `reactivate`: POST to re-enable a member.
     """
 
     queryset = OrganizationMembership.objects.select_related("user", "user__profile")
@@ -144,6 +149,88 @@ class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
                 .order_by("id")
             )
         return OrganizationMembership.objects.none()
+
+    @extend_schema(
+        summary="Deactivate an organization member",
+        responses={
+            200: OrganizationMembershipSerializer,
+            400: OpenApiResponse(description="Cannot deactivate self or last active admin"),
+            403: OpenApiResponse(description="Not an admin"),
+            404: OpenApiResponse(description="Member not found or cross-org"),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="deactivate")
+    def deactivate(self, request, pk=None):
+        """Deactivate a member (set is_active=False).
+
+        Guards:
+        - Cannot deactivate own membership (self-lockout prevention).
+        - Cannot deactivate the last active admin (org lockout prevention).
+
+        Idempotency: deactivating an already-inactive member is a no-op success.
+        """
+        target = (
+            self.get_object()
+        )  # Permission checks via IsOrganizationAdmin.has_object_permission
+        user = request.user
+
+        # Guard: prevent self-deactivation
+        if target.user_id == user.id:
+            raise PermissionDenied(detail="Cannot deactivate your own membership.")
+
+        # Guard: prevent deactivating the last active admin
+        # Count OTHER active admins; if this is the last one, refuse
+        if target.is_admin:
+            org_id = target.organization_id
+            other_active_admin_count = (
+                OrganizationMembership.objects.filter(
+                    organization_id=org_id,
+                    role=target.role,  # Same role filter (ADMIN)
+                    is_active=True,
+                )
+                .exclude(id=target.id)  # Exclude the target itself
+                .count()
+            )
+            if other_active_admin_count == 0:
+                raise ValidationError(
+                    detail="Cannot deactivate the last active admin of the organization."
+                )
+
+        # Deactivate (idempotent: no-op if already inactive)
+        target.is_active = False
+        target.save(update_fields=["is_active"])
+
+        # Return the updated membership
+        serializer = self.get_serializer(target)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Reactivate an organization member",
+        responses={
+            200: OrganizationMembershipSerializer,
+            403: OpenApiResponse(description="Not an admin"),
+            404: OpenApiResponse(description="Member not found or cross-org"),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="reactivate")
+    def reactivate(self, request, pk=None):
+        """Reactivate a member (set is_active=True).
+
+        No guards — re-enabling is always safe.
+
+        Idempotency: reactivating an already-active member is a no-op success.
+        """
+        target = (
+            self.get_object()
+        )  # Permission checks via IsOrganizationAdmin.has_object_permission
+
+        # Reactivate (idempotent: no-op if already active)
+        target.is_active = True
+        target.save(update_fields=["is_active"])
+
+        # Return the updated membership
+        serializer = self.get_serializer(target)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class AcceptInvitationView(generics.CreateAPIView):

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -178,8 +178,12 @@ class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
         if target.user_id == user.id:
             raise PermissionDenied(detail="Cannot deactivate your own membership.")
 
-        # Guard: prevent deactivating the last active admin
-        # Count OTHER active admins; if this is the last one, refuse
+        # Guard: prevent deactivating the last active admin (defense-in-depth).
+        # This guard is currently unreachable via this endpoint because the requester
+        # must be an active admin of the org (IsOrganizationAdmin), and the self-lockout
+        # guard above blocks the only path that could drop the org to zero admins
+        # (requester attempting to deactivate themselves). Retained to protect any future
+        # non-self deactivation paths (e.g., bulk action or service-layer call).
         if target.is_admin:
             org_id = target.organization_id
             other_active_admin_count = (

--- a/schema.yml
+++ b/schema.yml
@@ -4210,10 +4210,15 @@ paths:
     get:
       operationId: organization_members_list
       description: |-
-        A viewset for listing and retrieving organization members.
+        A viewset for listing, retrieving, and managing organization members.
 
         Admin-only endpoint — lists both active and inactive members of the caller's
         organization, suitable for a datatable view. Non-admin members get 403.
+
+        Actions:
+        - `deactivate`: POST to disable a member (prevent self-deactivation and
+          protect the last active admin).
+        - `reactivate`: POST to re-enable a member.
       parameters:
       - name: limit
         required: false
@@ -4243,10 +4248,15 @@ paths:
     get:
       operationId: organization_members_formatted_list
       description: |-
-        A viewset for listing and retrieving organization members.
+        A viewset for listing, retrieving, and managing organization members.
 
         Admin-only endpoint — lists both active and inactive members of the caller's
         organization, suitable for a datatable view. Non-admin members get 403.
+
+        Actions:
+        - `deactivate`: POST to disable a member (prevent self-deactivation and
+          protect the last active admin).
+        - `reactivate`: POST to re-enable a member.
       parameters:
       - in: path
         name: format
@@ -4283,10 +4293,15 @@ paths:
     get:
       operationId: organization_members_retrieve
       description: |-
-        A viewset for listing and retrieving organization members.
+        A viewset for listing, retrieving, and managing organization members.
 
         Admin-only endpoint — lists both active and inactive members of the caller's
         organization, suitable for a datatable view. Non-admin members get 403.
+
+        Actions:
+        - `deactivate`: POST to disable a member (prevent self-deactivation and
+          protect the last active admin).
+        - `reactivate`: POST to re-enable a member.
       parameters:
       - in: path
         name: id
@@ -4309,10 +4324,15 @@ paths:
     get:
       operationId: organization_members_formatted_retrieve
       description: |-
-        A viewset for listing and retrieving organization members.
+        A viewset for listing, retrieving, and managing organization members.
 
         Admin-only endpoint — lists both active and inactive members of the caller's
         organization, suitable for a datatable view. Non-admin members get 403.
+
+        Actions:
+        - `deactivate`: POST to disable a member (prevent self-deactivation and
+          protect the last active admin).
+        - `reactivate`: POST to re-enable a member.
       parameters:
       - in: path
         name: format
@@ -4338,6 +4358,200 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationMembership'
           description: ''
+  /organization-members/{id}/deactivate/:
+    post:
+      operationId: organization_members_deactivate_create
+      description: |-
+        Deactivate a member (set is_active=False).
+
+        Guards:
+        - Cannot deactivate own membership (self-lockout prevention).
+        - Cannot deactivate the last active admin (org lockout prevention).
+
+        Idempotency: deactivating an already-inactive member is a no-op success.
+      summary: Deactivate an organization member
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organization-members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationMembership'
+          description: ''
+        '400':
+          description: Cannot deactivate self or last active admin
+        '403':
+          description: Not an admin
+        '404':
+          description: Member not found or cross-org
+  /organization-members/{id}/deactivate{format}:
+    post:
+      operationId: organization_members_deactivate_formatted_create
+      description: |-
+        Deactivate a member (set is_active=False).
+
+        Guards:
+        - Cannot deactivate own membership (self-lockout prevention).
+        - Cannot deactivate the last active admin (org lockout prevention).
+
+        Idempotency: deactivating an already-inactive member is a no-op success.
+      summary: Deactivate an organization member
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organization-members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationMembership'
+          description: ''
+        '400':
+          description: Cannot deactivate self or last active admin
+        '403':
+          description: Not an admin
+        '404':
+          description: Member not found or cross-org
+  /organization-members/{id}/reactivate/:
+    post:
+      operationId: organization_members_reactivate_create
+      description: |-
+        Reactivate a member (set is_active=True).
+
+        No guards — re-enabling is always safe.
+
+        Idempotency: reactivating an already-active member is a no-op success.
+      summary: Reactivate an organization member
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organization-members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationMembership'
+          description: ''
+        '403':
+          description: Not an admin
+        '404':
+          description: Member not found or cross-org
+  /organization-members/{id}/reactivate{format}:
+    post:
+      operationId: organization_members_reactivate_formatted_create
+      description: |-
+        Reactivate a member (set is_active=True).
+
+        No guards — re-enabling is always safe.
+
+        Idempotency: reactivating an already-active member is a no-op success.
+      summary: Reactivate an organization member
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organization-members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/OrganizationMembership'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationMembership'
+          description: ''
+        '403':
+          description: Not an admin
+        '404':
+          description: Member not found or cross-org
   /organizations/:
     post:
       operationId: organizations_create


### PR DESCRIPTION
## Summary
Phase 3 of the **REST API Frontend Gaps** plan — the admin "disable a user" action. Adds two admin-only actions on `OrganizationMembershipViewSet`:
- `POST /organization-members/{id}/deactivate/` — sets `is_active=False` (tenant-scoped disable; the member is then gated everywhere via the Phase 1 helper).
- `POST /organization-members/{id}/reactivate/` — sets `is_active=True` (the supported un-disable path).

Both are detail actions, so `IsOrganizationAdmin.has_object_permission` enforces admin + same-org (cross-org → 404, non-admin → 403). Both are idempotent.

## Guards
- **Self-lockout**: an admin cannot deactivate their own membership (403).
- **Last-admin**: defense-in-depth check that refuses removing the org's last active admin (400). Documented as currently unreachable through this endpoint — see the inline comment.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 3 + API Design 4.1.

## Review history
Layer-3 review flagged a "missing last-admin-refusal test", which led to a useful finding: that 400 branch is actually unreachable via HTTP (the requester must be an active admin, so they're always counted as another admin unless they're the target — in which case the self-lockout guard fires first). The real invariant (org never loses its last admin) is enforced by the self-lockout guard and is tested. The docs commit clarifies this and adds `test_sole_admin_cannot_self_deactivate`.

## Test plan
- `uv run pytest organizations/tests/test_views.py -n auto`
- Asserts: admin deactivates a member → 200 + DB false + member then gated on `/organizations/current/`; reactivate restores access; admin cannot deactivate self (403, sole-admin case included); non-admin → 403; cross-org → 404; idempotent re-calls → 200.
- Outer gate green: ruff, format --check, mypy (108 full-project errors, unchanged from base — zero new), makemigrations --check, check --deploy, `pytest -n auto` (1285 passed).