### PR TITLE
feat(organizations): add rooms-sync trigger, on-enable transition, and admin org update

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -66,12 +66,17 @@
 - **Model**: haiku. **Branch**: phase-6 (base phase-5). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/48
 - **Key**: `POST /calendar/{id}/admin-sync/` with `permission_classes=[IsOrganizationAdmin]` (admin-only, cross-org 404). Authenticates with the calendar OWNER's SocialAccount (resolved via CalendarOwnership default-first), NOT the admin's — test proves it. Guards: no owner / no linked account / bad datetimes → 400. Outer gate green (1304), mypy 108.
 
+### Phase 7 — Trigger org rooms/resources sync (admin) ✅
+- **Status**: done, reviewed (3 layers; Layer 3 #1 → transition was on an unreachable update endpoint + tests patched perms → opened admin update via get_permissions; #2 → hardened: dropped dead on_commit try/except, fixed schema, select_for_update against double-fire), pushed, PR opened.
+- **Model**: sonnet (resumed after a socket error mid-run); fixers: sonnet + haiku. **Branch**: phase-7 (base phase-6). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/49
+- **Key**: `OrganizationService.request_rooms_sync` (DRY, used by create_organization too); `POST /organizations/{id}/sync-rooms/` admin action; should_sync_rooms False→True transition fires once (locked). **IMPORTANT reusable infra**: `OrganizationViewSet.get_permissions()` now gates update/partial_update with IsOrganizationAdmin — admins can configure their own org (previously update was unreachable for all). Outer gate green (1320), mypy 108.
+- **Reusable note**: org update is admin-only now; org-config edits go through PATCH /organizations/{id}/.
+
 ## Current Phase
-Phase 7 — Trigger organization rooms/resources sync (admin) (next).
-- NOTE: existing `OrganizationService.create_organization` triggers rooms import via `self.calendar_service.initialize_without_provider(user_or_token=creator, organization=org)` then `request_organization_calendar_resources_import(start, end)` (window now..+365d). Phase 7 should DRY this into a shared service method and reuse for both create_organization and the new action + the should_sync_rooms False→True transition.
+Phase 8 — Transfer event between calendars (admin) (next). Service: `CalendarService.transfer_event(event, new_calendar) -> CalendarEvent` (~2115). Admin `@action transfer` on CalendarEventViewSet, body target_calendar_id (in-org). Provider-sync side effects → Tier 3.
 
 ## Remaining Phases
-8 (transfer event), 9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -65,15 +65,36 @@ class OrganizationService:
         )
 
         if should_sync_rooms:
-            self.calendar_service.initialize_without_provider(
-                user_or_token=creator, organization=self.organization
-            )
-            now = datetime.datetime.now(tz=datetime.UTC)
-            self.calendar_service.request_organization_calendar_resources_import(
-                start_time=now,
-                end_time=now + datetime.timedelta(days=365),
+            self.request_rooms_sync(
+                organization=self.organization,
+                requested_by=creator,
             )
         return self.organization
+
+    def request_rooms_sync(
+        self,
+        organization: Organization,
+        requested_by: User,
+        start_time: datetime.datetime | None = None,
+        end_time: datetime.datetime | None = None,
+    ) -> None:
+        """
+        Initialize the calendar service without a provider and enqueue a
+        calendar resources import for the given organization.
+
+        :param organization: The organization to sync rooms for.
+        :param requested_by: The user (or token) authorizing the sync.
+        :param start_time: Import window start; defaults to now.
+        :param end_time: Import window end; defaults to now + 365 days.
+        """
+        self.calendar_service.initialize_without_provider(
+            user_or_token=requested_by, organization=organization
+        )
+        now = datetime.datetime.now(tz=datetime.UTC)
+        self.calendar_service.request_organization_calendar_resources_import(
+            start_time=start_time or now,
+            end_time=end_time or (now + datetime.timedelta(days=365)),
+        )
 
     @transaction.atomic()
     def invite_user_to_organization(

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -283,7 +283,12 @@ class TestOrganizationViewSet:
     def test_update_organization_authenticated_with_membership(
         self, auth_client, user, organization_with_membership
     ):
-        """Test updating an organization when user has membership"""
+        """Test updating an organization when user has a non-admin membership.
+
+        The organization_with_membership fixture creates a MEMBER-role membership.
+        IsOrganizationAdmin (applied to update/partial_update) rejects non-admin
+        members with 403.
+        """
         url = reverse("api:Organizations-detail", kwargs={"pk": organization_with_membership.pk})
         data = {
             "name": "Updated Organization Name",
@@ -291,18 +296,63 @@ class TestOrganizationViewSet:
         }
         response = auth_client.patch(url, data, format="json")
 
-        # Users with membership get 403 due to permission class logic
+        # Non-admin member → 403 (IsOrganizationAdmin denies)
         assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
 
+    def test_update_organization_admin_returns_200(self, user):
+        """Admin can PATCH their own organization — the configure-org use-case works."""
+        organization = OrganizationTestFactory.create_organization(name="Admin Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        admin_client = APIClient()
+        admin_client.force_authenticate(user=user)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": organization.pk})
+        response = admin_client.patch(url, {"name": "Admin Updated Name"}, format="json")
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.json()["name"] == "Admin Updated Name"
+
+    def test_update_organization_admin_cross_org_returns_404(self, user):
+        """Admin cannot PATCH an organization they don't belong to — 404."""
+        own_org = OrganizationTestFactory.create_organization(name="Own Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=own_org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        other_org = OrganizationTestFactory.create_organization(name="Other Org")
+
+        admin_client = APIClient()
+        admin_client.force_authenticate(user=user)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": other_org.pk})
+        response = admin_client.patch(url, {"name": "Hacked"}, format="json")
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
     def test_update_organization_authenticated_without_membership(self, auth_client, organization):
-        """Test updating an organization when user has no membership"""
+        """Test updating an organization when user has no membership.
+
+        IsOrganizationAdmin.has_permission returns False for membership-less users → 403.
+        (Previously expected 404 under OrganizationManagementPermission, but the update
+        action now uses IsOrganizationAdmin which rejects at has_permission before the
+        queryset is consulted.)
+        """
         url = reverse("api:Organizations-detail", kwargs={"pk": organization.pk})
         data = {
             "name": "Updated Organization Name",
         }
         response = auth_client.patch(url, data, format="json")
 
-        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
 
     def test_update_organization_unauthenticated(self, anonymous_client, organization):
         """Test updating an organization without authentication"""
@@ -344,20 +394,25 @@ class TestOrganizationPermissions:
     """Test suite for organization permissions"""
 
     def test_organization_permission_with_membership(self, auth_client, user):
-        """Test organization permissions when user has membership"""
+        """Test organization permissions when user has a non-admin (MEMBER) membership.
+
+        retrieve/delete: still gated by OrganizationManagementPermission → 403.
+        update: gated by IsOrganizationAdmin → non-admin member gets 403.
+        """
         organization = OrganizationTestFactory.create_organization()
+        # create_organization_membership uses baker default role = MEMBER
         OrganizationTestFactory.create_organization_membership(user, organization)
 
-        # Should NOT be able to retrieve due to permission class logic
+        # Should NOT be able to retrieve — OrganizationManagementPermission blocks members
         url = reverse("api:Organizations-detail", kwargs={"pk": organization.pk})
         response = auth_client.get(url)
         assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
 
-        # Should NOT be able to update due to permission class logic
+        # Should NOT be able to update — IsOrganizationAdmin blocks non-admin members
         response = auth_client.patch(url, {"name": "Updated Name"}, format="json")
         assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
 
-        # Should NOT be able to delete due to permission class logic
+        # Should NOT be able to delete — OrganizationManagementPermission blocks members
         response = auth_client.delete(url)
         assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
 
@@ -1880,13 +1935,13 @@ class TestSyncRoomsAction:
 class TestShouldSyncRoomsTransition:
     """Verify the False→True transition in OrganizationViewSet.update fires exactly once.
 
-    Because OrganizationManagementPermission blocks members from the default
-    PATCH endpoint, these tests patch the permission to allow the admin through
-    so the view logic can be exercised directly.
+    These tests use a real admin membership — no permission patching.
+    The update/partial_update actions are now gated by IsOrganizationAdmin so
+    the transition trigger is genuinely reachable by an admin PATCH.
     """
 
     def _make_admin_client_and_org(self, user, should_sync_rooms=False):
-        """Create org + admin membership; return (admin_client, organization)."""
+        """Create org + ADMIN membership; return (admin_client, organization)."""
         organization = baker.make(
             Organization, name="Transition Org", should_sync_rooms=should_sync_rooms
         )
@@ -1902,18 +1957,15 @@ class TestShouldSyncRoomsTransition:
         return client, organization
 
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
-    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
     @patch("organizations.services.OrganizationService.request_rooms_sync")
-    def test_patch_false_to_true_fires_sync_once(
-        self, mock_sync, _mock_perm, _mock_on_commit, user
-    ):
-        """PATCH should_sync_rooms False→True fires request_rooms_sync exactly once."""
+    def test_patch_false_to_true_fires_sync_once(self, mock_sync, _mock_on_commit, user):
+        """Admin PATCH should_sync_rooms False→True → 200; request_rooms_sync called once."""
         client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
 
         url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
         response = client.patch(url, {"should_sync_rooms": True}, format="json")
 
-        assert response.status_code in (status.HTTP_200_OK,), (
+        assert response.status_code == status.HTTP_200_OK, (
             f"Expected 200, got {response.status_code}: {response.content}"
         )
         mock_sync.assert_called_once()
@@ -1922,52 +1974,114 @@ class TestShouldSyncRoomsTransition:
         assert call_kwargs["requested_by"] == user
 
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
-    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
     @patch("organizations.services.OrganizationService.request_rooms_sync")
-    def test_patch_already_true_does_not_fire_sync(
-        self, mock_sync, _mock_perm, _mock_on_commit, user
-    ):
-        """PATCH on org with should_sync_rooms already True must NOT fire sync."""
+    def test_patch_already_true_does_not_fire_sync(self, mock_sync, _mock_on_commit, user):
+        """Admin PATCH on org with should_sync_rooms already True → 200; sync NOT fired."""
         client, org = self._make_admin_client_and_org(user, should_sync_rooms=True)
 
         url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
         response = client.patch(url, {"should_sync_rooms": True}, format="json")
 
-        assert response.status_code in (status.HTTP_200_OK,), (
+        assert response.status_code == status.HTTP_200_OK, (
             f"Expected 200, got {response.status_code}: {response.content}"
         )
         mock_sync.assert_not_called()
 
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
-    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
     @patch("organizations.services.OrganizationService.request_rooms_sync")
-    def test_patch_true_to_false_does_not_fire_sync(
-        self, mock_sync, _mock_perm, _mock_on_commit, user
-    ):
-        """PATCH should_sync_rooms True→False must NOT fire sync."""
+    def test_patch_true_to_false_does_not_fire_sync(self, mock_sync, _mock_on_commit, user):
+        """Admin PATCH should_sync_rooms True→False → 200; sync NOT fired."""
         client, org = self._make_admin_client_and_org(user, should_sync_rooms=True)
 
         url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
         response = client.patch(url, {"should_sync_rooms": False}, format="json")
 
-        assert response.status_code in (status.HTTP_200_OK,), (
+        assert response.status_code == status.HTTP_200_OK, (
             f"Expected 200, got {response.status_code}: {response.content}"
         )
         mock_sync.assert_not_called()
 
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
-    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
     @patch("organizations.services.OrganizationService.request_rooms_sync")
-    def test_patch_unrelated_field_does_not_fire_sync(
-        self, mock_sync, _mock_perm, _mock_on_commit, user
-    ):
-        """PATCH on unrelated field (name) while should_sync_rooms stays False — no sync."""
+    def test_patch_unrelated_field_does_not_fire_sync(self, mock_sync, _mock_on_commit, user):
+        """Admin PATCH on unrelated field (name) while should_sync_rooms stays False — no sync."""
         client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
 
         url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
         response = client.patch(url, {"name": "New Name"}, format="json")
 
-        assert response.status_code in (status.HTTP_200_OK,), (
+        assert response.status_code == status.HTTP_200_OK, (
             f"Expected 200, got {response.status_code}: {response.content}"
         )
         mock_sync.assert_not_called()
+
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_patch_non_admin_member_returns_403(self, mock_sync, user):
+        """Non-admin member PATCH → 403 (IsOrganizationAdmin denies); sync NOT fired."""
+        organization = baker.make(Organization, name="Non-Admin Org", should_sync_rooms=False)
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": organization.pk})
+        response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Expected 403, got {response.status_code}: {response.content}"
+        )
+        mock_sync.assert_not_called()
+
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_patch_membership_less_user_returns_403(self, mock_sync):
+        """Membership-less authenticated user PATCH → 403; sync NOT fired."""
+        from users.factories import UserFactory
+
+        membership_less_user = UserFactory().create_user()
+        organization = baker.make(Organization, name="No Member Org", should_sync_rooms=False)
+
+        client = APIClient()
+        client.force_authenticate(user=membership_less_user)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": organization.pk})
+        response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Expected 403, got {response.status_code}: {response.content}"
+        )
+        mock_sync.assert_not_called()
+
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_patch_unauthenticated_returns_401(self, mock_sync):
+        """Unauthenticated PATCH → 401; sync NOT fired."""
+        organization = baker.make(Organization, name="Anon Org", should_sync_rooms=False)
+        client = APIClient()
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": organization.pk})
+        response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, (
+            f"Expected 401, got {response.status_code}: {response.content}"
+        )
+        mock_sync.assert_not_called()
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_admin_can_set_should_sync_rooms_value_persists(self, mock_sync, _mock_on_commit, user):
+        """Admin PATCH should_sync_rooms → value persists in DB (configure-org use-case)."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Expected 200, got {response.status_code}: {response.content}"
+        )
+        # Verify the value was persisted to the DB.
+        org.refresh_from_db()
+        assert org.should_sync_rooms is True

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -1751,3 +1751,223 @@ class TestOrganizationMembershipViewSet:
         assert_response_status_code(response, status.HTTP_200_OK)
         result = response.json()
         assert result["organization"]["id"] == organization.id
+
+
+@pytest.mark.django_db
+class TestSyncRoomsAction:
+    """Test suite for POST /organizations/{id}/sync-rooms/ (Phase 7).
+
+    Only org admins may trigger the sync.  The underlying import is enqueued
+    via transaction.on_commit; tests verify that request_rooms_sync is called
+    with the expected arguments.
+    """
+
+    def _make_admin_client(self, user, organization):
+        """Return an APIClient force-authenticated as an active admin of ``organization``."""
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_admin_sync_rooms_default_times_returns_202(self, mock_sync, _mock_on_commit, user):
+        """Admin POST without body → 202; request_rooms_sync called with no explicit times."""
+        organization = OrganizationTestFactory.create_organization(name="Sync Org")
+        admin_client = self._make_admin_client(user, organization)
+
+        url = reverse("api:Organizations-sync-rooms", kwargs={"pk": organization.pk})
+        response = admin_client.post(url, {}, format="json")
+
+        assert_response_status_code(response, status.HTTP_202_ACCEPTED)
+        mock_sync.assert_called_once()
+        call_kwargs = mock_sync.call_args.kwargs
+        assert call_kwargs["organization"] == organization
+        assert call_kwargs["requested_by"] == user
+        assert call_kwargs["start_time"] is None
+        assert call_kwargs["end_time"] is None
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_admin_sync_rooms_explicit_times_returns_202(self, mock_sync, _mock_on_commit, user):
+        """Admin POST with ISO start_time/end_time → 202; service called with parsed datetimes."""
+        import datetime
+
+        organization = OrganizationTestFactory.create_organization(name="Explicit Sync Org")
+        admin_client = self._make_admin_client(user, organization)
+
+        start = datetime.datetime(2026, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2027, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
+
+        url = reverse("api:Organizations-sync-rooms", kwargs={"pk": organization.pk})
+        response = admin_client.post(
+            url,
+            {"start_time": start.isoformat(), "end_time": end.isoformat()},
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_202_ACCEPTED)
+        mock_sync.assert_called_once()
+        call_kwargs = mock_sync.call_args.kwargs
+        assert call_kwargs["start_time"] == start
+        assert call_kwargs["end_time"] == end
+
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_sync_rooms_non_admin_member_returns_403(self, mock_sync, user):
+        """Non-admin member → 403; request_rooms_sync must NOT be called."""
+        organization = OrganizationTestFactory.create_organization(name="Member Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        url = reverse("api:Organizations-sync-rooms", kwargs={"pk": organization.pk})
+        response = client.post(url, {}, format="json")
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        mock_sync.assert_not_called()
+
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_sync_rooms_cross_org_returns_404(self, mock_sync, user):
+        """Admin of org A cannot trigger sync for org B → 404."""
+        org_a = OrganizationTestFactory.create_organization(name="Org A")
+        org_b = OrganizationTestFactory.create_organization(name="Org B")
+        admin_client = self._make_admin_client(user, org_a)
+
+        url = reverse("api:Organizations-sync-rooms", kwargs={"pk": org_b.pk})
+        response = admin_client.post(url, {}, format="json")
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+        mock_sync.assert_not_called()
+
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_sync_rooms_unauthenticated_returns_401(self, mock_sync):
+        """Anonymous request → 401."""
+        organization = OrganizationTestFactory.create_organization(name="Anon Org")
+        client = APIClient()
+
+        url = reverse("api:Organizations-sync-rooms", kwargs={"pk": organization.pk})
+        response = client.post(url, {}, format="json")
+
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+        mock_sync.assert_not_called()
+
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_sync_rooms_bad_datetime_returns_400(self, mock_sync, user):
+        """Malformed datetime in body → 400; request_rooms_sync NOT called."""
+        organization = OrganizationTestFactory.create_organization(name="Bad DT Org")
+        admin_client = self._make_admin_client(user, organization)
+
+        url = reverse("api:Organizations-sync-rooms", kwargs={"pk": organization.pk})
+        response = admin_client.post(url, {"start_time": "not-a-datetime"}, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        mock_sync.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestShouldSyncRoomsTransition:
+    """Verify the False→True transition in OrganizationViewSet.update fires exactly once.
+
+    Because OrganizationManagementPermission blocks members from the default
+    PATCH endpoint, these tests patch the permission to allow the admin through
+    so the view logic can be exercised directly.
+    """
+
+    def _make_admin_client_and_org(self, user, should_sync_rooms=False):
+        """Create org + admin membership; return (admin_client, organization)."""
+        organization = baker.make(
+            Organization, name="Transition Org", should_sync_rooms=should_sync_rooms
+        )
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client, organization
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_patch_false_to_true_fires_sync_once(
+        self, mock_sync, _mock_perm, _mock_on_commit, user
+    ):
+        """PATCH should_sync_rooms False→True fires request_rooms_sync exactly once."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert response.status_code in (status.HTTP_200_OK,), (
+            f"Expected 200, got {response.status_code}: {response.content}"
+        )
+        mock_sync.assert_called_once()
+        call_kwargs = mock_sync.call_args.kwargs
+        assert call_kwargs["organization"].pk == org.pk
+        assert call_kwargs["requested_by"] == user
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_patch_already_true_does_not_fire_sync(
+        self, mock_sync, _mock_perm, _mock_on_commit, user
+    ):
+        """PATCH on org with should_sync_rooms already True must NOT fire sync."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=True)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert response.status_code in (status.HTTP_200_OK,), (
+            f"Expected 200, got {response.status_code}: {response.content}"
+        )
+        mock_sync.assert_not_called()
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_patch_true_to_false_does_not_fire_sync(
+        self, mock_sync, _mock_perm, _mock_on_commit, user
+    ):
+        """PATCH should_sync_rooms True→False must NOT fire sync."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=True)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(url, {"should_sync_rooms": False}, format="json")
+
+        assert response.status_code in (status.HTTP_200_OK,), (
+            f"Expected 200, got {response.status_code}: {response.content}"
+        )
+        mock_sync.assert_not_called()
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    @patch("organizations.views.OrganizationManagementPermission.has_permission", return_value=True)
+    @patch("organizations.services.OrganizationService.request_rooms_sync")
+    def test_patch_unrelated_field_does_not_fire_sync(
+        self, mock_sync, _mock_perm, _mock_on_commit, user
+    ):
+        """PATCH on unrelated field (name) while should_sync_rooms stays False — no sync."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(url, {"name": "New Name"}, format="json")
+
+        assert response.status_code in (status.HTTP_200_OK,), (
+            f"Expected 200, got {response.status_code}: {response.content}"
+        )
+        mock_sync.assert_not_called()

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -85,20 +85,28 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
         return Organization.objects.none()
 
     def update(self, request, *args, **kwargs):
-        """Override update to trigger rooms sync when should_sync_rooms flips False→True."""
+        """Override update to trigger rooms sync when should_sync_rooms flips False→True.
+
+        Uses select_for_update to lock the row during snapshot + write, serializing
+        concurrent PATCHes and preventing double-fire of the sync on False→True transition.
+        """
         partial = kwargs.get("partial", False)
-        instance = self.get_object()
 
-        # Snapshot the old value BEFORE the serializer writes to the DB.
-        old_should_sync_rooms = instance.should_sync_rooms
+        # Lock the row during snapshot + write.
+        with transaction.atomic():
+            instance = Organization.objects.select_for_update().get(pk=self.get_object().pk)
+            old_should_sync_rooms = instance.should_sync_rooms
 
-        serializer = self.get_update_serializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
-        self.perform_update(serializer)
+            serializer = self.get_update_serializer(instance, data=request.data, partial=partial)
+            serializer.is_valid(raise_exception=True)
+            self.perform_update(serializer)
 
-        # Detect False→True transition (exactly once — only when the flag just became True).
-        new_should_sync_rooms = serializer.instance.should_sync_rooms
-        if not old_should_sync_rooms and new_should_sync_rooms:
+            # Detect False→True transition (exactly once — only when the flag just became True).
+            new_should_sync_rooms = serializer.instance.should_sync_rooms
+            fire = (not old_should_sync_rooms) and new_should_sync_rooms
+
+        # Register the on_commit callback AFTER the atomic block (so it fires post-commit).
+        if fire:
             org = serializer.instance
             user = request.user
             org_service = self.organization_service
@@ -136,10 +144,8 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
     @extend_schema(
         summary="Trigger a rooms/resources import for the organization",
         responses={
-            202: OpenApiResponse(description="Sync enqueued"),
-            400: OpenApiResponse(
-                description="Bad request (invalid datetime format or service error)"
-            ),
+            202: OrganizationSerializer,
+            400: OpenApiResponse(description="Invalid datetime format"),
             403: OpenApiResponse(description="Not an admin"),
             404: OpenApiResponse(description="Organization not found"),
         },
@@ -188,10 +194,7 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
                 end_time=end_time,
             )
 
-        try:
-            transaction.on_commit(_trigger)
-        except Exception as exc:
-            raise ValidationError({"detail": str(exc)}) from exc
+        transaction.on_commit(_trigger)
 
         serializer = self.get_serializer(org)
         return Response(serializer.data, status=status.HTTP_202_ACCEPTED)

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -53,6 +53,20 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
     serializer_class = OrganizationSerializer
     permission_classes = (IsAuthenticated, OrganizationManagementPermission)
 
+    def get_permissions(self):
+        """
+        Override permissions per action:
+        - update / partial_update: admin-only (IsOrganizationAdmin).  An admin
+          can only reach their own org because get_queryset is scoped by
+          membership, so cross-org attempts return 404.
+        - All other actions keep the class-level defaults (IsAuthenticated +
+          OrganizationManagementPermission), which gates onboarding (create)
+          to membership-less users and locks down retrieve/destroy.
+        """
+        if self.action in ("update", "partial_update"):
+            return [IsAuthenticated(), IsOrganizationAdmin()]
+        return super().get_permissions()
+
     @inject
     def __init__(
         self,

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -1,4 +1,7 @@
+import datetime
 from typing import Annotated
+
+from django.db import transaction
 
 from dependency_injector.wiring import Provide, inject
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -50,12 +53,51 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
     serializer_class = OrganizationSerializer
     permission_classes = (IsAuthenticated, OrganizationManagementPermission)
 
+    @inject
+    def __init__(
+        self,
+        *args,
+        organization_service: Annotated[OrganizationService, Provide["organization_service"]],
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.organization_service = organization_service
+
     def get_queryset(self):
         user = self.request.user
         membership = get_active_organization_membership(user)
         if membership:
             return Organization.objects.filter(id=membership.organization_id)
         return Organization.objects.none()
+
+    def update(self, request, *args, **kwargs):
+        """Override update to trigger rooms sync when should_sync_rooms flips False→True."""
+        partial = kwargs.get("partial", False)
+        instance = self.get_object()
+
+        # Snapshot the old value BEFORE the serializer writes to the DB.
+        old_should_sync_rooms = instance.should_sync_rooms
+
+        serializer = self.get_update_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+
+        # Detect False→True transition (exactly once — only when the flag just became True).
+        new_should_sync_rooms = serializer.instance.should_sync_rooms
+        if not old_should_sync_rooms and new_should_sync_rooms:
+            org = serializer.instance
+            user = request.user
+            org_service = self.organization_service
+
+            def _trigger():
+                org_service.request_rooms_sync(organization=org, requested_by=user)
+
+            transaction.on_commit(_trigger)
+
+        return_serializer = self.get_retrieve_serializer(
+            self.get_return_object(serializer.instance)
+        )
+        return Response(return_serializer.data)
 
     @extend_schema(
         summary="Current organization + role for the authenticated user",
@@ -76,6 +118,69 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
             raise NotFound(detail="No organization membership.")
         serializer = CurrentMembershipSerializer(membership, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Trigger a rooms/resources import for the organization",
+        responses={
+            202: OpenApiResponse(description="Sync enqueued"),
+            400: OpenApiResponse(
+                description="Bad request (invalid datetime format or service error)"
+            ),
+            403: OpenApiResponse(description="Not an admin"),
+            404: OpenApiResponse(description="Organization not found"),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="sync-rooms",
+        permission_classes=[IsOrganizationAdmin],
+    )
+    def sync_rooms(self, request, pk=None):
+        """POST /organizations/{id}/sync-rooms/ — enqueue a calendar resources import.
+
+        Optional body fields:
+        - ``start_time``: ISO 8601 datetime for the import window start.
+        - ``end_time``: ISO 8601 datetime for the import window end.
+
+        Defaults (when omitted): ``start_time=now``, ``end_time=now+365d``.
+        Returns HTTP 202 on success.
+        """
+        org = self.get_object()
+
+        # Parse optional ISO datetime fields from the request body.
+        start_time: datetime.datetime | None = None
+        end_time: datetime.datetime | None = None
+
+        raw_start = request.data.get("start_time")
+        raw_end = request.data.get("end_time")
+
+        try:
+            if raw_start:
+                start_time = datetime.datetime.fromisoformat(raw_start)
+            if raw_end:
+                end_time = datetime.datetime.fromisoformat(raw_end)
+        except (ValueError, TypeError) as exc:
+            raise ValidationError({"detail": f"Invalid datetime format: {exc}"}) from exc
+
+        org_service = self.organization_service
+        user = request.user
+
+        def _trigger():
+            org_service.request_rooms_sync(
+                organization=org,
+                requested_by=user,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
+        try:
+            transaction.on_commit(_trigger)
+        except Exception as exc:
+            raise ValidationError({"detail": str(exc)}) from exc
+
+        serializer = self.get_serializer(org)
+        return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
 
 
 class OrganizationInvitationViewSet(NoUpdateVintaScheduleModelViewSet):

--- a/schema.yml
+++ b/schema.yml
@@ -4866,8 +4866,11 @@ paths:
           description: ''
     put:
       operationId: organizations_update
-      description: Override update to trigger rooms sync when should_sync_rooms flips
-        False→True.
+      description: |-
+        Override update to trigger rooms sync when should_sync_rooms flips False→True.
+
+        Uses select_for_update to lock the row during snapshot + write, serializing
+        concurrent PATCHes and preventing double-fire of the sync on False→True transition.
       parameters:
       - in: path
         name: id
@@ -4978,8 +4981,11 @@ paths:
           description: ''
     put:
       operationId: organizations_formatted_update
-      description: Override update to trigger rooms sync when should_sync_rooms flips
-        False→True.
+      description: |-
+        Override update to trigger rooms sync when should_sync_rooms flips False→True.
+
+        Uses select_for_update to lock the row during snapshot + write, serializing
+        concurrent PATCHes and preventing double-fire of the sync on False→True transition.
       parameters:
       - in: path
         name: format
@@ -5118,9 +5124,13 @@ paths:
       - cookieAuth: []
       responses:
         '202':
-          description: Sync enqueued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+          description: ''
         '400':
-          description: Bad request (invalid datetime format or service error)
+          description: Invalid datetime format
         '403':
           description: Not an admin
         '404':
@@ -5170,9 +5180,13 @@ paths:
       - cookieAuth: []
       responses:
         '202':
-          description: Sync enqueued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+          description: ''
         '400':
-          description: Bad request (invalid datetime format or service error)
+          description: Invalid datetime format
         '403':
           description: Not an admin
         '404':

--- a/schema.yml
+++ b/schema.yml
@@ -4866,7 +4866,8 @@ paths:
           description: ''
     put:
       operationId: organizations_update
-      description: A viewset for managing organizations.
+      description: Override update to trigger rooms sync when should_sync_rooms flips
+        False→True.
       parameters:
       - in: path
         name: id
@@ -4977,7 +4978,8 @@ paths:
           description: ''
     put:
       operationId: organizations_formatted_update
-      description: A viewset for managing organizations.
+      description: Override update to trigger rooms sync when should_sync_rooms flips
+        False→True.
       parameters:
       - in: path
         name: format
@@ -5078,6 +5080,103 @@ paths:
       responses:
         '204':
           description: No response body
+  /organizations/{id}/sync-rooms/:
+    post:
+      operationId: organizations_sync_rooms_create
+      description: |-
+        POST /organizations/{id}/sync-rooms/ — enqueue a calendar resources import.
+
+        Optional body fields:
+        - ``start_time``: ISO 8601 datetime for the import window start.
+        - ``end_time``: ISO 8601 datetime for the import window end.
+
+        Defaults (when omitted): ``start_time=now``, ``end_time=now+365d``.
+        Returns HTTP 202 on success.
+      summary: Trigger a rooms/resources import for the organization
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organizations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Organization'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Organization'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Organization'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '202':
+          description: Sync enqueued
+        '400':
+          description: Bad request (invalid datetime format or service error)
+        '403':
+          description: Not an admin
+        '404':
+          description: Organization not found
+  /organizations/{id}/sync-rooms{format}:
+    post:
+      operationId: organizations_sync_rooms_formatted_create
+      description: |-
+        POST /organizations/{id}/sync-rooms/ — enqueue a calendar resources import.
+
+        Optional body fields:
+        - ``start_time``: ISO 8601 datetime for the import window start.
+        - ``end_time``: ISO 8601 datetime for the import window end.
+
+        Defaults (when omitted): ``start_time=now``, ``end_time=now+365d``.
+        Returns HTTP 202 on success.
+      summary: Trigger a rooms/resources import for the organization
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - organizations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Organization'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Organization'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Organization'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '202':
+          description: Sync enqueued
+        '400':
+          description: Bad request (invalid datetime format or service error)
+        '403':
+          description: Not an admin
+        '404':
+          description: Organization not found
   /organizations/current/:
     get:
       operationId: organizations_current_retrieve


### PR DESCRIPTION
## Summary
Phase 7 of the **REST API Frontend Gaps** plan. Delivers the admin "sync rooms" capability and — necessarily — makes org configuration actually editable by admins:
- `POST /organizations/{id}/sync-rooms/` (admin) — enqueue an organization calendar-resources (rooms) import. Optional `start_time`/`end_time` (ISO; default now..+365d).
- `should_sync_rooms` False→True transition on org update auto-triggers the import exactly once.
- `OrganizationService.request_rooms_sync(...)` — shared method; `create_organization` now delegates to it (DRY).

## Why the permission change was required
The org `update`/`partial_update` endpoint was previously **unreachable for everyone** (`OrganizationManagementPermission.has_permission` only admits membership-less users, while `has_object_permission` requires a membership — a contradiction). That made both the should_sync_rooms transition AND the original requirement *"an admin must be able to configure their org to sync rooms"* impossible. This phase adds a `get_permissions()` override gating `update`/`partial_update` with `IsOrganizationAdmin` (create/retrieve/destroy unchanged), so admins can configure their own org. Members still get 403; cross-org 404.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 7 + API Design 4.3 + the "configure org to sync rooms" use-case.

## Review history
Two review passes. First surfaced that the transition lived on an unreachable endpoint and its tests only "passed" by patching the permission away — fixed by opening admin update and rewriting the tests with real admin clients. Second pass hardened the update path: removed a dead `try/except` around `on_commit` (it can't catch async service errors), corrected the OpenAPI for `sync_rooms`, and added a `select_for_update` lock so concurrent False→True PATCHes can't double-fire the import.

## Out-of-scope note
The underlying `request_organization_calendar_resources_import` enqueues `.delay` without `on_commit` internally (pre-existing). The new reachable paths (sync_rooms action + transition) defer via `on_commit` at the view layer; `create_organization`'s timing is unchanged.

## Test plan
- `uv run pytest organizations/tests/ -n auto`
- Asserts: admin sync-rooms 202 (explicit + default window); non-admin 403; cross-org 404; anon 401; bad datetime 400. Transition: False→True fires once; already-True / True→False / unchanged fire zero; non-admin 403 fires zero. Admin can PATCH should_sync_rooms and it persists. create_organization(should_sync_rooms=True) still triggers.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1320 passed).