### PR TITLE
feat(organizations): resolve active org from X-Organization-Id header

### DIFF
--- a/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
+++ b/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
@@ -28,11 +28,18 @@
 - **Review:** Layer-3 clean (no blockers); 1 SHOULD-FIX fixed (guard narrowed to active-only → restored to any-row), stale docstring + nondeterministic ordering fixed, added active-vs-inactive resolution test.
 - **Gate:** ruff + format + makemigrations --check + check --deploy green; `pytest -n auto` 1555 passed, 1 sanctioned pre-existing failure (`test_send_unknown_account_sms_success`, red on base too).
 
+### Phase 2a — Active-org resolver + header happy path ✅
+- **Model used:** claude-sonnet-4-6 (plan tier 3) · agent: implementer
+- **Branch:** plan/multi-org-membership/phase-2a · **base:** plan/multi-org-membership/phase-1
+- **PR:** https://github.com/vintasoftware/vinta-schedule-api/pull/69 (published, 4 inline comments)
+- **Summary:** `TenantScopedViewMixin` prepended to all 8 base viewsets; `initial()` resolves `X-Organization-Id` → caller's active membership, stashes on `request.organization`/`request.organization_membership`/`request.user._active_membership`. `get_active_organization_membership` reads the stash via `_UNSET` sentinel, off-request DB fallback. Happy-path rows only; 400/2b + 403/2c are no-regression stubs. Header lookup strictly scoped to the user's own memberships (tenant isolation). Malformed header falls through (no 500). Note: org PK is integer BigAutoField (plan said uuid).
+- **Review:** Layer-3 caught 1 BLOCKER — post-create `del` stash dropped to header-blind fallback → multi-org create-under-B 500'd; fixed by re-resolving after `perform_create` with a fail-before/pass-after regression test. Tests upgraded to exercise real tenant data through `CalendarViewSet`; malformed-header guard added.
+- **Gate:** ruff/format/mypy(baseline)/makemigrations/check --deploy green; `pytest -n auto` 1570 passed (1 sanctioned pre-existing twilio failure — being fixed on main, stack rebased).
+
 ## Current phase
-Phase 2a — Resolver + header happy path (Tier 3 · sonnet · implementer).
+Phase 2b — No-header multi-org → 400 (Tier 2 · haiku · implementer).
 
 ## Remaining phases
-- Phase 2a — Resolver + header happy path
 - Phase 2b — No-header multi-org → 400
 - Phase 2c — Non-member org → 403
 - Phase 3 — List my orgs endpoint

--- a/common/utils/view_utils.py
+++ b/common/utils/view_utils.py
@@ -1,9 +1,181 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
 from django.shortcuts import get_object_or_404
 
 import django_virtual_models as v
 from rest_framework import generics, mixins, status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ViewSetMixin
+
+
+logger = logging.getLogger(__name__)
+
+#: Header name used to select the active organization for a request.
+ACTIVE_ORG_HEADER = "X-Organization-Id"
+
+
+class TenantScopedViewMixin:
+    """Resolve the active organization for every DRF request.
+
+    This mixin must be included in every base viewset so that all internal REST
+    endpoints automatically pick up the ``X-Organization-Id`` header.  The resolver
+    runs **after** ``super().initial()`` so that DRF authentication has already
+    populated ``request.user`` — the JWT user is not available at Django-middleware
+    time.
+
+    After this mixin runs, three attributes are available on every DRF request:
+
+    - ``request.organization_membership`` — the resolved ``OrganizationMembership``
+      or ``None`` (gated / unauthenticated user).
+    - ``request.organization`` — the resolved ``Organization`` or ``None``.
+    - ``request.user._active_membership`` — same value as
+      ``request.organization_membership``.  ``get_active_organization_membership``
+      reads this stash so all ~60 existing call sites are header-aware without
+      change.
+
+    Resolution table (Phase 2a implements the happy-path rows; stubs for 2b/2c are noted):
+
+    +-----------------------+---------------------------------+------------------------------------------+
+    | Memberships (active)  | Header                          | Result (Phase 2a)                        |
+    +-----------------------+---------------------------------+------------------------------------------+
+    | 0                     | any                             | gated (membership = None)                |
+    | 1                     | absent                          | resolve to that membership               |
+    | 1                     | present, matches                | resolve to it                            |
+    | 2+                    | present, matches member         | resolve to named org                     |
+    | 2+                    | absent                          | fallback to first [Phase 2b → 400]       |
+    | any                   | present, non-member org         | fallback to first [Phase 2c → 403]       |
+    | any                   | present, non-integer            | fallback to first (malformed, not 500)   |
+    +-----------------------+---------------------------------+------------------------------------------+
+
+    Unauthenticated requests pass through untouched (the mixin sets ``None`` on
+    all three attributes so downstream code doesn't KeyError); DRF's own
+    authentication / permission stack returns 401 before any business logic runs.
+    """
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
+        """Run DRF initialisation, then resolve and stash the active org."""
+        super().initial(request, *args, **kwargs)  # type: ignore[misc]
+        self._resolve_active_organization(request)
+
+    def _resolve_active_organization(self, request: Request) -> None:  # noqa: C901
+        """Resolve ``X-Organization-Id`` → membership and stash on ``request`` + user.
+
+        This method is extracted from ``initial()`` so tests can call it in isolation
+        and so Phase 2b/2c can override or extend it without touching ``initial()``.
+        """
+        # Lazily import to avoid a circular import (organizations → common → organizations).
+        from organizations.models import OrganizationMembership  # noqa: PLC0415
+
+        # Default: nothing resolved yet.
+        resolved_membership: OrganizationMembership | None = None
+
+        user = getattr(request, "user", None)
+        is_authenticated = user is not None and getattr(user, "is_authenticated", False)
+
+        if is_authenticated:
+            org_id_header: str | None = request.headers.get(ACTIVE_ORG_HEADER)
+
+            if org_id_header:
+                # Validate that the header value is a valid integer before using it
+                # in a DB lookup. A non-coercible value (e.g. "abc") is treated as
+                # "no match" and falls through to the existing fallback, rather than
+                # raising a ValueError / 500 from the ORM.
+                try:
+                    int(org_id_header)
+                except (TypeError, ValueError):
+                    # Malformed header — treat as if no match was found.
+                    resolved_membership = (
+                        user.organization_memberships.filter(  # type: ignore[union-attr]
+                            is_active=True,
+                        )
+                        .select_related("organization")
+                        .order_by("created")
+                        .first()
+                    )
+                    logger.debug(
+                        "X-Organization-Id header '%s' is not a valid integer for "
+                        "user %s; falling back to single-membership resolution.",
+                        org_id_header,
+                        user.pk,  # type: ignore[union-attr]
+                    )
+                    # Skip the matching-lookup block below.
+                    org_id_header = None
+
+            if org_id_header:
+                # Header present and is a valid integer: try to find a matching active membership.
+                matching = (
+                    user.organization_memberships.filter(  # type: ignore[union-attr]
+                        is_active=True,
+                        organization_id=org_id_header,
+                    )
+                    .select_related("organization")
+                    .first()
+                )
+                if matching is not None:
+                    # Happy path: header names an org the user actively belongs to.
+                    resolved_membership = matching
+                else:
+                    # Phase 2c will raise PermissionDenied (403) here when the header
+                    # names an org the caller is not an active member of.
+                    # For now fall back to the pre-existing single-membership behaviour
+                    # so nothing regresses.
+                    resolved_membership = (
+                        user.organization_memberships.filter(  # type: ignore[union-attr]
+                            is_active=True,
+                        )
+                        .select_related("organization")
+                        .order_by("created")
+                        .first()
+                    )
+                    logger.debug(
+                        "X-Organization-Id header '%s' did not match any active membership for "
+                        "user %s; falling back to single-membership resolution. "
+                        "(Phase 2c will reject this with 403.)",
+                        org_id_header,
+                        user.pk,  # type: ignore[union-attr]
+                    )
+            else:
+                # Header absent: resolve to the single active membership when there
+                # is exactly one; otherwise use the first (stable ordering).
+                # Phase 2b will reject multi-org users who omit the header with 400.
+                active_memberships = list(
+                    user.organization_memberships.filter(  # type: ignore[union-attr]
+                        is_active=True,
+                    )
+                    .select_related("organization")
+                    .order_by("created")[:2]  # only need the first two to detect multi-org
+                )
+                if len(active_memberships) == 1:
+                    # Single-membership happy path: identical to today's behaviour.
+                    resolved_membership = active_memberships[0]
+                elif len(active_memberships) > 1:
+                    # Phase 2b will raise ValidationError (400) here for multi-org
+                    # users who omit the header. For now fall back to returning the
+                    # first membership so nothing regresses.
+                    resolved_membership = active_memberships[0]
+                    logger.debug(
+                        "User %s has multiple active memberships and no X-Organization-Id header; "
+                        "falling back to first membership. "
+                        "(Phase 2b will reject this with 400.)",
+                        user.pk,  # type: ignore[union-attr]
+                    )
+                # else: zero memberships → gated; resolved_membership stays None.
+
+        # Stash resolved values on the request and user so all downstream code
+        # (permissions, serializers, get_active_organization_membership) picks them up.
+        request.organization_membership = resolved_membership  # type: ignore[attr-defined]
+        request.organization = (  # type: ignore[attr-defined]
+            resolved_membership.organization if resolved_membership is not None else None
+        )
+        if is_authenticated and user is not None:
+            # Set even when None so get_active_organization_membership can
+            # distinguish "DRF request path resolved to gated" from
+            # "not on a DRF request at all" (_UNSET sentinel).
+            user._active_membership = resolved_membership  # type: ignore[union-attr]
 
 
 class RefetchReturnInstanceAfterWriteMixin:
@@ -197,6 +369,14 @@ class CreateModelMixin(RefetchReturnInstanceAfterWriteMixin, mixins.CreateModelM
         self.perform_create(serializer)
         instance = serializer.instance
 
+        # A service may have created the user's first membership during perform_create
+        # (e.g. OrganizationService.create_organization), making the stash set in
+        # TenantScopedViewMixin.initial() stale. Re-resolve so the post-create re-fetch
+        # honors the X-Organization-Id header (and any newly-created membership) instead
+        # of silently dropping to the header-blind single-membership fallback.
+        if hasattr(self, "_resolve_active_organization"):
+            self._resolve_active_organization(request)
+
         # re-fetches the instance so we get annotations, prefetches, and selects
         if hasattr(self, "get_return_queryset"):
             annotated_instance = self.get_return_queryset().get(pk=instance.pk)
@@ -254,6 +434,7 @@ class FilterOnlyOnListMixin:
 
 
 class VintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     CreateModelMixin,
     UpdateModelMixin,
     FilterOnlyOnListMixin,
@@ -270,6 +451,7 @@ class VintaScheduleModelViewSet(
 
 
 class ReadOnlyVintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     ViewSetMixin,
     RefetchReturnInstanceAfterWriteMixin,
     FilterOnlyOnListMixin,
@@ -287,6 +469,7 @@ class ReadOnlyVintaScheduleModelViewSet(
 
 
 class NoCreateVintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     ViewSetMixin,
     FilterOnlyOnListMixin,
     v.GenericVirtualModelViewMixin,
@@ -305,6 +488,7 @@ class NoCreateVintaScheduleModelViewSet(
 
 
 class NoUpdateVintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     ViewSetMixin,
     FilterOnlyOnListMixin,
     v.GenericVirtualModelViewMixin,
@@ -323,6 +507,7 @@ class NoUpdateVintaScheduleModelViewSet(
 
 
 class CreateAndReadVintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     ViewSetMixin,
     FilterOnlyOnListMixin,
     v.GenericVirtualModelViewMixin,
@@ -340,6 +525,7 @@ class CreateAndReadVintaScheduleModelViewSet(
 
 
 class NoListVintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     ViewSetMixin,
     FilterOnlyOnListMixin,
     v.GenericVirtualModelViewMixin,
@@ -358,6 +544,7 @@ class NoListVintaScheduleModelViewSet(
 
 
 class WriteOnlyVintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     ViewSetMixin,
     FilterOnlyOnListMixin,
     v.GenericVirtualModelViewMixin,
@@ -375,6 +562,7 @@ class WriteOnlyVintaScheduleModelViewSet(
 
 
 class NoDetailsVintaScheduleModelViewSet(
+    TenantScopedViewMixin,
     ViewSetMixin,
     FilterOnlyOnListMixin,
     v.GenericVirtualModelViewMixin,

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -15,6 +15,12 @@ if TYPE_CHECKING:
     from users.models import User
 
 
+# Sentinel distinguishes "not resolved yet" (off-DRF path) from ``None``
+# (resolved-to-gated / resolved-to-no-membership). Must be module-level so
+# the same object identity is checked everywhere.
+_UNSET: object = object()
+
+
 def get_active_organization_membership(
     user: User | None,
 ) -> OrganizationMembership | None:
@@ -27,19 +33,30 @@ def get_active_organization_membership(
         if not membership:
             return <empty queryset / clean denial>
 
-    Phase 1 implementation: returns the user's single active membership via a
-    manager query. Phase 2a will layer the ``_active_membership`` stash so
-    header-driven resolution is picked up here automatically.
+    On the DRF request path (Phase 2a+), ``TenantScopedViewMixin.initial()``
+    resolves the active membership from the ``X-Organization-Id`` header and
+    stashes it on ``user._active_membership``. This helper reads the stash so
+    the ~60 existing call sites are automatically header-aware without change.
+
+    Off the DRF request path (management commands, Celery tasks, tests that
+    bypass views), ``_active_membership`` is absent and the helper falls back
+    to the single-membership query so those callers keep working.
 
     A user with no active memberships returns None (gated). An inactive
     membership (is_active=False) is treated identically to no membership.
     """
     if user is None:
         return None
-    # Stable ordering: once later phases allow multiple active memberships, an
-    # accidental two-active-row state must resolve deterministically. Multi-active
-    # resolution becomes header-driven in Phase 2a, so this ordering is only a
-    # deterministic fallback.
+
+    stashed = getattr(user, "_active_membership", _UNSET)
+    if stashed is not _UNSET:
+        # DRF request path: the resolver has already run; trust its result
+        # (may be an OrganizationMembership or None for gated users).
+        return stashed  # type: ignore[return-value]
+
+    # Off-request path (management commands, Celery tasks, direct test calls):
+    # fall back to the single active membership query. Stable ordering ensures
+    # determinism if a user somehow ends up with two active memberships here.
     return user.organization_memberships.filter(is_active=True).order_by("created").first()  # type: ignore[union-attr]
 
 

--- a/organizations/tests/test_org_resolution.py
+++ b/organizations/tests/test_org_resolution.py
@@ -1,0 +1,448 @@
+"""Integration tests for active-org resolution (Phase 2a).
+
+Verifies that the ``TenantScopedViewMixin`` resolver correctly resolves the
+active organization from the ``X-Organization-Id`` header and stashes the result
+so ``get_active_organization_membership`` reads it.
+
+Use-case 2: active org selected via header.
+
+Phase 2b / 2c rejections (400 for missing header + multi-org users, 403 for
+non-member org header) are *not* tested here — those behaviours are added in
+Phases 2b and 2c.  The current tests verify only the happy-path rows:
+
+* Header present + caller is active member → resolve to that org.
+* Header absent + exactly one active membership → resolve to it (unchanged).
+"""
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from organizations.models import (
+    Organization,
+    OrganizationMembership,
+    OrganizationRole,
+    get_active_organization_membership,
+)
+
+
+User = get_user_model()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_org(name: str) -> Organization:
+    return Organization.objects.create(name=name)
+
+
+def _make_membership(
+    user: User,  # type: ignore[valid-type]
+    org: Organization,
+    *,
+    role: str = OrganizationRole.MEMBER,
+    is_active: bool = True,
+) -> OrganizationMembership:
+    """Create an OrganizationMembership directly (bypassing the invite flow)."""
+    return OrganizationMembership.objects.create(
+        user=user,
+        organization=org,
+        role=role,
+        is_active=is_active,
+    )
+
+
+def _auth_client_for(user: User) -> APIClient:  # type: ignore[valid-type]
+    """Return an API client authenticated as *user* via session login."""
+    from users.factories import DEFAULT_TEST_USER_PASSWORD
+
+    client = APIClient()
+    client.login(email=user.email, password=DEFAULT_TEST_USER_PASSWORD)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def org_a() -> Organization:
+    return _make_org("Org A")
+
+
+@pytest.fixture
+def org_b() -> Organization:
+    return _make_org("Org B")
+
+
+@pytest.fixture
+def two_org_user(user: User, org_a: Organization, org_b: Organization):  # type: ignore[valid-type]
+    """A user with active memberships in both Org A and Org B."""
+    _make_membership(user, org_a)
+    _make_membership(user, org_b)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Tests: header-driven resolution (happy path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestHeaderDrivenOrgResolution:
+    """Sending X-Organization-Id routes the request to the matching org."""
+
+    def test_header_org_a_returns_org_a_membership(
+        self,
+        two_org_user: User,
+        org_a: Organization,
+        org_b: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """Header naming Org A resolves to the Org A membership."""
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Organizations-current")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_a.pk))
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        data = response.json()
+        assert data["organization"]["id"] == org_a.pk
+
+    def test_header_org_b_returns_org_b_membership(
+        self,
+        two_org_user: User,
+        org_a: Organization,
+        org_b: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """Header naming Org B resolves to the Org B membership."""
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Organizations-current")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_b.pk))
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        data = response.json()
+        assert data["organization"]["id"] == org_b.pk
+
+    def test_switching_org_between_requests_works(
+        self,
+        two_org_user: User,
+        org_a: Organization,
+        org_b: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """Sending different org headers in successive requests resolves each one correctly."""
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Organizations-current")
+
+        response_a = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_a.pk))
+        response_b = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_b.pk))
+
+        assert response_a.status_code == status.HTTP_200_OK
+        assert response_b.status_code == status.HTTP_200_OK
+        assert response_a.json()["organization"]["id"] == org_a.pk
+        assert response_b.json()["organization"]["id"] == org_b.pk
+
+    def test_header_with_single_membership_user_resolves_that_org(
+        self,
+        user: User,
+        org_a: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """For a single-membership user, the header for their org resolves correctly."""
+        _make_membership(user, org_a)
+        client = _auth_client_for(user)
+        url = reverse("api:Organizations-current")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_a.pk))
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        data = response.json()
+        assert data["organization"]["id"] == org_a.pk
+
+
+# ---------------------------------------------------------------------------
+# Tests: header-absent resolution (single-membership happy path, no regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestHeaderAbsentSingleMembership:
+    """Without a header, a user with exactly one active membership resolves to it (unchanged)."""
+
+    def test_no_header_resolves_single_membership(
+        self,
+        user: User,
+        org_a: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """No header + one active membership → 200 with that org (preserved behavior)."""
+        _make_membership(user, org_a)
+        client = _auth_client_for(user)
+        url = reverse("api:Organizations-current")
+
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        data = response.json()
+        assert data["organization"]["id"] == org_a.pk
+
+    def test_no_header_gated_user_returns_404(self, user: User) -> None:  # type: ignore[valid-type]
+        """No header + zero active memberships → 404 (gated user, unchanged)."""
+        client = _auth_client_for(user)
+        url = reverse("api:Organizations-current")
+
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_no_header_inactive_membership_not_resolved(
+        self,
+        user: User,
+        org_a: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """An inactive membership is treated as gated (no active membership)."""
+        _make_membership(user, org_a, is_active=False)
+        client = _auth_client_for(user)
+        url = reverse("api:Organizations-current")
+
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unauthenticated_request_returns_401(self, org_a: Organization) -> None:
+        """Unauthenticated requests always get 401 (DRF auth gate runs before the resolver)."""
+        client = APIClient()
+        url = reverse("api:Organizations-current")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_a.pk))
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_active_organization_membership stash seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestActiveOrgStash:
+    """The resolver stashes the membership on user._active_membership so helpers see it."""
+
+    def test_get_active_org_membership_returns_header_resolved_membership(
+        self,
+        two_org_user: User,
+        org_a: Organization,
+        org_b: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """``get_active_organization_membership`` inside a view returns the header-resolved one.
+
+        We assert this end-to-end: the ``current`` action calls the helper internally
+        and returns data for the org named in the header — so if the returned org.id
+        matches the header, the stash seam is working.
+        """
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Organizations-current")
+
+        for org in (org_a, org_b):
+            response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org.pk))
+            assert response.status_code == status.HTTP_200_OK, response.content
+            assert response.json()["organization"]["id"] == org.pk, (
+                f"Expected org {org.pk} but got {response.json()['organization']['id']}"
+            )
+
+    def test_off_request_fallback_is_unaffected(
+        self,
+        user: User,
+        org_a: Organization,  # type: ignore[valid-type]
+    ) -> None:
+        """Off-DRF-request callers (no _active_membership stash) fall back to DB query.
+
+        Simulates a management command / Celery task calling the helper directly.
+        """
+        _make_membership(user, org_a)
+        # user._active_membership is NOT set here — no DRF request, no stash.
+        assert not hasattr(user, "_active_membership")
+
+        membership = get_active_organization_membership(user)
+
+        assert membership is not None
+        assert membership.organization_id == org_a.pk
+
+    def test_stash_none_when_gated_is_distinguishable_from_unset(
+        self,
+        user: User,  # type: ignore[valid-type]
+    ) -> None:
+        """After a DRF request for a gated user, _active_membership is None (not absent).
+
+        This lets get_active_organization_membership distinguish "DRF request,
+        resolved to gated" from "not on a DRF request at all".
+        """
+        client = _auth_client_for(user)
+        url = reverse("api:Organizations-current")
+        # Gated user — no memberships; current returns 404 but the stash should have None.
+        response = client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        # The stash check itself is indirect: the helper returned None (gated), which is
+        # the correct outcome. We verify the off-request user object has no stash yet.
+        assert not hasattr(user, "_active_membership")
+
+
+# ---------------------------------------------------------------------------
+# Tests: tenant-scoped queryset (CalendarViewSet) — list isolation + create
+# ---------------------------------------------------------------------------
+# Uses CalendarViewSet (GET /calendar/, POST /calendar/) because it is a
+# standard VintaScheduleModelViewSet with org-scoped get_queryset() and the
+# CalendarSerializer.create path goes through CreateModelMixin.create, making it
+# the ideal regression target for Finding 1 (del → re-resolve bug).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCalendarViewSetOrgScoping:
+    """X-Organization-Id header correctly scopes CalendarViewSet list and create."""
+
+    def test_list_with_header_a_returns_only_org_a_calendars(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """GET /calendar/ with header A returns only Org A calendars, not Org B."""
+        from calendar_integration.tests.test_views import CalendarIntegrationTestFactory
+
+        cal_a = CalendarIntegrationTestFactory.create_calendar(organization=org_a)
+        cal_b = CalendarIntegrationTestFactory.create_calendar(organization=org_b)
+
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(
+            url,
+            HTTP_X_ORGANIZATION_ID=str(org_a.pk),
+            data={"include_inactive": "true", "include_unlisted": "true"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        returned_ids = {item["id"] for item in response.json()["results"]}
+        assert cal_a.id in returned_ids, "Org A calendar should appear in the list"
+        assert cal_b.id not in returned_ids, "Org B calendar must NOT appear with Org A header"
+
+    def test_list_with_header_b_returns_only_org_b_calendars(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """GET /calendar/ with header B returns only Org B calendars, not Org A."""
+        from calendar_integration.tests.test_views import CalendarIntegrationTestFactory
+
+        cal_a = CalendarIntegrationTestFactory.create_calendar(organization=org_a)
+        cal_b = CalendarIntegrationTestFactory.create_calendar(organization=org_b)
+
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(
+            url,
+            HTTP_X_ORGANIZATION_ID=str(org_b.pk),
+            data={"include_inactive": "true", "include_unlisted": "true"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        returned_ids = {item["id"] for item in response.json()["results"]}
+        assert cal_b.id in returned_ids, "Org B calendar should appear in the list"
+        assert cal_a.id not in returned_ids, "Org A calendar must NOT appear with Org B header"
+
+    def test_create_under_header_b_returns_201_and_lands_in_org_b(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """POST /calendar/ with X-Organization-Id: B creates the calendar under Org B.
+
+        Regression test for Finding 1 (Phase 2a review): before the fix, ``del
+        user._active_membership`` in ``CreateModelMixin.create`` wiped the header-
+        resolved stash so the post-create re-fetch of the queryset fell into the
+        header-blind DB fallback (order_by("created").first() == Org A for this
+        two-org user), causing a cross-org DoesNotExist / 500.
+
+        The mock service is required because ``CalendarSerializer.create`` delegates
+        object creation to the injected ``CalendarService``; the mock returns a real
+        DB-backed ``Calendar`` row seeded under Org B so the viewset's post-create
+        ``get_queryset().get(pk=...)`` is a genuine org-scoped lookup.
+        """
+        from unittest.mock import Mock
+
+        from calendar_integration.models import Calendar
+        from calendar_integration.tests.test_views import CalendarIntegrationTestFactory
+        from di_core.containers import container
+
+        assert container is not None, "DI container must be wired during tests"
+        # Seed a real Calendar row in Org B — the mock service will return this.
+        created_calendar = CalendarIntegrationTestFactory.create_calendar(
+            organization=org_b,
+            name="New Virtual Calendar Under B",
+            description="Created under Org B",
+        )
+
+        mock_service = Mock()
+        mock_service.initialize_without_provider.return_value = None
+        mock_service.create_virtual_calendar.return_value = created_calendar
+
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        with container.calendar_service.override(mock_service):
+            response = client.post(
+                url,
+                data={"name": "New Virtual Calendar Under B", "description": "Created under Org B"},
+                format="json",
+                HTTP_X_ORGANIZATION_ID=str(org_b.pk),
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f"Expected 201 but got {response.status_code}; body: {response.content!r}. "
+            "If this is 500/DoesNotExist the Finding-1 fix is not applied."
+        )
+        # Confirm the returned calendar belongs to Org B (not Org A).
+        returned_id = response.json()["id"]
+        # Use filter_by_organization so we scope to Org B — if the calendar
+        # was mistakenly re-fetched under Org A the queryset would yield DoesNotExist.
+        cal = Calendar.objects.filter_by_organization(org_b.pk).get(pk=returned_id)
+        assert cal.organization_id == org_b.pk, (
+            f"Calendar was created/re-fetched under org {cal.organization_id} "
+            f"instead of Org B ({org_b.pk})."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: malformed X-Organization-Id header does not 500
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestMalformedOrgIdHeader:
+    """A non-integer X-Organization-Id header falls back gracefully, not 500."""
+
+    def test_non_integer_header_does_not_500(
+        self,
+        user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+    ) -> None:
+        """A header value like 'abc' should not raise ValueError / return 500."""
+        _make_membership(user, org_a)
+        client = _auth_client_for(user)
+        url = reverse("api:Organizations-current")
+
+        # "abc" cannot be coerced to int; the resolver must fall back gracefully.
+        response = client.get(url, HTTP_X_ORGANIZATION_ID="abc")
+
+        # The exact status depends on the fallback path (200 with single-membership
+        # fallback is fine; anything but 500 satisfies the requirement).
+        assert response.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR, (
+            f"Malformed header caused 500: {response.content!r}"
+        )


### PR DESCRIPTION
## Summary
Phase 2a of the **Multi-Organization Membership** plan. Adds a request-scoped resolver that
selects the active organization from the `X-Organization-Id` header and stashes it where the
existing tenant-scoping call sites already read — so multi-org switching works without touching
~60 call sites. Only the happy-path rows of the resolution table are implemented; the 400
(absent + multi-org) and 403 (non-member org) rows are deliberate no-regression stubs for
Phases 2b/2c.

## What changed
- New `TenantScopedViewMixin` in `common/utils/view_utils.py`, prepended to all 8 shared base viewsets. Its `initial()` runs `super().initial()` first (so DRF auth has populated `request.user`), then resolves `X-Organization-Id` → the caller's active membership and stashes it on `request.organization`, `request.organization_membership`, and `request.user._active_membership`.
- `get_active_organization_membership(user)` reads the `_active_membership` stash via an `_UNSET` sentinel (distinguishes "resolved to gated/None" from "not on a DRF request"); off-request callers (Celery, mgmt commands, direct tests) fall back to the single-membership DB query.
- The header lookup is strictly scoped to `request.user.organization_memberships` — no request can resolve to an org the caller isn't an active member of.
- Malformed (non-integer) header falls through to the fallback instead of 500.
- `CreateModelMixin.create` re-resolves the active org after `perform_create` (a service may have just created the user's first membership) so the post-create re-fetch honors the header.

## Plan reference
Plan `ai-plans/2026-06-13-MULTI_ORG_MEMBERSHIP_IMPLEMENTATION_PLAN.md` — Phase 2a + Guiding Decisions (resolution seam = stash on request/user) + API Design (resolution table). Use-case 2.

## Review history
Layer-3 adversarial review caught one BLOCKER: the original post-create `del user._active_membership` dropped to the header-blind fallback, so a multi-org user creating under header B then re-fetching via `get_queryset` (scoped to the first membership) would 500 / cross-org. Fixed by re-resolving after `perform_create`, with a fail-before/pass-after regression test through `CalendarViewSet`. Also fixed: tests now exercise real tenant data (list-A vs list-B + create-under-B 201) not just the `current` echo; malformed-header 500 guarded. Note: org PK is an integer `BigAutoField` (the plan said "uuid" — corrected here).

## Test plan
- `uv run pytest organizations/tests/test_org_resolution.py -vs`
- Asserts: header A → org-A data, header B → org-B data through `CalendarViewSet`; create under `X-Organization-Id: <B>` returns 201 and lands in org B (regression for the BLOCKER); single-membership absent-header behavior unchanged; gated + unauthenticated pass through; malformed header does not 500.
- Outer gate green: ruff, format --check, mypy (138, unchanged baseline), `makemigrations --check`, `check --deploy`, `pytest -n auto` (1570 passed; 1 sanctioned pre-existing failure).