### PR TITLE
feat(organizations): configure rooms-sync creds via org PATCH and fix the trigger

### DIFF
--- a/ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md
+++ b/ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md
@@ -521,51 +521,53 @@ Tests:
 
 Acceptance: `POST /invitations/{id}/resend/` regenerates + re-sends a pending invitation.
 
-### Phase 18 — Configure organization Google service account (admin)
+### Phase 18 — Rooms-sync configuration (via org partial-update) + working trigger (admin)
 
-**Goal**: an admin can configure the org's `GoogleCalendarServiceAccount` (the credentials the rooms/resource import authenticates with).
+**Goal**: an admin configures the org's Google service-account credentials **through `PATCH /organizations/{id}/`** (alongside `should_sync_rooms`), and the rooms-sync trigger actually runs by authenticating with those credentials.
 
-**Feature flag**: none — new endpoint.
+**Feature flag**: none — additive nested fields on an existing admin endpoint + a bug fix on the (currently-raising) trigger path.
 
-**Security note**: this endpoint accepts a Google service-account **private key**, stored via the model's `EncryptedCharField`. Write-only for secret fields (never returned in any response); admin-only; org-scoped. Treat as a credentials surface.
+**Security note**: the org partial-update accepts a Google service-account **private key**, stored via the model's `EncryptedCharField`. Secret fields (`private_key`, `private_key_id`) are **write-only** — never returned in any response. Admin-only (Phase 7 already gates org update with `IsOrganizationAdmin`); org-scoped.
+
+**Decision (per requester, 2026-06-05): rooms-sync config persists via the organization Partial Update** — do NOT add a separate service-account endpoint; nest it into `OrganizationSerializer`/`OrganizationViewSet.partial_update`.
 
 Changes:
-1. `GoogleServiceAccountViewSet` (create + retrieve/update; no list needed, one per org/resource) or a dedicated serializer-driven endpoint, `IsOrganizationAdmin`, org-scoped. Accepts `email`, `audience`, `public_key`, `private_key_id`, `private_key` (last two write-only). Response exposes only non-secret fields (e.g. `id`, `email`, `audience`, configured-at) — NEVER `private_key`/`private_key_id`.
-2. Route registration in `calendar_integration/routes.py`; `make update_schema`.
+1. `OrganizationSerializer`: add a nested, write-capable `google_service_account` representation (fields `email`, `audience`, `public_key`, `private_key_id`, `private_key`) where `private_key`/`private_key_id` are `write_only`. On the org's `update`/`partial_update`, create-or-update the org's `GoogleCalendarServiceAccount` from the nested payload (encrypted at rest). Read responses expose only non-secret fields (e.g. `email`, `audience`, `configured: true`) — NEVER the private key. `should_sync_rooms` continues to persist via the same PATCH.
+2. `OrganizationService.request_rooms_sync`: resolve the org's `GoogleCalendarServiceAccount`; if present, `calendar_service.authenticate(account=<service_account>, organization=org)` (NOT `initialize_without_provider`) then `request_organization_calendar_resources_import(...)`. If none configured → raise a clear, catchable error so the `sync_rooms` action + the should_sync_rooms False→True transition return **400** ("configure a Google service account first") rather than 500.
+3. `create_organization(should_sync_rooms=True)`: route through the same fixed path; if no service account exists at creation time, do NOT crash — skip the import gracefully (org creation must succeed; document the behavior).
+4. `make update_schema`.
 
-Spec use-case: "Admin configures their organization to sync rooms (service account credentials)."
+Spec use-case: "Admin configures their organization to sync rooms" + "Admin triggers a rooms sync (now actually executes)."
 
 Tests:
-- **Integration**: admin creates/sets the service account → 201/200, secret fields stored (encrypted) but NEVER echoed in the response; update rotates credentials; non-admin → 403; cross-org → 404; response contains no private key.
+- **Integration**: admin `PATCH /organizations/{id}/` with nested service-account creds (+ should_sync_rooms) → 200, creds stored encrypted, response NEVER echoes private_key/private_key_id; a second PATCH rotates them. With creds configured, `POST /organizations/{id}/sync-rooms/` authenticates with the `GoogleCalendarServiceAccount` (assert authenticate called with it) and enqueues the import; without creds → 400 (not 500). create_organization(should_sync_rooms=True) with no creds does not crash. non-admin → 403; cross-org → 404.
 
-**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. Credentials surface + write-only secret handling.
+**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. Credentials surface + nested write-only secrets + cross-service auth wiring + fixing a live break.
 
 **Reusable skills**: `create-rest-endpoint`.
 
-Acceptance: `POST /…/google-service-account/` stores the org's service-account credentials; secrets never returned.
+Acceptance: rooms-sync creds persist via org PATCH (secrets never returned); the trigger runs when configured and returns 400 (never 500) when not; org creation never crashes.
 
-### Phase 19 — Authenticate rooms-sync with the service account (fix the trigger)
+### Phase 19 — Service-layer hardening: on_commit enqueue + is_active query filtering
 
-**Goal**: make `request_rooms_sync` (and the `create_organization` rooms path) actually run — authenticate the service with the org's `GoogleCalendarServiceAccount` before `request_organization_calendar_resources_import`.
+**Goal**: make async enqueues transaction-safe at the service layer, and stop disabled calendars leaking through serializer/GraphQL querysets that don't filter `is_active`.
 
-**Feature flag**: none — bug fix on existing (currently-raising) paths.
+**Feature flag**: none — defensive correctness changes.
 
 Changes:
-1. `OrganizationService.request_rooms_sync`: resolve the org's `GoogleCalendarServiceAccount`; if present, `calendar_service.authenticate(account=<service_account>, organization=org)` (NOT `initialize_without_provider`) then `request_organization_calendar_resources_import(...)`. If no service account is configured → raise a clear, catchable error so the `sync_rooms` action returns **400** ("configure a Google service account first") rather than 500.
-2. `create_organization(should_sync_rooms=True)`: route through the same fixed path; if no service account exists at creation time, do NOT crash — skip/queue gracefully (document the chosen behavior; org creation must succeed).
-3. `sync_rooms` action + transition: surface the "no service account" case as 400.
-4. `make update_schema` (if responses change).
+1. **on_commit at the service layer**: wrap the `.delay(...)` calls inside `CalendarService.request_calendar_sync`, `request_organization_calendar_resources_import`, and `request_calendars_import` in `transaction.on_commit(...)` so the Celery task is enqueued only after the surrounding (ATOMIC_REQUESTS) transaction commits — removing the pre-existing race flagged in Phases 4/5/7. Verify existing callers/tests (some patch `transaction.on_commit` or use `captureOnCommitCallbacks`); adjust tests that asserted immediate `.delay` so they run the on_commit callback. Keep behavior correct under both request (atomic) and task (non-atomic) contexts.
+2. **is_active filtering** on calendar-listing querysets that currently omit it (flagged in Phase 9 follow-up): `CalendarBundleCreateSerializer` (and any resource-allocation serializer) child/queryset fields, and the public GraphQL calendars query (`public_api`/`<app>/graphql.py`). Default to active-only; where an existing relation must keep already-selected disabled calendars (mirror the Phase 10 union pattern), allow current selections but bar new disabled ones.
 
-Spec use-case: "Admin triggers a rooms sync (now actually executes)."
+Spec use-case: shared hardening — no new use-case (closes Phase 4/5/7 + Phase 9 follow-ups).
 
 Tests:
-- **Integration**: with a configured service account, `POST /organizations/{id}/sync-rooms/` authenticates with it (assert authenticate called with the GoogleCalendarServiceAccount) and enqueues the import; without one → 400 (not 500); create_organization(should_sync_rooms=True) with no service account does not crash; transition False→True with a service account triggers.
+- **Unit/Integration**: each wrapped service method enqueues its task via on_commit (assert with `captureOnCommitCallbacks`/the project pattern); the task does NOT fire if the transaction rolls back. Bundle-create + resource serializers exclude disabled calendars from selectable options; public GraphQL calendars query omits disabled calendars. Existing tests still pass.
 
-**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. Cross-service auth wiring + fixing a live break.
+**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. Touches a shared service used by many callers; transaction semantics + several querysets.
 
 **Reusable skills**: `create-rest-endpoint`.
 
-Acceptance: rooms sync runs when a service account is configured; returns 400 (never 500) when it isn't; org creation never crashes.
+Acceptance: the three service enqueues fire on commit (not before); disabled calendars no longer appear in bundle/resource selection or the public GraphQL calendars query; full suite green.
 
 ## 6. Risk & Rollout Notes
 

--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -12,16 +12,18 @@
 - Model haiku; fixer haiku. Branch phase-17 (base phase-16). PR: https://github.com/vintasoftware/vinta-schedule-api/pull/59
 - `POST /invitations/{id}/resend/` re-invokes invite_user_to_organization (resets token+expiry, resends email); accepted→400; org-scoped. Layer 3 → removed broad except (was masking 500s) + added real reset test. Stripped an AI co-author trailer. Outer gate green (1442), mypy 108.
 
+### Phase 18 — Rooms-sync config via org PATCH + working trigger ✅
+- **Status**: done, reviewed (3 layers; Layer 3 credentials-surface, 0 blockers; fixer → TOCTOU guard on post-commit trigger + validate-creds-before-write + test asserts), pushed, PR opened.
+- **Model**: sonnet; fixer sonnet. **Branch**: phase-18 (base phase-17). **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/60
+- **Key**: nested write-only google_service_account on OrganizationSerializer (secrets never returned; read = email/audience/configured); upsert in update() (atomic, org-level SA via calendar_fk__isnull=True, rotation=delete+create); request_rooms_sync authenticates with the SA (fixes the live 500); 400 when unconfigured; create_organization guarded; on_commit trigger TOCTOU-guarded. Outer gate green (1456), mypy 108. No trailer.
+
 ## Current Phase
-Phase 18 (REVISED per requester) — Rooms-sync config via org Partial Update + working trigger.
-- Config persists via `PATCH /organizations/{id}/` (nested google_service_account on OrganizationSerializer; private_key/private_key_id WRITE-ONLY, never returned). NOT a separate endpoint.
-- Fix the trigger: request_rooms_sync authenticates with the org's GoogleCalendarServiceAccount (NOT initialize_without_provider) then request_organization_calendar_resources_import; 400 (not 500) when unconfigured; create_organization must not crash when unconfigured.
-- Tier 3. Org update already admin-gated (Phase 7).
+Phase 19 (FINAL, REVISED per requester) — Service-layer hardening.
+1. on_commit at the service layer: wrap the `.delay(...)` inside CalendarService.request_calendar_sync, request_organization_calendar_resources_import, request_calendars_import. GOAL = exactly-ONE deferral, service-owned. View-layer on_commit wraps added earlier (Phase 4 request_import; Phase 7/18 sync_rooms+transition+create_organization) become redundant → remove them so callers invoke the service directly (avoid double-layer). Update tests (captureOnCommitCallbacks / patched on_commit).
+2. is_active filtering: bundle-create + resource-allocation serializer querysets + public GraphQL calendars query exclude disabled calendars; keep already-selected disabled (Phase 10 union pattern), bar new disabled.
 
 ## Remaining Phases
-Phase 19 (REVISED per requester) — Service-layer hardening:
-- Wrap .delay in transaction.on_commit inside CalendarService.request_calendar_sync, request_organization_calendar_resources_import, request_calendars_import (fix pre-existing race; adjust tests via captureOnCommitCallbacks).
-- is_active filtering on bundle-create/resource-allocation serializer querysets + public GraphQL calendars query (Phase 9 follow-up); keep already-selected disabled (Phase 10 union pattern), bar new disabled.
+(none after 19)
 
 ## Reusable infra
 - IsOrganizationAdmin; get_active_organization_membership; OrganizationSerializer + OrganizationViewSet.update (admin-gated, already overridden in Phase 7 with select_for_update + transition).

--- a/ai-plans/TRACKING_rest-api-frontend-gaps.md
+++ b/ai-plans/TRACKING_rest-api-frontend-gaps.md
@@ -2,30 +2,31 @@
 
 - **Plan**: ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md (Amendment section)
 - **Plan id**: rest-api-frontend-gaps
-- **Resumed**: 2026-06-05 (follow-up gaps after phases 0–16 shipped, PRs #42–#58)
 - **Run options**: auto-flow; inline PR comments ON
 - **Branch pattern**: stacked on phase-16 (last of the original run)
-- **mypy baseline**: 108 full-project errors (pre-existing); every phase must keep it at 108.
-
-## Context for these phases
-Two gaps: (1) resend invitation; (2) rooms-syncing unusable — `request_rooms_sync` + `create_organization` call initialize_without_provider (account=None) then request_organization_calendar_resources_import which requires a provider-authed service → RAISES; and no API to configure the org's GoogleCalendarServiceAccount.
-Decisions: fix trigger + add config endpoint; fix create_organization too; append phases.
+- **mypy baseline**: 108 full-project errors (pre-existing); keep at 108.
+- **POLICY REMINDER**: NO `Co-Authored-By` trailers in commits (project forbids; one slipped into Phase 17's first commit and was stripped — watch for it).
 
 ## Completed Phases (this amendment)
-(none yet)
+### Phase 17 — Resend organization invitation ✅
+- Model haiku; fixer haiku. Branch phase-17 (base phase-16). PR: https://github.com/vintasoftware/vinta-schedule-api/pull/59
+- `POST /invitations/{id}/resend/` re-invokes invite_user_to_organization (resets token+expiry, resends email); accepted→400; org-scoped. Layer 3 → removed broad except (was masking 500s) + added real reset test. Stripped an AI co-author trailer. Outer gate green (1442), mypy 108.
 
 ## Current Phase
-Phase 17 — Resend organization invitation (admin). resend @action on OrganizationInvitationViewSet → re-invoke invite_user_to_organization (already resets token+expiry+resends email); refuse if accepted. Tier 2.
+Phase 18 (REVISED per requester) — Rooms-sync config via org Partial Update + working trigger.
+- Config persists via `PATCH /organizations/{id}/` (nested google_service_account on OrganizationSerializer; private_key/private_key_id WRITE-ONLY, never returned). NOT a separate endpoint.
+- Fix the trigger: request_rooms_sync authenticates with the org's GoogleCalendarServiceAccount (NOT initialize_without_provider) then request_organization_calendar_resources_import; 400 (not 500) when unconfigured; create_organization must not crash when unconfigured.
+- Tier 3. Org update already admin-gated (Phase 7).
 
 ## Remaining Phases
-18 (configure org GoogleCalendarServiceAccount — admin, write-only secrets, Tier 3), 19 (authenticate rooms-sync with the service account; fix request_rooms_sync + create_organization; 400 not 500 when unconfigured — Tier 3).
+Phase 19 (REVISED per requester) — Service-layer hardening:
+- Wrap .delay in transaction.on_commit inside CalendarService.request_calendar_sync, request_organization_calendar_resources_import, request_calendars_import (fix pre-existing race; adjust tests via captureOnCommitCallbacks).
+- is_active filtering on bundle-create/resource-allocation serializer querysets + public GraphQL calendars query (Phase 9 follow-up); keep already-selected disabled (Phase 10 union pattern), bar new disabled.
 
-## Reusable infra (from phases 0–16)
-- `IsOrganizationAdmin` (organizations/permissions.py) — admin gate, collection + object (has_object_permission has hasattr(organization_id) fallback).
-- `get_active_organization_membership(user)` (organizations/models.py).
-- public_api REST surface pattern (SystemUserTokenViewSet) for new admin endpoints.
-- `OrganizationService.request_rooms_sync` (to fix in 19); `OrganizationService.invite_user_to_organization` (reset+resend, reuse in 17).
-- GoogleCalendarServiceAccount model: calendar_integration/models.py ~1541 (email, audience, public_key, private_key_id [Encrypted], private_key [Encrypted], org FK, calendar FK nullable).
+## Reusable infra
+- IsOrganizationAdmin; get_active_organization_membership; OrganizationSerializer + OrganizationViewSet.update (admin-gated, already overridden in Phase 7 with select_for_update + transition).
+- OrganizationService.request_rooms_sync (to fix in 18); GoogleCalendarServiceAccount model (calendar_integration/models.py ~1541; org FK, calendar FK nullable, email/audience/public_key, private_key_id+private_key EncryptedCharField).
+- CalendarService.authenticate(account, organization); is_authenticated_calendar_service requires account+calendar_adapter.
 
 ## Deferred
 None.

--- a/organizations/exceptions.py
+++ b/organizations/exceptions.py
@@ -6,6 +6,13 @@ class DuplicateInvitationError(ValidationError):
     default_code = "duplicate_invitation"
 
 
+class NoServiceAccountConfiguredError(ValidationError):
+    default_detail = (
+        "Configure a Google service account for this organization before syncing rooms."
+    )
+    default_code = "no_service_account_configured"
+
+
 class InvalidInvitationTokenError(ValidationError):
     default_detail = "Invalid or expired token"
     default_code = "invalid_invitation_token"

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from dependency_injector.wiring import Provide, inject
 from rest_framework import serializers
 
+from calendar_integration.models import GoogleCalendarServiceAccount
 from common.utils.serializer_utils import VirtualModelSerializer
 from organizations.models import Organization, OrganizationInvitation, OrganizationMembership
 from organizations.services import OrganizationService
@@ -12,7 +13,51 @@ from organizations.virtual_models import (
 )
 
 
+class GoogleServiceAccountWriteSerializer(serializers.Serializer):
+    """Write-only nested serializer for configuring a Google Calendar service account.
+
+    Used within OrganizationSerializer's ``google_service_account`` field.
+    Accepts all five credential fields; ``private_key`` and ``private_key_id``
+    are write-only and are never echoed back in any response.
+    """
+
+    email = serializers.EmailField()
+    audience = serializers.CharField(max_length=255)
+    public_key = serializers.CharField()
+    private_key_id = serializers.CharField(max_length=255, write_only=True)
+    private_key = serializers.CharField(write_only=True)
+
+
+class GoogleServiceAccountReadSerializer(serializers.Serializer):
+    """Read-only nested serializer for the Google Calendar service account status.
+
+    Exposes only non-secret fields plus a ``configured`` boolean flag so the
+    frontend can display whether credentials are set without ever returning
+    ``private_key`` or ``private_key_id``.
+    """
+
+    email = serializers.CharField(read_only=True)
+    audience = serializers.CharField(read_only=True)
+    configured = serializers.SerializerMethodField()
+
+    def get_configured(self, obj: GoogleCalendarServiceAccount) -> bool:
+        """Return True always — presence of the object means it is configured."""
+        return True
+
+
 class OrganizationSerializer(VirtualModelSerializer):
+    """Serializer for Organization instances.
+
+    The ``google_service_account`` field supports both reading and writing:
+    - **Write**: accepts ``email``, ``audience``, ``public_key``,
+      ``private_key_id`` (write-only), and ``private_key`` (write-only).
+      Omitting the field on PATCH leaves existing credentials unchanged.
+    - **Read**: returns ``email``, ``audience``, and ``configured: true/false``.
+      Secret fields are never returned.
+    """
+
+    google_service_account = serializers.SerializerMethodField()
+
     class Meta:
         model = Organization
         virtual_model = OrganizationVirtualModel
@@ -20,9 +65,21 @@ class OrganizationSerializer(VirtualModelSerializer):
             "id",
             "name",
             "should_sync_rooms",
+            "google_service_account",
             "created",
             "modified",
         )
+
+    def get_google_service_account(self, obj: Organization) -> dict | None:
+        """Return read-only service account info (no secrets), or None if unconfigured."""
+        account = (
+            GoogleCalendarServiceAccount.objects.filter_by_organization(obj.id)
+            .filter(calendar_fk__isnull=True)
+            .first()
+        )
+        if account is None:
+            return None
+        return GoogleServiceAccountReadSerializer(account).data
 
     @inject
     def __init__(

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import Annotated
 
 from django.db import IntegrityError, transaction
@@ -12,6 +13,7 @@ from vintasend.services.notification_service import (
     NotificationTypes,
 )
 
+from calendar_integration.models import GoogleCalendarServiceAccount
 from calendar_integration.services.calendar_service import CalendarService
 from common.utils.authentication_utils import (
     generate_long_lived_token,
@@ -22,6 +24,7 @@ from organizations.exceptions import (
     DuplicateInvitationError,
     InvalidInvitationTokenError,
     InvitationNotFoundError,
+    NoServiceAccountConfiguredError,
     UserAlreadyHasMembershipError,
 )
 from organizations.models import (
@@ -31,6 +34,9 @@ from organizations.models import (
     OrganizationRole,
 )
 from users.models import User
+
+
+logger = logging.getLogger(__name__)
 
 
 class OrganizationService:
@@ -65,10 +71,21 @@ class OrganizationService:
         )
 
         if should_sync_rooms:
-            self.request_rooms_sync(
-                organization=self.organization,
-                requested_by=creator,
-            )
+            # A newly created organization cannot have a service account yet, so
+            # request_rooms_sync will raise NoServiceAccountConfiguredError.  We
+            # catch it here and log a warning instead of crashing — org creation
+            # must always succeed; the admin can trigger the sync later once they
+            # have configured a Google service account via PATCH.
+            try:
+                self.request_rooms_sync(
+                    organization=self.organization,
+                    requested_by=creator,
+                )
+            except NoServiceAccountConfiguredError:
+                logger.warning(
+                    "Skipping rooms sync for new organization %s: no service account configured.",
+                    self.organization.id,
+                )
         return self.organization
 
     def request_rooms_sync(
@@ -78,18 +95,30 @@ class OrganizationService:
         start_time: datetime.datetime | None = None,
         end_time: datetime.datetime | None = None,
     ) -> None:
-        """
-        Initialize the calendar service without a provider and enqueue a
+        """Authenticate with the org's Google service account and enqueue a
         calendar resources import for the given organization.
+
+        Resolves the org-level ``GoogleCalendarServiceAccount`` (the one without
+        a ``calendar`` FK).  If none is configured, raises
+        ``NoServiceAccountConfiguredError`` (a DRF ValidationError / 400) so
+        callers can surface a clean error rather than a 500.
 
         :param organization: The organization to sync rooms for.
         :param requested_by: The user (or token) authorizing the sync.
         :param start_time: Import window start; defaults to now.
         :param end_time: Import window end; defaults to now + 365 days.
+        :raises NoServiceAccountConfiguredError: When no service account is
+            configured for the organization.
         """
-        self.calendar_service.initialize_without_provider(
-            user_or_token=requested_by, organization=organization
+        service_account = (
+            GoogleCalendarServiceAccount.objects.filter_by_organization(organization.id)
+            .filter(calendar_fk__isnull=True)
+            .first()
         )
+        if service_account is None:
+            raise NoServiceAccountConfiguredError()
+
+        self.calendar_service.authenticate(account=service_account, organization=organization)
         now = datetime.datetime.now(tz=datetime.UTC)
         self.calendar_service.request_organization_calendar_resources_import(
             start_time=start_time or now,

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -74,7 +74,14 @@ class TestOrganizationService:
     def test_create_organization_with_sync_rooms(
         self, organization_service, user, mock_calendar_service
     ):
-        """Test creating an organization with room syncing enabled."""
+        """Test creating an organization with room syncing enabled.
+
+        Phase 18: a newly-created org has no GoogleCalendarServiceAccount yet.
+        ``request_rooms_sync`` raises ``NoServiceAccountConfiguredError`` which
+        ``create_organization`` catches and logs; the org is still created and
+        the calendar service is NOT called (no import enqueued until the admin
+        configures a service account via PATCH).
+        """
         organization_name = "Test Organization with Rooms"
 
         organization = organization_service.create_organization(
@@ -92,28 +99,9 @@ class TestOrganizationService:
         assert db_organization.name == organization_name
         assert db_organization.should_sync_rooms is True
 
-        # Verify calendar service methods were called when should_sync_rooms=True
-        mock_calendar_service.initialize_without_provider.assert_called_once_with(
-            user_or_token=user, organization=organization
-        )
-        mock_calendar_service.request_organization_calendar_resources_import.assert_called_once()
-
-        # Verify the import call was made with correct time range (365 days from now)
-        call_args = mock_calendar_service.request_organization_calendar_resources_import.call_args
-        start_time = call_args[1]["start_time"]
-        end_time = call_args[1]["end_time"]
-
-        # Check that start_time is approximately now (within 1 minute tolerance)
-        now = datetime.datetime.now(tz=datetime.UTC)
-        time_diff = abs((start_time - now).total_seconds())
-        assert time_diff < 60, f"Start time should be close to now, but diff is {time_diff} seconds"
-
-        # Check that end_time is approximately 365 days from start_time
-        expected_end_time = start_time + datetime.timedelta(days=365)
-        time_diff = abs((end_time - expected_end_time).total_seconds())
-        assert time_diff < 60, (
-            f"End time should be 365 days from start time, but diff is {time_diff} seconds"
-        )
+        # Phase 18: no service account → neither authenticate nor the import is called.
+        mock_calendar_service.authenticate.assert_not_called()
+        mock_calendar_service.request_organization_calendar_resources_import.assert_not_called()
 
     def test_create_organization_default_sync_rooms_false(
         self, organization_service, user, mock_calendar_service
@@ -177,28 +165,45 @@ class TestOrganizationService:
     def test_create_organization_with_sync_rooms_calendar_service_exception(
         self, user, mock_calendar_service
     ):
-        """Test behavior when calendar service raises an exception during room sync."""
-        from di_core.containers import container
+        """Test behavior when calendar service raises an exception during room sync.
 
-        # Configure mock to raise an exception
-        mock_calendar_service.initialize_without_provider.side_effect = Exception(
-            "Calendar service error"
-        )
+        Phase 18: ``request_rooms_sync`` raises ``NoServiceAccountConfiguredError``
+        (a DRF ValidationError) before touching the calendar service because no
+        ``GoogleCalendarServiceAccount`` exists for a brand-new org.
+        ``create_organization`` catches ONLY that error and swallows it; the org
+        is still created successfully.
+
+        A generic, unexpected exception from the calendar service would still
+        propagate (not tested here — that path requires a service account to be
+        present, so it belongs in a unit test for ``request_rooms_sync`` itself).
+        """
+        from di_core.containers import container
 
         with container.calendar_service.override(mock_calendar_service):
             service = OrganizationService()
 
-            # The method should still raise the exception
-            with pytest.raises(Exception, match="Calendar service error"):
-                service.create_organization(
-                    creator=user, name="Test Organization Exception", should_sync_rooms=True
-                )
+            # Phase 18: org creation must succeed even though no SA is configured
+            # (the NoServiceAccountConfiguredError is caught and logged internally).
+            org = service.create_organization(
+                creator=user, name="Test Organization Exception", should_sync_rooms=True
+            )
+
+        assert org is not None
+        assert org.should_sync_rooms is True
+        # Calendar service must NOT have been touched (no SA → guard fires early).
+        mock_calendar_service.authenticate.assert_not_called()
+        mock_calendar_service.request_organization_calendar_resources_import.assert_not_called()
 
     @pytest.mark.parametrize("should_sync_rooms", [True, False])
     def test_create_organization_parametrized(
         self, organization_service, user, mock_calendar_service, should_sync_rooms
     ):
-        """Parametrized test for both sync_rooms scenarios."""
+        """Parametrized test for both sync_rooms scenarios.
+
+        Phase 18: when ``should_sync_rooms=True`` and no service account is
+        configured (as is always the case for a brand-new org), the import is
+        skipped gracefully — the calendar service is never called.
+        """
         organization_name = f"Test Organization Sync={should_sync_rooms}"
 
         organization = organization_service.create_organization(
@@ -208,12 +213,10 @@ class TestOrganizationService:
         # Verify organization was created correctly
         assert organization.should_sync_rooms == should_sync_rooms
 
-        if should_sync_rooms:
-            mock_calendar_service.initialize_without_provider.assert_called_once()
-            mock_calendar_service.request_organization_calendar_resources_import.assert_called_once()
-        else:
-            mock_calendar_service.initialize_without_provider.assert_not_called()
-            mock_calendar_service.request_organization_calendar_resources_import.assert_not_called()
+        # Phase 18: whether should_sync_rooms is True or False, the calendar service
+        # is never called during org creation because there is no service account yet.
+        mock_calendar_service.authenticate.assert_not_called()
+        mock_calendar_service.request_organization_calendar_resources_import.assert_not_called()
 
     @pytest.fixture
     def organization(self):

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -10,6 +10,7 @@ from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from calendar_integration.models import GoogleCalendarServiceAccount
 from common.utils.authentication_utils import generate_long_lived_token, hash_long_lived_token
 from organizations.exceptions import InvalidInvitationTokenError
 from organizations.models import (
@@ -1975,9 +1976,24 @@ class TestSyncRoomsAction:
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
     @patch("organizations.services.OrganizationService.request_rooms_sync")
     def test_admin_sync_rooms_default_times_returns_202(self, mock_sync, _mock_on_commit, user):
-        """Admin POST without body → 202; request_rooms_sync called with no explicit times."""
+        """Admin POST without body → 202; request_rooms_sync called with no explicit times.
+
+        Phase 18: a GoogleCalendarServiceAccount must exist for the org or the
+        view returns 400.  Provide one so the pre-flight check passes.
+        """
         organization = OrganizationTestFactory.create_organization(name="Sync Org")
         admin_client = self._make_admin_client(user, organization)
+        # Pre-flight requires a service account; provide one.
+        baker.make(
+            GoogleCalendarServiceAccount,
+            organization=organization,
+            calendar_fk=None,
+            email="sa@example.com",
+            audience="https://www.googleapis.com/auth/admin.directory.resource.calendar",
+            public_key="pk",
+            private_key_id="kid",
+            private_key="key",
+        )
 
         url = reverse("api:Organizations-sync-rooms", kwargs={"pk": organization.pk})
         response = admin_client.post(url, {}, format="json")
@@ -1993,11 +2009,26 @@ class TestSyncRoomsAction:
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
     @patch("organizations.services.OrganizationService.request_rooms_sync")
     def test_admin_sync_rooms_explicit_times_returns_202(self, mock_sync, _mock_on_commit, user):
-        """Admin POST with ISO start_time/end_time → 202; service called with parsed datetimes."""
+        """Admin POST with ISO start_time/end_time → 202; service called with parsed datetimes.
+
+        Phase 18: a GoogleCalendarServiceAccount must exist for the org or the
+        view returns 400.  Provide one so the pre-flight check passes.
+        """
         import datetime
 
         organization = OrganizationTestFactory.create_organization(name="Explicit Sync Org")
         admin_client = self._make_admin_client(user, organization)
+        # Pre-flight requires a service account; provide one.
+        baker.make(
+            GoogleCalendarServiceAccount,
+            organization=organization,
+            calendar_fk=None,
+            email="sa@example.com",
+            audience="https://www.googleapis.com/auth/admin.directory.resource.calendar",
+            public_key="pk",
+            private_key_id="kid",
+            private_key="key",
+        )
 
         start = datetime.datetime(2026, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
         end = datetime.datetime(2027, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
@@ -2101,8 +2132,23 @@ class TestShouldSyncRoomsTransition:
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
     @patch("organizations.services.OrganizationService.request_rooms_sync")
     def test_patch_false_to_true_fires_sync_once(self, mock_sync, _mock_on_commit, user):
-        """Admin PATCH should_sync_rooms False→True → 200; request_rooms_sync called once."""
+        """Admin PATCH should_sync_rooms False→True → 200; request_rooms_sync called once.
+
+        Phase 18: the view checks for a service account before firing the sync.
+        Provide one so the check passes.
+        """
         client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+        # Provide a service account so the pre-flight check passes.
+        baker.make(
+            GoogleCalendarServiceAccount,
+            organization=org,
+            calendar_fk=None,
+            email="sa@example.com",
+            audience="https://www.googleapis.com/auth/admin.directory.resource.calendar",
+            public_key="pk",
+            private_key_id="kid",
+            private_key="key",
+        )
 
         url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
         response = client.patch(url, {"should_sync_rooms": True}, format="json")
@@ -2215,8 +2261,23 @@ class TestShouldSyncRoomsTransition:
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
     @patch("organizations.services.OrganizationService.request_rooms_sync")
     def test_admin_can_set_should_sync_rooms_value_persists(self, mock_sync, _mock_on_commit, user):
-        """Admin PATCH should_sync_rooms → value persists in DB (configure-org use-case)."""
+        """Admin PATCH should_sync_rooms → value persists in DB (configure-org use-case).
+
+        Phase 18: the view checks for a service account before firing the sync.
+        Provide one so the check passes and the PATCH returns 200.
+        """
         client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+        # Provide a service account so the False→True transition check passes.
+        baker.make(
+            GoogleCalendarServiceAccount,
+            organization=org,
+            calendar_fk=None,
+            email="sa@example.com",
+            audience="https://www.googleapis.com/auth/admin.directory.resource.calendar",
+            public_key="pk",
+            private_key_id="kid",
+            private_key="key",
+        )
 
         url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
         response = client.patch(url, {"should_sync_rooms": True}, format="json")
@@ -2227,3 +2288,411 @@ class TestShouldSyncRoomsTransition:
         # Verify the value was persisted to the DB.
         org.refresh_from_db()
         assert org.should_sync_rooms is True
+
+
+# ---------------------------------------------------------------------------
+# Phase 18 — Rooms-sync configuration via org PATCH + working trigger
+# ---------------------------------------------------------------------------
+
+# Reusable service-account payload used across Phase 18 tests.
+_SA_PAYLOAD = {
+    "email": "rooms-sa@example.iam.gserviceaccount.com",
+    "audience": "https://www.googleapis.com/auth/admin.directory.resource.calendar",
+    "public_key": "test-public-key-value-not-a-real-key",
+    "private_key_id": "key-id-abc123",
+    "private_key": "test-private-key-value-not-a-real-key",
+}
+
+
+@pytest.mark.django_db
+class TestPhase18ServiceAccountConfig:
+    """Admin configures the org's Google service-account credentials via PATCH.
+
+    Security invariant: private_key and private_key_id are never returned in
+    any response.  Rotation: a second PATCH replaces the stored credentials.
+    """
+
+    def _make_admin(self, user, organization):
+        """Return an admin APIClient force-authenticated as an ADMIN of ``organization``."""
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client
+
+    def test_patch_with_service_account_creates_row_and_no_secrets_in_response(self, user):
+        """Admin PATCH with nested google_service_account → 200; row created; no secrets."""
+        org = baker.make(Organization, name="SA Org", should_sync_rooms=False)
+        client = self._make_admin(user, org)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(
+            url,
+            {"google_service_account": _SA_PAYLOAD},
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        body = response.json()
+
+        # Service account info is present in the response.
+        sa_response = body.get("google_service_account")
+        assert sa_response is not None, f"Expected google_service_account in response: {body}"
+        assert sa_response["configured"] is True
+        assert sa_response["email"] == _SA_PAYLOAD["email"]
+        assert sa_response["audience"] == _SA_PAYLOAD["audience"]
+
+        # Secrets MUST NOT be in the response.
+        assert "private_key" not in sa_response, "private_key must not be returned"
+        assert "private_key_id" not in sa_response, "private_key_id must not be returned"
+
+        # DB row created.
+        stored = (
+            GoogleCalendarServiceAccount.objects.filter_by_organization(org.id)
+            .filter(calendar_fk__isnull=True)
+            .first()
+        )
+        assert stored is not None, "GoogleCalendarServiceAccount row should have been created"
+        assert stored.email == _SA_PAYLOAD["email"]
+        assert stored.audience == _SA_PAYLOAD["audience"]
+
+    def test_second_patch_rotates_credentials(self, user):
+        """Second PATCH with different creds replaces the stored service account."""
+        org = baker.make(Organization, name="Rotate Org", should_sync_rooms=False)
+        client = self._make_admin(user, org)
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+
+        # First PATCH.
+        client.patch(url, {"google_service_account": _SA_PAYLOAD}, format="json")
+        first_sa = (
+            GoogleCalendarServiceAccount.objects.filter_by_organization(org.id)
+            .filter(calendar_fk__isnull=True)
+            .first()
+        )
+        assert first_sa is not None
+
+        # Second PATCH with a different email.
+        new_payload = dict(_SA_PAYLOAD)
+        new_payload["email"] = "rotated-sa@example.iam.gserviceaccount.com"
+        new_payload["private_key_id"] = "new-key-id-xyz"
+        response = client.patch(url, {"google_service_account": new_payload}, format="json")
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        # Exactly one row remains (the rotated one).
+        all_sa = list(
+            GoogleCalendarServiceAccount.objects.filter_by_organization(org.id).filter(
+                calendar_fk__isnull=True
+            )
+        )
+        assert len(all_sa) == 1, f"Expected exactly one SA row, got {len(all_sa)}"
+        assert all_sa[0].email == "rotated-sa@example.iam.gserviceaccount.com"
+
+        # Response reflects the rotated email.
+        body = response.json()
+        assert (
+            body["google_service_account"]["email"] == "rotated-sa@example.iam.gserviceaccount.com"
+        )
+        # Secrets still absent.
+        assert "private_key" not in body["google_service_account"]
+        assert "private_key_id" not in body["google_service_account"]
+
+    def test_patch_omitting_service_account_leaves_existing_unchanged(self, user):
+        """Omitting google_service_account on PATCH is a no-op for the SA row."""
+        org = baker.make(Organization, name="No-Op Org", should_sync_rooms=False)
+        client = self._make_admin(user, org)
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+
+        # Create the SA first.
+        client.patch(url, {"google_service_account": _SA_PAYLOAD}, format="json")
+        original_id = (
+            GoogleCalendarServiceAccount.objects.filter_by_organization(org.id)
+            .filter(calendar_fk__isnull=True)
+            .values_list("id", flat=True)
+            .first()
+        )
+
+        # PATCH only the name — google_service_account omitted.
+        response = client.patch(url, {"name": "No-Op Renamed"}, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        # The same row still exists.
+        after_id = (
+            GoogleCalendarServiceAccount.objects.filter_by_organization(org.id)
+            .filter(calendar_fk__isnull=True)
+            .values_list("id", flat=True)
+            .first()
+        )
+        assert after_id == original_id
+
+        # Response still shows configured.
+        body = response.json()
+        assert body["google_service_account"]["configured"] is True
+
+    def test_get_response_shows_configured_true_after_patch(self, user):
+        """After PATCH with SA creds, the read response shows configured=true."""
+        org = baker.make(Organization, name="Read Org", should_sync_rooms=False)
+        client = self._make_admin(user, org)
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+
+        # Ensure a SA exists.
+        baker.make(
+            GoogleCalendarServiceAccount,
+            organization=org,
+            calendar_fk=None,
+            email=_SA_PAYLOAD["email"],
+            audience=_SA_PAYLOAD["audience"],
+            public_key=_SA_PAYLOAD["public_key"],
+            private_key_id=_SA_PAYLOAD["private_key_id"],
+            private_key=_SA_PAYLOAD["private_key"],
+        )
+
+        # The read path is exercised via PATCH (which returns the object).
+        response = client.patch(url, {"name": "Read Org Renamed"}, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+        body = response.json()
+
+        assert body["google_service_account"] is not None
+        assert body["google_service_account"]["configured"] is True
+        assert body["google_service_account"]["email"] == _SA_PAYLOAD["email"]
+        assert "private_key" not in body["google_service_account"]
+        assert "private_key_id" not in body["google_service_account"]
+
+    def test_patch_service_account_non_admin_returns_403(self, auth_client, user):
+        """Non-admin member cannot configure the service account → 403."""
+        org = baker.make(Organization, name="Member SA Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = auth_client.patch(url, {"google_service_account": _SA_PAYLOAD}, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_patch_service_account_cross_org_returns_404(self, user):
+        """Admin cannot configure a service account on a different org → 404."""
+        own_org = baker.make(Organization, name="Own Org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=own_org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        other_org = baker.make(Organization, name="Other Org")
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        url = reverse("api:Organizations-detail", kwargs={"pk": other_org.pk})
+        response = client.patch(url, {"google_service_account": _SA_PAYLOAD}, format="json")
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+    def test_patch_service_account_unauthenticated_returns_401(self):
+        """Unauthenticated request cannot configure a service account → 401."""
+        org = baker.make(Organization, name="Anon SA Org")
+        client = APIClient()
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(url, {"google_service_account": _SA_PAYLOAD}, format="json")
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+
+@pytest.mark.django_db
+class TestPhase18SyncRoomsTrigger:
+    """POST sync-rooms works when creds configured; 400 (never 500) when not.
+
+    Mocks ``calendar_service.authenticate`` and
+    ``request_organization_calendar_resources_import`` so the tests do not hit
+    the Google API.  The test asserts that ``authenticate`` is called with the
+    stored ``GoogleCalendarServiceAccount``.
+    """
+
+    def _make_admin(self, user, organization):
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    def test_sync_rooms_with_service_account_calls_authenticate(self, _mock_on_commit, user):
+        """With a service account configured, sync-rooms authenticates with it."""
+        org = baker.make(Organization, name="SA Sync Org", should_sync_rooms=True)
+        sa = baker.make(
+            GoogleCalendarServiceAccount,
+            organization=org,
+            calendar_fk=None,
+            email=_SA_PAYLOAD["email"],
+            audience=_SA_PAYLOAD["audience"],
+            public_key=_SA_PAYLOAD["public_key"],
+            private_key_id=_SA_PAYLOAD["private_key_id"],
+            private_key=_SA_PAYLOAD["private_key"],
+        )
+        client = self._make_admin(user, org)
+
+        mock_calendar_service = MagicMock()
+        mock_calendar_service.authenticate.return_value = None
+        mock_calendar_service.request_organization_calendar_resources_import.return_value = None
+
+        from di_core.containers import container
+
+        with container.calendar_service.override(mock_calendar_service):
+            url = reverse("api:Organizations-sync-rooms", kwargs={"pk": org.pk})
+            response = client.post(url, {}, format="json")
+
+        assert_response_status_code(response, status.HTTP_202_ACCEPTED)
+
+        # authenticate must have been called with our service account.
+        mock_calendar_service.authenticate.assert_called_once()
+        call_kwargs = mock_calendar_service.authenticate.call_args.kwargs
+        assert call_kwargs["account"].id == sa.id
+        assert call_kwargs["organization"] == org
+
+        # import must have been called.
+        mock_calendar_service.request_organization_calendar_resources_import.assert_called_once()
+
+    def test_sync_rooms_without_service_account_returns_400(self, user):
+        """Without a service account configured, sync-rooms returns 400."""
+        org = baker.make(Organization, name="No SA Org", should_sync_rooms=True)
+        client = self._make_admin(user, org)
+
+        url = reverse("api:Organizations-sync-rooms", kwargs={"pk": org.pk})
+        response = client.post(url, {}, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        body = str(response.json()).lower()
+        assert "service account" in body or "configure" in body, (
+            f"Expected a 'service account' message in the 400 response: {body}"
+        )
+
+
+@pytest.mark.django_db
+class TestPhase18TransitionWithNoCredentials:
+    """Enabling should_sync_rooms False→True without creds → 400 (not 500)."""
+
+    def _make_admin_client_and_org(self, user, should_sync_rooms=False):
+        organization = baker.make(
+            Organization, name="Creds Transition Org", should_sync_rooms=should_sync_rooms
+        )
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client, organization
+
+    def test_enable_sync_rooms_without_creds_returns_400(self, user):
+        """PATCH enabling should_sync_rooms with no SA configured → 400."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+        body = str(response.json()).lower()
+        assert "service account" in body or "configure" in body, (
+            f"Expected a 'service account' message in 400 response: {body}"
+        )
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    def test_enable_sync_rooms_with_creds_in_same_patch_succeeds(self, _mock_on_commit, user):
+        """PATCH enabling should_sync_rooms + providing SA creds in same request → 200."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+
+        mock_calendar_service = MagicMock()
+        mock_calendar_service.authenticate.return_value = None
+        mock_calendar_service.request_organization_calendar_resources_import.return_value = None
+
+        from di_core.containers import container
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        with container.calendar_service.override(mock_calendar_service):
+            response = client.patch(
+                url,
+                {"should_sync_rooms": True, "google_service_account": _SA_PAYLOAD},
+                format="json",
+            )
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        body = response.json()
+        assert body["should_sync_rooms"] is True
+        assert body["google_service_account"]["configured"] is True
+
+    @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
+    def test_enable_sync_rooms_with_pre_existing_creds_succeeds(self, _mock_on_commit, user):
+        """PATCH enabling should_sync_rooms when SA already exists → 200; sync fires."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+
+        # Pre-configure a service account.
+        baker.make(
+            GoogleCalendarServiceAccount,
+            organization=org,
+            calendar_fk=None,
+            email=_SA_PAYLOAD["email"],
+            audience=_SA_PAYLOAD["audience"],
+            public_key=_SA_PAYLOAD["public_key"],
+            private_key_id=_SA_PAYLOAD["private_key_id"],
+            private_key=_SA_PAYLOAD["private_key"],
+        )
+
+        mock_calendar_service = MagicMock()
+        mock_calendar_service.authenticate.return_value = None
+        mock_calendar_service.request_organization_calendar_resources_import.return_value = None
+
+        from di_core.containers import container
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        with container.calendar_service.override(mock_calendar_service):
+            response = client.patch(url, {"should_sync_rooms": True}, format="json")
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        body = response.json()
+        assert body["should_sync_rooms"] is True
+
+
+@pytest.mark.django_db
+class TestPhase18CreateOrganizationNoCredentials:
+    """create_organization(should_sync_rooms=True) with no creds must not crash."""
+
+    def test_create_organization_with_sync_rooms_no_creds_does_not_crash(self, user):
+        """Org is created successfully even when no service account is available.
+
+        The rooms sync is silently skipped (warning logged); org creation returns
+        the new Organization without crashing.
+        """
+        from di_core.containers import container
+
+        # We don't override the calendar service here — the real code path should
+        # hit the NoServiceAccountConfiguredError guard in request_rooms_sync and
+        # swallow it gracefully inside create_organization.
+        service = container.organization_service()
+        org = service.create_organization(
+            creator=user,
+            name="NoCredOrg",
+            should_sync_rooms=True,
+        )
+
+        assert org is not None
+        assert org.name == "NoCredOrg"
+        assert org.should_sync_rooms is True
+
+        # Org and membership exist.
+        assert Organization.objects.filter(id=org.id).exists()
+        membership = OrganizationMembership.objects.get(user=user, organization=org)
+        assert membership is not None

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -2350,6 +2350,7 @@ class TestPhase18ServiceAccountConfig:
         # Secrets MUST NOT be in the response.
         assert "private_key" not in sa_response, "private_key must not be returned"
         assert "private_key_id" not in sa_response, "private_key_id must not be returned"
+        assert "public_key" not in sa_response, "public_key must not be returned"
 
         # DB row created.
         stored = (
@@ -2401,6 +2402,7 @@ class TestPhase18ServiceAccountConfig:
         # Secrets still absent.
         assert "private_key" not in body["google_service_account"]
         assert "private_key_id" not in body["google_service_account"]
+        assert "public_key" not in body["google_service_account"]
 
     def test_patch_omitting_service_account_leaves_existing_unchanged(self, user):
         """Omitting google_service_account on PATCH is a no-op for the SA row."""
@@ -2462,6 +2464,7 @@ class TestPhase18ServiceAccountConfig:
         assert body["google_service_account"]["email"] == _SA_PAYLOAD["email"]
         assert "private_key" not in body["google_service_account"]
         assert "private_key_id" not in body["google_service_account"]
+        assert "public_key" not in body["google_service_account"]
 
     def test_patch_service_account_non_admin_returns_403(self, auth_client, user):
         """Non-admin member cannot configure the service account → 403."""
@@ -2632,7 +2635,40 @@ class TestPhase18TransitionWithNoCredentials:
         assert_response_status_code(response, status.HTTP_200_OK)
         body = response.json()
         assert body["should_sync_rooms"] is True
-        assert body["google_service_account"]["configured"] is True
+        sa_response = body["google_service_account"]
+        assert sa_response["configured"] is True
+
+        # Secrets MUST NOT be in the response.
+        assert "private_key" not in sa_response, "private_key must not be returned"
+        assert "private_key_id" not in sa_response, "private_key_id must not be returned"
+        assert "public_key" not in sa_response, "public_key must not be returned"
+
+        # The sync trigger must have actually fired with the configured account.
+        mock_calendar_service.authenticate.assert_called_once()
+
+    def test_rename_and_enable_sync_without_creds_returns_400_and_name_unchanged(self, user):
+        """PATCH renaming the org AND enabling should_sync_rooms with no creds → 400;
+        the rename must NOT be persisted (no partial write)."""
+        client, org = self._make_admin_client_and_org(user, should_sync_rooms=False)
+        original_name = org.name
+
+        url = reverse("api:Organizations-detail", kwargs={"pk": org.pk})
+        response = client.patch(
+            url,
+            {"name": "Should Not Be Saved", "should_sync_rooms": True},
+            format="json",
+        )
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+        # The name must remain unchanged in the DB (no partial write).
+        org.refresh_from_db()
+        assert org.name == original_name, (
+            f"Expected org name to remain '{original_name}', got '{org.name}'"
+        )
+        assert org.should_sync_rooms is False, (
+            "should_sync_rooms must not have been enabled after a 400"
+        )
 
     @patch("organizations.views.transaction.on_commit", side_effect=lambda fn: fn())
     def test_enable_sync_rooms_with_pre_existing_creds_succeeds(self, _mock_on_commit, user):

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -103,6 +103,9 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
 
         Uses select_for_update to lock the row during snapshot + write, serializing
         concurrent PATCHes and preventing double-fire of the sync on False→True transition.
+
+        The creds check is performed BEFORE any write so that unrelated field changes (e.g.
+        renaming the org) are NOT persisted when the 400 is returned.
         """
         partial = kwargs.get("partial", False)
 
@@ -121,6 +124,23 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
 
             serializer = self.get_update_serializer(instance, data=request.data, partial=partial)
             serializer.is_valid(raise_exception=True)
+
+            # Compute desired transition BEFORE writing so we can reject early.
+            desired_should_sync_rooms = serializer.validated_data.get(
+                "should_sync_rooms", old_should_sync_rooms
+            )
+            fire = (not old_should_sync_rooms) and desired_should_sync_rooms
+
+            # Guard: enabling sync without any service account → 400 BEFORE any write.
+            if fire and sa_data is None:
+                has_existing_sa = (
+                    GoogleCalendarServiceAccount.objects.filter_by_organization(instance.id)
+                    .filter(calendar_fk__isnull=True)
+                    .exists()
+                )
+                if not has_existing_sa:
+                    raise NoServiceAccountConfiguredError()
+
             self.perform_update(serializer)
 
             # Upsert the service account if provided.
@@ -138,23 +158,6 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
                     private_key=sa_data["private_key"],
                 )
 
-            # Detect False→True transition (exactly once — only when the flag just became True).
-            new_should_sync_rooms = serializer.instance.should_sync_rooms
-            fire = (not old_should_sync_rooms) and new_should_sync_rooms
-
-            if fire:
-                # Check that a service account is configured (either just provided or pre-existing).
-                has_sa = sa_data is not None or (
-                    GoogleCalendarServiceAccount.objects.filter_by_organization(instance.id)
-                    .filter(calendar_fk__isnull=True)
-                    .exists()
-                )
-                if not has_sa:
-                    raise ValidationError(
-                        detail=NoServiceAccountConfiguredError.default_detail,
-                        code=NoServiceAccountConfiguredError.default_code,
-                    )
-
         # Register the on_commit callback AFTER the atomic block (so it fires post-commit).
         if fire:
             org = serializer.instance
@@ -162,7 +165,14 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
             org_service = self.organization_service
 
             def _trigger():
-                org_service.request_rooms_sync(organization=org, requested_by=user)
+                try:
+                    org_service.request_rooms_sync(organization=org, requested_by=user)
+                except NoServiceAccountConfiguredError:
+                    logger.warning(
+                        "rooms-sync trigger skipped: no service account configured for org %s "
+                        "(account may have been deleted between pre-flight check and commit)",
+                        org.id,
+                    )
 
             transaction.on_commit(_trigger)
 
@@ -247,12 +257,19 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
             raise NoServiceAccountConfiguredError()
 
         def _trigger():
-            org_service.request_rooms_sync(
-                organization=org,
-                requested_by=user,
-                start_time=start_time,
-                end_time=end_time,
-            )
+            try:
+                org_service.request_rooms_sync(
+                    organization=org,
+                    requested_by=user,
+                    start_time=start_time,
+                    end_time=end_time,
+                )
+            except NoServiceAccountConfiguredError:
+                logger.warning(
+                    "rooms-sync trigger skipped: no service account configured for org %s "
+                    "(account may have been deleted between pre-flight check and commit)",
+                    org.id,
+                )
 
         transaction.on_commit(_trigger)
 

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import Annotated
 
 from django.db import transaction
@@ -11,6 +12,7 @@ from rest_framework.exceptions import NotFound, PermissionDenied, ValidationErro
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from calendar_integration.models import GoogleCalendarServiceAccount
 from common.utils.view_utils import (
     NoListVintaScheduleModelViewSet,
     NoUpdateVintaScheduleModelViewSet,
@@ -20,6 +22,7 @@ from organizations.exceptions import (
     DuplicateInvitationError,
     InvalidInvitationTokenError,
     InvitationNotFoundError,
+    NoServiceAccountConfiguredError,
     UserAlreadyHasMembershipError,
 )
 from organizations.filtersets import OrganizationInvitationFilterSet
@@ -37,11 +40,15 @@ from organizations.permissions import (
 from organizations.serializers import (
     AcceptInvitationSerializer,
     CurrentMembershipSerializer,
+    GoogleServiceAccountWriteSerializer,
     OrganizationInvitationSerializer,
     OrganizationMembershipSerializer,
     OrganizationSerializer,
 )
 from organizations.services import OrganizationService
+
+
+logger = logging.getLogger(__name__)
 
 
 class OrganizationViewSet(NoListVintaScheduleModelViewSet):
@@ -85,12 +92,27 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
         return Organization.objects.none()
 
     def update(self, request, *args, **kwargs):
-        """Override update to trigger rooms sync when should_sync_rooms flips False→True.
+        """Override update to:
+
+        1. Upsert the org's ``GoogleCalendarServiceAccount`` when ``google_service_account``
+           is present in the request body (create-or-update, one per org, calendar FK=None).
+        2. Trigger rooms sync when ``should_sync_rooms`` flips False→True — but only when a
+           service account is configured (either already stored or just provided in this PATCH).
+           If the flag is being enabled and no service account is configured (neither stored
+           nor in the request), return **400** so the admin knows to configure first.
 
         Uses select_for_update to lock the row during snapshot + write, serializing
         concurrent PATCHes and preventing double-fire of the sync on False→True transition.
         """
         partial = kwargs.get("partial", False)
+
+        # Validate the nested google_service_account block if present, before entering the lock.
+        sa_data: dict | None = None
+        raw_sa = request.data.get("google_service_account")
+        if raw_sa is not None:
+            sa_serializer = GoogleServiceAccountWriteSerializer(data=raw_sa)
+            sa_serializer.is_valid(raise_exception=True)
+            sa_data = sa_serializer.validated_data
 
         # Lock the row during snapshot + write.
         with transaction.atomic():
@@ -101,9 +123,37 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
             serializer.is_valid(raise_exception=True)
             self.perform_update(serializer)
 
+            # Upsert the service account if provided.
+            if sa_data is not None:
+                GoogleCalendarServiceAccount.objects.filter_by_organization(instance.id).filter(
+                    calendar_fk__isnull=True
+                ).delete()
+                GoogleCalendarServiceAccount.objects.create(
+                    organization=instance,
+                    calendar_fk=None,
+                    email=sa_data["email"],
+                    audience=sa_data["audience"],
+                    public_key=sa_data["public_key"],
+                    private_key_id=sa_data["private_key_id"],
+                    private_key=sa_data["private_key"],
+                )
+
             # Detect False→True transition (exactly once — only when the flag just became True).
             new_should_sync_rooms = serializer.instance.should_sync_rooms
             fire = (not old_should_sync_rooms) and new_should_sync_rooms
+
+            if fire:
+                # Check that a service account is configured (either just provided or pre-existing).
+                has_sa = sa_data is not None or (
+                    GoogleCalendarServiceAccount.objects.filter_by_organization(instance.id)
+                    .filter(calendar_fk__isnull=True)
+                    .exists()
+                )
+                if not has_sa:
+                    raise ValidationError(
+                        detail=NoServiceAccountConfiguredError.default_detail,
+                        code=NoServiceAccountConfiguredError.default_code,
+                    )
 
         # Register the on_commit callback AFTER the atomic block (so it fires post-commit).
         if fire:
@@ -185,6 +235,16 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
 
         org_service = self.organization_service
         user = request.user
+
+        # Pre-flight: refuse early (400) if no service account is configured so the
+        # admin gets a clear error instead of a 500 when the on_commit fires.
+        has_sa = (
+            GoogleCalendarServiceAccount.objects.filter_by_organization(org.id)
+            .filter(calendar_fk__isnull=True)
+            .exists()
+        )
+        if not has_sa:
+            raise NoServiceAccountConfiguredError()
 
         def _trigger():
             org_service.request_rooms_sync(

--- a/schema.yml
+++ b/schema.yml
@@ -5325,7 +5325,14 @@ paths:
     put:
       operationId: organizations_update
       description: |-
-        Override update to trigger rooms sync when should_sync_rooms flips False→True.
+        Override update to:
+
+        1. Upsert the org's ``GoogleCalendarServiceAccount`` when ``google_service_account``
+           is present in the request body (create-or-update, one per org, calendar FK=None).
+        2. Trigger rooms sync when ``should_sync_rooms`` flips False→True — but only when a
+           service account is configured (either already stored or just provided in this PATCH).
+           If the flag is being enabled and no service account is configured (neither stored
+           nor in the request), return **400** so the admin knows to configure first.
 
         Uses select_for_update to lock the row during snapshot + write, serializing
         concurrent PATCHes and preventing double-fire of the sync on False→True transition.
@@ -5440,7 +5447,14 @@ paths:
     put:
       operationId: organizations_formatted_update
       description: |-
-        Override update to trigger rooms sync when should_sync_rooms flips False→True.
+        Override update to:
+
+        1. Upsert the org's ``GoogleCalendarServiceAccount`` when ``google_service_account``
+           is present in the request body (create-or-update, one per org, calendar FK=None).
+        2. Trigger rooms sync when ``should_sync_rooms`` flips False→True — but only when a
+           service account is configured (either already stored or just provided in this PATCH).
+           If the flag is being enabled and no service account is configured (neither stored
+           nor in the request), return **400** so the admin knows to configure first.
 
         Uses select_for_update to lock the row during snapshot + write, serializing
         concurrent PATCHes and preventing double-fire of the sync on False→True transition.
@@ -8364,6 +8378,15 @@ components:
         * `YEARLY` - Yearly
     Organization:
       type: object
+      description: |-
+        Serializer for Organization instances.
+
+        The ``google_service_account`` field supports both reading and writing:
+        - **Write**: accepts ``email``, ``audience``, ``public_key``,
+          ``private_key_id`` (write-only), and ``private_key`` (write-only).
+          Omitting the field on PATCH leaves existing credentials unchanged.
+        - **Read**: returns ``email``, ``audience``, and ``configured: true/false``.
+          Secret fields are never returned.
       properties:
         id:
           type: integer
@@ -8374,6 +8397,13 @@ components:
         should_sync_rooms:
           type: boolean
           description: Whether to sync rooms for this organization.
+        google_service_account:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: Return read-only service account info (no secrets), or None
+            if unconfigured.
+          readOnly: true
         created:
           type: string
           format: date-time
@@ -8384,6 +8414,7 @@ components:
           readOnly: true
       required:
       - created
+      - google_service_account
       - id
       - modified
       - name
@@ -9160,6 +9191,15 @@ components:
           readOnly: true
     PatchedOrganization:
       type: object
+      description: |-
+        Serializer for Organization instances.
+
+        The ``google_service_account`` field supports both reading and writing:
+        - **Write**: accepts ``email``, ``audience``, ``public_key``,
+          ``private_key_id`` (write-only), and ``private_key`` (write-only).
+          Omitting the field on PATCH leaves existing credentials unchanged.
+        - **Read**: returns ``email``, ``audience``, and ``configured: true/false``.
+          Secret fields are never returned.
       properties:
         id:
           type: integer
@@ -9170,6 +9210,13 @@ components:
         should_sync_rooms:
           type: boolean
           description: Whether to sync rooms for this organization.
+        google_service_account:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: Return read-only service account info (no secrets), or None
+            if unconfigured.
+          readOnly: true
         created:
           type: string
           format: date-time

--- a/schema.yml
+++ b/schema.yml
@@ -5336,6 +5336,9 @@ paths:
 
         Uses select_for_update to lock the row during snapshot + write, serializing
         concurrent PATCHes and preventing double-fire of the sync on False→True transition.
+
+        The creds check is performed BEFORE any write so that unrelated field changes (e.g.
+        renaming the org) are NOT persisted when the 400 is returned.
       parameters:
       - in: path
         name: id
@@ -5458,6 +5461,9 @@ paths:
 
         Uses select_for_update to lock the row during snapshot + write, serializing
         concurrent PATCHes and preventing double-fire of the sync on False→True transition.
+
+        The creds check is performed BEFORE any write so that unrelated field changes (e.g.
+        renaming the org) are NOT persisted when the 400 is returned.
       parameters:
       - in: path
         name: format


### PR DESCRIPTION
## Summary
Follow-up gap (plan amendment). Makes rooms-syncing actually usable:
- **Configure via org partial-update**: `PATCH /organizations/{id}/` accepts a nested `google_service_account` (email, audience, public_key + **write-only** private_key/private_key_id), upserting the org's `GoogleCalendarServiceAccount`. Per requester decision, config persists through the org Partial Update — no separate endpoint. Secrets are never returned (read shows email/audience + `configured`).
- **Fix the trigger**: `OrganizationService.request_rooms_sync` now authenticates the calendar service with that `GoogleCalendarServiceAccount` (the org-level one, `calendar_fk__isnull=True`) before `request_organization_calendar_resources_import`. Previously it called `initialize_without_provider` (account=None) → the import **raised at runtime**.

## Why this was a real bug
The import requires a provider-authenticated service (`is_authenticated_calendar_service` needs account + adapter). Phase 7's trigger and the pre-existing `create_organization` rooms path both used `initialize_without_provider`, so triggering a rooms import would 500. Now: configured → runs; not configured → **400** (never 500); `create_organization(should_sync_rooms=True)` with no creds no longer crashes (skips + logs).

## Plan reference
Plan `ai-plans/2026-06-05-REST_API_FRONTEND_GAPS_IMPLEMENTATION_PLAN.md` — Amendment, Phase 18.

## Review history
Layer-3 review (credentials surface): 0 blockers — confirmed secrets can't leak through any response/exception/log. Fixed its should-fixes: TOCTOU on the post-commit trigger (now try/except + log so a deleted account can't raise unhandled in the on_commit callback), and reordered `update()` so the "enabling sync needs creds" check runs **before** any write (a rename+enable-without-creds PATCH now 400s without persisting the rename). Added authenticate + no-`public_key` assertions and a no-partial-write test.

## Test plan
- `uv run pytest organizations/tests/ -n auto`
- Asserts: PATCH creds → 200, stored encrypted, response has NO private_key/private_key_id/public_key; rotate on 2nd PATCH; configured → sync-rooms authenticates with the SA + enqueues; unconfigured → 400 (not 500); enable-without-creds → 400 with no partial write; create_organization no-creds → no crash; non-admin 403; cross-org 404; anon 401.
- Outer gate green: ruff, format --check, mypy (108, unchanged), makemigrations --check, check --deploy, `pytest -n auto` (1456 passed).