### PR TITLE
feat(calendar): gate calendar disable by type and preserve bundle events

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -88,11 +88,17 @@
 - **Model**: sonnet; fixer: haiku. **Branch**: phase-10 (base phase-9). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/52
 - **Key**: `PATCH /calendar/{id}/bundle/` admin-only; `CalendarService.update_bundle_calendar` atomic reconciliation (add/remove children, exactly-one primary, validates bundle/primary/cross-org/no-nesting); serializer child queryset = active OR existing-children (keeps disabled existing, bars new disabled). Outer gate green (1349), mypy 108.
 
+### Phase 11 — Disable calendar bundle ✅
+- **Status**: done, reviewed (3 layers, clean), pushed, PR opened.
+- **Model**: sonnet. **Branch**: phase-11 (base phase-10). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/53
+- **Key**: destroy gating by type — BUNDLE → admin-only; non-bundle → owner-or-admin (tightened Phase 9's ungated destroy). Bundle disable leaves events/representations/children intact (Open Q #3). Outer gate green (1359), mypy 108.
+
 ## Current Phase
-Phase 11 — Disable calendar bundle (next). Extends Phase 9 destroy. PER RESOLVED OPEN QUESTION #3: LEAVE bundle events + representations (CalendarEvent/BlockedTime via bundle_primary_event) + child calendars intact; only hide the bundle calendar. ALSO gate destroy by object type: BUNDLE → org admin only; personal calendar → owner (CalendarOwnership) or admin (Phase 9 destroy was un-gated — any org member could disable any calendar; tighten here). Tier 3.
+Phase 12 — Create public-API token (admin) (next). NEW REST surface in public_api app (currently GraphQL-only, no routes.py). `POST /public-api-tokens/` → PublicAPIAuthService.create_system_user(integration_name, organization) returns (SystemUser, plaintext token); persist ResourceAccess rows (resource_name ∈ PublicAPIResources); return plaintext token ONCE. New public_api/routes.py + register in vinta_schedule_api/urls.py routes tuple. IsOrganizationAdmin. Tier 3.
+- public_api models: SystemUser(organization FK, integration_name unique, long_lived_token_hash, is_active), ResourceAccess(system_user FK, resource_name). Enum: public_api/constants.py PublicAPIResources.
 
 ## Remaining Phases
-12 (token create), 13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/calendar_integration/tests/test_views.py
+++ b/calendar_integration/tests/test_views.py
@@ -4769,3 +4769,274 @@ class TestCalendarBundleUpdateAction:
             child_calendar_fk_id=disabled_new.id,
             organization=organization,
         ).exists()
+
+
+@pytest.mark.django_db
+class TestCalendarDisableGating:
+    """Tests for Phase 11: object-type-aware gating on DELETE /calendar/{id}/.
+
+    BUNDLE   → admin-only; 403 for non-admins.
+    Non-bundle → owner or admin; 403 for non-owner non-admins.
+    Events/children preserved when a bundle is disabled.
+    """
+
+    # --- Shared helpers (mirrors TestCalendarBundleUpdateAction) ---
+
+    @staticmethod
+    def _make_bundle(organization):
+        """Create a bundle with two child calendars; return (bundle, child1, child2)."""
+        child1 = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="Bundle Child A",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        child2 = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="Bundle Child B",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        bundle = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            name="Test Bundle",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.BUNDLE,
+        )
+        baker.make(
+            ChildrenCalendarRelationship,
+            bundle_calendar=bundle,
+            child_calendar=child1,
+            organization=organization,
+            is_primary=True,
+        )
+        baker.make(
+            ChildrenCalendarRelationship,
+            bundle_calendar=bundle,
+            child_calendar=child2,
+            organization=organization,
+            is_primary=False,
+        )
+        return bundle, child1, child2
+
+    @staticmethod
+    def _make_admin(organization):
+        """Create an admin user+membership; return (user, APIClient)."""
+        from rest_framework.test import APIClient
+
+        admin = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=admin,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+        )
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        return admin, client
+
+    @staticmethod
+    def _make_member(organization):
+        """Create a regular member; return (user, APIClient)."""
+        from rest_framework.test import APIClient
+
+        member = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=member,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        client = APIClient()
+        client.force_authenticate(user=member)
+        return member, client
+
+    # --- BUNDLE disable tests ---
+
+    def test_bundle_disable_by_admin_204(self, organization):
+        """Org admin DELETEs a bundle → 204, bundle.is_active=False."""
+        bundle, _child1, _child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        url = reverse("api:Calendars-detail", kwargs={"pk": bundle.id})
+        response = admin_client.delete(url)
+
+        assert_response_status_code(response, status.HTTP_204_NO_CONTENT)
+        bundle.refresh_from_db()
+        assert bundle.is_active is False
+
+    def test_bundle_disable_hidden_from_default_list(self, organization):
+        """After admin disables a bundle, it no longer appears in the default list."""
+        bundle, _child1, _child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        url = reverse("api:Calendars-detail", kwargs={"pk": bundle.id})
+        admin_client.delete(url)
+
+        list_url = reverse("api:Calendars-list")
+        response = admin_client.get(list_url)
+        assert_response_status_code(response, status.HTTP_200_OK)
+        ids = [c["id"] for c in response.data["results"]]
+        assert bundle.id not in ids
+
+    def test_bundle_disable_child_calendars_remain_active(self, organization):
+        """Disabling a bundle must NOT affect child calendars — they stay is_active=True."""
+        bundle, child1, child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        url = reverse("api:Calendars-detail", kwargs={"pk": bundle.id})
+        admin_client.delete(url)
+
+        child1.refresh_from_db()
+        child2.refresh_from_db()
+        assert child1.is_active is True
+        assert child2.is_active is True
+
+    def test_bundle_disable_events_and_representations_preserved(self, organization):
+        """Disabling a bundle must NOT delete bundle events or representation BlockedTimes."""
+        bundle, child1, _child2 = self._make_bundle(organization)
+        _, admin_client = self._make_admin(organization)
+
+        # Create a bundle primary event on child1
+        primary_event = CalendarIntegrationTestFactory.create_calendar_event(
+            calendar=child1,
+            title="Bundle Primary Event",
+        )
+
+        # Create a representation CalendarEvent linked via bundle_primary_event
+        now = datetime.datetime.now(datetime.UTC)
+        representation_event = baker.make(
+            CalendarEvent,
+            calendar=child1,
+            organization=organization,
+            title="Representation Event",
+            bundle_primary_event=primary_event,
+            bundle_calendar=bundle,
+            external_id=f"repr_{uuid.uuid4().hex[:8]}",
+            timezone="UTC",
+            start_time_tz_unaware=now + datetime.timedelta(hours=1),
+            end_time_tz_unaware=now + datetime.timedelta(hours=2),
+        )
+
+        # Create a representation BlockedTime linked via bundle_primary_event
+        representation_blocked = baker.make(
+            BlockedTime,
+            calendar=child1,
+            organization=organization,
+            reason="Bundle representation blocked time",
+            bundle_primary_event=primary_event,
+            timezone="UTC",
+            start_time_tz_unaware=now + datetime.timedelta(hours=1),
+            end_time_tz_unaware=now + datetime.timedelta(hours=2),
+        )
+
+        url = reverse("api:Calendars-detail", kwargs={"pk": bundle.id})
+        admin_client.delete(url)
+
+        # Events must still exist
+        assert CalendarEvent.objects.filter(id=primary_event.id).exists()
+        assert CalendarEvent.objects.filter(id=representation_event.id).exists()
+        # BlockedTime must still exist
+        assert BlockedTime.objects.filter(id=representation_blocked.id).exists()
+
+    def test_bundle_disable_by_non_admin_member_403(self, organization):
+        """Non-admin org member cannot disable a bundle → 403, bundle unchanged."""
+        bundle, _child1, _child2 = self._make_bundle(organization)
+        _, member_client = self._make_member(organization)
+
+        url = reverse("api:Calendars-detail", kwargs={"pk": bundle.id})
+        response = member_client.delete(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        bundle.refresh_from_db()
+        assert bundle.is_active is True
+
+    # --- Non-bundle (personal) calendar disable tests ---
+
+    def test_personal_calendar_disable_by_owner_204(self, organization):
+        """Calendar owner can disable their own personal calendar → 204."""
+        from rest_framework.test import APIClient
+
+        owner = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=owner,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        personal = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        CalendarIntegrationTestFactory.create_calendar_ownership(owner, personal)
+
+        client = APIClient()
+        client.force_authenticate(user=owner)
+        url = reverse("api:Calendars-detail", kwargs={"pk": personal.id})
+        response = client.delete(url)
+
+        assert_response_status_code(response, status.HTTP_204_NO_CONTENT)
+        personal.refresh_from_db()
+        assert personal.is_active is False
+
+    def test_personal_calendar_disable_by_non_owner_non_admin_403(self, organization):
+        """Non-owner, non-admin member cannot disable another user's calendar → 403."""
+        other_user = baker.make(User)
+        baker.make(
+            OrganizationMembership,
+            user=other_user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+        )
+        personal = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        # personal belongs to another user; other_user has no ownership
+
+        _, member_client = self._make_member(organization)
+        url = reverse("api:Calendars-detail", kwargs={"pk": personal.id})
+        response = member_client.delete(url)
+
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        personal.refresh_from_db()
+        assert personal.is_active is True
+
+    def test_personal_calendar_disable_by_admin_not_owner_204(self, organization):
+        """Org admin who does NOT own the calendar can still disable it → 204."""
+        personal = CalendarIntegrationTestFactory.create_calendar(
+            organization=organization,
+            calendar_type=CalendarType.PERSONAL,
+        )
+        # Don't create ownership for the admin
+
+        _, admin_client = self._make_admin(organization)
+        url = reverse("api:Calendars-detail", kwargs={"pk": personal.id})
+        response = admin_client.delete(url)
+
+        assert_response_status_code(response, status.HTTP_204_NO_CONTENT)
+        personal.refresh_from_db()
+        assert personal.is_active is False
+
+    # --- Cross-org and anon edge cases ---
+
+    def test_disable_cross_org_calendar_404(self, organization):
+        """Calendar from another org is not in queryset → 404."""
+        _, admin_client = self._make_admin(organization)
+
+        other_org = CalendarIntegrationTestFactory.create_organization(name="Other Org")
+        other_calendar = CalendarIntegrationTestFactory.create_calendar(organization=other_org)
+
+        url = reverse("api:Calendars-detail", kwargs={"pk": other_calendar.id})
+        response = admin_client.delete(url)
+
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+        other_calendar.refresh_from_db()
+        assert other_calendar.is_active is True
+
+    def test_disable_calendar_anonymous_401(self, anonymous_client, organization):
+        """Unauthenticated request → 401."""
+        calendar = CalendarIntegrationTestFactory.create_calendar(organization=organization)
+        url = reverse("api:Calendars-detail", kwargs={"pk": calendar.id})
+        response = anonymous_client.delete(url)
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -10,9 +10,10 @@ from dependency_injector.wiring import Provide, inject
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
 
+from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import (
     CalendarGroupError,
     CalendarIntegrationError,
@@ -105,15 +106,49 @@ class CalendarViewSet(VintaScheduleModelViewSet):
         summary="Soft-disable a calendar",
         description=(
             "Disables a calendar by setting is_active=False instead of deleting the row. "
-            "Idempotent: disabling an already-inactive calendar is a no-op. "
             "The row persists and is hidden from default list/detail queries. "
-            "Bundle calendars may additionally cascade to their child representations."
+            "\n\n"
+            "**Authorization rules (enforced after org-scoping):**\n"
+            "- BUNDLE calendar: caller must be an org admin. Non-admin members receive 403.\n"
+            "- Non-bundle calendar (PERSONAL/RESOURCE/VIRTUAL): caller must own the calendar "
+            "(CalendarOwnership) or be an org admin. Non-owner non-admins receive 403.\n"
+            "\n\n"
+            "**Bundle semantics:** disabling a bundle sets only the bundle calendar inactive. "
+            "Child calendars, bundle events, and their representation BlockedTimes/events are "
+            "deliberately left untouched (event cancellation is out of scope; see plan Phase 11)."
         ),
         responses={204: None},
     )
     def destroy(self, request, *args, **kwargs):
-        """Soft-disable the calendar (set is_active=False) instead of hard-deleting."""
+        """Soft-disable the calendar (set is_active=False) instead of hard-deleting.
+
+        Applies object-type-aware permission gating:
+        - BUNDLE: admin-only (bundles are management resources).
+        - Non-bundle: owner or admin.
+        """
         calendar = self.get_object()
+
+        if calendar.calendar_type == CalendarType.BUNDLE:
+            # Bundle calendars are management resources — admin-only disable.
+            # Intentionally: only the bundle wrapper is hidden; child calendars, bundle
+            # events, and their representation BlockedTimes/events are left intact.
+            # Event cancellation is explicitly out of scope (see plan Phase 11, Open Q #3:
+            # "Leave events, hide bundle; surface a follow-up if cancellation is desired.").
+            if not request.user.is_organization_admin(calendar.organization_id):
+                raise PermissionDenied("Only org admins can disable a bundle calendar.")
+        else:
+            # Non-bundle calendars (PERSONAL/RESOURCE/VIRTUAL): owner or admin.
+            is_owner = CalendarOwnership.objects.filter(
+                calendar=calendar,
+                user=request.user,
+                organization_id=calendar.organization_id,
+            ).exists()
+            is_admin = request.user.is_organization_admin(calendar.organization_id)
+            if not (is_owner or is_admin):
+                raise PermissionDenied(
+                    "You must own this calendar or be an org admin to disable it."
+                )
+
         calendar.is_active = False
         calendar.save(update_fields=["is_active"])
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/schema.yml
+++ b/schema.yml
@@ -3585,10 +3585,15 @@ paths:
           description: ''
     delete:
       operationId: calendar_destroy
-      description: 'Disables a calendar by setting is_active=False instead of deleting
-        the row. Idempotent: disabling an already-inactive calendar is a no-op. The
-        row persists and is hidden from default list/detail queries. Bundle calendars
-        may additionally cascade to their child representations.'
+      description: "Disables a calendar by setting is_active=False instead of deleting
+        the row. The row persists and is hidden from default list/detail queries.
+        \n\n**Authorization rules (enforced after org-scoping):**\n- BUNDLE calendar:
+        caller must be an org admin. Non-admin members receive 403.\n- Non-bundle
+        calendar (PERSONAL/RESOURCE/VIRTUAL): caller must own the calendar (CalendarOwnership)
+        or be an org admin. Non-owner non-admins receive 403.\n\n\n**Bundle semantics:**
+        disabling a bundle sets only the bundle calendar inactive. Child calendars,
+        bundle events, and their representation BlockedTimes/events are deliberately
+        left untouched (event cancellation is out of scope; see plan Phase 11)."
       summary: Soft-disable a calendar
       parameters:
       - in: path
@@ -3714,10 +3719,15 @@ paths:
           description: ''
     delete:
       operationId: calendar_formatted_destroy
-      description: 'Disables a calendar by setting is_active=False instead of deleting
-        the row. Idempotent: disabling an already-inactive calendar is a no-op. The
-        row persists and is hidden from default list/detail queries. Bundle calendars
-        may additionally cascade to their child representations.'
+      description: "Disables a calendar by setting is_active=False instead of deleting
+        the row. The row persists and is hidden from default list/detail queries.
+        \n\n**Authorization rules (enforced after org-scoping):**\n- BUNDLE calendar:
+        caller must be an org admin. Non-admin members receive 403.\n- Non-bundle
+        calendar (PERSONAL/RESOURCE/VIRTUAL): caller must own the calendar (CalendarOwnership)
+        or be an org admin. Non-owner non-admins receive 403.\n\n\n**Bundle semantics:**
+        disabling a bundle sets only the bundle calendar inactive. Child calendars,
+        bundle events, and their representation BlockedTimes/events are deliberately
+        left untouched (event cancellation is out of scope; see plan Phase 11)."
       summary: Soft-disable a calendar
       parameters:
       - in: path


### PR DESCRIPTION
## Summary
Phase 11 of the **REST API Frontend Gaps** plan — "admin disables a calendar bundle". Extends the Phase 9 soft-disable with object-type-aware permission gating and the resolved bundle-disable semantics.

## What changed
- `CalendarViewSet.destroy` gating: **BUNDLE** calendar → org admin only; **non-bundle** (personal/resource/virtual) → owner (CalendarOwnership) or org admin. (Phase 9's destroy was un-gated — any org member could disable any org calendar; this closes that.)
- Bundle disable semantics (per resolved Open Question #3): only the bundle wrapper is hidden — child calendars, bundle events, and their representation events/blocked-times are left intact. No cascade/cancellation.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 11 + Guiding Decision (bundle disable reuses soft-disable) + Open Questions #3 (leave events, hide bundle).

## Review history
Layer-3 review: clean, no blockers. Confirmed no bypass (non-admin can't disable a bundle; non-owner non-admin can't disable a personal calendar), no event/child cascade, and that the Phase 9 soft-disable tests still pass (they already set ownership).

## Test plan
- `uv run pytest calendar_integration/tests/test_views.py -k "disable or soft" -vs`
- Asserts: admin disables bundle → 204 + hidden, child calendars stay active, bundle events + representations preserved; non-admin bundle disable → 403; personal disable by owner → 204; by non-owner non-admin → 403; by admin-not-owner → 204; cross-org → 404; anon → 401.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1359 passed).