### PR TITLE
feat(organizations): reject non-member X-Organization-Id with 403

### DIFF
--- a/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
+++ b/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
@@ -47,11 +47,23 @@
 ## Stack note
 2026-06-13: rebased base/phase-1/phase-2a onto origin/main (twilio fix `3286b69`); force-pushed; PR bases intact. No sanctioned failures remain — full suite must be 100% green.
 
+### Phase 2c — Non-member org → 403 ✅
+- **Model used:** claude-sonnet-4-6 · agent: implementer (first attempt died on a socket error after partial code edit; a fresh implementer verified the edit + added tests/gate/commit)
+- **Branch:** plan/multi-org-membership/phase-2c · **base:** plan/multi-org-membership/phase-2b
+- **PR:** https://github.com/vintasoftware/vinta-schedule-api/pull/71 (published, 2 inline comments)
+- **Summary:** valid-int header for a non-member (or inactive-membership) org → 403 PermissionDenied; opt-out skips both 400 and 403. Resolution table closed.
+- **Review:** Layer-3 clean (no blockers). 401-before-403 confirmed; opt-out can't leak wrong org.
+- **Gate:** full suite green — `pytest -n auto` 1583 passed, 0 failures.
+
+## Carry-forward notes
+- **For Phase 5 (create-additional-org):** the post-`perform_create` re-resolve in `CreateModelMixin.create` can call `_resolve_active_organization`, which can now raise 400/403 AFTER the write commits. Unreachable today (initial() rejects first), but once multi-org create is reachable, add a test that a create cannot 400/403 post-write (or guard the re-resolve to not raise after commit).
+- **Plan doc nit:** plan text says header is a `uuid`; org PK is integer BigAutoField. Cosmetic; fix opportunistically.
+
 ## Current phase
-Phase 2c — Non-member org → 403 (Tier 2 · sonnet · implementer).
+Phase 3 — List my orgs endpoint (Tier 2 · haiku · implementer).
 
 ## Remaining phases
-- Phase 2c — Non-member org → 403
+- Phase 3 — List my orgs endpoint (GET /organizations/mine/)
 - Phase 3 — List my orgs endpoint
 - Phase 4 — Multi-org invitation accept
 - Phase 5 — Create additional org

--- a/common/utils/view_utils.py
+++ b/common/utils/view_utils.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404
 
 import django_virtual_models as v
 from rest_framework import generics, mixins, status
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ViewSetMixin
@@ -38,7 +38,7 @@ class TenantScopedViewMixin:
       reads this stash so all ~60 existing call sites are header-aware without
       change.
 
-    Resolution table (Phase 2b implements the multi-org-no-header 400; 2c stubbed):
+    Resolution table (Phase 2b: multi-org-no-header 400; Phase 2c: non-member 403):
 
     +-----------------------+---------------------------------+------------------------------------------+
     | Memberships (active)  | Header                          | Result                                   |
@@ -48,7 +48,7 @@ class TenantScopedViewMixin:
     | 1                     | present, matches                | resolve to it                            |
     | 2+                    | present, matches member         | resolve to named org                     |
     | 2+                    | absent                          | **400** (X-Organization-Id required)     |
-    | any                   | present, non-member org         | fallback to first [Phase 2c → 403]       |
+    | any                   | present, non-member org         | **403** (PermissionDenied)               |
     | any                   | present, non-integer            | treated as absent header                 |
     |                       |                                 | (1 → resolve · 2+ → 400 · 0 → gated)     |
     +-----------------------+---------------------------------+------------------------------------------+
@@ -62,9 +62,10 @@ class TenantScopedViewMixin:
     header (e.g. the org-discovery ``GET /organizations/mine/`` endpoint and the
     onboarding/gated flows) sets the class attribute
     ``active_org_resolution_optional = True``.  When set, the ``2+ / absent`` case
-    does **not** raise — the active org simply resolves to ``None`` (left gated)
-    so the view can list the caller's memberships.  Defaults to ``False``; no
-    existing view sets it (Phase 3 wires it onto the ``mine`` endpoint).
+    does **not** raise a 400, and the ``non-member org`` case does **not** raise a
+    403 — the active org simply resolves to ``None`` (left gated) so the view can
+    list the caller's memberships.  Defaults to ``False``; no existing view sets it
+    (Phase 3 wires it onto the ``mine`` endpoint).
 
     Unauthenticated requests pass through untouched (the mixin sets ``None`` on
     all three attributes so downstream code doesn't KeyError); DRF's own
@@ -72,9 +73,10 @@ class TenantScopedViewMixin:
     """
 
     #: When ``True``, a multi-org caller that omits ``X-Organization-Id`` is *not*
-    #: rejected with a 400 — the active org resolves to ``None`` instead.  Concrete
-    #: views that must function without the header (org discovery, onboarding) opt
-    #: in.  See the class docstring's resolution table for the affected row.
+    #: rejected with a 400, and a header naming a non-member org is *not* rejected
+    #: with a 403 — the active org resolves to ``None`` instead.  Concrete views
+    #: that must function without the header (org discovery, onboarding) opt in.
+    #: See the class docstring's resolution table for the affected rows.
     active_org_resolution_optional: bool = False
 
     def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
@@ -133,22 +135,25 @@ class TenantScopedViewMixin:
                     # Happy path: header names an org the user actively belongs to.
                     resolved_membership = matching
                 else:
-                    # Phase 2c will raise PermissionDenied (403) here when the header
-                    # names an org the caller is not an active member of.
-                    # For now fall back to the pre-existing single-membership behaviour
-                    # so nothing regresses.
-                    resolved_membership = (
-                        user.organization_memberships.filter(  # type: ignore[union-attr]
-                            is_active=True,
+                    # Header names an org the caller is not an active member of
+                    # (either the org doesn't exist, the user has no membership in
+                    # it, or the membership exists but is inactive).  Raise 403
+                    # unless the concrete view opted out of strict resolution
+                    # (active_org_resolution_optional = True).
+                    if not getattr(self, "active_org_resolution_optional", False):
+                        logger.debug(
+                            "X-Organization-Id header '%s' did not match any active membership for "
+                            "user %s; raising PermissionDenied (403).",
+                            org_id_header,
+                            user.pk,  # type: ignore[union-attr]
                         )
-                        .select_related("organization")
-                        .order_by("created")
-                        .first()
-                    )
+                        raise PermissionDenied(
+                            "X-Organization-Id header names an organization you are not an "
+                            "active member of."
+                        )
                     logger.debug(
                         "X-Organization-Id header '%s' did not match any active membership for "
-                        "user %s; falling back to single-membership resolution. "
-                        "(Phase 2c will reject this with 403.)",
+                        "user %s; view opted out of the 403 — resolving to gated (None).",
                         org_id_header,
                         user.pk,  # type: ignore[union-attr]
                     )

--- a/organizations/tests/test_org_resolution.py
+++ b/organizations/tests/test_org_resolution.py
@@ -1,4 +1,4 @@
-"""Integration tests for active-org resolution (Phase 2a + 2b).
+"""Integration tests for active-org resolution (Phase 2a + 2b + 2c).
 
 Verifies that the ``TenantScopedViewMixin`` resolver correctly resolves the
 active organization from the ``X-Organization-Id`` header and stashes the result
@@ -18,7 +18,11 @@ Phase 2b adds the multi-org-no-header rejection:
 * The 0-membership (gated) and single-membership rows are unchanged.
 * A view setting ``active_org_resolution_optional = True`` is exempt from the 400.
 
-Phase 2c (non-member org header → 403) is *not* tested here.
+Phase 2c adds the non-member rejection:
+
+* Header naming an org the caller is not an active member of (no membership, or
+  an inactive membership) → **403** ``PermissionDenied``.
+* A view setting ``active_org_resolution_optional = True`` is exempt from the 403.
 """
 
 from django.contrib.auth import get_user_model
@@ -26,7 +30,7 @@ from django.urls import reverse
 
 import pytest
 from rest_framework import status
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 
@@ -586,10 +590,21 @@ class _StrictView(TenantScopedViewMixin):
     active_org_resolution_optional = False
 
 
-def _drf_request_for(user: User) -> Request:  # type: ignore[valid-type]
-    """Build a DRF Request authenticated as *user* with no X-Organization-Id header."""
+def _drf_request_for(
+    user: User,  # type: ignore[valid-type]
+    *,
+    org_id_header: str | None = None,
+) -> Request:
+    """Build a DRF Request authenticated as *user*.
+
+    If *org_id_header* is given it is sent as the ``X-Organization-Id`` header;
+    otherwise the request carries no header.
+    """
     factory = APIRequestFactory()
-    django_request = factory.get("/anything/")
+    if org_id_header is not None:
+        django_request = factory.get("/anything/", HTTP_X_ORGANIZATION_ID=org_id_header)
+    else:
+        django_request = factory.get("/anything/")
     force_authenticate(django_request, user=user)
     drf_request = Request(django_request)
     # force_authenticate stamps the wsgi request; mirror it on the DRF request so
@@ -632,4 +647,118 @@ class TestActiveOrgResolutionOptionalOptOut:
         request = _drf_request_for(two_org_user)
 
         with pytest.raises(ValidationError):
+            view._resolve_active_organization(request)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2c — Tests: header naming a non-member org is rejected with 403
+# ---------------------------------------------------------------------------
+# A valid-integer X-Organization-Id that names an organization the caller is
+# *not* an active member of (org the user has no membership in, or a membership
+# that exists but is inactive) is rejected with 403 PermissionDenied. The
+# malformed-header and absent-header rules (Phase 2b) are unaffected. A view
+# setting ``active_org_resolution_optional = True`` is exempt from the 403 and
+# resolves to gated (None).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def org_c() -> Organization:
+    """A third org the user is not a member of."""
+    return _make_org("Org C")
+
+
+@pytest.mark.django_db
+class TestNonMemberOrgHeaderRejected:
+    """A header naming an org the caller is not an active member of → 403."""
+
+    def test_header_for_non_member_org_returns_403(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+        org_c: Organization,
+    ) -> None:
+        """GET /calendar/ with a header naming an org the user has no membership in → 403."""
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_c.pk))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+
+    def test_header_for_inactive_membership_org_returns_403(
+        self,
+        user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """A header naming an org where the user's membership is inactive → 403.
+
+        The resolver's matching lookup filters ``is_active=True``, so an inactive
+        membership yields ``matching is None`` and is rejected just like a
+        non-member org.
+        """
+        # Active membership in A (so the user is authenticated/non-gated) plus an
+        # inactive membership in B named by the header.
+        _make_membership(user, org_a)
+        _make_membership(user, org_b, is_active=False)
+        client = _auth_client_for(user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_b.pk))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+
+    def test_header_for_member_org_still_returns_200(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+    ) -> None:
+        """A header naming a member org still resolves to 200 (no regression)."""
+        client = _auth_client_for(two_org_user)
+        url = reverse("api:Calendars-list")
+
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(org_a.pk))
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+
+
+@pytest.mark.django_db
+class TestNonMemberOrgHeaderOptOut:
+    """A view with active_org_resolution_optional = True is exempt from the 403."""
+
+    def test_opt_out_view_does_not_raise_for_non_member_header(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+        org_c: Organization,
+    ) -> None:
+        """active_org_resolution_optional = True + non-member header → no 403; gated (None)."""
+        view = _OptOutView()
+        request = _drf_request_for(two_org_user, org_id_header=str(org_c.pk))
+
+        # Must not raise PermissionDenied.
+        view._resolve_active_organization(request)  # type: ignore[attr-defined]
+
+        assert request.organization_membership is None  # type: ignore[attr-defined]
+        assert request.organization is None  # type: ignore[attr-defined]
+
+    def test_strict_view_raises_for_non_member_header(
+        self,
+        two_org_user: User,  # type: ignore[valid-type]
+        org_a: Organization,
+        org_b: Organization,
+        org_c: Organization,
+    ) -> None:
+        """The default (strict) view raises PermissionDenied for the same input.
+
+        Confirms the opt-out is what suppresses the 403, not some other difference.
+        """
+        view = _StrictView()
+        request = _drf_request_for(two_org_user, org_id_header=str(org_c.pk))
+
+        with pytest.raises(PermissionDenied):
             view._resolve_active_organization(request)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
Phase 2c of the **Multi-Organization Membership** plan — the last resolver phase. A request whose
`X-Organization-Id` names an org the caller is NOT an active member of is now refused with **403**,
instead of silently falling back to the caller's first membership. This closes the resolution
table.

## What changed
- `TenantScopedViewMixin._resolve_active_organization`: the valid-integer-but-no-matching-active-membership branch raises `PermissionDenied` → 403, replacing the Phase 2a/2b fallback stub. Covers both "not a member of that org" and "membership in that org is `is_active=False`" (the lookup filters `is_active=True`).
- The `active_org_resolution_optional` opt-out now skips BOTH the 2b 400 and the 2c 403, resolving to gated `None` — so Phase 3's `GET /organizations/mine/` and onboarding flows are unaffected by a stray header.
- Untouched: malformed-header handling (absent-header semantics), absent-header 400, happy-path resolution.

## Plan reference
Plan `ai-plans/2026-06-13-MULTI_ORG_MEMBERSHIP_IMPLEMENTATION_PLAN.md` — Phase 2c + API Design resolution table. Use-case 4.

## Review history
Layer-3 review: no blockers. Confirmed the 403 fires on exactly the non-member branch (no spurious 403 for members, no surviving wrong-org fallback), inactive-membership → 403 is correct, 401 still precedes 403 for unauthenticated callers, and the opt-out can't re-enable a silent wrong-org resolution. One noted latent concern (post-`perform_create` re-resolve could raise after commit) is unreachable on the strict path — `initial()` rejects before `perform_create` — and is carried as a Phase 5 tracking note for when multi-org create becomes reachable.

## Test plan
- `uv run pytest organizations/tests/test_org_resolution.py -vs`
- Asserts: non-member org header → 403 (real `CalendarViewSet`); inactive-membership org header → 403; member org header → 200; opt-out view + non-member header → not 403 (resolves gated); unauthenticated → 401 (precedes 403).
- Outer gate fully green: ruff, format, mypy (baseline), `makemigrations --check`, `check --deploy`, `pytest -n auto` (1583 passed, 0 failures).