### PR TITLE
feat(calendar): add request-sync action for owned calendars

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -55,11 +55,17 @@
 - **Known nit**: unused injected `calendar_service` param remains (noted in PR; cleanup later).
 - **Pattern for Phases 5/6/7**: resolve fresh service per target if deferring authenticate()+enqueue; otherwise authenticate inline + call synchronously is fine when returning a result.
 
+### Phase 5 — Request own calendar sync ✅
+- **Status**: done, reviewed (3 layers; Layer 3 → 2 fixes: use serializer for input validation + guard None social account), pushed, PR opened.
+- **Model**: haiku; fixers: haiku x1. **Branch**: phase-5 (base phase-4). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/47
+- **Key**: `POST /calendar/{id}/request-sync/` owner-only (get_object org-scope + CalendarOwnership check). Input via `CalendarSyncRequestSerializer`. None-account → 400. Returns `CalendarSync` (id+status) at 202. New `CalendarSyncSerializer`. Outer gate green (1297), mypy 108.
+- **Out-of-scope flagged**: `request_calendar_sync` enqueues `.delay` without on_commit (pre-existing; phase 6 shares it). Candidate follow-up.
+
 ## Current Phase
-Phase 5 — Request own calendar sync (next).
+Phase 6 — Admin syncs another user's calendar (next).
 
 ## Remaining Phases
-6 (admin sync other), 7 (rooms sync trigger), 8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+7 (rooms sync trigger), 8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -22,6 +22,7 @@ from calendar_integration.models import (
     CalendarGroupSlot,
     CalendarGroupSlotMembership,
     CalendarOwnership,
+    CalendarSync,
     EventAttendance,
     EventExternalAttendance,
     EventRecurrenceException,
@@ -84,6 +85,30 @@ class CalendarOwnershipSerializer(VirtualModelSerializer):
             "created",
             "modified",
         )
+
+
+class CalendarSyncSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CalendarSync
+        fields = (
+            "id",
+            "status",
+            "start_datetime",
+            "end_datetime",
+            "should_update_events",
+            "error_message",
+        )
+        read_only_fields = (
+            "id",
+            "status",
+            "error_message",
+        )
+
+
+class CalendarSyncRequestSerializer(serializers.Serializer):
+    start_datetime = serializers.DateTimeField(required=True)
+    end_datetime = serializers.DateTimeField(required=True)
+    should_update_events = serializers.BooleanField(required=False, default=False)
 
 
 class CalendarSerializer(VirtualModelSerializer):

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -1872,6 +1872,28 @@ class TestCalendarViewSet:
         )
         assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
 
+    def test_request_sync_no_social_account_for_provider(self, auth_client, user, calendar):
+        """Test sync fails with 400 when user has no linked account for calendar provider"""
+        # Create calendar ownership for the user
+        CalendarIntegrationTestFactory.create_calendar_ownership(user, calendar)
+
+        # Do NOT create a social account for this provider - this is the test case
+
+        url = reverse("api:Calendars-request-sync", kwargs={"pk": calendar.id})
+
+        response = auth_client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert "No linked account found" in str(response.data)
+        assert calendar.provider in str(response.data)
+
 
 @pytest.mark.django_db
 class TestCalendarIntegrationPermissions:

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -1738,6 +1738,140 @@ class TestCalendarViewSet:
                     callback()
                 assert mock_service.request_calendars_import.call_count == 2
 
+    def test_request_sync_owner_syncs_own_calendar(
+        self, auth_client, user, calendar, social_account
+    ):
+        """Test owner syncs their own calendar with valid range"""
+        from di_core.containers import container
+
+        # Create calendar ownership for the user
+        CalendarIntegrationTestFactory.create_calendar_ownership(user, calendar)
+
+        # Create a mock calendar service
+        mock_calendar_service = Mock()
+        mock_calendar_service.authenticate.return_value = None
+
+        # Create a mock CalendarSync instance
+        mock_calendar_sync = Mock()
+        mock_calendar_sync.id = 123
+        mock_calendar_sync.status = "NOT_STARTED"
+        mock_calendar_sync.start_datetime = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+        mock_calendar_sync.end_datetime = datetime.datetime(2024, 1, 31, tzinfo=datetime.UTC)
+        mock_calendar_sync.should_update_events = False
+        mock_calendar_sync.error_message = ""
+        mock_calendar_service.request_calendar_sync.return_value = mock_calendar_sync
+
+        url = reverse("api:Calendars-request-sync", kwargs={"pk": calendar.id})
+
+        with container.calendar_service.override(mock_calendar_service):
+            response = auth_client.post(
+                url,
+                data={
+                    "start_datetime": "2024-01-01T00:00:00Z",
+                    "end_datetime": "2024-01-31T23:59:59Z",
+                    "should_update_events": False,
+                },
+                format="json",
+            )
+
+            # Verify response
+            assert_response_status_code(response, status.HTTP_202_ACCEPTED)
+            assert response.data["id"] == 123
+            assert response.data["status"] == "NOT_STARTED"
+
+            # Verify the mock was called with the correct arguments
+            mock_calendar_service.authenticate.assert_called_once()
+            mock_calendar_service.request_calendar_sync.assert_called_once()
+
+    def test_request_sync_non_owner_forbidden(self, auth_client, user, calendar):
+        """Test non-owner cannot sync a calendar"""
+        # Don't create calendar ownership - user is not an owner
+        url = reverse("api:Calendars-request-sync", kwargs={"pk": calendar.id})
+
+        response = auth_client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        assert "do not own this calendar" in response.data["detail"].lower()
+
+    def test_request_sync_cross_org_calendar_not_found(
+        self, auth_client, user, calendar, organization
+    ):
+        """Test cross-org calendar returns 404"""
+        # Create a different organization and calendar
+        other_org = CalendarIntegrationTestFactory.create_organization(name="Other Org")
+        other_calendar = CalendarIntegrationTestFactory.create_calendar(organization=other_org)
+
+        # User is only a member of the first org (from fixture)
+        url = reverse("api:Calendars-request-sync", kwargs={"pk": other_calendar.id})
+
+        response = auth_client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_request_sync_missing_datetimes(self, auth_client, user, calendar):
+        """Test missing datetime parameters returns 400"""
+        # Create calendar ownership
+        CalendarIntegrationTestFactory.create_calendar_ownership(user, calendar)
+
+        url = reverse("api:Calendars-request-sync", kwargs={"pk": calendar.id})
+
+        # Missing both datetimes
+        response = auth_client.post(url, data={}, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+        # Missing end_datetime
+        response = auth_client.post(
+            url,
+            data={"start_datetime": "2024-01-01T00:00:00Z"},
+            format="json",
+        )
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_request_sync_invalid_datetimes(self, auth_client, user, calendar):
+        """Test invalid datetime format returns 400"""
+        # Create calendar ownership
+        CalendarIntegrationTestFactory.create_calendar_ownership(user, calendar)
+
+        url = reverse("api:Calendars-request-sync", kwargs={"pk": calendar.id})
+
+        response = auth_client.post(
+            url,
+            data={
+                "start_datetime": "invalid-date",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_request_sync_unauthenticated(self, anonymous_client, calendar):
+        """Test unauthenticated user cannot sync"""
+        url = reverse("api:Calendars-request-sync", kwargs={"pk": calendar.id})
+
+        response = anonymous_client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
 
 @pytest.mark.django_db
 class TestCalendarIntegrationPermissions:

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -208,27 +208,26 @@ class CalendarViewSet(VintaScheduleModelViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        # Parse and validate datetime fields
-        start_datetime_str = request.data.get("start_datetime")
-        end_datetime_str = request.data.get("end_datetime")
-
-        if not start_datetime_str or not end_datetime_str:
-            raise ValidationError(
-                {"non_field_errors": ["start_datetime and end_datetime are required"]}
-            )
-
-        try:
-            start_datetime = datetime.datetime.fromisoformat(
-                start_datetime_str.replace("Z", "+00:00")
-            )
-            end_datetime = datetime.datetime.fromisoformat(end_datetime_str.replace("Z", "+00:00"))
-        except (ValueError, CalendarIntegrationError) as e:
-            raise ValidationError({"non_field_errors": [f"Invalid datetime format: {e!s}"]}) from e
-
-        should_update_events = request.data.get("should_update_events", False)
+        # Validate request input using serializer
+        input_serializer = CalendarSyncRequestSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+        data = input_serializer.validated_data
+        start_datetime = data["start_datetime"]
+        end_datetime = data["end_datetime"]
+        should_update_events = data["should_update_events"]
 
         # Get social account for authentication
         social_account = SocialAccount.objects.filter(user=user, provider=calendar.provider).first()
+
+        # Guard against missing social account
+        if social_account is None:
+            raise ValidationError(
+                {
+                    "non_field_errors": [
+                        f"No linked account found for provider '{calendar.provider}'."
+                    ]
+                }
+            )
 
         membership = get_active_organization_membership(user)
         if not membership:

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -29,6 +29,7 @@ from calendar_integration.models import (
     Calendar,
     CalendarEvent,
     CalendarGroup,
+    CalendarOwnership,
 )
 from calendar_integration.permissions import (
     CalendarAvailabilityPermission,
@@ -53,6 +54,8 @@ from calendar_integration.serializers import (
     CalendarGroupRangeAvailabilitySerializer,
     CalendarGroupSerializer,
     CalendarSerializer,
+    CalendarSyncRequestSerializer,
+    CalendarSyncSerializer,
     EventBulkModificationSerializer,
     EventRecurringExceptionSerializer,
     UnavailableTimeWindowSerializer,
@@ -169,6 +172,87 @@ class CalendarViewSet(VintaScheduleModelViewSet):
                 status=status.HTTP_202_ACCEPTED,
             )
         except (ValueError, CalendarIntegrationError) as e:
+            raise ValidationError({"non_field_errors": [str(e)]}) from e
+
+    @extend_schema(
+        summary="Request calendar sync",
+        description="Request synchronization of an owned calendar over a date range.",
+        request=CalendarSyncRequestSerializer,
+        responses={202: CalendarSyncSerializer()},
+    )
+    @action(
+        methods=["post"],
+        detail=True,
+        url_path="request-sync",
+        url_name="request-sync",
+    )
+    @inject
+    def request_sync(
+        self,
+        request,
+        pk=None,
+        calendar_service: Annotated[CalendarService, Provide["calendar_service"]] = None,  # type: ignore
+    ):
+        """Request synchronization of an owned calendar over a date range."""
+        calendar = self.get_object()
+        user = request.user
+
+        # Check ownership - user must own this calendar
+        if not CalendarOwnership.objects.filter(
+            calendar=calendar,
+            user=user,
+            organization_id=calendar.organization_id,
+        ).exists():
+            return Response(
+                {"detail": "You do not own this calendar."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # Parse and validate datetime fields
+        start_datetime_str = request.data.get("start_datetime")
+        end_datetime_str = request.data.get("end_datetime")
+
+        if not start_datetime_str or not end_datetime_str:
+            raise ValidationError(
+                {"non_field_errors": ["start_datetime and end_datetime are required"]}
+            )
+
+        try:
+            start_datetime = datetime.datetime.fromisoformat(
+                start_datetime_str.replace("Z", "+00:00")
+            )
+            end_datetime = datetime.datetime.fromisoformat(end_datetime_str.replace("Z", "+00:00"))
+        except (ValueError, CalendarIntegrationError) as e:
+            raise ValidationError({"non_field_errors": [f"Invalid datetime format: {e!s}"]}) from e
+
+        should_update_events = request.data.get("should_update_events", False)
+
+        # Get social account for authentication
+        social_account = SocialAccount.objects.filter(user=user, provider=calendar.provider).first()
+
+        membership = get_active_organization_membership(user)
+        if not membership:
+            return Response(
+                {"detail": "User is not an active member of any organization."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        try:
+            calendar_service.authenticate(
+                account=social_account,
+                organization=membership.organization,
+            )
+
+            calendar_sync = calendar_service.request_calendar_sync(
+                calendar=calendar,
+                start_datetime=start_datetime,
+                end_datetime=end_datetime,
+                should_update_events=should_update_events,
+            )
+
+            serializer = CalendarSyncSerializer(calendar_sync)
+            return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
+        except (ValueError, CalendarIntegrationError, NotImplementedError) as e:
             raise ValidationError({"non_field_errors": [str(e)]}) from e
 
     @extend_schema(

--- a/schema.yml
+++ b/schema.yml
@@ -3752,6 +3752,83 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedAvailableTimeWindowList'
           description: ''
+  /calendar/{id}/request-sync/:
+    post:
+      operationId: calendar_request_sync_create
+      description: Request synchronization of an owned calendar over a date range.
+      summary: Request calendar sync
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarSync'
+          description: ''
+  /calendar/{id}/request-sync{format}:
+    post:
+      operationId: calendar_request_sync_formatted_create
+      description: Request synchronization of an owned calendar over a date range.
+      summary: Request calendar sync
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarSync'
+          description: ''
   /calendar/{id}/unavailable-windows/:
     get:
       operationId: calendar_unavailable_windows_list
@@ -6783,6 +6860,61 @@ components:
       required:
       - available_calendar_ids
       - slot_id
+    CalendarSync:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        status:
+          allOf:
+          - $ref: '#/components/schemas/CalendarSyncStatusEnum'
+          readOnly: true
+        start_datetime:
+          type: string
+          format: date-time
+        end_datetime:
+          type: string
+          format: date-time
+        should_update_events:
+          type: boolean
+        error_message:
+          type: string
+          readOnly: true
+      required:
+      - end_datetime
+      - error_message
+      - id
+      - should_update_events
+      - start_datetime
+      - status
+    CalendarSyncRequest:
+      type: object
+      properties:
+        start_datetime:
+          type: string
+          format: date-time
+        end_datetime:
+          type: string
+          format: date-time
+        should_update_events:
+          type: boolean
+          default: false
+      required:
+      - end_datetime
+      - start_datetime
+    CalendarSyncStatusEnum:
+      enum:
+      - success
+      - failed
+      - in_progress
+      - not_started
+      type: string
+      description: |-
+        * `success` - Success
+        * `failed` - Failed
+        * `in_progress` - In Progress
+        * `not_started` - Not Started
     CalendarTypeEnum:
       enum:
       - personal


### PR DESCRIPTION
## Summary
Phase 5 of the **REST API Frontend Gaps** plan — the sync half of "request a calendar to sync". Adds `POST /calendar/{id}/request-sync/`: an authenticated user syncs a calendar they OWN over a date range. Returns the created `CalendarSync` (id + status) so the frontend can poll progress.

## Behavior
- Owner-only: `get_object()` org-scopes (cross-org → 404) and an explicit `CalendarOwnership` check restricts to owners (non-owner active member → 403). Admin cross-user sync is Phase 6.
- Body validated by `CalendarSyncRequestSerializer` (`start_datetime`, `end_datetime` required; `should_update_events` optional bool) → 400 on missing/invalid.
- No linked account for the calendar's provider → 400 (explicit guard, avoids a 500).
- 202 Accepted + serialized `CalendarSync`.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 5 + API Design 4.2 + Open Questions (return sync id+status).

## Review history
Layer-3 review caught two issues, both fixed in the second commit: (1) the new `CalendarSyncRequestSerializer` was dead — the action now uses it for input validation (which also gives proper boolean coercion of `should_update_events`); (2) the `social_account` lookup could be `None` and reach `authenticate()` as a 500 — now guarded with a 400. Regression test added for the no-account case.

## Out-of-scope note
`CalendarService.request_calendar_sync` enqueues `sync_calendar_task.delay(...)` without `transaction.on_commit` (pre-existing, shared by Phase 6's admin-sync). Not changed here to avoid destabilizing task/test callers; flagged as a follow-up refactor candidate.

## Test plan
- `uv run pytest calendar_integration/tests/test_views.py -n auto`
- Asserts: owner → 202 + CalendarSync id/status; non-owner → 403; cross-org → 404; missing/invalid datetimes → 400; no linked account → 400; anonymous → 401.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1297 passed).