### PR TITLE
feat(calendar): add bundle update action

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -83,11 +83,16 @@
 - **Key**: `Calendar.is_active` (migration 0011, db_default True). get_queryset hides inactive unless `?include_inactive=true` (uniform across actions). DELETE → soft-disable (204, idempotent). is_active read-only in serializer. Outer gate green (1338), mypy 108.
 - **FOLLOW-UP for Phase 10/11**: serializer querysets (bundle-create, resource-allocation) + public GraphQL calendars query don't filter is_active → disabled calendars still selectable/listed there. Consider when touching bundles.
 
+### Phase 10 — Update calendar bundle ✅
+- **Status**: done, reviewed (3 layers; Layer 3 → fixed disabled-existing-child trap via union queryset), pushed, PR opened.
+- **Model**: sonnet; fixer: haiku. **Branch**: phase-10 (base phase-9). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/52
+- **Key**: `PATCH /calendar/{id}/bundle/` admin-only; `CalendarService.update_bundle_calendar` atomic reconciliation (add/remove children, exactly-one primary, validates bundle/primary/cross-org/no-nesting); serializer child queryset = active OR existing-children (keeps disabled existing, bars new disabled). Outer gate green (1349), mypy 108.
+
 ## Current Phase
-Phase 10 — Update calendar bundle (next). `PATCH /calendar/{id}/bundle/` reconcile ChildrenCalendarRelationship (add/remove children, set is_primary) for a BUNDLE calendar. New CalendarBundleUpdateSerializer (child_calendars, primary_calendar). Existing create is POST /calendar/bundle/ (CalendarService.create_bundle_calendar). Tier 3.
+Phase 11 — Disable calendar bundle (next). Extends Phase 9 destroy. PER RESOLVED OPEN QUESTION #3: LEAVE bundle events + representations (CalendarEvent/BlockedTime via bundle_primary_event) + child calendars intact; only hide the bundle calendar. ALSO gate destroy by object type: BUNDLE → org admin only; personal calendar → owner (CalendarOwnership) or admin (Phase 9 destroy was un-gated — any org member could disable any calendar; tighten here). Tier 3.
 
 ## Remaining Phases
-11 (bundle disable), 12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -23,6 +23,7 @@ from calendar_integration.models import (
     CalendarGroupSlotMembership,
     CalendarOwnership,
     CalendarSync,
+    ChildrenCalendarRelationship,
     EventAttendance,
     EventExternalAttendance,
     EventRecurrenceException,
@@ -261,19 +262,39 @@ class CalendarBundleUpdateSerializer(serializers.Serializer):
         active_membership = (
             get_active_organization_membership(user) if user and user.is_authenticated else None
         )
-        active_org_qs = (
-            Calendar.objects.filter_by_organization(
-                organization_id=active_membership.organization_id
-            ).filter(is_active=True)
-            if active_membership
-            else Calendar.original_manager.none()
-        )
+
+        # Build queryset: active calendars + existing children (even if disabled)
+        org_id = active_membership.organization_id if active_membership else None
+
+        if org_id:
+            from django.db.models import Q
+
+            # Get the target bundle from context (passed from the view)
+            bundle = self.context.get("bundle") if self.context else None
+
+            # Fetch existing child IDs
+            existing_child_ids = []
+            if bundle:
+                existing_child_ids = list(
+                    ChildrenCalendarRelationship.objects.filter(
+                        bundle_calendar=bundle,
+                        organization_id=org_id,
+                    ).values_list("child_calendar_fk_id", flat=True)
+                )
+
+            # Build the queryset: (active OR in existing_child_ids) AND org-scoped
+            qs = Calendar.objects.filter_by_organization(organization_id=org_id).filter(
+                Q(is_active=True) | Q(id__in=existing_child_ids)
+            )
+        else:
+            qs = Calendar.original_manager.none()
+
         self.fields["bundle_calendars"] = serializers.PrimaryKeyRelatedField(
             many=True,
-            queryset=active_org_qs,
+            queryset=qs,
         )
         self.fields["primary_calendar"] = serializers.PrimaryKeyRelatedField(
-            queryset=active_org_qs,
+            queryset=qs,
             allow_null=True,
             required=False,
         )

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -11,7 +11,11 @@ from dependency_injector.wiring import Provide, inject
 from rest_framework import serializers
 
 from calendar_integration.constants import CalendarProvider, CalendarType
-from calendar_integration.exceptions import CalendarGroupError, CalendarServiceNotInjectedError
+from calendar_integration.exceptions import (
+    CalendarGroupError,
+    CalendarIntegrationError,
+    CalendarServiceNotInjectedError,
+)
 from calendar_integration.models import (
     AvailableTime,
     BlockedTime,
@@ -240,7 +244,7 @@ class CalendarBundleCreateSerializer(VirtualModelSerializer):
             raise serializers.ValidationError(
                 {"non_field_errors": ["User has no organization membership."]}
             )
-        self.calendar_service.initialize_without_provider(membership.organization)
+        self.calendar_service.initialize_without_provider(organization=membership.organization)
 
         return self.calendar_service.create_bundle_calendar(
             name=validated_data.get("name"),
@@ -253,7 +257,14 @@ class CalendarBundleCreateSerializer(VirtualModelSerializer):
 class CalendarBundleUpdateSerializer(serializers.Serializer):
     """Serializer for updating a bundle calendar's child calendars and primary calendar."""
 
-    def __init__(self, *args, **kwargs):
+    @inject
+    def __init__(
+        self,
+        *args,
+        calendar_service: Annotated["CalendarService | None", Provide["calendar_service"]] = None,
+        **kwargs,
+    ):
+        self.calendar_service = calendar_service
         super().__init__(*args, **kwargs)
         user = (
             self.context["request"].user if self.context and self.context.get("request") else None
@@ -269,8 +280,8 @@ class CalendarBundleUpdateSerializer(serializers.Serializer):
         if org_id:
             from django.db.models import Q
 
-            # Get the target bundle from context (passed from the view)
-            bundle = self.context.get("bundle") if self.context else None
+            # The bundle being updated is passed as `instance`.
+            bundle = self.instance
 
             # Fetch existing child IDs
             existing_child_ids = []
@@ -306,6 +317,9 @@ class CalendarBundleUpdateSerializer(serializers.Serializer):
         return bundle_calendars
 
     def validate(self, attrs: dict) -> dict:
+        if self.instance and self.instance.calendar_type != CalendarType.BUNDLE:
+            raise serializers.ValidationError("Calendar is not a bundle.")
+
         primary_calendar: Calendar | None = attrs.get("primary_calendar")
         bundle_calendars: list[Calendar] = attrs.get("bundle_calendars", [])
 
@@ -315,6 +329,26 @@ class CalendarBundleUpdateSerializer(serializers.Serializer):
             )
 
         return attrs
+
+    def update(self, instance: Calendar, validated_data: dict) -> Calendar:
+        user = self.context["request"].user
+        membership = get_active_organization_membership(user)
+        if not membership:
+            raise serializers.ValidationError(
+                {"non_field_errors": ["User has no organization membership."]}
+            )
+
+        self.calendar_service.initialize_without_provider(organization=membership.organization)
+        try:
+            self.calendar_service.update_bundle_calendar(
+                bundle_calendar=instance,
+                child_calendars=validated_data["bundle_calendars"],
+                primary_calendar=validated_data.get("primary_calendar"),
+            )
+        except (ValueError, CalendarIntegrationError) as e:
+            raise serializers.ValidationError(str(e)) from e
+
+        return instance
 
 
 class EventRecurringExceptionSerializer(serializers.Serializer):

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -249,6 +249,53 @@ class CalendarBundleCreateSerializer(VirtualModelSerializer):
         )
 
 
+class CalendarBundleUpdateSerializer(serializers.Serializer):
+    """Serializer for updating a bundle calendar's child calendars and primary calendar."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = (
+            self.context["request"].user if self.context and self.context.get("request") else None
+        )
+
+        active_membership = (
+            get_active_organization_membership(user) if user and user.is_authenticated else None
+        )
+        active_org_qs = (
+            Calendar.objects.filter_by_organization(
+                organization_id=active_membership.organization_id
+            ).filter(is_active=True)
+            if active_membership
+            else Calendar.original_manager.none()
+        )
+        self.fields["bundle_calendars"] = serializers.PrimaryKeyRelatedField(
+            many=True,
+            queryset=active_org_qs,
+        )
+        self.fields["primary_calendar"] = serializers.PrimaryKeyRelatedField(
+            queryset=active_org_qs,
+            allow_null=True,
+            required=False,
+        )
+
+    def validate_bundle_calendars(self, bundle_calendars):
+        """Require at least two children, mirroring create."""
+        if len(bundle_calendars) < 2:
+            raise serializers.ValidationError("At least two calendars are required in a bundle.")
+        return bundle_calendars
+
+    def validate(self, attrs: dict) -> dict:
+        primary_calendar: Calendar | None = attrs.get("primary_calendar")
+        bundle_calendars: list[Calendar] = attrs.get("bundle_calendars", [])
+
+        if primary_calendar and primary_calendar not in bundle_calendars:
+            raise serializers.ValidationError(
+                "primary_calendar must be one of the bundle_calendars."
+            )
+
+        return attrs
+
+
 class EventRecurringExceptionSerializer(serializers.Serializer):
     """Serializer for creating recurring event exceptions."""
 

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -736,6 +736,91 @@ class CalendarService(BaseCalendarService):
 
         return bundle_calendar
 
+    @transaction.atomic()
+    def update_bundle_calendar(
+        self,
+        bundle_calendar: Calendar,
+        child_calendars: Iterable[Calendar],
+        primary_calendar: Calendar | None = None,
+    ) -> Calendar:
+        """
+        Reconcile the children and primary designation for an existing bundle calendar.
+
+        Adds `ChildrenCalendarRelationship` rows for newly-added children, removes rows
+        for dropped children, and updates `is_primary` so that exactly one row is primary
+        when `primary_calendar` is provided.
+
+        :param bundle_calendar: The bundle Calendar instance to update.
+        :param child_calendars: Full desired set of child Calendar instances.
+        :param primary_calendar: The child to designate as primary; must be in child_calendars.
+        :return: The (unchanged) bundle_calendar instance after reconciliation.
+        :raises ValueError: If bundle_calendar is not a BUNDLE type, children are cross-org,
+                            or primary_calendar is not in child_calendars.
+        """
+        if not is_initialized_or_authenticated_calendar_service(self):
+            raise
+
+        if bundle_calendar.calendar_type != CalendarType.BUNDLE:
+            raise ValueError("Calendar is not a bundle.")
+
+        child_calendars_list = list(child_calendars)
+
+        if primary_calendar and primary_calendar not in child_calendars_list:
+            raise ValueError("Primary calendar must be one of the child calendars.")
+
+        for calendar in child_calendars_list:
+            if calendar.organization_id != self.organization.id:
+                raise ValueError(
+                    "All child calendars must belong to the same organization as the bundle."
+                )
+            if calendar.calendar_type == CalendarType.BUNDLE:
+                raise ValueError(
+                    "Child calendars of a bundle must not be bundle calendars themselves."
+                )
+
+        desired_ids = {cal.id for cal in child_calendars_list}
+
+        existing_relationships = list(
+            ChildrenCalendarRelationship.objects.filter(
+                bundle_calendar=bundle_calendar,
+                organization=self.organization,
+            )
+        )
+        existing_ids = {rel.child_calendar_fk_id for rel in existing_relationships}
+
+        # Remove dropped children
+        for rel in existing_relationships:
+            if rel.child_calendar_fk_id not in desired_ids:
+                rel.delete()
+
+        # Add new children
+        for calendar in child_calendars_list:
+            if calendar.id not in existing_ids:
+                is_primary = primary_calendar is not None and calendar.id == primary_calendar.id
+                ChildrenCalendarRelationship.objects.create(
+                    bundle_calendar=bundle_calendar,
+                    child_calendar=calendar,
+                    organization=self.organization,
+                    is_primary=is_primary,
+                )
+
+        # Reconcile is_primary on remaining + newly-added relationships
+        if primary_calendar is not None:
+            ChildrenCalendarRelationship.objects.filter(
+                bundle_calendar=bundle_calendar,
+                organization=self.organization,
+            ).exclude(
+                child_calendar_fk_id=primary_calendar.id,
+            ).update(is_primary=False)
+
+            ChildrenCalendarRelationship.objects.filter(
+                bundle_calendar=bundle_calendar,
+                organization=self.organization,
+                child_calendar_fk_id=primary_calendar.id,
+            ).update(is_primary=True)
+
+        return bundle_calendar
+
     def _create_bundle_event(
         self, bundle_calendar: Calendar, event_data: "CalendarEventInputData"
     ) -> CalendarEvent:

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -4692,3 +4692,80 @@ class TestCalendarBundleUpdateAction:
         response = anonymous_client.patch(url, data, format="json")
 
         assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+    def test_bundle_update_keeps_existing_disabled_child(self, organization):
+        """
+        Bundle has child A (active) + child B; disable B (is_active=False) directly;
+        admin PATCHes the bundle resending [A, B] (+ valid primary among them) → 200,
+        B remains a child, reconciliation succeeds.
+        Proves the trap is gone.
+        """
+        bundle, child_active, child_disabled = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        # Disable child_disabled
+        child_disabled.is_active = False
+        child_disabled.save(update_fields=["is_active"])
+
+        # Admin PATCHes with both children
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {
+            "bundle_calendars": [child_active.id, child_disabled.id],
+            "primary_calendar": child_active.id,
+        }
+
+        response = admin_client.patch(url, data, format="json")
+
+        # Should succeed (200)
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.data["id"] == bundle.id
+
+        # child_disabled should still be a child
+        assert ChildrenCalendarRelationship.objects.filter(
+            bundle_calendar=bundle,
+            child_calendar_fk_id=child_disabled.id,
+            organization=organization,
+        ).exists()
+
+        # child_active should still be a child and marked primary
+        assert ChildrenCalendarRelationship.objects.filter(
+            bundle_calendar=bundle,
+            child_calendar_fk_id=child_active.id,
+            organization=organization,
+            is_primary=True,
+        ).exists()
+
+    def test_bundle_update_rejects_new_disabled_child(self, organization):
+        """
+        A disabled calendar that is NOT currently a child cannot be ADDED → 400.
+        Proves new-disabled still barred.
+        """
+        bundle, child_active, _child_other = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        # Create a disabled calendar that is NOT a child
+        disabled_new = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="Disabled New",
+            calendar_type=CalendarType.PERSONAL,
+        )
+        disabled_new.is_active = False
+        disabled_new.save(update_fields=["is_active"])
+
+        # Try to add it as a child
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {
+            "bundle_calendars": [child_active.id, disabled_new.id],
+        }
+
+        response = admin_client.patch(url, data, format="json")
+
+        # Should fail (400)
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+        # disabled_new should NOT be a child
+        assert not ChildrenCalendarRelationship.objects.filter(
+            bundle_calendar=bundle,
+            child_calendar_fk_id=disabled_new.id,
+            organization=organization,
+        ).exists()

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -4575,7 +4575,7 @@ class TestCalendarBundleUpdateAction:
         response = admin_client.patch(url, data, format="json")
 
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
-        assert "not a bundle" in response.data["detail"].lower()
+        assert "not a bundle" in str(response.data["non_field_errors"]).lower()
 
     def test_update_bundle_fewer_than_two_children_400(self, organization):
         """Providing only one child calendar returns 400."""

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -18,6 +18,7 @@ from calendar_integration.models import (
     Calendar,
     CalendarEvent,
     CalendarOwnership,
+    ChildrenCalendarRelationship,
     RecurrenceRule,
 )
 from calendar_integration.services.dataclasses import (
@@ -4416,3 +4417,278 @@ class TestRecurringBlockedAndAvailableTimeViewSets:
 
         response = auth_client.get(available_time_url, params)
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+
+@pytest.mark.django_db
+class TestCalendarBundleUpdateAction:
+    """Tests for PATCH /calendar/{id}/bundle/ (update bundle children and primary)."""
+
+    # --- Helpers ---
+
+    @staticmethod
+    def _make_bundle(organization):
+        """Create a bundle calendar with two child calendars; return (bundle, child1, child2)."""
+        child1 = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="Child A",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        child2 = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="Child B",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        bundle = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="My Bundle",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.BUNDLE,
+        )
+        # Wire up relationships directly (bypass service for test setup)
+        baker.make(
+            ChildrenCalendarRelationship,
+            bundle_calendar=bundle,
+            child_calendar=child1,
+            organization=organization,
+            is_primary=True,
+        )
+        baker.make(
+            ChildrenCalendarRelationship,
+            bundle_calendar=bundle,
+            child_calendar=child2,
+            organization=organization,
+            is_primary=False,
+        )
+        return bundle, child1, child2
+
+    @staticmethod
+    def _make_admin(organization):
+        """Create an admin user and membership; return (user, APIClient)."""
+        from rest_framework.test import APIClient
+
+        admin = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        return admin, client
+
+    @staticmethod
+    def _make_member(organization):
+        """Create a regular member and return (user, APIClient)."""
+        from rest_framework.test import APIClient
+
+        member = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=member,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        client = APIClient()
+        client.force_authenticate(user=member)
+        return member, client
+
+    # --- Happy-path ---
+
+    def test_update_bundle_add_child_remove_child_change_primary(self, organization):
+        """Admin adds a child, removes a child, and changes primary → 200, DB updated."""
+        bundle, child1, child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        child3 = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="Child C",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+        )
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {
+            "bundle_calendars": [child2.id, child3.id],  # drop child1, add child3
+            "primary_calendar": child3.id,
+        }
+
+        response = admin_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.data["id"] == bundle.id
+
+        # child1 should be gone
+        assert not ChildrenCalendarRelationship.objects.filter(
+            bundle_calendar=bundle,
+            child_calendar_fk_id=child1.id,
+            organization=organization,
+        ).exists()
+
+        # child2 retained, child3 added
+        assert ChildrenCalendarRelationship.objects.filter(
+            bundle_calendar=bundle,
+            child_calendar_fk_id=child2.id,
+            organization=organization,
+        ).exists()
+        assert ChildrenCalendarRelationship.objects.filter(
+            bundle_calendar=bundle,
+            child_calendar_fk_id=child3.id,
+            organization=organization,
+        ).exists()
+
+        # Exactly one primary — child3
+        assert (
+            ChildrenCalendarRelationship.objects.filter(
+                bundle_calendar=bundle,
+                organization=organization,
+                is_primary=True,
+            ).count()
+            == 1
+        )
+        assert (
+            ChildrenCalendarRelationship.objects.get(
+                bundle_calendar=bundle,
+                organization=organization,
+                is_primary=True,
+            ).child_calendar_fk_id
+            == child3.id
+        )
+
+    # --- Validation errors ---
+
+    def test_update_bundle_non_bundle_calendar_400(self, organization):
+        """PATCH on a PERSONAL calendar returns 400."""
+        _, admin_client = self._make_admin(organization)
+        personal = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        child1 = CalendarIntegrationTestFactory.create_calendar(organization=organization)
+        child2 = CalendarIntegrationTestFactory.create_calendar(organization=organization)
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": personal.id})
+        data = {"bundle_calendars": [child1.id, child2.id]}
+
+        response = admin_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        assert "not a bundle" in response.data["detail"].lower()
+
+    def test_update_bundle_fewer_than_two_children_400(self, organization):
+        """Providing only one child calendar returns 400."""
+        bundle, child1, _child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {"bundle_calendars": [child1.id]}
+
+        response = admin_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_bundle_primary_not_in_children_400(self, organization):
+        """primary_calendar not in bundle_calendars returns 400."""
+        bundle, child1, child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        outside = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            calendar_type=CalendarType.PERSONAL,
+        )
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {
+            "bundle_calendars": [child1.id, child2.id],
+            "primary_calendar": outside.id,
+        }
+
+        response = admin_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_bundle_child_not_in_org_400(self, organization):
+        """Child calendar from another org is rejected by PrimaryKeyRelatedField → 400."""
+        bundle, child1, _child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        other_org = CalendarIntegrationTestFactory.create_organization(name="Other Org")
+        cross_org_calendar = CalendarIntegrationTestFactory.create_calendar(
+            organization=other_org,
+        )
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {
+            "bundle_calendars": [child1.id, cross_org_calendar.id],
+        }
+
+        response = admin_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_bundle_disabled_child_calendar_400(self, organization):
+        """Providing an is_active=False calendar as a child is rejected → 400."""
+        bundle, child1, _child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        disabled = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        disabled.is_active = False
+        disabled.save(update_fields=["is_active"])
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {"bundle_calendars": [child1.id, disabled.id]}
+
+        response = admin_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    # --- Permission and access ---
+
+    def test_update_bundle_non_admin_member_403(self, organization):
+        """Regular member receives 403."""
+        bundle, child1, child2 = self._make_bundle(organization)
+        _, member_client = self._make_member(organization)
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {"bundle_calendars": [child1.id, child2.id]}
+
+        response = member_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_update_bundle_cross_org_bundle_404(self):
+        """Bundle from a different org yields 404 via org-scoped get_queryset."""
+        org_a = CalendarIntegrationTestFactory.create_organization(name="Org A")
+        org_b = CalendarIntegrationTestFactory.create_organization(name="Org B")
+
+        _, admin_client = self._make_admin(org_a)
+
+        # Bundle lives in org_b
+        _, child1, child2 = self._make_bundle(org_b)
+        other_bundle = CalendarIntegrationTestFactory.create_calendar(
+            organization=org_b,
+            calendar_type=CalendarType.BUNDLE,
+        )
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": other_bundle.id})
+        data = {"bundle_calendars": [child1.id, child2.id]}
+
+        response = admin_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_update_bundle_anonymous_401(self, anonymous_client, organization):
+        """Unauthenticated request returns 401."""
+        bundle, _, _ = self._make_bundle(organization)
+
+        url = reverse("api:Calendars-bundle-update", kwargs={"pk": bundle.id})
+        data = {"bundle_calendars": [1, 2]}
+
+        response = anonymous_client.patch(url, data, format="json")
+
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -13,7 +13,6 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import (
     CalendarGroupError,
     CalendarIntegrationError,
@@ -162,50 +161,17 @@ class CalendarViewSet(VintaScheduleModelViewSet):
         url_name="bundle-update",
         permission_classes=[IsOrganizationAdmin],
     )
-    @inject
-    def update_bundle(
-        self,
-        request,
-        pk: str | None = None,
-        calendar_service: Annotated[CalendarService, Provide["calendar_service"]] = None,  # type: ignore
-    ) -> Response:
+    def update_bundle(self, request, pk: str | None = None) -> Response:
         """Update the children and primary calendar of an existing bundle (admin only)."""
         calendar = self.get_object()
 
-        if calendar.calendar_type != CalendarType.BUNDLE:
-            return Response(
-                {"detail": "Calendar is not a bundle."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Pass the bundle into serializer context so it can fetch existing children
-        context = {**self.get_serializer_context(), "bundle": calendar}
         serializer = CalendarBundleUpdateSerializer(
+            instance=calendar,
             data=request.data,
-            context=context,
+            context=self.get_serializer_context(),
         )
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        membership = get_active_organization_membership(request.user)
-        if not membership:
-            return Response(
-                {"detail": "User is not an active member of any organization."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
-
-        try:
-            calendar_service.initialize_without_provider(organization=membership.organization)
-            calendar_service.update_bundle_calendar(
-                bundle_calendar=calendar,
-                child_calendars=serializer.validated_data["bundle_calendars"],
-                primary_calendar=serializer.validated_data.get("primary_calendar"),
-            )
-        except (ValueError, CalendarIntegrationError) as e:
-            return Response(
-                {"detail": str(e)},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
 
         updated_bundle = self.get_queryset().get(id=calendar.id)
         return Response(

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -178,9 +178,11 @@ class CalendarViewSet(VintaScheduleModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # Pass the bundle into serializer context so it can fetch existing children
+        context = {**self.get_serializer_context(), "bundle": calendar}
         serializer = CalendarBundleUpdateSerializer(
             data=request.data,
-            context=self.get_serializer_context(),
+            context=context,
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -13,6 +13,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import (
     CalendarGroupError,
     CalendarIntegrationError,
@@ -48,6 +49,7 @@ from calendar_integration.serializers import (
     BulkAvailableTimeSerializer,
     BulkBlockedTimeSerializer,
     CalendarBundleCreateSerializer,
+    CalendarBundleUpdateSerializer,
     CalendarEventSerializer,
     CalendarEventTransferSerializer,
     CalendarGroupAvailabilityQuerySerializer,
@@ -140,6 +142,73 @@ class CalendarViewSet(VintaScheduleModelViewSet):
         return Response(
             self.get_serializer_class()(instance=optimized_calendar_bundle).data,
             status=status.HTTP_201_CREATED,
+        )
+
+    @extend_schema(
+        summary="Update a bundle calendar's children and primary",
+        description=(
+            "Reconcile the child calendars and primary designation for an existing bundle. "
+            "Provide the full desired set of bundle_calendars; children not in the list will "
+            "be removed and new ones will be added. Optionally specify primary_calendar (must "
+            "be one of bundle_calendars). Admin only. Returns the updated bundle calendar."
+        ),
+        request=CalendarBundleUpdateSerializer,
+        responses={200: CalendarSerializer},
+    )
+    @action(
+        methods=["patch"],
+        detail=True,
+        url_path="bundle",
+        url_name="bundle-update",
+        permission_classes=[IsOrganizationAdmin],
+    )
+    @inject
+    def update_bundle(
+        self,
+        request,
+        pk: str | None = None,
+        calendar_service: Annotated[CalendarService, Provide["calendar_service"]] = None,  # type: ignore
+    ) -> Response:
+        """Update the children and primary calendar of an existing bundle (admin only)."""
+        calendar = self.get_object()
+
+        if calendar.calendar_type != CalendarType.BUNDLE:
+            return Response(
+                {"detail": "Calendar is not a bundle."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = CalendarBundleUpdateSerializer(
+            data=request.data,
+            context=self.get_serializer_context(),
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        membership = get_active_organization_membership(request.user)
+        if not membership:
+            return Response(
+                {"detail": "User is not an active member of any organization."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        try:
+            calendar_service.initialize_without_provider(organization=membership.organization)
+            calendar_service.update_bundle_calendar(
+                bundle_calendar=calendar,
+                child_calendars=serializer.validated_data["bundle_calendars"],
+                primary_calendar=serializer.validated_data.get("primary_calendar"),
+            )
+        except (ValueError, CalendarIntegrationError) as e:
+            return Response(
+                {"detail": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        updated_bundle = self.get_queryset().get(id=calendar.id)
+        return Response(
+            CalendarSerializer(instance=updated_bundle).data,
+            status=status.HTTP_200_OK,
         )
 
     @extend_schema(

--- a/schema.yml
+++ b/schema.yml
@@ -3920,6 +3920,89 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedAvailableTimeWindowList'
           description: ''
+  /calendar/{id}/bundle/:
+    patch:
+      operationId: calendar_bundle_partial_update
+      description: Reconcile the child calendars and primary designation for an existing
+        bundle. Provide the full desired set of bundle_calendars; children not in
+        the list will be removed and new ones will be added. Optionally specify primary_calendar
+        (must be one of bundle_calendars). Admin only. Returns the updated bundle
+        calendar.
+      summary: Update a bundle calendar's children and primary
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarBundleUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarBundleUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarBundleUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Calendar'
+          description: ''
+  /calendar/{id}/bundle{format}:
+    patch:
+      operationId: calendar_bundle_formatted_partial_update
+      description: Reconcile the child calendars and primary designation for an existing
+        bundle. Provide the full desired set of bundle_calendars; children not in
+        the list will be removed and new ones will be added. Optionally specify primary_calendar
+        (must be one of bundle_calendars). Admin only. Returns the updated bundle
+        calendar.
+      summary: Update a bundle calendar's children and primary
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarBundleUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarBundleUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarBundleUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Calendar'
+          description: ''
   /calendar/{id}/request-sync/:
     post:
       operationId: calendar_request_sync_create
@@ -8080,6 +8163,18 @@ components:
             (sets this to False) instead of deleting the row. Opt-in to see disabled
             calendars via ?include_inactive=true. Default True keeps every existing
             read unchanged.
+    PatchedCalendarBundleUpdate:
+      type: object
+      description: Serializer for updating a bundle calendar's child calendars and
+        primary calendar.
+      properties:
+        bundle_calendars:
+          type: array
+          items:
+            type: integer
+        primary_calendar:
+          type: integer
+          nullable: true
     PatchedCalendarEvent:
       type: object
       properties:


### PR DESCRIPTION
## Summary
Phase 10 of the **REST API Frontend Gaps** plan. Adds `PATCH /calendar/{id}/bundle/` (admin-only): reconcile a bundle calendar's child calendars and primary designation. Complements the existing `POST /calendar/bundle/` create.

## What changed
- `CalendarService.update_bundle_calendar(bundle, child_calendars, primary_calendar)` — atomic reconciliation of `ChildrenCalendarRelationship` rows (add new, remove dropped, exactly one primary). Validates bundle type, primary∈children, same-org, no nested bundles.
- `CalendarBundleUpdateSerializer` — org-scoped child/primary fields; `update_bundle` PATCH action gated by `IsOrganizationAdmin`; non-bundle target → 400.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 10 + API Design 4.6.

## Review history
Layer-3 review: production-ready, no blockers. Fixed one UX trap it flagged — a bundle child disabled after creation could no longer be resubmitted (the active-only queryset rejected it, blocking all bundle edits). The serializer queryset now allows the bundle's existing children regardless of is_active, while still barring brand-new disabled children. Two tests added for both sides.

## Test plan
- `uv run pytest calendar_integration/tests/test_views.py -k bundle -vs`
- Asserts: add/remove child + change primary → 200 with exactly one primary; non-bundle 400; <2 children 400; primary-not-in-children 400; cross-org child 400; NEW disabled child rejected 400; EXISTING disabled child kept on update 200; non-admin 403; cross-org bundle 404; anon 401.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1349 passed).