### PR TITLE
feat(organizations): require X-Organization-Id for multi-org requests

### DIFF
--- a/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
+++ b/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
@@ -36,11 +36,21 @@
 - **Review:** Layer-3 caught 1 BLOCKER — post-create `del` stash dropped to header-blind fallback → multi-org create-under-B 500'd; fixed by re-resolving after `perform_create` with a fail-before/pass-after regression test. Tests upgraded to exercise real tenant data through `CalendarViewSet`; malformed-header guard added.
 - **Gate:** ruff/format/mypy(baseline)/makemigrations/check --deploy green; `pytest -n auto` 1570 passed (1 sanctioned pre-existing twilio failure — being fixed on main, stack rebased).
 
+### Phase 2b — No-header multi-org → 400 ✅
+- **Model used:** claude-sonnet-4-6 (plan tier 2; used sonnet) · agent: implementer
+- **Branch:** plan/multi-org-membership/phase-2b · **base:** plan/multi-org-membership/phase-2a
+- **PR:** https://github.com/vintasoftware/vinta-schedule-api/pull/70 (published, 3 inline comments)
+- **Summary:** absent-header + 2+ active memberships → 400 `X-Organization-Id header required`. Added `active_org_resolution_optional` opt-out (Phase 3 mine uses it). Malformed header unified to absent-header semantics (multi-org → 400, single → resolve) — safer than the old silent first-org fallback.
+- **Review:** Layer-3 caught a malformed-header edge (silent first-org pick for multi-org) → unified to 400, removed dead fallback, added multi-org-malformed test.
+- **Gate:** full suite green — `pytest -n auto` 1578 passed, 0 failures.
+
+## Stack note
+2026-06-13: rebased base/phase-1/phase-2a onto origin/main (twilio fix `3286b69`); force-pushed; PR bases intact. No sanctioned failures remain — full suite must be 100% green.
+
 ## Current phase
-Phase 2b — No-header multi-org → 400 (Tier 2 · haiku · implementer).
+Phase 2c — Non-member org → 403 (Tier 2 · sonnet · implementer).
 
 ## Remaining phases
-- Phase 2b — No-header multi-org → 400
 - Phase 2c — Non-member org → 403
 - Phase 3 — List my orgs endpoint
 - Phase 4 — Multi-org invitation accept

--- a/common/utils/view_utils.py
+++ b/common/utils/view_utils.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 
 import django_virtual_models as v
 from rest_framework import generics, mixins, status
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ViewSetMixin
@@ -37,24 +38,44 @@ class TenantScopedViewMixin:
       reads this stash so all ~60 existing call sites are header-aware without
       change.
 
-    Resolution table (Phase 2a implements the happy-path rows; stubs for 2b/2c are noted):
+    Resolution table (Phase 2b implements the multi-org-no-header 400; 2c stubbed):
 
     +-----------------------+---------------------------------+------------------------------------------+
-    | Memberships (active)  | Header                          | Result (Phase 2a)                        |
+    | Memberships (active)  | Header                          | Result                                   |
     +-----------------------+---------------------------------+------------------------------------------+
     | 0                     | any                             | gated (membership = None)                |
     | 1                     | absent                          | resolve to that membership               |
     | 1                     | present, matches                | resolve to it                            |
     | 2+                    | present, matches member         | resolve to named org                     |
-    | 2+                    | absent                          | fallback to first [Phase 2b → 400]       |
+    | 2+                    | absent                          | **400** (X-Organization-Id required)     |
     | any                   | present, non-member org         | fallback to first [Phase 2c → 403]       |
-    | any                   | present, non-integer            | fallback to first (malformed, not 500)   |
+    | any                   | present, non-integer            | treated as absent header                 |
+    |                       |                                 | (1 → resolve · 2+ → 400 · 0 → gated)     |
     +-----------------------+---------------------------------+------------------------------------------+
+
+    The ``2+ / absent`` row raises ``rest_framework.exceptions.ValidationError``
+    (rendered as **400** with body ``{"detail": "X-Organization-Id header
+    required."}``) so a multi-org caller can never resolve to an ambiguous,
+    implicit organization.
+
+    **Opt-out:** a concrete view that must serve multi-org callers *without* the
+    header (e.g. the org-discovery ``GET /organizations/mine/`` endpoint and the
+    onboarding/gated flows) sets the class attribute
+    ``active_org_resolution_optional = True``.  When set, the ``2+ / absent`` case
+    does **not** raise — the active org simply resolves to ``None`` (left gated)
+    so the view can list the caller's memberships.  Defaults to ``False``; no
+    existing view sets it (Phase 3 wires it onto the ``mine`` endpoint).
 
     Unauthenticated requests pass through untouched (the mixin sets ``None`` on
     all three attributes so downstream code doesn't KeyError); DRF's own
     authentication / permission stack returns 401 before any business logic runs.
     """
+
+    #: When ``True``, a multi-org caller that omits ``X-Organization-Id`` is *not*
+    #: rejected with a 400 — the active org resolves to ``None`` instead.  Concrete
+    #: views that must function without the header (org discovery, onboarding) opt
+    #: in.  See the class docstring's resolution table for the affected row.
+    active_org_resolution_optional: bool = False
 
     def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         """Run DRF initialisation, then resolve and stash the active org."""
@@ -82,27 +103,20 @@ class TenantScopedViewMixin:
             if org_id_header:
                 # Validate that the header value is a valid integer before using it
                 # in a DB lookup. A non-coercible value (e.g. "abc") is treated as
-                # "no match" and falls through to the existing fallback, rather than
-                # raising a ValueError / 500 from the ORM.
+                # an absent header rather than raising a ValueError / 500 from the
+                # ORM. We intentionally apply the *same* rules as a missing header
+                # (single → resolve, multi-org → 400, gated → gated) so a garbage
+                # header can never silently pick an org for a multi-org caller.
                 try:
                     int(org_id_header)
                 except (TypeError, ValueError):
-                    # Malformed header — treat as if no match was found.
-                    resolved_membership = (
-                        user.organization_memberships.filter(  # type: ignore[union-attr]
-                            is_active=True,
-                        )
-                        .select_related("organization")
-                        .order_by("created")
-                        .first()
-                    )
                     logger.debug(
                         "X-Organization-Id header '%s' is not a valid integer for "
-                        "user %s; falling back to single-membership resolution.",
+                        "user %s; treating it as an absent header.",
                         org_id_header,
                         user.pk,  # type: ignore[union-attr]
                     )
-                    # Skip the matching-lookup block below.
+                    # Fall through to the absent-header branch below.
                     org_id_header = None
 
             if org_id_header:
@@ -140,8 +154,9 @@ class TenantScopedViewMixin:
                     )
             else:
                 # Header absent: resolve to the single active membership when there
-                # is exactly one; otherwise use the first (stable ordering).
-                # Phase 2b will reject multi-org users who omit the header with 400.
+                # is exactly one. A multi-org caller who omits the header is
+                # rejected with 400 (unless the view opts out via
+                # ``active_org_resolution_optional``); zero memberships → gated.
                 active_memberships = list(
                     user.organization_memberships.filter(  # type: ignore[union-attr]
                         is_active=True,
@@ -153,14 +168,17 @@ class TenantScopedViewMixin:
                     # Single-membership happy path: identical to today's behaviour.
                     resolved_membership = active_memberships[0]
                 elif len(active_memberships) > 1:
-                    # Phase 2b will raise ValidationError (400) here for multi-org
-                    # users who omit the header. For now fall back to returning the
-                    # first membership so nothing regresses.
-                    resolved_membership = active_memberships[0]
+                    # Multi-org caller with no header: the active org is ambiguous.
+                    # Reject with 400 so we never silently pick one — unless the
+                    # concrete view opted out (org discovery / onboarding), in which
+                    # case resolution falls through to gated (None).
+                    if not getattr(self, "active_org_resolution_optional", False):
+                        raise ValidationError(
+                            {"detail": "X-Organization-Id header required."},
+                        )
                     logger.debug(
-                        "User %s has multiple active memberships and no X-Organization-Id header; "
-                        "falling back to first membership. "
-                        "(Phase 2b will reject this with 400.)",
+                        "User %s has multiple active memberships and no X-Organization-Id "
+                        "header; view opted out of the 400 — resolving to gated (None).",
                         user.pk,  # type: ignore[union-attr]
                     )
                 # else: zero memberships → gated; resolved_membership stays None.

--- a/organizations/tests/test_org_resolution.py
+++ b/organizations/tests/test_org_resolution.py
@@ -1,17 +1,24 @@
-"""Integration tests for active-org resolution (Phase 2a).
+"""Integration tests for active-org resolution (Phase 2a + 2b).
 
 Verifies that the ``TenantScopedViewMixin`` resolver correctly resolves the
 active organization from the ``X-Organization-Id`` header and stashes the result
 so ``get_active_organization_membership`` reads it.
 
 Use-case 2: active org selected via header.
+Use-case 3: header-absent multi-org request is rejected with 400.
 
-Phase 2b / 2c rejections (400 for missing header + multi-org users, 403 for
-non-member org header) are *not* tested here — those behaviours are added in
-Phases 2b and 2c.  The current tests verify only the happy-path rows:
+Phase 2a covers the happy-path rows:
 
 * Header present + caller is active member → resolve to that org.
 * Header absent + exactly one active membership → resolve to it (unchanged).
+
+Phase 2b adds the multi-org-no-header rejection:
+
+* Header absent + 2+ active memberships → **400** ``X-Organization-Id header required.``
+* The 0-membership (gated) and single-membership rows are unchanged.
+* A view setting ``active_org_resolution_optional = True`` is exempt from the 400.
+
+Phase 2c (non-member org header → 403) is *not* tested here.
 """
 
 from django.contrib.auth import get_user_model
@@ -19,8 +26,11 @@ from django.urls import reverse
 
 import pytest
 from rest_framework import status
-from rest_framework.test import APIClient
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 
+from common.utils.view_utils import TenantScopedViewMixin
 from organizations.models import (
     Organization,
     OrganizationMembership,
@@ -426,23 +436,200 @@ class TestCalendarViewSetOrgScoping:
 
 @pytest.mark.django_db
 class TestMalformedOrgIdHeader:
-    """A non-integer X-Organization-Id header falls back gracefully, not 500."""
+    """A non-integer X-Organization-Id header is treated as an absent header.
 
-    def test_non_integer_header_does_not_500(
+    Same rules as a missing header: single membership → resolve (200), multi-org
+    → 400, gated → gated. A garbage header must never silently pick an org for a
+    multi-org caller.
+    """
+
+    def test_single_membership_non_integer_header_resolves(
         self,
         user: User,  # type: ignore[valid-type]
         org_a: Organization,
     ) -> None:
-        """A header value like 'abc' should not raise ValueError / return 500."""
+        """One active membership + 'abc' header → 200 (treated as absent, resolves)."""
         _make_membership(user, org_a)
         client = _auth_client_for(user)
         url = reverse("api:Organizations-current")
 
-        # "abc" cannot be coerced to int; the resolver must fall back gracefully.
+        # "abc" cannot be coerced to int; the resolver treats it as an absent
+        # header and resolves the single membership.
         response = client.get(url, HTTP_X_ORGANIZATION_ID="abc")
 
-        # The exact status depends on the fallback path (200 with single-membership
-        # fallback is fine; anything but 500 satisfies the requirement).
-        assert response.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR, (
-            f"Malformed header caused 500: {response.content!r}"
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Malformed header with single membership should resolve to 200; "
+            f"got {response.status_code}: {response.content!r}"
         )
+
+    def test_multi_org_non_integer_header_returns_400(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """Two active memberships + 'abc' header → 400 (same as absent header).
+
+        The malformed header is treated as absent, so a multi-org caller hits the
+        ambiguity 400 rather than silently resolving to the first org.
+        """
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID="abc")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert response.json() == {"detail": _MISSING_HEADER_DETAIL}
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b — Tests: multi-org caller with no header is rejected with 400
+# ---------------------------------------------------------------------------
+# Use-case 3: a user with 2+ active memberships who omits X-Organization-Id must
+# get a clear 400, never an ambiguous implicit org. We exercise a real
+# tenant-scoped viewset (CalendarViewSet list) so the 400 is asserted end-to-end
+# through TenantScopedViewMixin.initial().
+# ---------------------------------------------------------------------------
+
+#: The exact body the resolver returns for the multi-org-no-header case.
+_MISSING_HEADER_DETAIL = "X-Organization-Id header required."
+
+
+@pytest.mark.django_db
+class TestMultiOrgNoHeaderRejected:
+    """A multi-org caller that omits the header is rejected with 400."""
+
+    def test_two_memberships_no_header_returns_400(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """GET /calendar/ with two active memberships and NO header → 400 with detail."""
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert response.json() == {"detail": _MISSING_HEADER_DETAIL}
+
+    def test_single_membership_no_header_still_resolves(
+        self,
+        user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+    ) -> None:
+        """Exactly one active membership + no header → 200 (no regression, not 400)."""
+        _make_membership(user, org_a)
+        client = _auth_client_for(user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+
+    def test_gated_user_no_header_is_not_400(
+        self,
+        user: User,  # type: ignore[valid-type]
+    ) -> None:
+        """Zero active memberships + no header → gated, never 400 (onboarding unchanged).
+
+        A gated user resolves to no active org, so the org-scoped list yields an
+        empty page; the resolver must not raise the multi-org 400.
+        """
+        client = _auth_client_for(user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url)
+
+        assert response.status_code != status.HTTP_400_BAD_REQUEST, response.content
+        # Gated → no active org → empty result set, never the multi-org rejection.
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["results"] == []
+
+    def test_two_memberships_with_valid_header_still_resolves(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """Two memberships + a valid header → 200 (no regression)."""
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_a.pk))
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b — Tests: active_org_resolution_optional opt-out
+# ---------------------------------------------------------------------------
+# A concrete view may set ``active_org_resolution_optional = True`` (Phase 3's
+# GET /organizations/mine/ and onboarding flows) so that a multi-org caller with
+# no header is NOT rejected — the resolver falls through to gated (None) instead.
+#
+# We assert the opt-out by driving the mixin's resolver directly with a throwaway
+# view, since no shipped view sets the attribute in this phase.
+# ---------------------------------------------------------------------------
+
+
+class _OptOutView(TenantScopedViewMixin):
+    """Throwaway view that opts out of the multi-org-no-header 400."""
+
+    active_org_resolution_optional = True
+
+
+class _StrictView(TenantScopedViewMixin):
+    """Throwaway view that keeps the default (strict) multi-org-no-header 400."""
+
+    active_org_resolution_optional = False
+
+
+def _drf_request_for(user: User) -> Request:  # type: ignore[valid-type]
+    """Build a DRF Request authenticated as *user* with no X-Organization-Id header."""
+    factory = APIRequestFactory()
+    django_request = factory.get("/anything/")
+    force_authenticate(django_request, user=user)
+    drf_request = Request(django_request)
+    # force_authenticate stamps the wsgi request; mirror it on the DRF request so
+    # the resolver's getattr(request, "user", None) sees the authenticated user.
+    drf_request.user = user
+    return drf_request
+
+
+@pytest.mark.django_db
+class TestActiveOrgResolutionOptionalOptOut:
+    """A view with active_org_resolution_optional = True is exempt from the 400."""
+
+    def test_opt_out_view_does_not_raise_for_multi_org_no_header(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """active_org_resolution_optional = True → no 400; resolves to gated (None)."""
+        view = _OptOutView()
+        request = _drf_request_for(two_org_user)
+
+        # Must not raise ValidationError.
+        view._resolve_active_organization(request)  # type: ignore[attr-defined]
+
+        assert request.organization_membership is None  # type: ignore[attr-defined]
+        assert request.organization is None  # type: ignore[attr-defined]
+
+    def test_strict_view_raises_for_multi_org_no_header(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """The default (strict) view raises ValidationError for the same input.
+
+        Confirms the opt-out is what suppresses the 400, not some other difference.
+        """
+        view = _StrictView()
+        request = _drf_request_for(two_org_user)
+
+        with pytest.raises(ValidationError):
+            view._resolve_active_organization(request)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
Phase 2b of the **Multi-Organization Membership** plan. A caller with 2+ active memberships who
omits `X-Organization-Id` now gets a **400** instead of silently resolving to an arbitrary org.
Single-membership callers and gated (onboarding) users are unaffected.

## What changed
- `TenantScopedViewMixin._resolve_active_organization`: the absent-header + 2+ active-membership row now raises `ValidationError` → 400 `{"detail": "X-Organization-Id header required."}`. Rows kept unchanged: 0 → gated, 1 + absent → resolve, header-present-match → resolve, non-member org → still the Phase 2c fallback stub.
- A **malformed (non-integer) header** is now treated identically to a missing header — single → resolve, multi-org → 400, gated → gated. This replaced the earlier "fall back to the first membership" stub, which would have silently served org A's data to a multi-org caller who sent garbage (a tenant-ambiguity bug).
- New opt-out class attribute `active_org_resolution_optional: bool = False`. A view that must serve multi-org callers without the header (Phase 3's `GET /organizations/mine/`, onboarding) sets it `True` to skip the 400 and resolve to gated. No shipped view sets it this phase.

## Plan reference
Plan `ai-plans/2026-06-13-MULTI_ORG_MEMBERSHIP_IMPLEMENTATION_PLAN.md` — Phase 2b + API Design resolution table. Use-case 3.

## Review history
Layer-3 review caught one edge BLOCKER: malformed-header handling for a multi-org caller. Resolved by unifying malformed → absent-header semantics (the safe 400) and removing the dead fallback, plus a multi-org-malformed test asserting 400 and tightening the single-membership-malformed test to assert 200.

## Test plan
- `uv run pytest organizations/tests/test_org_resolution.py -vs`
- Asserts: two memberships + no header → 400 through `CalendarViewSet`; one membership + no header → 200; gated user + no header → not 400 (onboarding intact); two memberships + valid header → 200; multi-org + malformed header → 400; single membership + malformed header → 200; opt-out view → not 400.
- Outer gate fully green: ruff, format, mypy (baseline), `makemigrations --check`, `check --deploy`, `pytest -n auto` (1578 passed, 0 failures).