### PR TITLE
feat(public_api): add admin REST endpoint to create API tokens

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -93,12 +93,17 @@
 - **Model**: sonnet. **Branch**: phase-11 (base phase-10). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/53
 - **Key**: destroy gating by type — BUNDLE → admin-only; non-bundle → owner-or-admin (tightened Phase 9's ungated destroy). Bundle disable leaves events/representations/children intact (Open Q #3). Outer gate green (1359), mypy 108.
 
+### Phase 12 — Create public-API token (admin) ✅
+- **Status**: done, reviewed (3 layers; Layer 3 → BLOCKER: savepoint for duplicate-name under ATOMIC_REQUESTS + schema/dead-code fixes), pushed, PR opened.
+- **Model**: sonnet; fixer: haiku. **Branch**: phase-12 (base phase-11). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/54
+- **Key**: NEW public_api REST surface — `SystemUserTokenViewSet` (create-only), `public_api/routes.py` wired into urls. `POST /public-api-tokens/` admin-only → create_system_user, persist ResourceAccess, return plaintext token ONCE (hash never serialized). Duplicate name → 400 via nested savepoint (ATOMIC_REQUESTS-safe). Serializers: `SystemUserTokenCreateSerializer`, `SystemUserTokenResponseSerializer`. Outer gate green (1376), mypy 108.
+- **Infra for 13/14/15**: extend SystemUserTokenViewSet; org-scoped get_queryset already returns SystemUser for caller's org (anon-guarded).
+
 ## Current Phase
-Phase 12 — Create public-API token (admin) (next). NEW REST surface in public_api app (currently GraphQL-only, no routes.py). `POST /public-api-tokens/` → PublicAPIAuthService.create_system_user(integration_name, organization) returns (SystemUser, plaintext token); persist ResourceAccess rows (resource_name ∈ PublicAPIResources); return plaintext token ONCE. New public_api/routes.py + register in vinta_schedule_api/urls.py routes tuple. IsOrganizationAdmin. Tier 3.
-- public_api models: SystemUser(organization FK, integration_name unique, long_lived_token_hash, is_active), ResourceAccess(system_user FK, resource_name). Enum: public_api/constants.py PublicAPIResources.
+Phase 13 — List public-API tokens (admin) (next). Add list+retrieve to SystemUserTokenViewSet; new list serializer exposing id/integration_name/is_active/available_resources — NEVER token or long_lived_token_hash. Tier 2.
 
 ## Remaining Phases
-13 (token list), 14 (token revoke), 15 (token edit perms), 16 (events expanded).
+14 (token revoke), 15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/public_api/routes.py
+++ b/public_api/routes.py
@@ -1,0 +1,11 @@
+from common.types import RouteDict
+from public_api.views import SystemUserTokenViewSet
+
+
+routes: list[RouteDict] = [
+    {
+        "regex": r"public-api-tokens",
+        "viewset": SystemUserTokenViewSet,
+        "basename": "PublicAPITokens",
+    },
+]

--- a/public_api/serializers.py
+++ b/public_api/serializers.py
@@ -1,15 +1,24 @@
-from rest_framework import serializers
+from typing import Annotated
 
+from django.db import IntegrityError, transaction
+
+from dependency_injector.wiring import Provide, inject
+from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+
+from organizations.models import get_active_organization_membership
 from public_api.constants import PublicAPIResources
 from public_api.models import ResourceAccess, SystemUser
+from public_api.services import PublicAPIAuthService
 
 
 class SystemUserTokenCreateSerializer(serializers.Serializer):
     """Input serializer for creating a new public-API token (SystemUser + ResourceAccess rows).
 
     Accepts ``integration_name`` and ``available_resources`` (a non-empty list of valid
-    ``PublicAPIResources`` values).  On a successful create the view adds a write-once
-    ``token`` field to the response data; this serializer never stores or exposes
+    ``PublicAPIResources`` values).  ``create()`` provisions the ``SystemUser`` via the
+    injected auth service and bulk-creates the ``ResourceAccess`` grants, attaching the
+    write-once plaintext ``token`` to the returned instance.  Never stores or exposes
     ``long_lived_token_hash``.
     """
 
@@ -19,6 +28,53 @@ class SystemUserTokenCreateSerializer(serializers.Serializer):
         required=True,
         allow_empty=False,
     )
+
+    @inject
+    def __init__(
+        self,
+        *args,
+        public_api_auth_service: Annotated[
+            "PublicAPIAuthService | None", Provide["public_api_auth_service"]
+        ] = None,
+        **kwargs,
+    ) -> None:
+        self.public_api_auth_service = public_api_auth_service
+        super().__init__(*args, **kwargs)
+
+    def create(self, validated_data: dict) -> SystemUser:
+        request = self.context["request"]
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            # IsOrganizationAdmin already guards this; defensive fallback.
+            raise PermissionDenied("No active organisation membership.")
+
+        integration_name: str = validated_data["integration_name"]
+        available_resources: list[str] = validated_data["available_resources"]
+
+        try:
+            with transaction.atomic():
+                system_user, plaintext_token = self.public_api_auth_service.create_system_user(
+                    integration_name=integration_name,
+                    organization=membership.organization,
+                )
+                ResourceAccess.objects.bulk_create(
+                    [
+                        ResourceAccess(system_user=system_user, resource_name=resource_name)
+                        for resource_name in available_resources
+                    ]
+                )
+        except IntegrityError as e:
+            raise serializers.ValidationError(
+                {
+                    "integration_name": [
+                        f"A token with integration_name '{integration_name}' already exists."
+                    ]
+                }
+            ) from e
+
+        # Expose the plaintext token once via a pseudo-attribute for the response serializer.
+        system_user.token = plaintext_token  # type: ignore[attr-defined]
+        return system_user
 
 
 class SystemUserTokenResponseSerializer(serializers.ModelSerializer):

--- a/public_api/serializers.py
+++ b/public_api/serializers.py
@@ -20,16 +20,6 @@ class SystemUserTokenCreateSerializer(serializers.Serializer):
         allow_empty=False,
     )
 
-    def validate_available_resources(self, value: list[str]) -> list[str]:
-        """Validate every entry is a known PublicAPIResources value."""
-        valid_values = {choice[0] for choice in PublicAPIResources.choices}
-        invalid = [v for v in value if v not in valid_values]
-        if invalid:
-            raise serializers.ValidationError(
-                f"Invalid resource value(s): {invalid}. Must be one of: {sorted(valid_values)}."
-            )
-        return value
-
 
 class SystemUserTokenResponseSerializer(serializers.ModelSerializer):
     """Read serializer for the created SystemUser.

--- a/public_api/serializers.py
+++ b/public_api/serializers.py
@@ -1,0 +1,54 @@
+from rest_framework import serializers
+
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess, SystemUser
+
+
+class SystemUserTokenCreateSerializer(serializers.Serializer):
+    """Input serializer for creating a new public-API token (SystemUser + ResourceAccess rows).
+
+    Accepts ``integration_name`` and ``available_resources`` (a non-empty list of valid
+    ``PublicAPIResources`` values).  On a successful create the view adds a write-once
+    ``token`` field to the response data; this serializer never stores or exposes
+    ``long_lived_token_hash``.
+    """
+
+    integration_name = serializers.CharField(max_length=150, required=True)
+    available_resources = serializers.ListField(
+        child=serializers.ChoiceField(choices=PublicAPIResources.choices),
+        required=True,
+        allow_empty=False,
+    )
+
+    def validate_available_resources(self, value: list[str]) -> list[str]:
+        """Validate every entry is a known PublicAPIResources value."""
+        valid_values = {choice[0] for choice in PublicAPIResources.choices}
+        invalid = [v for v in value if v not in valid_values]
+        if invalid:
+            raise serializers.ValidationError(
+                f"Invalid resource value(s): {invalid}. Must be one of: {sorted(valid_values)}."
+            )
+        return value
+
+
+class SystemUserTokenResponseSerializer(serializers.ModelSerializer):
+    """Read serializer for the created SystemUser.
+
+    Includes the write-once ``token`` field (sourced from the view) and
+    ``available_resources`` (derived from the related ``ResourceAccess`` rows).
+    Never exposes ``long_lived_token_hash``.
+    """
+
+    available_resources = serializers.SerializerMethodField()
+    token = serializers.CharField(read_only=True)
+
+    class Meta:
+        model = SystemUser
+        fields = ("id", "integration_name", "is_active", "available_resources", "token")
+        read_only_fields = fields
+
+    def get_available_resources(self, obj: SystemUser) -> list[str]:
+        """Return a list of resource_name values from the related ResourceAccess rows."""
+        return list(
+            ResourceAccess.objects.filter(system_user=obj).values_list("resource_name", flat=True)
+        )

--- a/public_api/tests/test_views.py
+++ b/public_api/tests/test_views.py
@@ -151,6 +151,20 @@ class TestSystemUserTokenViewSetCreate:
         assert "token" in data
         assert data["token"]  # non-empty string
 
+    def test_response_includes_id_and_is_active(self, admin_client, organization):
+        """Response body includes id and is_active fields."""
+        payload = {
+            "integration_name": "id_active_test",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_201_CREATED)
+        data = response.json()
+        assert "id" in data
+        assert data["id"] is not None
+        assert "is_active" in data
+        assert data["is_active"] is True
+
     def test_response_includes_integration_name(self, admin_client, organization):
         """Response body contains the submitted integration_name."""
         payload = {
@@ -246,8 +260,23 @@ class TestSystemUserTokenViewSetCreate:
         response = admin_client.post(self._url(), payload, format="json")
         assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
 
+    def test_missing_integration_name_returns_400(self, admin_client, organization):
+        """Missing integration_name in request body yields HTTP 400."""
+        payload = {
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        assert "integration_name" in data
+
     def test_duplicate_integration_name_returns_400(self, admin_client, organization):
-        """A duplicate integration_name yields HTTP 400 (not 500 from IntegrityError)."""
+        """A duplicate integration_name yields HTTP 400 (not 500 from IntegrityError).
+
+        The savepoint in create() ensures that the IntegrityError on duplicate
+        integration_name is caught and rolled back without poisoning the outer
+        request transaction — this is critical under ATOMIC_REQUESTS=True in production.
+        """
         payload = {
             "integration_name": "dup_name",
             "available_resources": [PublicAPIResources.CALENDAR],

--- a/public_api/tests/test_views.py
+++ b/public_api/tests/test_views.py
@@ -1,0 +1,311 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess, SystemUser
+from users.models import Profile
+
+
+User = get_user_model()
+
+
+def assert_response_status_code(response, expected_status_code):
+    assert response.status_code == expected_status_code, (
+        f"Status {response.status_code} != {expected_status_code}\n"
+        f"Response: {json.dumps(response.json() if hasattr(response, 'json') and callable(response.json) else str(response.content))}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization():
+    """A test organization."""
+    return baker.make(Organization, name="Test Org")
+
+
+@pytest.fixture
+def other_organization():
+    """A second organization for cross-org isolation tests."""
+    return baker.make(Organization, name="Other Org")
+
+
+@pytest.fixture
+def admin_user(organization):
+    """A User with an ADMIN membership in *organization*."""
+    user = baker.make(User, email="admin@example.com")
+    baker.make(Profile, user=user)
+    baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=organization,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+    return user
+
+
+@pytest.fixture
+def member_user(organization):
+    """A User with a MEMBER membership in *organization*."""
+    user = baker.make(User, email="member@example.com")
+    baker.make(Profile, user=user)
+    baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=organization,
+        role=OrganizationRole.MEMBER,
+        is_active=True,
+    )
+    return user
+
+
+@pytest.fixture
+def membership_less_user():
+    """A User with no OrganizationMembership at all."""
+    user = baker.make(User, email="gated@example.com")
+    baker.make(Profile, user=user)
+    return user
+
+
+@pytest.fixture
+def admin_client(admin_user):
+    """APIClient authenticated as the admin user."""
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def member_client(member_user):
+    """APIClient authenticated as the member user."""
+    client = APIClient()
+    client.force_authenticate(user=member_user)
+    return client
+
+
+@pytest.fixture
+def anonymous_client():
+    """Unauthenticated APIClient."""
+    return APIClient()
+
+
+@pytest.fixture
+def membership_less_client(membership_less_user):
+    """APIClient authenticated as a user with no membership."""
+    client = APIClient()
+    client.force_authenticate(user=membership_less_user)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestSystemUserTokenViewSetCreate:
+    """POST /public-api-tokens/ — Phase 12 create-only endpoint."""
+
+    CREATE_URL = "api:PublicAPITokens-list"
+
+    def _url(self):
+        return reverse(self.CREATE_URL)
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_admin_creates_token_returns_201(self, admin_client, organization):
+        """Admin can create a token; 201 returned with full payload."""
+        payload = {
+            "integration_name": "my_integration",
+            "available_resources": [
+                PublicAPIResources.CALENDAR,
+                PublicAPIResources.CALENDAR_EVENT,
+            ],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_201_CREATED)
+
+    def test_response_includes_plaintext_token(self, admin_client, organization):
+        """Response body contains a non-empty plaintext ``token``."""
+        payload = {
+            "integration_name": "token_test",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_201_CREATED)
+        data = response.json()
+        assert "token" in data
+        assert data["token"]  # non-empty string
+
+    def test_response_includes_integration_name(self, admin_client, organization):
+        """Response body contains the submitted integration_name."""
+        payload = {
+            "integration_name": "name_check",
+            "available_resources": [PublicAPIResources.USER],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_201_CREATED)
+        assert response.json()["integration_name"] == "name_check"
+
+    def test_response_includes_available_resources(self, admin_client, organization):
+        """Response body lists all requested resources."""
+        resources = [PublicAPIResources.CALENDAR, PublicAPIResources.USER]
+        payload = {
+            "integration_name": "resource_check",
+            "available_resources": resources,
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_201_CREATED)
+        returned_resources = set(response.json()["available_resources"])
+        assert returned_resources == set(resources)
+
+    def test_response_is_active_true(self, admin_client, organization):
+        """Newly created token is active."""
+        payload = {
+            "integration_name": "active_check",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_201_CREATED)
+        assert response.json()["is_active"] is True
+
+    def test_system_user_row_created_for_caller_org(self, admin_client, admin_user, organization):
+        """A SystemUser row is created and scoped to the caller's organisation."""
+        payload = {
+            "integration_name": "org_scope_check",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        admin_client.post(self._url(), payload, format="json")
+        system_user = SystemUser.objects.get(integration_name="org_scope_check")
+        assert system_user.organization_id == organization.id
+        assert system_user.is_active is True
+
+    def test_resource_access_rows_created(self, admin_client, organization):
+        """A ResourceAccess row is persisted for each requested resource."""
+        resources = [
+            PublicAPIResources.CALENDAR,
+            PublicAPIResources.CALENDAR_EVENT,
+            PublicAPIResources.USER,
+        ]
+        payload = {
+            "integration_name": "ra_check",
+            "available_resources": resources,
+        }
+        admin_client.post(self._url(), payload, format="json")
+        system_user = SystemUser.objects.get(integration_name="ra_check")
+        persisted = set(
+            ResourceAccess.objects.filter(system_user=system_user).values_list(
+                "resource_name", flat=True
+            )
+        )
+        assert persisted == set(resources)
+
+    def test_long_lived_token_hash_not_in_response(self, admin_client, organization):
+        """The ``long_lived_token_hash`` field must never appear in the response."""
+        payload = {
+            "integration_name": "no_hash_check",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_201_CREATED)
+        assert "long_lived_token_hash" not in response.json()
+
+    # ------------------------------------------------------------------
+    # Validation errors
+    # ------------------------------------------------------------------
+
+    def test_invalid_resource_value_returns_400(self, admin_client, organization):
+        """An unrecognised resource value yields HTTP 400."""
+        payload = {
+            "integration_name": "bad_resource",
+            "available_resources": ["not_a_real_resource"],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_empty_available_resources_returns_400(self, admin_client, organization):
+        """An empty available_resources list yields HTTP 400."""
+        payload = {
+            "integration_name": "empty_resources",
+            "available_resources": [],
+        }
+        response = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_duplicate_integration_name_returns_400(self, admin_client, organization):
+        """A duplicate integration_name yields HTTP 400 (not 500 from IntegrityError)."""
+        payload = {
+            "integration_name": "dup_name",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        # First create succeeds
+        response1 = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response1, status.HTTP_201_CREATED)
+
+        # Second with same integration_name should be 400
+        response2 = admin_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response2, status.HTTP_400_BAD_REQUEST)
+        data = response2.json()
+        assert "integration_name" in data
+
+    # ------------------------------------------------------------------
+    # Permission / auth failures
+    # ------------------------------------------------------------------
+
+    def test_member_user_gets_403(self, member_client, organization):
+        """A non-admin member is rejected with HTTP 403."""
+        payload = {
+            "integration_name": "member_attempt",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = member_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_membership_less_user_gets_403(self, membership_less_client):
+        """A user with no membership is rejected with HTTP 403."""
+        payload = {
+            "integration_name": "gated_attempt",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = membership_less_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_anonymous_user_gets_401(self, anonymous_client):
+        """An unauthenticated request is rejected with HTTP 401."""
+        payload = {
+            "integration_name": "anon_attempt",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        response = anonymous_client.post(self._url(), payload, format="json")
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+    # ------------------------------------------------------------------
+    # Org scoping
+    # ------------------------------------------------------------------
+
+    def test_created_system_user_scoped_to_caller_org_not_other(
+        self, admin_client, admin_user, organization, other_organization
+    ):
+        """SystemUser is created for the admin's org, not any other org."""
+        payload = {
+            "integration_name": "scope_isolation",
+            "available_resources": [PublicAPIResources.CALENDAR],
+        }
+        admin_client.post(self._url(), payload, format="json")
+        system_user = SystemUser.objects.get(integration_name="scope_isolation")
+        assert system_user.organization_id == organization.id
+        assert system_user.organization_id != other_organization.id

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -1,0 +1,115 @@
+import logging
+from typing import TYPE_CHECKING, Annotated
+
+from django.db import IntegrityError
+
+from dependency_injector.wiring import Provide, inject
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from organizations.models import get_active_organization_membership
+from organizations.permissions import IsOrganizationAdmin
+from public_api.models import ResourceAccess, SystemUser
+from public_api.serializers import (
+    SystemUserTokenCreateSerializer,
+    SystemUserTokenResponseSerializer,
+)
+from public_api.services import PublicAPIAuthService
+
+
+if TYPE_CHECKING:
+    pass
+
+
+logger = logging.getLogger(__name__)
+
+
+class SystemUserTokenViewSet(GenericViewSet):
+    """Admin-only viewset for creating public-API tokens (SystemUser + ResourceAccess rows).
+
+    Phase 12: create only.  List / retrieve / revoke / edit-grants are future phases.
+
+    ``POST /public-api-tokens/`` creates a new ``SystemUser`` for the caller's
+    organisation, persists the requested ``ResourceAccess`` rows, and returns the
+    plaintext token **once**.  The token is never recoverable after this response.
+    """
+
+    permission_classes = (IsOrganizationAdmin,)
+    serializer_class = SystemUserTokenCreateSerializer
+
+    @inject
+    def __init__(
+        self,
+        *args,
+        public_api_auth_service: Annotated[
+            PublicAPIAuthService, Provide["public_api_auth_service"]
+        ],
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.public_api_auth_service = public_api_auth_service
+
+    def get_queryset(self):  # type: ignore[override]
+        """Org-scoped queryset — used for router introspection."""
+        user = self.request.user
+        membership = get_active_organization_membership(user)
+        if membership:
+            return SystemUser.objects.filter(organization_id=membership.organization_id)
+        return SystemUser.objects.none()
+
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        """Create a SystemUser and ResourceAccess rows; return the plaintext token once.
+
+        Returns HTTP 201 on success.  The response body includes ``id``,
+        ``integration_name``, ``is_active``, ``available_resources``, and a
+        write-once ``token`` field — never ``long_lived_token_hash``.
+
+        HTTP 400 is returned for:
+        - Invalid or unknown ``available_resources`` values.
+        - Empty ``available_resources`` list.
+        - Duplicate ``integration_name`` (unique constraint).
+
+        HTTP 403 is returned for non-admin callers; HTTP 401 for unauthenticated.
+        """
+        membership = get_active_organization_membership(request.user)  # type: ignore[arg-type]
+        if membership is None:
+            # IsOrganizationAdmin.has_permission already guards this; defensive fallback.
+            return Response(
+                {"detail": "No active organisation membership."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = SystemUserTokenCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        integration_name: str = serializer.validated_data["integration_name"]
+        available_resources: list[str] = serializer.validated_data["available_resources"]
+        organization = membership.organization
+
+        try:
+            system_user, plaintext_token = self.public_api_auth_service.create_system_user(
+                integration_name=integration_name,
+                organization=organization,
+            )
+        except IntegrityError:
+            return Response(
+                {
+                    "integration_name": [
+                        f"A token with integration_name '{integration_name}' already exists."
+                    ]
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Persist one ResourceAccess row per requested resource.
+        for resource_name in available_resources:
+            ResourceAccess.objects.create(system_user=system_user, resource_name=resource_name)
+
+        # Build the response data: include the plaintext token ONCE via a pseudo-attribute.
+        system_user.token = plaintext_token  # type: ignore[attr-defined]
+        response_serializer = SystemUserTokenResponseSerializer(
+            system_user, context={"request": request}
+        )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -1,9 +1,5 @@
 import logging
-from typing import Annotated
 
-from django.db import IntegrityError, transaction
-
-from dependency_injector.wiring import Provide, inject
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.request import Request
@@ -12,12 +8,11 @@ from rest_framework.viewsets import GenericViewSet
 
 from organizations.models import get_active_organization_membership
 from organizations.permissions import IsOrganizationAdmin
-from public_api.models import ResourceAccess, SystemUser
+from public_api.models import SystemUser
 from public_api.serializers import (
     SystemUserTokenCreateSerializer,
     SystemUserTokenResponseSerializer,
 )
-from public_api.services import PublicAPIAuthService
 
 
 logger = logging.getLogger(__name__)
@@ -35,18 +30,6 @@ class SystemUserTokenViewSet(GenericViewSet):
 
     permission_classes = (IsOrganizationAdmin,)
     serializer_class = SystemUserTokenCreateSerializer
-
-    @inject
-    def __init__(
-        self,
-        *args,
-        public_api_auth_service: Annotated[
-            PublicAPIAuthService, Provide["public_api_auth_service"]
-        ],
-        **kwargs,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.public_api_auth_service = public_api_auth_service
 
     def get_queryset(self):  # type: ignore[override]
         """Org-scoped queryset — used for router introspection."""
@@ -76,43 +59,10 @@ class SystemUserTokenViewSet(GenericViewSet):
 
         HTTP 403 is returned for non-admin callers; HTTP 401 for unauthenticated.
         """
-        membership = get_active_organization_membership(request.user)  # type: ignore[arg-type]
-        if membership is None:
-            # IsOrganizationAdmin.has_permission already guards this; defensive fallback.
-            return Response(
-                {"detail": "No active organisation membership."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
-
-        serializer = SystemUserTokenCreateSerializer(data=request.data)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        system_user = serializer.save()
 
-        integration_name: str = serializer.validated_data["integration_name"]
-        available_resources: list[str] = serializer.validated_data["available_resources"]
-        organization = membership.organization
-
-        try:
-            with transaction.atomic():
-                system_user, plaintext_token = self.public_api_auth_service.create_system_user(
-                    integration_name=integration_name,
-                    organization=organization,
-                )
-        except IntegrityError:
-            return Response(
-                {
-                    "integration_name": [
-                        f"A token with integration_name '{integration_name}' already exists."
-                    ]
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Persist one ResourceAccess row per requested resource.
-        for resource_name in available_resources:
-            ResourceAccess.objects.create(system_user=system_user, resource_name=resource_name)
-
-        # Build the response data: include the plaintext token ONCE via a pseudo-attribute.
-        system_user.token = plaintext_token  # type: ignore[attr-defined]
         response_serializer = SystemUserTokenResponseSerializer(
             system_user, context={"request": request}
         )

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -1,9 +1,10 @@
 import logging
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 
 from dependency_injector.wiring import Provide, inject
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,10 +18,6 @@ from public_api.serializers import (
     SystemUserTokenResponseSerializer,
 )
 from public_api.services import PublicAPIAuthService
-
-
-if TYPE_CHECKING:
-    pass
 
 
 logger = logging.getLogger(__name__)
@@ -54,11 +51,17 @@ class SystemUserTokenViewSet(GenericViewSet):
     def get_queryset(self):  # type: ignore[override]
         """Org-scoped queryset — used for router introspection."""
         user = self.request.user
+        if not user.is_authenticated:
+            return SystemUser.objects.none()
         membership = get_active_organization_membership(user)
         if membership:
             return SystemUser.objects.filter(organization_id=membership.organization_id)
         return SystemUser.objects.none()
 
+    @extend_schema(
+        request=SystemUserTokenCreateSerializer,
+        responses={201: SystemUserTokenResponseSerializer},
+    )
     def create(self, request: Request, *args, **kwargs) -> Response:
         """Create a SystemUser and ResourceAccess rows; return the plaintext token once.
 
@@ -89,10 +92,11 @@ class SystemUserTokenViewSet(GenericViewSet):
         organization = membership.organization
 
         try:
-            system_user, plaintext_token = self.public_api_auth_service.create_system_user(
-                integration_name=integration_name,
-                organization=organization,
-            )
+            with transaction.atomic():
+                system_user, plaintext_token = self.public_api_auth_service.create_system_user(
+                    integration_name=integration_name,
+                    organization=organization,
+                )
         except IntegrityError:
             return Response(
                 {

--- a/schema.yml
+++ b/schema.yml
@@ -5760,6 +5760,94 @@ paths:
               schema:
                 $ref: '#/components/schemas/Profile'
           description: ''
+  /public-api-tokens/:
+    post:
+      operationId: public_api_tokens_create
+      description: |-
+        Create a SystemUser and ResourceAccess rows; return the plaintext token once.
+
+        Returns HTTP 201 on success.  The response body includes ``id``,
+        ``integration_name``, ``is_active``, ``available_resources``, and a
+        write-once ``token`` field — never ``long_lived_token_hash``.
+
+        HTTP 400 is returned for:
+        - Invalid or unknown ``available_resources`` values.
+        - Empty ``available_resources`` list.
+        - Duplicate ``integration_name`` (unique constraint).
+
+        HTTP 403 is returned for non-admin callers; HTTP 401 for unauthenticated.
+      tags:
+      - public-api-tokens
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SystemUserTokenCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SystemUserTokenCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SystemUserTokenCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUserTokenCreate'
+          description: ''
+  /public-api-tokens{format}:
+    post:
+      operationId: public_api_tokens_formatted_create
+      description: |-
+        Create a SystemUser and ResourceAccess rows; return the plaintext token once.
+
+        Returns HTTP 201 on success.  The response body includes ``id``,
+        ``integration_name``, ``is_active``, ``available_resources``, and a
+        write-once ``token`` field — never ``long_lived_token_hash``.
+
+        HTTP 400 is returned for:
+        - Invalid or unknown ``available_resources`` values.
+        - Empty ``available_resources`` list.
+        - Duplicate ``integration_name`` (unique constraint).
+
+        HTTP 403 is returned for non-admin callers; HTTP 401 for unauthenticated.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - public-api-tokens
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SystemUserTokenCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SystemUserTokenCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SystemUserTokenCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUserTokenCreate'
+          description: ''
   /public/organizations/{organization_id}/events/:
     get:
       operationId: public_organizations_events_list
@@ -6540,6 +6628,44 @@ components:
           type: string
       required:
       - token
+    AvailableResourcesEnum:
+      enum:
+      - calendar_event
+      - calendar
+      - recurrence_rule
+      - external_attendee
+      - external_attendance
+      - attendance
+      - user
+      - resource_allocation
+      - event_recurring_exception
+      - blocked_time
+      - blocked_time_recurring_exception
+      - available_time
+      - available_time_recurring_exception
+      - availability_windows
+      - unavailable_windows
+      - organization
+      - calendar_group
+      type: string
+      description: |-
+        * `calendar_event` - Calendar Event
+        * `calendar` - Calendar
+        * `recurrence_rule` - Recurrence Rule
+        * `external_attendee` - External Attendee
+        * `external_attendance` - External Attendance
+        * `attendance` - Attendance
+        * `user` - User
+        * `resource_allocation` - Resource Allocation
+        * `event_recurring_exception` - Event Recurring Exception
+        * `blocked_time` - Blocked Time
+        * `blocked_time_recurring_exception` - Blocked Time Recurring Exception
+        * `available_time` - Available Time
+        * `available_time_recurring_exception` - Available Time Recurring Exception
+        * `availability_windows` - Availability Windows
+        * `unavailable_windows` - Unavailable Windows
+        * `organization` - Organization
+        * `calendar_group` - Calendar Group
     AvailableTime:
       type: object
       description: Serializer for AvailableTime model with recurring support.
@@ -8515,6 +8641,26 @@ components:
       description: |-
         * `member` - Member
         * `admin` - Admin
+    SystemUserTokenCreate:
+      type: object
+      description: |-
+        Input serializer for creating a new public-API token (SystemUser + ResourceAccess rows).
+
+        Accepts ``integration_name`` and ``available_resources`` (a non-empty list of valid
+        ``PublicAPIResources`` values).  On a successful create the view adds a write-once
+        ``token`` field to the response data; this serializer never stores or exposes
+        ``long_lived_token_hash``.
+      properties:
+        integration_name:
+          type: string
+          maxLength: 150
+        available_resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableResourcesEnum'
+      required:
+      - available_resources
+      - integration_name
     UnavailableTimeWindow:
       type: object
       properties:

--- a/schema.yml
+++ b/schema.yml
@@ -8647,8 +8647,9 @@ components:
         Input serializer for creating a new public-API token (SystemUser + ResourceAccess rows).
 
         Accepts ``integration_name`` and ``available_resources`` (a non-empty list of valid
-        ``PublicAPIResources`` values).  On a successful create the view adds a write-once
-        ``token`` field to the response data; this serializer never stores or exposes
+        ``PublicAPIResources`` values).  ``create()`` provisions the ``SystemUser`` via the
+        injected auth service and bulk-creates the ``ResourceAccess`` grants, attaching the
+        write-once plaintext ``token`` to the returned instance.  Never stores or exposes
         ``long_lived_token_hash``.
       properties:
         integration_name:

--- a/schema.yml
+++ b/schema.yml
@@ -5798,7 +5798,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SystemUserTokenCreate'
+                $ref: '#/components/schemas/SystemUserTokenResponse'
           description: ''
   /public-api-tokens{format}:
     post:
@@ -5846,7 +5846,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SystemUserTokenCreate'
+                $ref: '#/components/schemas/SystemUserTokenResponse'
           description: ''
   /public/organizations/{organization_id}/events/:
     get:
@@ -8661,6 +8661,41 @@ components:
       required:
       - available_resources
       - integration_name
+    SystemUserTokenResponse:
+      type: object
+      description: |-
+        Read serializer for the created SystemUser.
+
+        Includes the write-once ``token`` field (sourced from the view) and
+        ``available_resources`` (derived from the related ``ResourceAccess`` rows).
+        Never exposes ``long_lived_token_hash``.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        integration_name:
+          type: string
+          readOnly: true
+        is_active:
+          type: boolean
+          readOnly: true
+          description: Indicates if the user is active.
+        available_resources:
+          type: array
+          items:
+            type: string
+          description: Return a list of resource_name values from the related ResourceAccess
+            rows.
+          readOnly: true
+        token:
+          type: string
+          readOnly: true
+      required:
+      - available_resources
+      - id
+      - integration_name
+      - is_active
+      - token
     UnavailableTimeWindow:
       type: object
       properties:

--- a/vinta_schedule_api/urls.py
+++ b/vinta_schedule_api/urls.py
@@ -16,6 +16,7 @@ from calendar_integration.routes import routes as calendar_integration_routes
 from organizations.routes import routes as organizations_routes
 from organizations.views import AcceptInvitationView
 from payments.routes import routes as payments_routes
+from public_api.routes import routes as public_api_routes
 from public_api.schema import schema
 from users.routes import routes as users_routes
 from webhooks.routes import routes as webhooks_routes
@@ -27,6 +28,7 @@ routes = (
     *calendar_integration_routes,
     *organizations_routes,
     *payments_routes,
+    *public_api_routes,
     *users_routes,
     *webhooks_routes,
 )


### PR DESCRIPTION
## Summary
Phase 12 of the **REST API Frontend Gaps** plan. Adds the first private-REST surface to the `public_api` app (previously GraphQL-only): `POST /public-api-tokens/` (admin-only) creates a `SystemUser` + its `ResourceAccess` grants and returns the plaintext token **once**.

## What changed
- `SystemUserTokenViewSet` (create-only, `IsOrganizationAdmin`), org-scoped to the caller.
- `SystemUserTokenCreateSerializer` (integration_name + available_resources∈PublicAPIResources, non-empty) and `SystemUserTokenResponseSerializer` (id, integration_name, is_active, available_resources, write-once token — never the hash).
- New `public_api/routes.py` wired into `vinta_schedule_api/urls.py`.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 12 + API Design 4.7 + Guiding Decision (token surface = private REST admin-only). Create-only; list/revoke/edit are Phases 13–15.

## Review history
Layer-3 review found a **production blocker**: catching `IntegrityError` (duplicate integration_name) without a savepoint poisons the request transaction under `ATOMIC_REQUESTS=True`, turning the intended 400 into a 500 (the test only passed because test settings don't enable ATOMIC_REQUESTS). Fixed by wrapping the create in a nested `transaction.atomic()` savepoint. Also corrected the OpenAPI 201 schema (was the input serializer — token field undocumented), removed a dead validator + dead TYPE_CHECKING block, guarded get_queryset for anon, and added id/required-field tests.

## Test plan
- `uv run pytest public_api/tests/ -vs`
- Asserts: admin create → 201 + plaintext token + id/is_active/available_resources, ResourceAccess rows created, hash never in response, SystemUser org-scoped; invalid/empty resources → 400; missing integration_name → 400; duplicate integration_name → 400 (not 500); non-admin → 403; anon → 401.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1376 passed).