### PR TITLE
feat(calendar): add admin event transfer action

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -72,11 +72,16 @@
 - **Key**: `OrganizationService.request_rooms_sync` (DRY, used by create_organization too); `POST /organizations/{id}/sync-rooms/` admin action; should_sync_rooms False→True transition fires once (locked). **IMPORTANT reusable infra**: `OrganizationViewSet.get_permissions()` now gates update/partial_update with IsOrganizationAdmin — admins can configure their own org (previously update was unreachable for all). Outer gate green (1320), mypy 108.
 - **Reusable note**: org update is admin-only now; org-config edits go through PATCH /organizations/{id}/.
 
+### Phase 8 — Transfer event between calendars (admin) ✅
+- **Status**: done, reviewed (3 layers; Layer 3 → added same-calendar no-op test), pushed, PR opened.
+- **Model**: sonnet; fixer: haiku. **Branch**: phase-8 (base phase-7). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/50
+- **Key**: `POST /calendar-events/{id}/transfer/` admin-only; authenticates with SOURCE calendar owner's account (transfer reads source event from provider); target resolved via filter_by_organization; same-calendar no-op → 400. Outer gate green (1329), mypy 108.
+
 ## Current Phase
-Phase 8 — Transfer event between calendars (admin) (next). Service: `CalendarService.transfer_event(event, new_calendar) -> CalendarEvent` (~2115). Admin `@action transfer` on CalendarEventViewSet, body target_calendar_id (in-org). Provider-sync side effects → Tier 3.
+Phase 9 — Calendar soft-disable (next). Add `Calendar.is_active` (BooleanField default True, db_default True, db_index) + migration (add-migration skill; non-partitioned table). CalendarViewSet.get_queryset filters is_active=True unless `?include_inactive=true`; override destroy/perform_destroy → set is_active=False (no row delete). Tier 3. CAUTION: CalendarViewSet has many existing tests; default-active keeps reads unchanged, but DELETE behavior changes (existing hard-delete tests must be updated to expect soft-disable).
 
 ## Remaining Phases
-9 (calendar soft-disable), 10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+10 (bundle update), 11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -111,6 +111,10 @@ class CalendarSyncRequestSerializer(serializers.Serializer):
     should_update_events = serializers.BooleanField(required=False, default=False)
 
 
+class CalendarImportRequestSerializer(serializers.Serializer):
+    sync_after_import = serializers.BooleanField(required=False, default=True)
+
+
 class CalendarSerializer(VirtualModelSerializer):
     class Meta:
         model = Calendar
@@ -1124,6 +1128,21 @@ class CalendarEventSerializer(VirtualModelSerializer):
         Returns True if this event is a recurring event.
         """
         return obj.is_recurring
+
+
+class CalendarEventTransferSerializer(serializers.Serializer):
+    target_calendar_id = serializers.IntegerField()
+
+    def validate_target_calendar_id(self, value):
+        event = self.context["event"]
+        if value == event.calendar_fk_id:
+            raise serializers.ValidationError("Event is already on the target calendar.")
+        try:
+            return Calendar.objects.filter_by_organization(event.organization_id).get(id=value)
+        except Calendar.DoesNotExist as exc:
+            raise serializers.ValidationError(
+                "target_calendar_id invalid or not in your organization."
+            ) from exc
 
 
 class SerializedParentBlockedTimeTypedDict(TypedDict):

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -605,6 +605,40 @@ class TestCalendarEventViewSet:
         assert account_arg == owner_social_account
         assert account_arg.user == source_owner
 
+    def test_transfer_event_same_calendar_no_op(self, organization, calendar, calendar_event):
+        """Admin tries to transfer event to its own calendar → 400, no service call."""
+        from rest_framework.test import APIClient
+
+        from di_core.containers import container
+
+        # Admin user
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        # Mock calendar service
+        mock_calendar_service = Mock()
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+
+        with container.calendar_service.override(mock_calendar_service):
+            response = client.post(
+                url, data={"target_calendar_id": calendar_event.calendar_fk_id}, format="json"
+            )
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert response.data["detail"] == "Event is already on the target calendar."
+
+        # Verify service was NOT called (guard returned before authentication)
+        mock_calendar_service.authenticate.assert_not_called()
+        mock_calendar_service.transfer_event.assert_not_called()
+
     def test_transfer_event_non_admin_forbidden(self, organization, calendar, calendar_event):
         """Non-admin active member receives 403."""
         from rest_framework.test import APIClient

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -633,7 +633,7 @@ class TestCalendarEventViewSet:
             )
 
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
-        assert response.data["detail"] == "Event is already on the target calendar."
+        assert response.data["target_calendar_id"][0] == "Event is already on the target calendar."
 
         # Verify service was NOT called (guard returned before authentication)
         mock_calendar_service.authenticate.assert_not_called()
@@ -742,7 +742,7 @@ class TestCalendarEventViewSet:
 
         response = client.post(url, data={"target_calendar_id": 999999}, format="json")
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
-        assert "invalid or not in your organization" in response.data["detail"]
+        assert "invalid or not in your organization" in response.data["target_calendar_id"][0]
 
     def test_transfer_event_target_calendar_not_in_org(
         self, organization, calendar, calendar_event
@@ -776,7 +776,7 @@ class TestCalendarEventViewSet:
 
         response = client.post(url, data={"target_calendar_id": other_calendar.id}, format="json")
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
-        assert "invalid or not in your organization" in response.data["detail"]
+        assert "invalid or not in your organization" in response.data["target_calendar_id"][0]
 
     def test_transfer_event_source_owner_no_linked_account(
         self, organization, calendar, calendar_event

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -527,6 +527,263 @@ class TestCalendarEventViewSet:
 
         assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
 
+    # --- Transfer action tests ---
+
+    def test_transfer_event_success(self, organization, calendar, calendar_event):
+        """Admin transfers an in-org event to an in-org target calendar."""
+        from rest_framework.test import APIClient
+
+        from di_core.containers import container
+
+        # Admin user
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        # Source calendar owner
+        source_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=source_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        CalendarIntegrationTestFactory.create_calendar_ownership(source_owner, calendar)
+
+        owner_social_account = baker.make(
+            SocialAccount,
+            user=source_owner,
+            provider=calendar.provider,
+        )
+        baker.make(
+            SocialToken,
+            account=owner_social_account,
+            token="fake_access_token",
+            token_secret="fake_refresh_token",
+            expires_at=datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1),
+        )
+
+        # Target calendar in the same org
+        target_calendar = CalendarIntegrationTestFactory.create_calendar(organization=organization)
+
+        # Mock return value — a new event on the target calendar
+        transferred_event = CalendarIntegrationTestFactory.create_calendar_event(
+            calendar=target_calendar,
+            title=calendar_event.title,
+        )
+
+        mock_calendar_service = Mock()
+        mock_calendar_service.authenticate.return_value = None
+        mock_calendar_service.transfer_event.return_value = transferred_event
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+
+        with container.calendar_service.override(mock_calendar_service):
+            response = client.post(
+                url, data={"target_calendar_id": target_calendar.id}, format="json"
+            )
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.data["id"] == transferred_event.id
+
+        # Verify transfer_event called with correct args
+        mock_calendar_service.transfer_event.assert_called_once_with(
+            event=calendar_event,
+            new_calendar=target_calendar,
+        )
+
+        # Verify service authenticated with SOURCE OWNER's account
+        authenticate_call_args = mock_calendar_service.authenticate.call_args
+        assert authenticate_call_args is not None
+        account_arg = authenticate_call_args[1]["account"]
+        assert account_arg == owner_social_account
+        assert account_arg.user == source_owner
+
+    def test_transfer_event_non_admin_forbidden(self, organization, calendar, calendar_event):
+        """Non-admin active member receives 403."""
+        from rest_framework.test import APIClient
+
+        member_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=member_user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+
+        target_calendar = CalendarIntegrationTestFactory.create_calendar(organization=organization)
+
+        client = APIClient()
+        client.force_authenticate(user=member_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+
+        response = client.post(url, data={"target_calendar_id": target_calendar.id}, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_transfer_event_cross_org_event_not_found(self, organization):
+        """Event from a different org yields 404 (org-scoped queryset)."""
+        from rest_framework.test import APIClient
+
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        other_org = CalendarIntegrationTestFactory.create_organization(name="Other Org")
+        other_calendar = CalendarIntegrationTestFactory.create_calendar(organization=other_org)
+        other_event = CalendarIntegrationTestFactory.create_calendar_event(calendar=other_calendar)
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": other_event.id})
+
+        response = client.post(url, data={"target_calendar_id": 1}, format="json")
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_transfer_event_missing_target_calendar_id(
+        self, organization, calendar, calendar_event
+    ):
+        """Missing target_calendar_id body field yields 400."""
+        from rest_framework.test import APIClient
+
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        source_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=source_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        CalendarIntegrationTestFactory.create_calendar_ownership(source_owner, calendar)
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+
+        response = client.post(url, data={}, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_transfer_event_invalid_target_calendar_id(
+        self, organization, calendar, calendar_event
+    ):
+        """Non-existent target_calendar_id yields 400."""
+        from rest_framework.test import APIClient
+
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        source_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=source_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        CalendarIntegrationTestFactory.create_calendar_ownership(source_owner, calendar)
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+
+        response = client.post(url, data={"target_calendar_id": 999999}, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert "invalid or not in your organization" in response.data["detail"]
+
+    def test_transfer_event_target_calendar_not_in_org(
+        self, organization, calendar, calendar_event
+    ):
+        """target_calendar_id from a different org yields 400."""
+        from rest_framework.test import APIClient
+
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        source_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=source_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        CalendarIntegrationTestFactory.create_calendar_ownership(source_owner, calendar)
+
+        other_org = CalendarIntegrationTestFactory.create_organization(name="Other Org")
+        other_calendar = CalendarIntegrationTestFactory.create_calendar(organization=other_org)
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+
+        response = client.post(url, data={"target_calendar_id": other_calendar.id}, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert "invalid or not in your organization" in response.data["detail"]
+
+    def test_transfer_event_source_owner_no_linked_account(
+        self, organization, calendar, calendar_event
+    ):
+        """Source calendar owner has no linked social account → 400."""
+        from rest_framework.test import APIClient
+
+        admin_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin_user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+
+        source_owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=source_owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        CalendarIntegrationTestFactory.create_calendar_ownership(source_owner, calendar)
+        # Intentionally do NOT create a SocialAccount for source_owner
+
+        target_calendar = CalendarIntegrationTestFactory.create_calendar(organization=organization)
+
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+
+        response = client.post(url, data={"target_calendar_id": target_calendar.id}, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert "no linked" in response.data["detail"].lower()
+
+    def test_transfer_event_unauthenticated(self, anonymous_client, calendar_event):
+        """Unauthenticated request yields 401."""
+        url = reverse("api:CalendarEvents-transfer", kwargs={"pk": calendar_event.id})
+        response = anonymous_client.post(url, data={"target_calendar_id": 1}, format="json")
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
 
 @pytest.mark.django_db
 class TestRecurringCalendarEventViewSet:

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -661,6 +661,116 @@ class CalendarEventViewSet(VintaScheduleModelViewSet):
         except (ValueError, CalendarIntegrationError) as e:
             raise ValidationError({"non_field_errors": [str(e)]}) from e
 
+    @extend_schema(
+        summary="Transfer event to another calendar (admin)",
+        description=(
+            "Move an event from its current calendar to a target calendar within the same "
+            "organization. The service authenticates with the SOURCE calendar owner's credentials "
+            "to read and delete the event from the provider. Admin only."
+        ),
+        request={"type": "object", "properties": {"target_calendar_id": {"type": "integer"}}},
+        responses={200: CalendarEventSerializer},
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="transfer",
+        url_name="transfer",
+        permission_classes=[IsOrganizationAdmin],
+    )
+    @inject
+    def transfer(
+        self,
+        request,
+        pk: str | None = None,
+        calendar_service: Annotated[CalendarService, Provide["calendar_service"]] = None,  # type: ignore
+    ) -> Response:
+        """Transfer an event to a different calendar (admin-only)."""
+        event = self.get_object()  # org-scoped → cross-org yields 404; non-admin → 403
+
+        # --- Parse and validate body ---
+        target_calendar_id = request.data.get("target_calendar_id")
+        if target_calendar_id is None:
+            return Response(
+                {"detail": "target_calendar_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Reject no-op transfers
+        if str(target_calendar_id) == str(event.calendar_fk_id):
+            return Response(
+                {"detail": "Event is already on the target calendar."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Resolve the target calendar within the event's organization
+        try:
+            target_calendar = Calendar.objects.filter_by_organization(event.organization_id).get(
+                id=target_calendar_id
+            )
+        except Calendar.DoesNotExist:
+            return Response(
+                {"detail": "target_calendar_id invalid or not in your organization."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # --- Authenticate with the SOURCE calendar owner's credentials ---
+        source_calendar = event.calendar
+        ownership = (
+            CalendarOwnership.objects.filter(
+                calendar=source_calendar,
+                organization_id=source_calendar.organization_id,
+            )
+            .order_by("-is_default", "id")
+            .first()
+        )
+
+        if not ownership:
+            return Response(
+                {"detail": "Source calendar has no owner; cannot read from provider."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        source_owner = ownership.user
+        owner_social_account = SocialAccount.objects.filter(
+            user=source_owner, provider=source_calendar.provider
+        ).first()
+
+        if not owner_social_account:
+            return Response(
+                {
+                    "detail": (
+                        f"Source calendar owner has no linked {source_calendar.provider} account; "
+                        "cannot transfer event."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Use admin's organization for service context
+        membership = get_active_organization_membership(request.user)
+        if not membership:
+            return Response(
+                {"detail": "User is not an active member of any organization."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        try:
+            calendar_service.authenticate(
+                account=owner_social_account,
+                organization=membership.organization,
+            )
+            new_event = calendar_service.transfer_event(
+                event=event,
+                new_calendar=target_calendar,
+            )
+            return Response(
+                CalendarEventSerializer(new_event, context=self.get_serializer_context()).data,
+                status=status.HTTP_200_OK,
+            )
+        except (ValueError, CalendarIntegrationError, NotImplementedError) as e:
+            raise ValidationError({"non_field_errors": [str(e)]}) from e
+
 
 class BlockedTimeViewSet(VintaScheduleModelViewSet):
     """

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -49,6 +49,7 @@ from calendar_integration.serializers import (
     BulkBlockedTimeSerializer,
     CalendarBundleCreateSerializer,
     CalendarEventSerializer,
+    CalendarEventTransferSerializer,
     CalendarGroupAvailabilityQuerySerializer,
     CalendarGroupEventCreateSerializer,
     CalendarGroupRangeAvailabilitySerializer,
@@ -668,7 +669,7 @@ class CalendarEventViewSet(VintaScheduleModelViewSet):
             "organization. The service authenticates with the SOURCE calendar owner's credentials "
             "to read and delete the event from the provider. Admin only."
         ),
-        request={"type": "object", "properties": {"target_calendar_id": {"type": "integer"}}},
+        request=CalendarEventTransferSerializer,
         responses={200: CalendarEventSerializer},
     )
     @action(
@@ -688,31 +689,11 @@ class CalendarEventViewSet(VintaScheduleModelViewSet):
         """Transfer an event to a different calendar (admin-only)."""
         event = self.get_object()  # org-scoped → cross-org yields 404; non-admin → 403
 
-        # --- Parse and validate body ---
-        target_calendar_id = request.data.get("target_calendar_id")
-        if target_calendar_id is None:
-            return Response(
-                {"detail": "target_calendar_id is required."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Reject no-op transfers
-        if str(target_calendar_id) == str(event.calendar_fk_id):
-            return Response(
-                {"detail": "Event is already on the target calendar."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Resolve the target calendar within the event's organization
-        try:
-            target_calendar = Calendar.objects.filter_by_organization(event.organization_id).get(
-                id=target_calendar_id
-            )
-        except Calendar.DoesNotExist:
-            return Response(
-                {"detail": "target_calendar_id invalid or not in your organization."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        input_serializer = CalendarEventTransferSerializer(
+            data=request.data, context={**self.get_serializer_context(), "event": event}
+        )
+        input_serializer.is_valid(raise_exception=True)
+        target_calendar = input_serializer.validated_data["target_calendar_id"]
 
         # --- Authenticate with the SOURCE calendar owner's credentials ---
         source_calendar = event.calendar

--- a/schema.yml
+++ b/schema.yml
@@ -2624,15 +2624,16 @@ paths:
       - calendar-events
       requestBody:
         content:
-          type:
+          application/json:
             schema:
-              type: object
-              additionalProperties: {}
-              description: Unspecified request body
-          properties:
+              $ref: '#/components/schemas/CalendarEventTransfer'
+          application/x-www-form-urlencoded:
             schema:
-              target_calendar_id:
-                type: integer
+              $ref: '#/components/schemas/CalendarEventTransfer'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarEventTransfer'
+        required: true
       security:
       - jwtAuth: []
       - cookieAuth: []
@@ -2668,15 +2669,16 @@ paths:
       - calendar-events
       requestBody:
         content:
-          type:
+          application/json:
             schema:
-              type: object
-              additionalProperties: {}
-              description: Unspecified request body
-          properties:
+              $ref: '#/components/schemas/CalendarEventTransfer'
+          application/x-www-form-urlencoded:
             schema:
-              target_calendar_id:
-                type: integer
+              $ref: '#/components/schemas/CalendarEventTransfer'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarEventTransfer'
+        required: true
       security:
       - jwtAuth: []
       - cookieAuth: []
@@ -6977,6 +6979,13 @@ components:
       - start_time
       - timezone
       - title
+    CalendarEventTransfer:
+      type: object
+      properties:
+        target_calendar_id:
+          type: integer
+      required:
+      - target_calendar_id
     CalendarGroup:
       type: object
       properties:

--- a/schema.yml
+++ b/schema.yml
@@ -2606,6 +2606,87 @@ paths:
           description: ''
         '204':
           description: No response body
+  /calendar-events/{id}/transfer/:
+    post:
+      operationId: calendar_events_transfer_create
+      description: Move an event from its current calendar to a target calendar within
+        the same organization. The service authenticates with the SOURCE calendar
+        owner's credentials to read and delete the event from the provider. Admin
+        only.
+      summary: Transfer event to another calendar (admin)
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-events
+      requestBody:
+        content:
+          type:
+            schema:
+              type: object
+              additionalProperties: {}
+              description: Unspecified request body
+          properties:
+            schema:
+              target_calendar_id:
+                type: integer
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+  /calendar-events/{id}/transfer{format}:
+    post:
+      operationId: calendar_events_transfer_formatted_create
+      description: Move an event from its current calendar to a target calendar within
+        the same organization. The service authenticates with the SOURCE calendar
+        owner's credentials to read and delete the event from the provider. Admin
+        only.
+      summary: Transfer event to another calendar (admin)
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar-events
+      requestBody:
+        content:
+          type:
+            schema:
+              type: object
+              additionalProperties: {}
+              description: Unspecified request body
+          properties:
+            schema:
+              target_calendar_id:
+                type: integer
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
   /calendar-groups/:
     get:
       operationId: calendar_groups_list


### PR DESCRIPTION
## Summary
Phase 8 of the **REST API Frontend Gaps** plan. Adds `POST /calendar-events/{id}/transfer/` (admin-only): moves an event from one calendar to another within the org, via `CalendarService.transfer_event`. Returns the new event (200).

## Behavior
- Admin-only (`IsOrganizationAdmin`); event org-scoped (cross-org → 404); non-admin → 403.
- `target_calendar_id` required, must resolve within the event's organization (else 400); same-calendar transfer is a 400 no-op.
- Authenticates with the **source** calendar owner's account (transfer reads the source event from its provider) — not the admin's. No owner / no linked account → 400.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 8 + API Design 4.4.

## Review history
Layer-3 review: no blockers. Added the missing test for the same-calendar no-op guard. Noted (not enforced) that the target isn't restricted to PERSONAL calendars — left open since an admin may legitimately transfer to a virtual/bundle calendar.

## Test plan
- `uv run pytest calendar_integration/tests/test_views.py -k transfer -vs`
- Asserts: admin transfer success (transfer_event called with event+target, authenticated with the SOURCE owner's account); non-admin 403; cross-org event 404; missing/invalid/cross-org target 400; same-calendar no-op 400 (service not called); no source owner/account 400; anon 401.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1329 passed).