### PR TITLE
refactor(calendar): extract shared context + utils, fix multi-tenant calendar-lookup cache

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_SERVICE_REFACTOR.md
+++ b/ai-plans/TRACKING_CALENDAR_SERVICE_REFACTOR.md
@@ -1,0 +1,47 @@
+# Tracking — Calendar Service Refactor
+
+- **Plan**: `ai-plans/2026-06-13-CALENDAR_SERVICE_REFACTOR_IMPLEMENTATION_PLAN.md`
+- **Started**: 2026-06-13
+- **Last updated**: 2026-06-13
+- **Feature flag**: none (pure refactor)
+
+## Run options
+- `commit_strategy_resolved`: stacked-branches
+- `pause_between_phases`: false (auto-flow)
+- `generate_inline_comments`: true
+- `use_worktree`: true
+  - `worktree_path`: `.claude/worktrees/plan-calendar-service-refactor`
+  - `worktree_branch`: `plan/calendar-service-refactor/wt`
+  - `worktree_summary`: `.vinta-ai-workflows/worktrees/plan-calendar-service-refactor.yaml`
+- Branch pattern: `plan/calendar-service-refactor/phase-{id}` (stacked, base `…/wt`)
+
+## Completed Phases
+
+### Phase 0 — Shared context, utils module, and lru_cache fix ✅
+- **Status**: complete, PR open
+- **Model**: claude-sonnet-4-6 (plan tier: Tier 3) + fixer (claude-sonnet-4-6)
+- **Branch**: `plan/calendar-service-refactor/phase-0` (base `plan/calendar-service-refactor/wt`)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/65 (status=published, 5 inline comments)
+- **Files**: `calendar_integration/services/calendar_service_context.py` (new), `calendar_integration/services/calendar_service_utils.py` (new), `calendar_integration/services/calendar_service.py` (edited), `calendar_integration/tests/services/test_calendar_service_utils.py` (new)
+- **Summary**: Added `CalendarServiceContext` frozen dataclass (built once in `authenticate()`/`initialize_without_provider()`, consumed by sub-services in later phases). Moved cross-cutting helpers (timezone conversion, event serialization family, permission-granting, calendar lookups) into `calendar_service_utils.py` as module-level functions; facade methods delegate to them as thin wrappers. Fixed the multi-tenant `lru_cache` bug: calendar lookups now use a per-instance dict keyed on `(organization_id, id_or_external_id)`, reset on every (re)auth — replacing `@lru_cache` which could leak another org's Calendar. Regression test added.
+- **Review**: Layer-3 found 0 blockers; fixer reverted an unsanctioned behavior change in `serialize_event_data_input` (restored byte-for-byte, pinned the preserved latent bug with a test), hoisted late imports, added the mandated delegation test + resource-path test.
+- **Gate**: calendar_integration suite 1014 passed; full suite 1563 passed + 1 pre-existing unrelated failure (`accounts/.../test_send_unknown_account_sms_success`).
+- **Carry-forward notes**:
+  - `CalendarServiceContext` is built but NOT yet consumed — Phase 2+ sub-services receive it (perf guardrail: authenticate once).
+  - Per-instance calendar cache is unbounded (vs old `maxsize=128`) — acceptable now; revisit if a long-lived sync iterates thousands of calendars.
+  - Latent bug in `serialize_event_data_input` resources branch deliberately preserved + pinned by a test; a real fix is out of scope (candidate Open-Questions follow-up).
+
+## Current Phase
+- Phase 1 — Extract `RecurrenceManager` helper (next).
+
+## Remaining Phases
+- Phase 1 — Extract `RecurrenceManager` helper (Tier 4)
+- Phase 2 — Extract `CalendarEventService` (Tier 4)
+- Phase 3 — Extract `CalendarBundleService` (Tier 3)
+- Phase 4 — Extract `AvailabilityService` (Tier 4)
+- Phase 5 — Extract `CalendarSyncService` (Tier 4)
+- Phase 6 — Extract `CalendarWebhookService` (Tier 3)
+- Phase 7 — Shrink the facade and finalize wiring (Tier 2)
+
+## Deferred Phases
+- None (no cross-repo phases; no feature-flag-removal phase — pure refactor).

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -2,9 +2,7 @@ import copy
 import datetime
 import json
 import logging
-import zoneinfo
 from collections.abc import Callable, Iterable
-from functools import lru_cache
 from typing import Annotated, Any, Literal, TypedDict, cast
 
 from django.conf import settings
@@ -61,6 +59,34 @@ from calendar_integration.models import (
 from calendar_integration.querysets import CalendarEventQuerySet
 from calendar_integration.recurrence_utils import OccurrenceValidator, RecurrenceRuleSplitter
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.calendar_service_context import CalendarServiceContext
+from calendar_integration.services.calendar_service_utils import (
+    convert_naive_utc_datetime_to_timezone as _convert_naive_utc_datetime_to_timezone,
+)
+from calendar_integration.services.calendar_service_utils import (
+    get_calendar_by_external_id as _get_calendar_by_external_id_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    get_calendar_by_id as _get_calendar_by_id_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    grant_calendar_owner_permissions as _grant_calendar_owner_permissions_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    grant_event_attendee_permissions as _grant_event_attendee_permissions_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    serialize_event as _serialize_event_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    serialize_event_data_input as _serialize_event_data_input_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    serialize_event_external_attendee as _serialize_event_external_attendee_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    serialize_event_internal_attendee as _serialize_event_internal_attendee_util,
+)
 from calendar_integration.services.calendar_side_effects_service import CalendarSideEffectsService
 from calendar_integration.services.dataclasses import (
     ApplicationCalendarData,
@@ -130,6 +156,13 @@ class CalendarService(BaseCalendarService):
         self.calendar_adapter = None
         self.calendar_side_effects_service = calendar_side_effects_service
         self.calendar_permission_service = calendar_permission_service
+        # Per-instance calendar lookup cache: keyed on (organization_id, id_or_external_id).
+        # This replaces the @lru_cache approach which was keyed only on id/external_id and
+        # could return a cached Calendar from a different organization when the service
+        # instance is reused across organizations (multi-tenant safety bug).
+        self._calendar_cache: dict[tuple[int, str | int], Calendar] = {}
+        # Shared auth-context snapshot; set by authenticate() / initialize_without_provider().
+        self._context: CalendarServiceContext | None = None
 
     def _grant_calendar_owner_permissions(self, calendar: Calendar) -> None:
         """
@@ -138,28 +171,7 @@ class CalendarService(BaseCalendarService):
         if not self.calendar_permission_service:
             return
 
-        # Grant permissions to all calendar owners
-        calendar_owners = User.objects.filter(
-            calendar_ownerships__calendar=calendar,
-            calendar_ownerships__organization=calendar.organization,
-        ).distinct()
-
-        for owner in calendar_owners:
-            # Check if user already has a token for this calendar
-            existing_token = CalendarManagementToken.objects.filter(
-                user=owner,
-                calendar_fk_id=calendar.id,
-                organization_id=calendar.organization_id,
-                event_fk_id__isnull=True,
-                revoked_at__isnull=True,
-            ).first()
-
-            if not existing_token:
-                self.calendar_permission_service.create_calendar_owner_token(
-                    organization_id=calendar.organization_id,
-                    user=owner,
-                    calendar_id=calendar.id,
-                )
+        _grant_calendar_owner_permissions_util(self.calendar_permission_service, calendar)
 
     def _grant_event_attendee_permissions(self, event: CalendarEvent) -> None:
         """
@@ -168,127 +180,21 @@ class CalendarService(BaseCalendarService):
         if not self.calendar_permission_service:
             return
 
-        # Grant permissions to internal attendees
-        for attendance in event.attendances.all():
-            # Check if user already has a token for this event
-            existing_token = CalendarManagementToken.objects.filter(
-                user=attendance.user,
-                event_fk_id=event.id,
-                organization_id=event.organization_id,
-                revoked_at__isnull=True,
-            ).first()
-
-            if not existing_token:
-                self.calendar_permission_service.create_attendee_token(
-                    organization_id=attendance.organization_id,
-                    user=attendance.user,
-                    event_id=event.id,
-                )
-
-        # Grant permissions to external attendees
-        for external_attendance in event.external_attendances.filter_by_organization(  # type: ignore
-            event.organization_id
-        ):
-            # Check if external attendee already has a token for this event
-            existing_token = CalendarManagementToken.objects.filter(
-                organization_id=event.organization_id,
-                external_attendee_fk_id=external_attendance.external_attendee_fk_id,
-                event_fk_id=event.id,
-                revoked_at__isnull=True,
-            ).first()
-
-            if not existing_token:
-                self.calendar_permission_service.create_external_attendee_update_token(
-                    organization_id=external_attendance.organization_id,
-                    event_id=event.id,
-                    external_attendee_id=external_attendance.external_attendee_fk_id,  # type: ignore
-                )
+        _grant_event_attendee_permissions_util(self.calendar_permission_service, event)
 
     def _serialize_event_internal_attendee(
         self, attendance: EventAttendance
     ) -> EventInternalAttendeeData:
-        return EventInternalAttendeeData(
-            user_id=attendance.user.id,
-            email=attendance.user.email,
-            name=attendance.user.get_full_name(),
-            status=cast(Literal["accepted", "declined", "pending"], attendance.status),
-        )
+        return _serialize_event_internal_attendee_util(attendance)
 
     def _serialize_event_external_attendee(
         self, external_attendance: EventExternalAttendance
     ) -> EventExternalAttendeeData:
-        return EventExternalAttendeeData(
-            email=external_attendance.external_attendee_fk.email,  # type: ignore
-            name=external_attendance.external_attendee_fk.name,  # type: ignore
-            status=cast(
-                Literal["accepted", "declined", "pending"],
-                external_attendance.status,
-            ),
-        )
+        return _serialize_event_external_attendee_util(external_attendance)
 
     def _serialize_event(self, event: CalendarEvent) -> CalendarEventData:
         """Build webhook payload for calendar event."""
-
-        return CalendarEventData(
-            id=event.id,
-            calendar_id=event.calendar_fk_id,  # type: ignore
-            start_time=event.start_time,
-            end_time=event.end_time,
-            timezone=event.timezone,
-            title=event.title,
-            description=event.description,
-            calendar_settings=CalendarSettingsData(
-                manage_available_windows=event.calendar_fk.manage_available_windows,  # type: ignore
-                accepts_public_scheduling=event.calendar_fk.accepts_public_scheduling,  # type: ignore
-            ),
-            original_payload=event.meta.get("latest_original_payload", {})
-            if hasattr(event, "meta") and event.meta
-            else {},
-            attendees=[
-                self._serialize_event_internal_attendee(attendance)
-                # For recurring instances, get attendances from the parent event; for regular events, use their own
-                for attendance in (
-                    event.parent_recurring_object.attendances.all()
-                    if event.parent_recurring_object
-                    else (event.attendances.all() if event.id else [])
-                )
-            ],
-            external_attendees=[
-                self._serialize_event_external_attendee(external_attendance)
-                # For recurring instances, get external attendances from the parent event; for regular events, use their own
-                for external_attendance in (
-                    event.parent_recurring_object.external_attendances.all()
-                    if event.parent_recurring_object
-                    else (event.external_attendances.all() if event.id else [])
-                )
-            ],
-            resources=[
-                ResourceData(
-                    title=resource_allocation.calendar.name,
-                    email=resource_allocation.calendar.email,
-                    external_id=resource_allocation.calendar.external_id,
-                    status=cast(
-                        Literal["accepted", "declined", "pending"],
-                        resource_allocation.status,
-                    ),
-                )
-                # For recurring instances, get resource allocations from the parent event; for regular events, use their own
-                for resource_allocation in (
-                    event.parent_recurring_object.resource_allocations.all()
-                    if event.parent_recurring_object
-                    else (event.resource_allocations.all() if event.id else [])
-                )
-            ],
-            external_id=event.external_id,
-            recurrence_rule=(
-                event.recurrence_rule.to_rrule_string() if event.recurrence_rule else None
-            ),
-            status="confirmed",
-            is_recurring=event.is_recurring,
-            recurring_event_id=(
-                event.parent_recurring_object_fk_id if event.parent_recurring_object_fk_id else None  # type: ignore
-            ),
-        )
+        return _serialize_event_util(event)
 
     @staticmethod
     def _get_calendar_adapter_cls_for_provider(provider: CalendarProvider):
@@ -424,6 +330,20 @@ class CalendarService(BaseCalendarService):
         self.organization = organization
         self.calendar_adapter, self.account = self.get_calendar_adapter_for_account(account)
 
+        # Reset the per-instance calendar lookup cache whenever the auth context changes.
+        # This ensures no stale cross-organization entries survive a re-authentication.
+        self._calendar_cache = {}
+
+        # Build the immutable auth-context snapshot consumed by sub-services.
+        self._context = CalendarServiceContext(
+            organization=self.organization,
+            user_or_token=self.user_or_token,
+            account=self.account,
+            calendar_adapter=self.calendar_adapter,
+            calendar_permission_service=self.calendar_permission_service,
+            calendar_side_effects_service=self.calendar_side_effects_service,
+        )
+
     def initialize_without_provider(
         self,
         user_or_token: User | str | SystemUser | None = None,
@@ -446,6 +366,19 @@ class CalendarService(BaseCalendarService):
             self.calendar_permission_service.initialize_with_token(
                 self.user_or_token, organization_id=self.organization.id
             )
+
+        # Reset the per-instance calendar lookup cache whenever the auth context changes.
+        self._calendar_cache = {}
+
+        # Build the immutable auth-context snapshot consumed by sub-services.
+        self._context = CalendarServiceContext(
+            organization=self.organization,
+            user_or_token=self.user_or_token,
+            account=self.account,
+            calendar_adapter=self.calendar_adapter,
+            calendar_permission_service=self.calendar_permission_service,
+            calendar_side_effects_service=self.calendar_side_effects_service,
+        )
 
     def request_organization_calendar_resources_import(
         self,
@@ -612,27 +545,25 @@ class CalendarService(BaseCalendarService):
 
         return created_calendar
 
-    @lru_cache(maxsize=128)  # noqa: B019
     def _get_calendar_by_external_id(self, calendar_external_id: str) -> Calendar:
         if not is_authenticated_calendar_service(self):
             raise
 
-        query_kwargs = {
-            "external_id": calendar_external_id,
-            "organization_id": self.organization.id,
-        }
-        if self.calendar_adapter:
-            query_kwargs["provider"] = self.calendar_adapter.provider
-        return Calendar.objects.get(**query_kwargs)
+        return _get_calendar_by_external_id_util(
+            self._calendar_cache,
+            calendar_external_id,
+            self.organization,
+            self.calendar_adapter,
+        )
 
-    @lru_cache(maxsize=128)  # noqa: B019
     def _get_calendar_by_id(self, calendar_id: int) -> Calendar:
         if not is_initialized_or_authenticated_calendar_service(self):
             raise
 
-        return Calendar.objects.get(
-            id=calendar_id,
-            organization_id=self.organization.id,
+        return _get_calendar_by_id_util(
+            self._calendar_cache,
+            calendar_id,
+            self.organization,
         )
 
     def request_calendars_import(self, sync_after_import: bool = True) -> None:
@@ -1116,119 +1047,22 @@ class CalendarService(BaseCalendarService):
 
         return self.calendar_adapter
 
-    def convert_naive_utc_datetime_to_timezone(self, datetime_obj: datetime.datetime, iana_tz: str):
+    def convert_naive_utc_datetime_to_timezone(
+        self, datetime_obj: datetime.datetime, iana_tz: str
+    ) -> datetime.datetime:
         """Return the naive local wall-clock of an instant in the given IANA timezone.
 
-        Used to populate ``*_tz_unaware`` fields: the model stores the naive local
-        wall-clock paired with the IANA ``timezone``, and the DB-generated
-        ``start_time``/``end_time`` re-derive the true instant from them via
-        ``convert_naive_utc_to_timezone``. Naive inputs are treated as UTC.
-
-        Previously this did ``datetime_obj.replace(tzinfo=target_tz)``, which keeps the
-        wall-clock and swaps the zone — storing the instant instead of the local
-        wall-clock and shifting synced times by the zone offset. ``astimezone`` converts
-        the instant correctly.
+        Delegates to the shared module-level utility in ``calendar_service_utils``.
+        See that function's docstring for full semantics.
 
         e.g. 12:00Z + "America/Recife" -> 09:00 (naive).
         """
-        try:
-            target_tz = zoneinfo.ZoneInfo(iana_tz)
-        except zoneinfo.ZoneInfoNotFoundError as e:
-            raise ValueError(f"Invalid IANA timezone: {iana_tz}") from e
-
-        if datetime_obj.tzinfo is None:
-            datetime_obj = datetime_obj.replace(tzinfo=datetime.UTC)
-        # Local wall-clock, tagged UTC so it stores cleanly under USE_TZ (matching how
-        # the batch-create path stores tz_unaware). The generated start_time/end_time
-        # re-interpret this wall-clock in `timezone` to recover the true instant.
-        local_wall_clock = datetime_obj.astimezone(target_tz).replace(tzinfo=None)
-        return local_wall_clock.replace(tzinfo=datetime.UTC)
+        return _convert_naive_utc_datetime_to_timezone(datetime_obj, iana_tz)
 
     def _serialize_event_data_input(
         self, event: CalendarEvent, event_data: CalendarEventInputData
     ) -> CalendarEventData:
-        new_attendance_user_ids = [a.user_id for a in event_data.attendances]
-        new_external_attendances_attendee_ids = [
-            a.external_attendee.id for a in event_data.external_attendances
-        ]
-        attendances_users_by_id = {
-            u.id: u for u in User.objects.filter(id__in=new_attendance_user_ids)
-        }
-        existing_attendances_by_user_id = {
-            a.user_id: a
-            for a in EventAttendance.objects.filter(
-                event=event, user__id__in=new_attendance_user_ids
-            )
-        }
-        existing_external_attendances_by_attendee_id = {
-            a.external_attendee.id: a
-            for a in EventExternalAttendance.objects.filter(
-                event=event, external_attendee__id__in=new_external_attendances_attendee_ids
-            )
-        }
-        return CalendarEventData(
-            id=event.id,
-            calendar_id=event.calendar_fk_id,  # type: ignore
-            start_time=event_data.start_time,
-            end_time=event_data.end_time,
-            timezone=event_data.timezone,
-            title=event_data.title,
-            description=event_data.description,
-            calendar_settings=CalendarSettingsData(
-                manage_available_windows=event.calendar_fk.manage_available_windows,  # type: ignore
-                accepts_public_scheduling=event.calendar_fk.accepts_public_scheduling,  # type: ignore
-            ),
-            original_payload={},  # doesn't matter
-            attendees=[
-                EventInternalAttendeeData(
-                    user_id=attendance.user_id,
-                    email=attendances_users_by_id[attendance.user_id].email,
-                    name=attendances_users_by_id[attendance.user_id].get_full_name(),
-                    status=cast(
-                        Literal["accepted", "declined", "pending"],
-                        existing_attendances_by_user_id.get(attendance.user_id, "pending"),
-                    ),
-                )
-                # For recurring instances, get attendances from the parent event; for regular events, use their own
-                for attendance in event_data.attendances
-            ],
-            external_attendees=[
-                EventExternalAttendeeData(
-                    email=external_attendance.external_attendee.email,
-                    name=external_attendance.external_attendee.name,
-                    status=cast(
-                        Literal["accepted", "declined", "pending"],
-                        existing_external_attendances_by_attendee_id.get(
-                            external_attendance.external_attendee.id, "pending"
-                        ),
-                    ),
-                )
-                # For recurring instances, get external attendances from the parent event; for regular events, use their own
-                for external_attendance in event_data.external_attendances
-            ],
-            resources=[
-                ResourceData(
-                    title=resource_allocation.calendar.name,
-                    email=resource_allocation.calendar.email,
-                    external_id=resource_allocation.calendar.external_id,
-                    status=cast(
-                        Literal["accepted", "declined", "pending"],
-                        resource_allocation.status,
-                    ),
-                )
-                # For recurring instances, get resource allocations from the parent event; for regular events, use their own
-                for resource_allocation in Calendar.objects.filter(
-                    organization=self.organization,
-                    id__in=[r.resource_id for r in event_data.resource_allocations],
-                    calendar_type=CalendarType.RESOURCE,
-                )
-            ],
-            external_id=event.external_id,
-            recurrence_rule=event_data.recurrence_rule,
-            status="confirmed",
-            is_recurring=bool(event_data.recurrence_rule),
-            recurring_event_id=None,
-        )
+        return _serialize_event_data_input_util(event, event_data, self.organization)
 
     @transaction.atomic()
     def create_event(self, calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:

--- a/calendar_integration/services/calendar_service_context.py
+++ b/calendar_integration/services/calendar_service_context.py
@@ -1,0 +1,49 @@
+"""Shared authentication context passed to all CalendarService sub-services.
+
+The facade (``CalendarService``) builds one instance of this after ``authenticate()``
+or ``initialize_without_provider()`` and hands it to every sub-service it constructs.
+Sub-services read the context instead of reaching back into the facade, so they are
+decoupled and independently testable.
+
+Note: the facade *also* keeps its own instance attributes (``organization``,
+``account``, etc.) because the type-guards in ``type_guards.py`` inspect those
+attributes on the facade directly. The context is a separate, immutable snapshot.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from allauth.socialaccount.models import SocialAccount
+
+    from calendar_integration.models import GoogleCalendarServiceAccount
+    from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+    from calendar_integration.services.calendar_side_effects_service import (
+        CalendarSideEffectsService,
+    )
+    from calendar_integration.services.protocols.calendar_adapter import CalendarAdapter
+    from organizations.models import Organization
+    from public_api.models import SystemUser
+    from users.models import User
+
+
+@dataclasses.dataclass(frozen=True)
+class CalendarServiceContext:
+    """Immutable snapshot of the auth state built by ``CalendarService`` after authentication.
+
+    All fields are optional because the context is built in two states:
+    - **authenticated** (via ``authenticate()``): all fields set.
+    - **initialized without provider** (via ``initialize_without_provider()``): only
+      ``organization`` and ``user_or_token`` are set; ``account``, ``calendar_adapter``,
+      ``calendar_permission_service``, and ``calendar_side_effects_service`` may be ``None``.
+    """
+
+    organization: Organization | None
+    user_or_token: User | str | SystemUser | None
+    account: SocialAccount | GoogleCalendarServiceAccount | None
+    calendar_adapter: CalendarAdapter | None
+    calendar_permission_service: CalendarPermissionService | None
+    calendar_side_effects_service: CalendarSideEffectsService | None

--- a/calendar_integration/services/calendar_service_utils.py
+++ b/calendar_integration/services/calendar_service_utils.py
@@ -1,0 +1,421 @@
+"""Shared utility functions for CalendarService and its sub-services.
+
+These are module-level functions (not methods) extracted from ``CalendarService``.
+They take all required state as explicit parameters so they are independently
+testable without constructing a full service instance.
+
+The per-instance calendar-lookup cache (``get_calendar_by_id`` /
+``get_calendar_by_external_id``) uses a plain dict keyed on
+``(organization_id, <id>)`` — NOT ``functools.lru_cache``.  The old
+``@lru_cache`` on instance methods (``# noqa: B019``) is a multi-tenant bug:
+``lru_cache`` keys only on positional args; when the same service instance is
+reused across two organizations (a pattern the DI container allows), the first
+org's ``Calendar`` is returned for the second org's query.
+"""
+
+from __future__ import annotations
+
+import datetime
+import zoneinfo
+from typing import TYPE_CHECKING, Literal, cast
+
+from calendar_integration.constants import CalendarType
+from calendar_integration.models import (
+    Calendar,
+    CalendarEvent,
+    CalendarManagementToken,
+    EventAttendance,
+    EventExternalAttendance,
+)
+from calendar_integration.services.dataclasses import (
+    CalendarEventData,
+    CalendarEventInputData,
+    CalendarSettingsData,
+    EventExternalAttendeeData,
+    EventInternalAttendeeData,
+    ResourceData,
+)
+from users.models import User
+
+
+if TYPE_CHECKING:
+    from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+    from calendar_integration.services.protocols.calendar_adapter import CalendarAdapter
+    from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# Timezone conversion
+# ---------------------------------------------------------------------------
+
+
+def convert_naive_utc_datetime_to_timezone(
+    datetime_obj: datetime.datetime, iana_tz: str
+) -> datetime.datetime:
+    """Return the naive local wall-clock of an instant in the given IANA timezone.
+
+    Used to populate ``*_tz_unaware`` fields: the model stores the naive local
+    wall-clock paired with the IANA ``timezone``, and the DB-generated
+    ``start_time``/``end_time`` re-derive the true instant from them via
+    ``convert_naive_utc_to_timezone``. Naive inputs are treated as UTC.
+
+    Previously this did ``datetime_obj.replace(tzinfo=target_tz)``, which keeps the
+    wall-clock and swaps the zone — storing the instant instead of the local
+    wall-clock and shifting synced times by the zone offset. ``astimezone`` converts
+    the instant correctly.
+
+    e.g. 12:00Z + "America/Recife" -> 09:00 (naive).
+    """
+    try:
+        target_tz = zoneinfo.ZoneInfo(iana_tz)
+    except zoneinfo.ZoneInfoNotFoundError as e:
+        raise ValueError(f"Invalid IANA timezone: {iana_tz}") from e
+
+    if datetime_obj.tzinfo is None:
+        datetime_obj = datetime_obj.replace(tzinfo=datetime.UTC)
+    # Local wall-clock, tagged UTC so it stores cleanly under USE_TZ (matching how
+    # the batch-create path stores tz_unaware). The generated start_time/end_time
+    # re-interpret this wall-clock in `timezone` to recover the true instant.
+    local_wall_clock = datetime_obj.astimezone(target_tz).replace(tzinfo=None)
+    return local_wall_clock.replace(tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Event serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def serialize_event_internal_attendee(attendance: EventAttendance) -> EventInternalAttendeeData:
+    """Serialize an internal event attendance to ``EventInternalAttendeeData``."""
+    return EventInternalAttendeeData(
+        user_id=attendance.user.id,
+        email=attendance.user.email,
+        name=attendance.user.get_full_name(),
+        status=cast(Literal["accepted", "declined", "pending"], attendance.status),
+    )
+
+
+def serialize_event_external_attendee(
+    external_attendance: EventExternalAttendance,
+) -> EventExternalAttendeeData:
+    """Serialize an external event attendance to ``EventExternalAttendeeData``."""
+    return EventExternalAttendeeData(
+        email=external_attendance.external_attendee_fk.email,  # type: ignore[attr-defined]
+        name=external_attendance.external_attendee_fk.name,  # type: ignore[attr-defined]
+        status=cast(
+            Literal["accepted", "declined", "pending"],
+            external_attendance.status,
+        ),
+    )
+
+
+def serialize_event(event: CalendarEvent) -> CalendarEventData:
+    """Build a ``CalendarEventData`` payload from a ``CalendarEvent`` instance.
+
+    For recurring instances the attendees, external attendees, and resource
+    allocations are pulled from the parent recurring object.
+    """
+    return CalendarEventData(
+        id=event.id,
+        calendar_id=event.calendar_fk_id,  # type: ignore[arg-type]
+        start_time=event.start_time,
+        end_time=event.end_time,
+        timezone=event.timezone,
+        title=event.title,
+        description=event.description,
+        calendar_settings=CalendarSettingsData(
+            manage_available_windows=event.calendar_fk.manage_available_windows,  # type: ignore[attr-defined]
+            accepts_public_scheduling=event.calendar_fk.accepts_public_scheduling,  # type: ignore[attr-defined]
+        ),
+        original_payload=event.meta.get("latest_original_payload", {})
+        if hasattr(event, "meta") and event.meta
+        else {},
+        attendees=[
+            serialize_event_internal_attendee(attendance)
+            # For recurring instances, get attendances from the parent event; for regular events, use their own
+            for attendance in (
+                event.parent_recurring_object.attendances.all()
+                if event.parent_recurring_object
+                else (event.attendances.all() if event.id else [])
+            )
+        ],
+        external_attendees=[
+            serialize_event_external_attendee(external_attendance)
+            # For recurring instances, get external attendances from the parent event; for regular events, use their own
+            for external_attendance in (
+                event.parent_recurring_object.external_attendances.all()
+                if event.parent_recurring_object
+                else (event.external_attendances.all() if event.id else [])
+            )
+        ],
+        resources=[
+            ResourceData(
+                title=resource_allocation.calendar.name,  # type: ignore[union-attr]
+                email=resource_allocation.calendar.email,  # type: ignore[union-attr]
+                external_id=resource_allocation.calendar.external_id,  # type: ignore[union-attr]
+                status=cast(
+                    Literal["accepted", "declined", "pending"],
+                    resource_allocation.status,
+                ),
+            )
+            # For recurring instances, get resource allocations from the parent event; for regular events, use their own
+            for resource_allocation in (
+                event.parent_recurring_object.resource_allocations.all()
+                if event.parent_recurring_object
+                else (event.resource_allocations.all() if event.id else [])
+            )
+        ],
+        external_id=event.external_id,
+        recurrence_rule=(
+            event.recurrence_rule.to_rrule_string() if event.recurrence_rule else None
+        ),
+        status="confirmed",
+        is_recurring=event.is_recurring,
+        recurring_event_id=(
+            event.parent_recurring_object_fk_id  # type: ignore[arg-type]
+            if event.parent_recurring_object_fk_id
+            else None
+        ),
+    )
+
+
+def serialize_event_data_input(
+    event: CalendarEvent,
+    event_data: CalendarEventInputData,
+    organization: Organization,
+) -> CalendarEventData:
+    """Build a ``CalendarEventData`` payload from input data and an existing event.
+
+    This is used when creating or updating events to produce the payload for
+    side-effects (webhooks, notifications) before the ORM object has been fully
+    reloaded with related data.
+
+    ``organization`` is required for the resource-calendar lookup (multi-tenant
+    guard: only calendars belonging to ``organization`` are considered).
+    """
+    new_attendance_user_ids = [a.user_id for a in event_data.attendances]
+    new_external_attendances_attendee_ids = [
+        a.external_attendee.id for a in event_data.external_attendances
+    ]
+    attendances_users_by_id = {u.id: u for u in User.objects.filter(id__in=new_attendance_user_ids)}
+    existing_attendances_by_user_id = {
+        a.user_id: a
+        for a in EventAttendance.objects.filter(event=event, user__id__in=new_attendance_user_ids)
+    }
+    existing_external_attendances_by_attendee_id = {
+        a.external_attendee.id: a
+        for a in EventExternalAttendance.objects.filter(
+            event=event, external_attendee__id__in=new_external_attendances_attendee_ids
+        )
+    }
+    return CalendarEventData(
+        id=event.id,
+        calendar_id=event.calendar_fk_id,  # type: ignore[arg-type]
+        start_time=event_data.start_time,
+        end_time=event_data.end_time,
+        timezone=event_data.timezone,
+        title=event_data.title,
+        description=event_data.description,
+        calendar_settings=CalendarSettingsData(
+            manage_available_windows=event.calendar_fk.manage_available_windows,  # type: ignore[attr-defined]
+            accepts_public_scheduling=event.calendar_fk.accepts_public_scheduling,  # type: ignore[attr-defined]
+        ),
+        original_payload={},  # doesn't matter
+        attendees=[
+            EventInternalAttendeeData(
+                user_id=attendance.user_id,
+                email=attendances_users_by_id[attendance.user_id].email,
+                name=attendances_users_by_id[attendance.user_id].get_full_name(),
+                status=cast(
+                    Literal["accepted", "declined", "pending"],
+                    existing_attendances_by_user_id.get(attendance.user_id, "pending"),
+                ),
+            )
+            # For recurring instances, get attendances from the parent event; for regular events, use their own
+            for attendance in event_data.attendances
+        ],
+        external_attendees=[
+            EventExternalAttendeeData(
+                email=external_attendance.external_attendee.email,
+                name=external_attendance.external_attendee.name,
+                status=cast(
+                    Literal["accepted", "declined", "pending"],
+                    existing_external_attendances_by_attendee_id.get(
+                        external_attendance.external_attendee.id, "pending"
+                    ),
+                ),
+            )
+            # For recurring instances, get external attendances from the parent event; for regular events, use their own
+            for external_attendance in event_data.external_attendances
+        ],
+        resources=[
+            ResourceData(
+                title=resource_allocation.calendar.name,
+                email=resource_allocation.calendar.email,
+                external_id=resource_allocation.calendar.external_id,
+                status=cast(
+                    Literal["accepted", "declined", "pending"],
+                    resource_allocation.status,
+                ),
+            )
+            # For recurring instances, get resource allocations from the parent event; for regular events, use their own
+            for resource_allocation in Calendar.objects.filter(
+                organization=organization,
+                id__in=[r.resource_id for r in event_data.resource_allocations],
+                calendar_type=CalendarType.RESOURCE,
+            )
+        ],
+        external_id=event.external_id,
+        recurrence_rule=event_data.recurrence_rule,
+        status="confirmed",
+        is_recurring=bool(event_data.recurrence_rule),
+        recurring_event_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Permission-granting helpers
+# ---------------------------------------------------------------------------
+
+
+def grant_calendar_owner_permissions(
+    permission_service: CalendarPermissionService, calendar: Calendar
+) -> None:
+    """Grant calendar management permissions to all owners of a calendar.
+
+    No-ops gracefully if ``permission_service`` is ``None``.
+    """
+    # Grant permissions to all calendar owners
+    calendar_owners = User.objects.filter(
+        calendar_ownerships__calendar=calendar,
+        calendar_ownerships__organization=calendar.organization,
+    ).distinct()
+
+    for owner in calendar_owners:
+        # Check if user already has a token for this calendar
+        existing_token = CalendarManagementToken.objects.filter(
+            user=owner,
+            calendar_fk_id=calendar.id,
+            organization_id=calendar.organization_id,
+            event_fk_id__isnull=True,
+            revoked_at__isnull=True,
+        ).first()
+
+        if not existing_token:
+            permission_service.create_calendar_owner_token(
+                organization_id=calendar.organization_id,
+                user=owner,
+                calendar_id=calendar.id,
+            )
+
+
+def grant_event_attendee_permissions(
+    permission_service: CalendarPermissionService, event: CalendarEvent
+) -> None:
+    """Grant event management permissions to all attendees of an event.
+
+    No-ops gracefully if ``permission_service`` is ``None``.
+    """
+    # Grant permissions to internal attendees
+    for attendance in event.attendances.all():
+        # Check if user already has a token for this event
+        existing_token = CalendarManagementToken.objects.filter(
+            user=attendance.user,
+            event_fk_id=event.id,
+            organization_id=event.organization_id,
+            revoked_at__isnull=True,
+        ).first()
+
+        if not existing_token:
+            permission_service.create_attendee_token(
+                organization_id=attendance.organization_id,
+                user=attendance.user,
+                event_id=event.id,
+            )
+
+    # Grant permissions to external attendees
+    for external_attendance in event.external_attendances.filter_by_organization(  # type: ignore[attr-defined]
+        event.organization_id
+    ):
+        # Check if external attendee already has a token for this event
+        existing_token = CalendarManagementToken.objects.filter(
+            organization_id=event.organization_id,
+            external_attendee_fk_id=external_attendance.external_attendee_fk_id,
+            event_fk_id=event.id,
+            revoked_at__isnull=True,
+        ).first()
+
+        if not existing_token:
+            permission_service.create_external_attendee_update_token(
+                organization_id=external_attendance.organization_id,
+                event_id=event.id,
+                external_attendee_id=external_attendance.external_attendee_fk_id,  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# Calendar lookups — org-scoped per-instance cache (lru_cache bug fix)
+# ---------------------------------------------------------------------------
+# The original code used @lru_cache on instance methods.  lru_cache keys only
+# on positional args, so it ignores ``self.organization`` — a reused service
+# instance can return a cached Calendar from org A when queried for org B.
+#
+# The fix: accept an explicit ``cache`` dict keyed on ``(organization_id, <id>)``
+# that the facade owns and initialises in ``__init__``.  The cache is per-instance
+# (allocated in ``CalendarService.__init__``), not module-level.
+#
+# CallerAPI:
+#   cache: dict[tuple[int, str | int], Calendar]  (facade owns it)
+#   get_calendar_by_external_id(cache, calendar_external_id, organization, calendar_adapter)
+#   get_calendar_by_id(cache, calendar_id, organization)
+
+
+def get_calendar_by_external_id(
+    cache: dict[tuple[int, str | int], Calendar],
+    calendar_external_id: str,
+    organization: Organization,
+    calendar_adapter: CalendarAdapter | None,
+) -> Calendar:
+    """Look up a ``Calendar`` by external ID, scoped to ``organization``.
+
+    Results are memoized in ``cache`` keyed on ``(organization_id, external_id)``
+    so repeated calls within the same service lifecycle avoid extra DB round-trips
+    without leaking data across organizations.
+    """
+    cache_key: tuple[int, str | int] = (organization.id, calendar_external_id)
+    if cache_key in cache:
+        return cache[cache_key]
+
+    query_kwargs: dict[str, object] = {
+        "external_id": calendar_external_id,
+        "organization_id": organization.id,
+    }
+    if calendar_adapter:
+        query_kwargs["provider"] = calendar_adapter.provider
+
+    result = Calendar.objects.get(**query_kwargs)
+    cache[cache_key] = result
+    return result
+
+
+def get_calendar_by_id(
+    cache: dict[tuple[int, str | int], Calendar],
+    calendar_id: int,
+    organization: Organization,
+) -> Calendar:
+    """Look up a ``Calendar`` by internal ID, scoped to ``organization``.
+
+    Results are memoized in ``cache`` keyed on ``(organization_id, calendar_id)``
+    so repeated calls within the same service lifecycle avoid extra DB round-trips
+    without leaking data across organizations.
+    """
+    cache_key: tuple[int, str | int] = (organization.id, calendar_id)
+    if cache_key in cache:
+        return cache[cache_key]
+
+    result = Calendar.objects.get(
+        id=calendar_id,
+        organization_id=organization.id,
+    )
+    cache[cache_key] = result
+    return result

--- a/calendar_integration/tests/services/test_calendar_service_utils.py
+++ b/calendar_integration/tests/services/test_calendar_service_utils.py
@@ -1,0 +1,370 @@
+"""Tests for calendar_service_utils module-level helpers.
+
+Covers:
+- timezone conversion equivalence with the original CalendarService method.
+- event-serialization equivalence (serialize_event / serialize_event_internal_attendee /
+  serialize_event_external_attendee).
+- Regression test for the multi-tenant lru_cache bug in the calendar lookups:
+  a single shared cache must never return org A's Calendar when queried for org B.
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import Calendar, CalendarEvent, EventAttendance
+from calendar_integration.services.calendar_service_utils import (
+    convert_naive_utc_datetime_to_timezone,
+    get_calendar_by_external_id,
+    get_calendar_by_id,
+    serialize_event_data_input,
+    serialize_event_internal_attendee,
+)
+from calendar_integration.services.dataclasses import (
+    CalendarEventData,
+    CalendarEventInputData,
+    ResourceAllocationInputData,
+)
+from organizations.models import Organization
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db):
+    """Primary test organization."""
+    return Organization.objects.create(name="Utils Test Org A")
+
+
+@pytest.fixture
+def organization_b(db):
+    """Secondary test organization for multi-tenant checks."""
+    return Organization.objects.create(name="Utils Test Org B")
+
+
+@pytest.fixture
+def calendar_a(db, organization):
+    """A calendar belonging to org A with a specific external_id."""
+    return Calendar.objects.create(
+        name="Org A Calendar",
+        external_id="ext_cal_org_a",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def calendar_b(db, organization_b):
+    """A calendar belonging to org B — same external_id as calendar_a."""
+    return Calendar.objects.create(
+        name="Org B Calendar",
+        external_id="ext_cal_org_b",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization_b,
+    )
+
+
+@pytest.fixture
+def calendar_same_ext_id_org_b(db, organization, organization_b):
+    """Org B calendar that shares the same external_id as calendar_a — the key collision case."""
+    return Calendar.objects.create(
+        name="Org B Calendar (same ext_id)",
+        external_id="ext_cal_org_a",  # intentionally same as calendar_a
+        provider=CalendarProvider.GOOGLE,
+        organization=organization_b,
+    )
+
+
+@pytest.fixture
+def mock_adapter():
+    """A minimal CalendarAdapter mock with provider=GOOGLE."""
+    adapter = MagicMock()
+    adapter.provider = CalendarProvider.GOOGLE
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Timezone conversion
+# ---------------------------------------------------------------------------
+
+
+class TestConvertNaiveUtcDatetimeToTimezone:
+    """Tests for convert_naive_utc_datetime_to_timezone module function.
+
+    The function must behave identically to the original CalendarService method
+    it replaces.
+    """
+
+    def test_utc_stays_utc(self):
+        dt = datetime.datetime(2025, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+        result = convert_naive_utc_datetime_to_timezone(dt, "UTC")
+        # 12:00Z in UTC -> 12:00 local (naive), then re-tagged to UTC
+        assert result.hour == 12
+        assert result.tzinfo == datetime.UTC
+
+    def test_converts_to_negative_offset_timezone(self):
+        """12:00Z in America/Recife (UTC-3) should yield 09:00."""
+        dt = datetime.datetime(2025, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+        result = convert_naive_utc_datetime_to_timezone(dt, "America/Recife")
+        assert result.hour == 9
+        assert result.tzinfo == datetime.UTC
+
+    def test_converts_to_positive_offset_timezone(self):
+        """12:00Z in Europe/Berlin (UTC+2 in summer) should yield 14:00."""
+        dt = datetime.datetime(2025, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+        result = convert_naive_utc_datetime_to_timezone(dt, "Europe/Berlin")
+        assert result.hour == 14
+        assert result.tzinfo == datetime.UTC
+
+    def test_naive_input_treated_as_utc(self):
+        """A naive datetime must be treated as UTC, not shifted."""
+        dt = datetime.datetime(2025, 6, 15, 12, 0, 0)  # no tzinfo
+        result = convert_naive_utc_datetime_to_timezone(dt, "America/Recife")
+        assert result.hour == 9  # same as the aware UTC version
+
+    def test_invalid_iana_tz_raises_value_error(self):
+        dt = datetime.datetime(2025, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+        with pytest.raises(ValueError, match="Invalid IANA timezone"):
+            convert_naive_utc_datetime_to_timezone(dt, "Not/A/Timezone")
+
+
+# ---------------------------------------------------------------------------
+# Calendar lookup — multi-tenant regression test (the lru_cache bug)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCalendarByExternalIdMultiTenant:
+    """Regression test for the lru_cache multi-tenant bug.
+
+    With @lru_cache(maxsize=128) on the instance method, the cache key was only
+    the positional args (calendar_external_id).  When a service instance was
+    reused across two organizations, the first org's Calendar was returned for
+    the second org's query with the same external_id.
+
+    The fix uses a dict keyed on (organization_id, external_id).  This test
+    asserts the correct Calendar is returned for each org even when both have the
+    same external_id value.
+    """
+
+    def test_same_external_id_different_orgs_return_correct_calendar(
+        self, db, calendar_a, calendar_same_ext_id_org_b, organization, organization_b, mock_adapter
+    ):
+        """A shared cache must never return org A's Calendar for org B."""
+        shared_cache: dict[tuple[int, str | int], Calendar] = {}
+
+        # First lookup — org A
+        result_a = get_calendar_by_external_id(
+            shared_cache,
+            calendar_external_id="ext_cal_org_a",
+            organization=organization,
+            calendar_adapter=mock_adapter,
+        )
+        assert result_a.id == calendar_a.id
+        assert result_a.organization_id == organization.id
+
+        # Second lookup — org B, same external_id as org A's calendar
+        result_b = get_calendar_by_external_id(
+            shared_cache,
+            calendar_external_id="ext_cal_org_a",
+            organization=organization_b,
+            calendar_adapter=mock_adapter,
+        )
+        assert result_b.id == calendar_same_ext_id_org_b.id
+        assert result_b.organization_id == organization_b.id
+
+        # The two results must differ — this is the bug being prevented
+        assert result_a.id != result_b.id
+
+    def test_cache_is_populated_on_first_lookup(self, db, calendar_a, organization, mock_adapter):
+        """After a lookup the cache entry must be present so the next call avoids a DB query."""
+        cache: dict[tuple[int, str | int], Calendar] = {}
+        assert len(cache) == 0
+
+        get_calendar_by_external_id(
+            cache,
+            calendar_external_id="ext_cal_org_a",
+            organization=organization,
+            calendar_adapter=mock_adapter,
+        )
+        assert (organization.id, "ext_cal_org_a") in cache
+
+    def test_cached_result_is_returned_on_second_lookup(
+        self, db, calendar_a, organization, mock_adapter
+    ):
+        """The second call with the same (org, external_id) must return the cached object."""
+        cache: dict[tuple[int, str | int], Calendar] = {}
+        first = get_calendar_by_external_id(cache, "ext_cal_org_a", organization, mock_adapter)
+        second = get_calendar_by_external_id(cache, "ext_cal_org_a", organization, mock_adapter)
+        assert first is second  # identity — same object from cache
+
+
+class TestGetCalendarByIdMultiTenant:
+    """Regression test: get_calendar_by_id must key cache on (org_id, calendar_id)."""
+
+    def test_same_calendar_id_different_orgs(self, db, organization, organization_b):
+        """Two calendars with the same DB pk in different orgs (hypothetically) are distinct."""
+        # In practice the same PK can't exist twice in the same table, but we can verify
+        # that the cache key includes org_id by using two _different_ calendars and
+        # confirming each is returned for its respective org.
+        cal_a = Calendar.objects.create(
+            name="Org A Cal",
+            external_id="ext_a",
+            provider=CalendarProvider.GOOGLE,
+            organization=organization,
+        )
+        cal_b = Calendar.objects.create(
+            name="Org B Cal",
+            external_id="ext_b",
+            provider=CalendarProvider.GOOGLE,
+            organization=organization_b,
+        )
+
+        cache: dict[tuple[int, str | int], Calendar] = {}
+        result_a = get_calendar_by_id(cache, cal_a.id, organization)
+        result_b = get_calendar_by_id(cache, cal_b.id, organization_b)
+
+        assert result_a.id == cal_a.id
+        assert result_b.id == cal_b.id
+        # Both cache entries coexist keyed by their respective (org_id, cal_id) tuples
+        assert (organization.id, cal_a.id) in cache
+        assert (organization_b.id, cal_b.id) in cache
+
+    def test_org_scoped_lookup_excludes_other_org(self, db, organization, organization_b):
+        """Querying a calendar from another org raises DoesNotExist (not a cross-org leak)."""
+        cal_a = Calendar.objects.create(
+            name="Org A Cal",
+            external_id="ext_a_only",
+            provider=CalendarProvider.GOOGLE,
+            organization=organization,
+        )
+        cache: dict[tuple[int, str | int], Calendar] = {}
+
+        with pytest.raises(Calendar.DoesNotExist):
+            # cal_a belongs to org A — lookup against org B must fail
+            get_calendar_by_id(cache, cal_a.id, organization_b)
+
+
+# ---------------------------------------------------------------------------
+# Event serialization equivalence
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeEventInternalAttendee:
+    """serialize_event_internal_attendee should match the former method's output."""
+
+    def test_basic_fields(self, db, organization):
+        """Check that user fields are correctly mapped to EventInternalAttendeeData."""
+        user = User.objects.create_user(email="attendee@example.com", password="pw")
+        Profile.objects.update_or_create(
+            user=user, defaults={"first_name": "Alice", "last_name": "Smith"}
+        )
+
+        calendar = Calendar.objects.create(
+            name="Test Cal",
+            external_id="ext_01",
+            provider=CalendarProvider.GOOGLE,
+            organization=organization,
+        )
+        event = CalendarEvent.objects.create(
+            calendar_fk=calendar,
+            organization=organization,
+            title="Test Event",
+            start_time_tz_unaware=datetime.datetime(2025, 6, 20, 10, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2025, 6, 20, 11, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+        attendance = EventAttendance.objects.create(
+            event=event,
+            user=user,
+            organization=organization,
+            status="accepted",
+        )
+
+        result = serialize_event_internal_attendee(attendance)
+
+        assert result.user_id == user.id
+        assert result.email == "attendee@example.com"
+        assert result.name == "Alice Smith"
+        assert result.status == "accepted"
+
+
+class TestSerializeEventDataInputResourceAllocations:
+    """Pin the behavior of serialize_event_data_input on the resource-allocation path.
+
+    NOTE: This test documents and pins a *known pre-existing latent bug* that the
+    Phase 0 refactor deliberately preserves byte-for-byte. The resources comprehension
+    iterates ``Calendar`` objects (the ``Calendar.objects.filter(...)`` result) but then
+    accesses ``resource_allocation.calendar.name`` / ``.status`` as if each item were a
+    ``ResourceAllocation``. A ``Calendar`` has no ``.calendar`` attribute, so when the
+    resource_allocations match a RESOURCE calendar in the org, evaluating the resources
+    list raises ``AttributeError``. We assert that here so the preserved behavior is
+    explicit and any future "fix" is a deliberate, reviewed change rather than an
+    accidental Phase 0 deviation.
+    """
+
+    def test_matching_resource_allocation_raises_attribute_error(self, db, organization):
+        """A non-empty resource_allocations path that matches a RESOURCE Calendar raises."""
+        resource_calendar = Calendar.objects.create(
+            name="Conference Room A",
+            email="room-a@example.com",
+            external_id="ext_resource_a",
+            provider=CalendarProvider.GOOGLE,
+            calendar_type=CalendarType.RESOURCE,
+            organization=organization,
+        )
+        owning_calendar = Calendar.objects.create(
+            name="Owning Cal",
+            external_id="ext_owning",
+            provider=CalendarProvider.GOOGLE,
+            organization=organization,
+        )
+        event = CalendarEvent.objects.create(
+            calendar_fk=owning_calendar,
+            organization=organization,
+            title="Event With Resource",
+            start_time_tz_unaware=datetime.datetime(2025, 6, 20, 10, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2025, 6, 20, 11, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+        event_data = CalendarEventInputData(
+            title="Event With Resource",
+            description="",
+            start_time=datetime.datetime(2025, 6, 20, 10, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2025, 6, 20, 11, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            resource_allocations=[ResourceAllocationInputData(resource_id=resource_calendar.id)],
+        )
+
+        # The (restored) original comprehension iterates Calendar objects but accesses
+        # ``.calendar`` on them — Calendar has no such attribute -> AttributeError.
+        with pytest.raises(AttributeError):
+            serialize_event_data_input(event, event_data, organization)
+
+
+class TestSerializeEventDelegation:
+    """The facade CalendarService._serialize_event must forward to the util function."""
+
+    def test_serialize_event_delegates_to_util(self, monkeypatch):
+        """CalendarService._serialize_event forwards to the module-level util and returns it."""
+        from calendar_integration.services import calendar_service as calendar_service_module
+        from calendar_integration.services.calendar_service import CalendarService
+
+        sentinel_event = object()
+        sentinel_result = MagicMock(spec=CalendarEventData)
+
+        forwarded = MagicMock(return_value=sentinel_result)
+        monkeypatch.setattr(calendar_service_module, "_serialize_event_util", forwarded)
+
+        service = CalendarService()
+        result = service._serialize_event(sentinel_event)  # type: ignore[arg-type]
+
+        forwarded.assert_called_once_with(sentinel_event)
+        assert result is sentinel_result


### PR DESCRIPTION
## Summary
Phase 0 of the calendar-service refactor (splitting the 4,726-line `CalendarService` monolith into a thin facade + focused sub-services). This is **pure scaffolding** that later phases build on, plus one sanctioned correctness fix:

1. **`CalendarServiceContext`** (`calendar_service_context.py`) — a frozen dataclass snapshot of the auth context (organization, user_or_token, account, calendar_adapter, permission/side-effects services). Built once in `authenticate()` / `initialize_without_provider()`; consumed by the sub-services extracted in Phases 2–6.
2. **`calendar_service_utils.py`** — moves the cross-cutting helpers out of the class as module-level functions: timezone conversion, the event-serialization family, permission-granting, and the two calendar lookups. The facade methods now delegate to them (kept as thin wrappers this phase; shrunk in Phase 7).
3. **Multi-tenant `lru_cache` fix** — the calendar lookups were `@lru_cache`-decorated instance methods keyed only on `id`/`external_id`. On a reused service instance that could return **another organization's** `Calendar`. Replaced with a per-instance dict keyed on `(organization_id, id_or_external_id)`, reset on every (re)authentication.

## Behavior preservation
Everything except the lru fix is byte-for-byte. The full `calendar_integration` suite (1014 tests) passes with **no edits to existing assertions**. Where the original code carried a latent bug, it is preserved deliberately and pinned by a test (see inline comments) — out of scope to fix here.

## No feature flag
Pure refactor — correctness is proven by the unchanged existing suite. The lone behavior change (lru fix) is guarded by a new regression test, not a flag. Per the plan's Goals/Non-goals.

## Plan reference
Plan `ai-plans/2026-06-13-CALENDAR_SERVICE_REFACTOR_IMPLEMENTATION_PLAN.md`, Phase 0.

## Review history
Layer-3 adversarial review: 0 blockers. Should-fixes addressed in-phase: reverted an unsanctioned behavior change in `serialize_event_data_input` (the refactor had "fixed" a latent bug — restored byte-for-byte and pinned it with a test); hoisted two function-local imports to module level; added the plan-mandated delegation test + a `serialize_event_data_input` resource-path test; typed the test cache dicts. NIT deferred: the per-instance cache is unbounded vs the old `maxsize=128` — bounded in practice by distinct calendars per org per instance lifetime (noted, not a leak on current call sites).

## Test plan
- `uv run pytest calendar_integration/tests/ -n auto` → 1014 passed.
- Outer gate: `ruff check` clean, `check --deploy` (5 pre-existing security warnings only), `pytest -n auto` → 1563 passed. The single failure `accounts/tests/test_account_adapters.py::...test_send_unknown_account_sms_success` is pre-existing on `main` (unrelated SMS-adapter test) and the diff is calendar-only.