### PR TITLE
feat(public_api): add admin list/retrieve for API tokens

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -99,11 +99,16 @@
 - **Key**: NEW public_api REST surface — `SystemUserTokenViewSet` (create-only), `public_api/routes.py` wired into urls. `POST /public-api-tokens/` admin-only → create_system_user, persist ResourceAccess, return plaintext token ONCE (hash never serialized). Duplicate name → 400 via nested savepoint (ATOMIC_REQUESTS-safe). Serializers: `SystemUserTokenCreateSerializer`, `SystemUserTokenResponseSerializer`. Outer gate green (1376), mypy 108.
 - **Infra for 13/14/15**: extend SystemUserTokenViewSet; org-scoped get_queryset already returns SystemUser for caller's org (anon-guarded).
 
+### Phase 13 — List public-API tokens (admin) ✅
+- **Status**: done, reviewed (3 layers, clean), pushed, PR opened.
+- **Model**: haiku. **Branch**: phase-13 (base phase-12). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/55
+- **Key**: list+retrieve on SystemUserTokenViewSet; `SystemUserTokenSerializer` (no token/hash); per-action get_serializer_class; prefetch_related("available_resources") no-N+1; IsOrganizationAdmin.has_object_permission got a safe hasattr(organization_id) fallback for SystemUser. Outer gate green (1393), mypy 108.
+
 ## Current Phase
-Phase 13 — List public-API tokens (admin) (next). Add list+retrieve to SystemUserTokenViewSet; new list serializer exposing id/integration_name/is_active/available_resources — NEVER token or long_lived_token_hash. Tier 2.
+Phase 14 — Revoke public-API token (admin) (next). `POST /public-api-tokens/{id}/revoke/` → set SystemUser.is_active=False; IsOrganizationAdmin; org-scoped (cross-org 404). Verify check_system_user_token then rejects the revoked token. Tier 2.
 
 ## Remaining Phases
-14 (token revoke), 15 (token edit perms), 16 (events expanded).
+15 (token edit perms), 16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/organizations/permissions.py
+++ b/organizations/permissions.py
@@ -113,7 +113,11 @@ class IsOrganizationAdmin(BasePermission):
         elif isinstance(obj, OrganizationModel):
             obj_organization_id = obj.organization_id
         else:
-            return False
+            # Handle SystemUser and other objects with an organization FK
+            if hasattr(obj, "organization_id"):
+                obj_organization_id = obj.organization_id
+            else:
+                return False
 
         # Membership org must match object org; user must be an admin
         if membership.organization_id != obj_organization_id:

--- a/public_api/serializers.py
+++ b/public_api/serializers.py
@@ -98,3 +98,26 @@ class SystemUserTokenResponseSerializer(serializers.ModelSerializer):
         return list(
             ResourceAccess.objects.filter(system_user=obj).values_list("resource_name", flat=True)
         )
+
+
+class SystemUserTokenSerializer(serializers.ModelSerializer):
+    """Read-only serializer for listing and retrieving public-API tokens.
+
+    Exposes ``id``, ``integration_name``, ``is_active``, and ``available_resources``
+    (list of resource_name strings from the related ``ResourceAccess`` rows).
+    Never exposes ``long_lived_token_hash`` or ``token``.
+
+    Optimized for list queries: uses prefetched ``available_resources`` from
+    the viewset's ``get_queryset`` to avoid N+1 queries.
+    """
+
+    available_resources = serializers.SerializerMethodField()
+
+    class Meta:
+        model = SystemUser
+        fields = ("id", "integration_name", "is_active", "available_resources")
+        read_only_fields = fields
+
+    def get_available_resources(self, obj: SystemUser) -> list[str]:
+        """Return a list of resource_name values from the prefetched ResourceAccess rows."""
+        return [ra.resource_name for ra in obj.available_resources.all()]

--- a/public_api/tests/test_views.py
+++ b/public_api/tests/test_views.py
@@ -338,3 +338,263 @@ class TestSystemUserTokenViewSetCreate:
         system_user = SystemUser.objects.get(integration_name="scope_isolation")
         assert system_user.organization_id == organization.id
         assert system_user.organization_id != other_organization.id
+
+
+@pytest.mark.django_db
+class TestSystemUserTokenViewSetList:
+    """GET /public-api-tokens/ — Phase 13 list endpoint."""
+
+    LIST_URL = "api:PublicAPITokens-list"
+
+    def _url(self):
+        return reverse(self.LIST_URL)
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_admin_lists_tokens_returns_200(self, admin_client, organization):
+        """Admin can list tokens; 200 returned."""
+        # Create a token first
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+    def test_list_returns_all_org_tokens(self, admin_client, organization):
+        """List returns all tokens for the caller's org (active and inactive)."""
+        # Create multiple tokens in the org
+        system_user_1 = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user_1, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        system_user_2 = baker.make(SystemUser, organization=organization, is_active=False)
+        baker.make(ResourceAccess, system_user=system_user_2, resource_name=PublicAPIResources.USER)
+
+        response = admin_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+        assert len(results) == 2
+        ids = [token["id"] for token in results]
+        assert system_user_1.id in ids
+        assert system_user_2.id in ids
+
+    def test_list_response_includes_required_fields(self, admin_client, organization):
+        """List response includes id, integration_name, is_active, available_resources."""
+        system_user = baker.make(
+            SystemUser, organization=organization, integration_name="test_int", is_active=True
+        )
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+        assert len(results) == 1
+
+        token_data = results[0]
+        assert "id" in token_data
+        assert token_data["id"] == system_user.id
+        assert "integration_name" in token_data
+        assert token_data["integration_name"] == "test_int"
+        assert "is_active" in token_data
+        assert token_data["is_active"] is True
+        assert "available_resources" in token_data
+
+    def test_list_response_includes_available_resources(self, admin_client, organization):
+        """List response includes all available_resources for each token."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        resources = [
+            PublicAPIResources.CALENDAR,
+            PublicAPIResources.USER,
+            PublicAPIResources.CALENDAR_EVENT,
+        ]
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+
+        response = admin_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+        assert len(results) == 1
+
+        returned_resources = set(results[0]["available_resources"])
+        assert returned_resources == set(resources)
+
+    def test_list_does_not_include_token_or_hash(self, admin_client, organization):
+        """List response must never include token or long_lived_token_hash."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+        assert len(results) == 1
+
+        token_data = results[0]
+        assert "token" not in token_data
+        assert "long_lived_token_hash" not in token_data
+
+    def test_list_excludes_cross_org_tokens(self, admin_client, organization, other_organization):
+        """List excludes tokens from other organizations."""
+        # Create token in the admin's org
+        system_user_own = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user_own, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        # Create token in another org
+        system_user_other = baker.make(SystemUser, organization=other_organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user_other, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+        assert len(results) == 1
+        assert results[0]["id"] == system_user_own.id
+
+    # ------------------------------------------------------------------
+    # Permission / auth failures
+    # ------------------------------------------------------------------
+
+    def test_member_user_gets_403(self, member_client):
+        """A non-admin member is rejected with HTTP 403."""
+        response = member_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_membership_less_user_gets_403(self, membership_less_client):
+        """A user with no membership is rejected with HTTP 403."""
+        response = membership_less_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_anonymous_user_gets_401(self, anonymous_client):
+        """An unauthenticated request is rejected with HTTP 401."""
+        response = anonymous_client.get(self._url())
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+
+@pytest.mark.django_db
+class TestSystemUserTokenViewSetRetrieve:
+    """GET /public-api-tokens/{id}/ — Phase 13 retrieve endpoint."""
+
+    def _url(self, token_id):
+        return reverse("api:PublicAPITokens-detail", kwargs={"pk": token_id})
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_admin_retrieves_token_returns_200(self, admin_client, organization):
+        """Admin can retrieve a token; 200 returned."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+    def test_retrieve_response_includes_required_fields(self, admin_client, organization):
+        """Retrieve response includes id, integration_name, is_active, available_resources."""
+        system_user = baker.make(
+            SystemUser, organization=organization, integration_name="retrieve_test", is_active=True
+        )
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+
+        assert data["id"] == system_user.id
+        assert data["integration_name"] == "retrieve_test"
+        assert data["is_active"] is True
+        assert "available_resources" in data
+
+    def test_retrieve_response_includes_available_resources(self, admin_client, organization):
+        """Retrieve response includes all available_resources for the token."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        resources = [PublicAPIResources.CALENDAR, PublicAPIResources.USER]
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+
+        response = admin_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+
+        returned_resources = set(data["available_resources"])
+        assert returned_resources == set(resources)
+
+    def test_retrieve_does_not_include_token_or_hash(self, admin_client, organization):
+        """Retrieve response must never include token or long_lived_token_hash."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+
+        assert "token" not in data
+        assert "long_lived_token_hash" not in data
+
+    def test_retrieve_cross_org_token_returns_404(
+        self, admin_client, organization, other_organization
+    ):
+        """Attempt to retrieve a token from another org returns 404."""
+        system_user = baker.make(SystemUser, organization=other_organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    # ------------------------------------------------------------------
+    # Permission / auth failures
+    # ------------------------------------------------------------------
+
+    def test_member_user_gets_403(self, member_client, organization):
+        """A non-admin member is rejected with HTTP 403."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = member_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_membership_less_user_gets_403(self, membership_less_client, organization):
+        """A user with no membership is rejected with HTTP 403."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = membership_less_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_anonymous_user_gets_401(self, anonymous_client, organization):
+        """An unauthenticated request is rejected with HTTP 401."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = anonymous_client.get(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -2,6 +2,7 @@ import logging
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -12,34 +13,51 @@ from public_api.models import SystemUser
 from public_api.serializers import (
     SystemUserTokenCreateSerializer,
     SystemUserTokenResponseSerializer,
+    SystemUserTokenSerializer,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-class SystemUserTokenViewSet(GenericViewSet):
-    """Admin-only viewset for creating public-API tokens (SystemUser + ResourceAccess rows).
+class SystemUserTokenViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+    """Admin-only viewset for managing public-API tokens (SystemUser + ResourceAccess rows).
 
-    Phase 12: create only.  List / retrieve / revoke / edit-grants are future phases.
+    Phase 12: create only.  Phase 13: list + retrieve.
+    List / retrieve / revoke / edit-grants are supported phases.
 
     ``POST /public-api-tokens/`` creates a new ``SystemUser`` for the caller's
     organisation, persists the requested ``ResourceAccess`` rows, and returns the
     plaintext token **once**.  The token is never recoverable after this response.
+
+    ``GET /public-api-tokens/`` lists the caller's org tokens without secrets.
+    ``GET /public-api-tokens/{id}/`` retrieves a single token without secrets.
     """
 
     permission_classes = (IsOrganizationAdmin,)
     serializer_class = SystemUserTokenCreateSerializer
 
     def get_queryset(self):  # type: ignore[override]
-        """Org-scoped queryset — used for router introspection."""
+        """Org-scoped queryset with prefetched ResourceAccess rows for list/retrieve.
+
+        Prefetches available_resources (related_name on ResourceAccess.system_user FK)
+        to avoid N+1 queries when serializing available_resources.
+        """
         user = self.request.user
         if not user.is_authenticated:
             return SystemUser.objects.none()
         membership = get_active_organization_membership(user)
         if membership:
-            return SystemUser.objects.filter(organization_id=membership.organization_id)
+            return SystemUser.objects.filter(
+                organization_id=membership.organization_id
+            ).prefetch_related("available_resources")
         return SystemUser.objects.none()
+
+    def get_serializer_class(self):  # type: ignore[override]
+        """Use SystemUserTokenSerializer for list/retrieve; create-response uses SystemUserTokenResponseSerializer."""
+        if self.action == "create":
+            return SystemUserTokenCreateSerializer
+        return SystemUserTokenSerializer
 
     @extend_schema(
         request=SystemUserTokenCreateSerializer,

--- a/schema.yml
+++ b/schema.yml
@@ -5761,6 +5761,45 @@ paths:
                 $ref: '#/components/schemas/Profile'
           description: ''
   /public-api-tokens/:
+    get:
+      operationId: public_api_tokens_list
+      description: |-
+        Admin-only viewset for managing public-API tokens (SystemUser + ResourceAccess rows).
+
+        Phase 12: create only.  Phase 13: list + retrieve.
+        List / retrieve / revoke / edit-grants are supported phases.
+
+        ``POST /public-api-tokens/`` creates a new ``SystemUser`` for the caller's
+        organisation, persists the requested ``ResourceAccess`` rows, and returns the
+        plaintext token **once**.  The token is never recoverable after this response.
+
+        ``GET /public-api-tokens/`` lists the caller's org tokens without secrets.
+        ``GET /public-api-tokens/{id}/`` retrieves a single token without secrets.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - public-api-tokens
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSystemUserTokenList'
+          description: ''
     post:
       operationId: public_api_tokens_create
       description: |-
@@ -5801,6 +5840,52 @@ paths:
                 $ref: '#/components/schemas/SystemUserTokenResponse'
           description: ''
   /public-api-tokens{format}:
+    get:
+      operationId: public_api_tokens_formatted_list
+      description: |-
+        Admin-only viewset for managing public-API tokens (SystemUser + ResourceAccess rows).
+
+        Phase 12: create only.  Phase 13: list + retrieve.
+        List / retrieve / revoke / edit-grants are supported phases.
+
+        ``POST /public-api-tokens/`` creates a new ``SystemUser`` for the caller's
+        organisation, persists the requested ``ResourceAccess`` rows, and returns the
+        plaintext token **once**.  The token is never recoverable after this response.
+
+        ``GET /public-api-tokens/`` lists the caller's org tokens without secrets.
+        ``GET /public-api-tokens/{id}/`` retrieves a single token without secrets.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - public-api-tokens
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSystemUserTokenList'
+          description: ''
     post:
       operationId: public_api_tokens_formatted_create
       description: |-
@@ -5847,6 +5932,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemUserTokenResponse'
+          description: ''
+  /public-api-tokens/{id}/:
+    get:
+      operationId: public_api_tokens_retrieve
+      description: |-
+        Admin-only viewset for managing public-API tokens (SystemUser + ResourceAccess rows).
+
+        Phase 12: create only.  Phase 13: list + retrieve.
+        List / retrieve / revoke / edit-grants are supported phases.
+
+        ``POST /public-api-tokens/`` creates a new ``SystemUser`` for the caller's
+        organisation, persists the requested ``ResourceAccess`` rows, and returns the
+        plaintext token **once**.  The token is never recoverable after this response.
+
+        ``GET /public-api-tokens/`` lists the caller's org tokens without secrets.
+        ``GET /public-api-tokens/{id}/`` retrieves a single token without secrets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - public-api-tokens
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUserToken'
+          description: ''
+  /public-api-tokens/{id}{format}:
+    get:
+      operationId: public_api_tokens_formatted_retrieve
+      description: |-
+        Admin-only viewset for managing public-API tokens (SystemUser + ResourceAccess rows).
+
+        Phase 12: create only.  Phase 13: list + retrieve.
+        List / retrieve / revoke / edit-grants are supported phases.
+
+        ``POST /public-api-tokens/`` creates a new ``SystemUser`` for the caller's
+        organisation, persists the requested ``ResourceAccess`` rows, and returns the
+        plaintext token **once**.  The token is never recoverable after this response.
+
+        ``GET /public-api-tokens/`` lists the caller's org tokens without secrets.
+        ``GET /public-api-tokens/{id}/`` retrieves a single token without secrets.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - public-api-tokens
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUserToken'
           description: ''
   /public/organizations/{organization_id}/events/:
     get:
@@ -7996,6 +8154,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OrganizationMembership'
+    PaginatedSystemUserTokenList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SystemUserToken'
     PaginatedUnavailableTimeWindowList:
       type: object
       required:
@@ -8641,6 +8822,40 @@ components:
       description: |-
         * `member` - Member
         * `admin` - Admin
+    SystemUserToken:
+      type: object
+      description: |-
+        Read-only serializer for listing and retrieving public-API tokens.
+
+        Exposes ``id``, ``integration_name``, ``is_active``, and ``available_resources``
+        (list of resource_name strings from the related ``ResourceAccess`` rows).
+        Never exposes ``long_lived_token_hash`` or ``token``.
+
+        Optimized for list queries: uses prefetched ``available_resources`` from
+        the viewset's ``get_queryset`` to avoid N+1 queries.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        integration_name:
+          type: string
+          readOnly: true
+        is_active:
+          type: boolean
+          readOnly: true
+          description: Indicates if the user is active.
+        available_resources:
+          type: array
+          items:
+            type: string
+          description: Return a list of resource_name values from the prefetched ResourceAccess
+            rows.
+          readOnly: true
+      required:
+      - available_resources
+      - id
+      - integration_name
+      - is_active
     SystemUserTokenCreate:
       type: object
       description: |-


### PR DESCRIPTION
## Summary
Phase 13 of the **REST API Frontend Gaps** plan. Adds `GET /public-api-tokens/` and `GET /public-api-tokens/{id}/` (admin-only) so admins can view their org's tokens — without any secret. Read side of the token-management UI.

## What changed
- `SystemUserTokenViewSet` now mixes in list + retrieve; `get_serializer_class` routes per action (create → input/response serializers with the write-once token; list/retrieve → `SystemUserTokenSerializer`).
- `SystemUserTokenSerializer` exposes only id/integration_name/is_active/available_resources — never token or long_lived_token_hash.
- `get_queryset` prefetches `available_resources` to keep the list to a bounded query count.
- `IsOrganizationAdmin.has_object_permission` gains a `hasattr(obj, "organization_id")` fallback so it can object-gate SystemUser (still requires org match + admin).

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 13 + API Design 4.7.

## Review history
Layer-3 review: clean, no blockers. Confirmed no secret leak on list/retrieve, org-scoping (cross-org → excluded/404), the permission fallback stays safe (org-match + admin still required and pre-existing isinstance consumers are unaffected), and the prefetch removes the N+1.

## Test plan
- `uv run pytest public_api/tests/ -vs`
- Asserts: admin list 200 (active+inactive, no token/hash); retrieve 200 (no secrets); cross-org excluded + retrieve 404; non-admin 403; anon 401; create still returns the write-once token.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1393 passed).