### PR TITLE
feat(public_api): add admin token revoke action

### DIFF
--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -104,11 +104,16 @@
 - **Model**: haiku. **Branch**: phase-13 (base phase-12). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/55
 - **Key**: list+retrieve on SystemUserTokenViewSet; `SystemUserTokenSerializer` (no token/hash); per-action get_serializer_class; prefetch_related("available_resources") no-N+1; IsOrganizationAdmin.has_object_permission got a safe hasattr(organization_id) fallback for SystemUser. Outer gate green (1393), mypy 108.
 
+### Phase 14 — Revoke public-API token (admin) ✅
+- **Status**: done, reviewed (3 layers, clean), pushed, PR opened.
+- **Model**: haiku. **Branch**: phase-14 (base phase-13). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/56
+- **Key**: `POST /public-api-tokens/{id}/revoke/` admin-only → is_active=False; end-to-end test proves check_system_user_token then returns False; idempotent; no-secret response. Outer gate green (1403), mypy 108.
+
 ## Current Phase
-Phase 14 — Revoke public-API token (admin) (next). `POST /public-api-tokens/{id}/revoke/` → set SystemUser.is_active=False; IsOrganizationAdmin; org-scoped (cross-org 404). Verify check_system_user_token then rejects the revoked token. Tier 2.
+Phase 15 — Edit public-API token permissions (admin) (next). PATCH /public-api-tokens/{id}/ — `SystemUserTokenUpdateSerializer` accepts available_resources ONLY; reconcile ResourceAccess rows (add missing, remove dropped); never re-issue secret or change integration_name. Add update/partial_update to viewset (get_serializer_class → update serializer for those actions). IsOrganizationAdmin. Tier 2.
 
 ## Remaining Phases
-15 (token edit perms), 16 (events expanded).
+16 (events expanded).
 
 ## Reusable infra notes (for later phases)
 - `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, works at collection + object level. Use for all admin endpoints.

--- a/public_api/tests/test_views.py
+++ b/public_api/tests/test_views.py
@@ -598,3 +598,174 @@ class TestSystemUserTokenViewSetRetrieve:
 
         response = anonymous_client.get(self._url(system_user.id))
         assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+
+@pytest.mark.django_db
+class TestSystemUserTokenViewSetRevoke:
+    """POST /public-api-tokens/{id}/revoke/ — Phase 14 revoke action."""
+
+    def _url(self, token_id):
+        return reverse("api:PublicAPITokens-revoke", kwargs={"pk": token_id})
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_admin_revokes_token_returns_200(self, admin_client, organization):
+        """Admin can revoke a token; 200 returned."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+    def test_revoke_sets_is_active_false(self, admin_client, organization):
+        """Revoking a token sets SystemUser.is_active to False."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        # Verify the token is now inactive in DB
+        system_user.refresh_from_db()
+        assert system_user.is_active is False
+
+    def test_revoke_response_includes_required_fields(self, admin_client, organization):
+        """Revoke response includes id, integration_name, is_active, available_resources."""
+        system_user = baker.make(
+            SystemUser,
+            organization=organization,
+            integration_name="revoke_test",
+            is_active=True,
+        )
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+
+        assert "id" in data
+        assert data["id"] == system_user.id
+        assert "integration_name" in data
+        assert data["integration_name"] == "revoke_test"
+        assert "is_active" in data
+        assert data["is_active"] is False
+        assert "available_resources" in data
+
+    def test_revoke_response_does_not_include_token(self, admin_client, organization):
+        """Revoke response must never include token or long_lived_token_hash."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+
+        assert "token" not in data
+        assert "long_lived_token_hash" not in data
+
+    def test_revoke_makes_token_fail_verification(
+        self, admin_client, admin_user, organization, di_container
+    ):
+        """After revoke, check_system_user_token returns (user, False)."""
+        # Create a token and capture the plaintext
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        # Simulate token creation flow to get the plaintext
+        public_api_auth_service = di_container.public_api_auth_service()
+        system_user, plaintext_token = public_api_auth_service.create_system_user(
+            integration_name="verify_revoke_test",
+            organization=organization,
+        )
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        # Verify token works before revoke
+        _, is_valid_before = public_api_auth_service.check_system_user_token(
+            system_user.id, plaintext_token
+        )
+        assert is_valid_before is True
+
+        # Revoke the token
+        response = admin_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        # Verify token now fails
+        _, is_valid_after = public_api_auth_service.check_system_user_token(
+            system_user.id, plaintext_token
+        )
+        assert is_valid_after is False
+
+    def test_revoking_already_revoked_token_is_idempotent(self, admin_client, organization):
+        """Revoking an already-revoked token is a 200 no-op."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=False)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        # Revoke an already-inactive token
+        response = admin_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        # Verify it remains inactive
+        system_user.refresh_from_db()
+        assert system_user.is_active is False
+
+    def test_revoke_cross_org_token_returns_404(
+        self, admin_client, organization, other_organization
+    ):
+        """Attempt to revoke a token from another org returns 404."""
+        system_user = baker.make(SystemUser, organization=other_organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = admin_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    # ------------------------------------------------------------------
+    # Permission / auth failures
+    # ------------------------------------------------------------------
+
+    def test_member_user_gets_403(self, member_client, organization):
+        """A non-admin member is rejected with HTTP 403."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = member_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_membership_less_user_gets_403(self, membership_less_client, organization):
+        """A user with no membership is rejected with HTTP 403."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = membership_less_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_anonymous_user_gets_401(self, anonymous_client, organization):
+        """An unauthenticated request is rejected with HTTP 401."""
+        system_user = baker.make(SystemUser, organization=organization, is_active=True)
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        response = anonymous_client.post(self._url(system_user.id))
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -2,6 +2,7 @@ import logging
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -85,3 +86,22 @@ class SystemUserTokenViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet)
             system_user, context={"request": request}
         )
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(responses={200: SystemUserTokenSerializer})
+    @action(detail=True, methods=["post"], url_path="revoke")
+    def revoke(self, request: Request, pk=None) -> Response:
+        """Revoke a public-API token by setting its SystemUser.is_active to False.
+
+        The token will no longer authenticate requests via check_system_user_token.
+        This is idempotent: revoking an already-revoked token is a 200 no-op.
+
+        Returns HTTP 200 with the updated token serialized via SystemUserTokenSerializer.
+        HTTP 403 is returned for non-admin callers; HTTP 404 if the token does not
+        exist or belongs to another organization; HTTP 401 for unauthenticated.
+        """
+        system_user = self.get_object()
+        system_user.is_active = False
+        system_user.save(update_fields=["is_active"])
+
+        serializer = SystemUserTokenSerializer(system_user, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/schema.yml
+++ b/schema.yml
@@ -6006,6 +6006,95 @@ paths:
               schema:
                 $ref: '#/components/schemas/SystemUserToken'
           description: ''
+  /public-api-tokens/{id}/revoke/:
+    post:
+      operationId: public_api_tokens_revoke_create
+      description: |-
+        Revoke a public-API token by setting its SystemUser.is_active to False.
+
+        The token will no longer authenticate requests via check_system_user_token.
+        This is idempotent: revoking an already-revoked token is a 200 no-op.
+
+        Returns HTTP 200 with the updated token serialized via SystemUserTokenSerializer.
+        HTTP 403 is returned for non-admin callers; HTTP 404 if the token does not
+        exist or belongs to another organization; HTTP 401 for unauthenticated.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - public-api-tokens
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SystemUserToken'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SystemUserToken'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SystemUserToken'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUserToken'
+          description: ''
+  /public-api-tokens/{id}/revoke{format}:
+    post:
+      operationId: public_api_tokens_revoke_formatted_create
+      description: |-
+        Revoke a public-API token by setting its SystemUser.is_active to False.
+
+        The token will no longer authenticate requests via check_system_user_token.
+        This is idempotent: revoking an already-revoked token is a 200 no-op.
+
+        Returns HTTP 200 with the updated token serialized via SystemUserTokenSerializer.
+        HTTP 403 is returned for non-admin callers; HTTP 404 if the token does not
+        exist or belongs to another organization; HTTP 401 for unauthenticated.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - public-api-tokens
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SystemUserToken'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SystemUserToken'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SystemUserToken'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemUserToken'
+          description: ''
   /public/organizations/{organization_id}/events/:
     get:
       operationId: public_organizations_events_list


### PR DESCRIPTION
## Summary
Phase 14 of the **REST API Frontend Gaps** plan. Adds `POST /public-api-tokens/{id}/revoke/` (admin-only): invalidates a token by setting its `SystemUser.is_active=False`. Revoked tokens then fail `check_system_user_token` (which already returns `(user, False)` for inactive users), so the GraphQL API rejects them.

## Behavior
- Admin-only detail action; cross-org token → 404; non-admin → 403; anon → 401.
- Idempotent: revoking an already-revoked token is a 200 no-op.
- Returns the no-secret serializer (is_active=False); never the token/hash.

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Phase 14 + API Design 4.7.

## Review history
Layer-3 review: clean, no blockers. The key end-to-end test creates a token, confirms `check_system_user_token` is True, revokes via the endpoint, then asserts it returns False.

## Test plan
- `uv run pytest public_api/tests/ -vs`
- Asserts: admin revoke → 200 + is_active False + auth then rejected; idempotent re-revoke 200; cross-org 404; non-admin 403; anon 401; no secret in response.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1403 passed).