### PR TITLE
feat(calendar): add admin-sync action for org calendars

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -61,11 +61,17 @@
 - **Key**: `POST /calendar/{id}/request-sync/` owner-only (get_object org-scope + CalendarOwnership check). Input via `CalendarSyncRequestSerializer`. None-account → 400. Returns `CalendarSync` (id+status) at 202. New `CalendarSyncSerializer`. Outer gate green (1297), mypy 108.
 - **Out-of-scope flagged**: `request_calendar_sync` enqueues `.delay` without on_commit (pre-existing; phase 6 shares it). Candidate follow-up.
 
+### Phase 6 — Admin syncs another user's calendar ✅
+- **Status**: done, reviewed (3 layers, clean), pushed, PR opened.
+- **Model**: haiku. **Branch**: phase-6 (base phase-5). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/48
+- **Key**: `POST /calendar/{id}/admin-sync/` with `permission_classes=[IsOrganizationAdmin]` (admin-only, cross-org 404). Authenticates with the calendar OWNER's SocialAccount (resolved via CalendarOwnership default-first), NOT the admin's — test proves it. Guards: no owner / no linked account / bad datetimes → 400. Outer gate green (1304), mypy 108.
+
 ## Current Phase
-Phase 6 — Admin syncs another user's calendar (next).
+Phase 7 — Trigger organization rooms/resources sync (admin) (next).
+- NOTE: existing `OrganizationService.create_organization` triggers rooms import via `self.calendar_service.initialize_without_provider(user_or_token=creator, organization=org)` then `request_organization_calendar_resources_import(start, end)` (window now..+365d). Phase 7 should DRY this into a shared service method and reuse for both create_organization and the new action + the should_sync_rooms False→True transition.
 
 ## Remaining Phases
-7 (rooms sync trigger), 8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -24,7 +24,7 @@ from calendar_integration.services.dataclasses import (
     AvailableTimeWindow,
     UnavailableTimeWindow,
 )
-from organizations.models import Organization, OrganizationMembership
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
 
 
 User = get_user_model()
@@ -1893,6 +1893,307 @@ class TestCalendarViewSet:
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
         assert "No linked account found" in str(response.data)
         assert calendar.provider in str(response.data)
+
+    def test_admin_sync_another_users_calendar(self, auth_client, organization, calendar):
+        """Test admin syncs another user's calendar"""
+        from di_core.containers import container
+
+        # Create admin user in the organization
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        # Create calendar owner (different user)
+        calendar_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=calendar_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+
+        # Create calendar ownership linking owner to calendar
+        CalendarIntegrationTestFactory.create_calendar_ownership(calendar_owner, calendar)
+
+        # Create social account for the calendar owner (not the admin)
+        owner_social_account = baker.make(
+            SocialAccount,
+            user=calendar_owner,
+            provider=calendar.provider,
+        )
+        baker.make(
+            SocialToken,
+            account=owner_social_account,
+            token="fake_access_token",
+            token_secret="fake_refresh_token",
+            expires_at=datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1),
+        )
+
+        # Create a mock calendar service
+        mock_calendar_service = Mock()
+        mock_calendar_service.authenticate.return_value = None
+
+        # Create a mock CalendarSync instance
+        mock_calendar_sync = Mock()
+        mock_calendar_sync.id = 123
+        mock_calendar_sync.status = "NOT_STARTED"
+        mock_calendar_sync.start_datetime = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+        mock_calendar_sync.end_datetime = datetime.datetime(2024, 1, 31, tzinfo=datetime.UTC)
+        mock_calendar_sync.should_update_events = False
+        mock_calendar_sync.error_message = ""
+        mock_calendar_service.request_calendar_sync.return_value = mock_calendar_sync
+
+        # Authenticate as admin and make request
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+
+        url = reverse("api:Calendars-admin-sync", kwargs={"pk": calendar.id})
+
+        with container.calendar_service.override(mock_calendar_service):
+            response = client.post(
+                url,
+                data={
+                    "start_datetime": "2024-01-01T00:00:00Z",
+                    "end_datetime": "2024-01-31T23:59:59Z",
+                    "should_update_events": False,
+                },
+                format="json",
+            )
+
+            # Verify response
+            assert_response_status_code(response, status.HTTP_202_ACCEPTED)
+            assert response.data["id"] == 123
+            assert response.data["status"] == "NOT_STARTED"
+
+            # Verify authenticate was called with OWNER's account, not admin's
+            authenticate_call_args = mock_calendar_service.authenticate.call_args
+            assert authenticate_call_args is not None
+            account_arg = authenticate_call_args[1]["account"]
+            assert account_arg == owner_social_account
+            assert account_arg.user == calendar_owner
+            assert account_arg.user != admin_user
+
+            # Verify request_calendar_sync was called
+            mock_calendar_service.request_calendar_sync.assert_called_once()
+
+    def test_admin_sync_non_admin_member_forbidden(self, auth_client, organization, calendar):
+        """Test non-admin member cannot sync any calendar"""
+        # Create regular member user
+        member_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=member_user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+
+        # Create calendar owner (another user)
+        calendar_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=calendar_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+
+        # Create calendar ownership
+        CalendarIntegrationTestFactory.create_calendar_ownership(calendar_owner, calendar)
+
+        # Authenticate as regular member
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(user=member_user)
+
+        url = reverse("api:Calendars-admin-sync", kwargs={"pk": calendar.id})
+
+        response = client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_sync_cross_org_calendar_not_found(self, auth_client, organization):
+        """Test admin cannot sync calendar from different organization"""
+        # Create admin in first organization
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        # Create calendar in different organization
+        other_org = CalendarIntegrationTestFactory.create_organization(name="Other Org")
+        other_calendar = CalendarIntegrationTestFactory.create_calendar(organization=other_org)
+
+        # Authenticate as admin and try to sync cross-org calendar
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+
+        url = reverse("api:Calendars-admin-sync", kwargs={"pk": other_calendar.id})
+
+        response = client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_admin_sync_owner_has_no_linked_account(self, auth_client, organization, calendar):
+        """Test admin cannot sync if calendar owner has no linked account for provider"""
+        # Create admin user
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        # Create calendar owner
+        calendar_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=calendar_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+
+        # Create calendar ownership
+        CalendarIntegrationTestFactory.create_calendar_ownership(calendar_owner, calendar)
+
+        # Do NOT create social account for the owner - this is the test case
+
+        # Authenticate as admin and make request
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+
+        url = reverse("api:Calendars-admin-sync", kwargs={"pk": calendar.id})
+
+        response = client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert "has no linked" in response.data["detail"].lower()
+        assert calendar.provider in response.data["detail"]
+
+    def test_admin_sync_calendar_has_no_owner(self, auth_client, organization):
+        """Test admin cannot sync calendar with no owner"""
+        # Create admin user
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        # Create calendar with no ownership
+        calendar = CalendarIntegrationTestFactory.create_calendar(organization=organization)
+
+        # Authenticate as admin and make request
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+
+        url = reverse("api:Calendars-admin-sync", kwargs={"pk": calendar.id})
+
+        response = client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert "has no owner" in response.data["detail"].lower()
+
+    def test_admin_sync_invalid_datetimes(self, auth_client, organization, calendar):
+        """Test admin-sync with invalid datetimes returns 400"""
+        # Create admin user
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        # Create calendar owner
+        calendar_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=calendar_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+
+        # Create calendar ownership
+        CalendarIntegrationTestFactory.create_calendar_ownership(calendar_owner, calendar)
+
+        # Authenticate as admin
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+
+        url = reverse("api:Calendars-admin-sync", kwargs={"pk": calendar.id})
+
+        response = client.post(
+            url,
+            data={
+                "start_datetime": "invalid-date",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_admin_sync_unauthenticated(self, anonymous_client, calendar):
+        """Test unauthenticated user cannot admin-sync"""
+        url = reverse("api:Calendars-admin-sync", kwargs={"pk": calendar.id})
+
+        response = anonymous_client.post(
+            url,
+            data={
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-31T23:59:59Z",
+            },
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
 
 
 @pytest.mark.django_db

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -64,6 +64,7 @@ from calendar_integration.services.calendar_group_service import CalendarGroupSe
 from calendar_integration.services.calendar_service import CalendarService
 from common.utils.view_utils import VintaScheduleModelViewSet
 from organizations.models import get_active_organization_membership
+from organizations.permissions import IsOrganizationAdmin
 
 
 class CalendarViewSet(VintaScheduleModelViewSet):
@@ -239,6 +240,97 @@ class CalendarViewSet(VintaScheduleModelViewSet):
         try:
             calendar_service.authenticate(
                 account=social_account,
+                organization=membership.organization,
+            )
+
+            calendar_sync = calendar_service.request_calendar_sync(
+                calendar=calendar,
+                start_datetime=start_datetime,
+                end_datetime=end_datetime,
+                should_update_events=should_update_events,
+            )
+
+            serializer = CalendarSyncSerializer(calendar_sync)
+            return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
+        except (ValueError, CalendarIntegrationError, NotImplementedError) as e:
+            raise ValidationError({"non_field_errors": [str(e)]}) from e
+
+    @extend_schema(
+        summary="Admin syncs another user's calendar",
+        description="Admin syncs any calendar in the organization over a date range.",
+        request=CalendarSyncRequestSerializer,
+        responses={202: CalendarSyncSerializer()},
+    )
+    @action(
+        methods=["post"],
+        detail=True,
+        url_path="admin-sync",
+        url_name="admin-sync",
+        permission_classes=[IsOrganizationAdmin],
+    )
+    @inject
+    def admin_sync(
+        self,
+        request,
+        pk=None,
+        calendar_service: Annotated[CalendarService, Provide["calendar_service"]] = None,  # type: ignore
+    ):
+        """Admin syncs any calendar in the organization over a date range."""
+        calendar = self.get_object()  # org-scoped via get_queryset
+        user = request.user
+
+        # Validate request input using serializer
+        input_serializer = CalendarSyncRequestSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+        data = input_serializer.validated_data
+        start_datetime = data["start_datetime"]
+        end_datetime = data["end_datetime"]
+        should_update_events = data["should_update_events"]
+
+        # Resolve the calendar's owner via CalendarOwnership
+        # Use the default owner if multiple owners exist; else the first
+        ownership = (
+            CalendarOwnership.objects.filter(
+                calendar=calendar,
+                organization_id=calendar.organization_id,
+            )
+            .order_by("-is_default", "id")
+            .first()
+        )
+
+        if not ownership:
+            return Response(
+                {"detail": "Calendar has no owner; cannot sync."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        calendar_owner = ownership.user
+
+        # Resolve the owner's SocialAccount for the calendar's provider
+        owner_social_account = SocialAccount.objects.filter(
+            user=calendar_owner, provider=calendar.provider
+        ).first()
+
+        if not owner_social_account:
+            return Response(
+                {
+                    "detail": f"Calendar owner has no linked {calendar.provider} account; cannot sync."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Get the admin's organization membership (already checked by IsOrganizationAdmin)
+        membership = get_active_organization_membership(user)
+        if not membership:
+            return Response(
+                {"detail": "User is not an active member of any organization."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        try:
+            # Authenticate with the OWNER's account, not the admin's
+            calendar_service.authenticate(
+                account=owner_social_account,
                 organization=membership.organization,
             )
 

--- a/schema.yml
+++ b/schema.yml
@@ -3649,6 +3649,83 @@ paths:
       responses:
         '204':
           description: No response body
+  /calendar/{id}/admin-sync/:
+    post:
+      operationId: calendar_admin_sync_create
+      description: Admin syncs any calendar in the organization over a date range.
+      summary: Admin syncs another user's calendar
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarSync'
+          description: ''
+  /calendar/{id}/admin-sync{format}:
+    post:
+      operationId: calendar_admin_sync_formatted_create
+      description: Admin syncs any calendar in the organization over a date range.
+      summary: Admin syncs another user's calendar
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarSyncRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarSync'
+          description: ''
   /calendar/{id}/available-windows/:
     get:
       operationId: calendar_available_windows_list


### PR DESCRIPTION
## Summary
Phase 6 of the **REST API Frontend Gaps** plan — an org admin manually syncs **any** calendar in their organization (not just their own). Adds `POST /calendar/{id}/admin-sync/`, admin-only, returning the created `CalendarSync` (id + status) at 202.

The security-critical detail: syncing someone else's external calendar requires the **calendar owner's** OAuth credentials — the admin doesn't hold them. So the action authenticates the `CalendarService` with the owner's `SocialAccount`, never the admin's.

## Behavior
- `permission_classes=[IsOrganizationAdmin]` on the action → non-admin member 403; cross-org calendar 404 (org-scoped queryset).
- Owner resolved via `CalendarOwnership` (default owner first); no owner → 400; owner has no linked account for the provider → 400.
- Body validated by `CalendarSyncRequestSerializer` → 400 on invalid.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 6 + API Design 4.2.

## Review history
Layer-3 review: clean, no findings. The happy-path test explicitly asserts `authenticate()` received the owner's account (and that it is not the admin's).

## Out-of-scope note
Shares `CalendarService.request_calendar_sync`, whose `.delay()` is not `on_commit`-wrapped (pre-existing; flagged in Phase 5). Not changed here.

## Test plan
- `uv run pytest calendar_integration/tests/test_views.py -n auto`
- Asserts: admin syncs another in-org user's calendar → 202 + authenticate called with the OWNER's account; non-admin → 403; cross-org → 404; no owner → 400; owner has no linked account → 400; invalid datetimes → 400; anon → 401.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1304 passed).