### PR TITLE
feat(organizations): add GET /organizations/mine/ membership list

### DIFF
--- a/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
+++ b/ai-plans/TRACKING_MULTI_ORG_MEMBERSHIP.md
@@ -59,11 +59,19 @@
 - **For Phase 5 (create-additional-org):** the post-`perform_create` re-resolve in `CreateModelMixin.create` can call `_resolve_active_organization`, which can now raise 400/403 AFTER the write commits. Unreachable today (initial() rejects first), but once multi-org create is reachable, add a test that a create cannot 400/403 post-write (or guard the re-resolve to not raise after commit).
 - **Plan doc nit:** plan text says header is a `uuid`; org PK is integer BigAutoField. Cosmetic; fix opportunistically.
 
+### Phase 3 — List my orgs endpoint ✅
+- **Model used:** claude-sonnet-4-6 · agent: implementer
+- **Branch:** plan/multi-org-membership/phase-3 · **base:** plan/multi-org-membership/phase-2c
+- **PR:** https://github.com/vintasoftware/vinta-schedule-api/pull/73 (published, 3 inline comments)
+- **Summary:** `GET /organizations/mine/` bare-array list of active memberships ({org id,name}, role), gated → `200 []`. Per-action opt-out `active_org_optional_actions=("mine",)` (only mine waives header). New `OrganizationMembership.objects.active_for_user`. `pagination_class=None` + schema regen.
+- **Review:** Layer-3 caught a BLOCKER — spectacular inferred a paginated envelope vs the bare-list runtime; fixed with `pagination_class=None` + schema regen + bare-array test. Added opt-out isolation test (current still 400). Inline query → manager method.
+- **Gate:** full suite green — `pytest -n auto` 1594 passed, 0 failures.
+
 ## Current phase
-Phase 3 — List my orgs endpoint (Tier 2 · haiku · implementer).
+Phase 4 — Multi-org invitation accept (Tier 3 · sonnet · migration-author).
 
 ## Remaining phases
-- Phase 3 — List my orgs endpoint (GET /organizations/mine/)
+- Phase 4 — Multi-org invitation accept
 - Phase 3 — List my orgs endpoint
 - Phase 4 — Multi-org invitation accept
 - Phase 5 — Create additional org

--- a/common/utils/view_utils.py
+++ b/common/utils/view_utils.py
@@ -58,14 +58,24 @@ class TenantScopedViewMixin:
     required."}``) so a multi-org caller can never resolve to an ambiguous,
     implicit organization.
 
-    **Opt-out:** a concrete view that must serve multi-org callers *without* the
-    header (e.g. the org-discovery ``GET /organizations/mine/`` endpoint and the
-    onboarding/gated flows) sets the class attribute
-    ``active_org_resolution_optional = True``.  When set, the ``2+ / absent`` case
-    does **not** raise a 400, and the ``non-member org`` case does **not** raise a
-    403 — the active org simply resolves to ``None`` (left gated) so the view can
-    list the caller's memberships.  Defaults to ``False``; no existing view sets it
-    (Phase 3 wires it onto the ``mine`` endpoint).
+    **Opt-out (class-level):** a concrete view that must serve multi-org callers
+    *without* the header (e.g. the org-discovery ``GET /organizations/mine/``
+    endpoint and the onboarding/gated flows) sets the class attribute
+    ``active_org_resolution_optional = True``.  When set, the ``2+ / absent``
+    case does **not** raise a 400, and the ``non-member org`` case does **not**
+    raise a 403 — the active org simply resolves to ``None`` (left gated) so the
+    view can list the caller's memberships.  Defaults to ``False``.
+
+    **Opt-out (per-action):** when only a *specific* action on an otherwise
+    strict viewset must bypass the header requirement, list that action name in
+    the ``active_org_optional_actions`` tuple instead.  The resolver treats a
+    request as opted-out when ``active_org_resolution_optional is True`` **or**
+    ``self.action in self.active_org_optional_actions``.  ``self.action`` is set
+    by ``ViewSetMixin.initialize_request`` before ``initial()`` runs, so the
+    check is always current.  Example: ``active_org_optional_actions = ("mine",)``
+    on ``OrganizationViewSet`` waives the header for the ``mine`` action only,
+    leaving ``current``, ``update``, and ``sync-rooms`` with the full 400/403
+    enforcement.
 
     Unauthenticated requests pass through untouched (the mixin sets ``None`` on
     all three attributes so downstream code doesn't KeyError); DRF's own
@@ -78,6 +88,35 @@ class TenantScopedViewMixin:
     #: that must function without the header (org discovery, onboarding) opt in.
     #: See the class docstring's resolution table for the affected rows.
     active_org_resolution_optional: bool = False
+
+    #: Per-action opt-out: list action names for which the header requirement is
+    #: waived.  When ``self.action`` (set by ``ViewSetMixin.initialize_request``
+    #: before ``initial()`` runs) is in this tuple, the resolver behaves exactly
+    #: as if ``active_org_resolution_optional = True`` for that single action —
+    #: the multi-org 400 and non-member 403 are suppressed, and the active org
+    #: resolves to ``None`` instead.  Use this on a viewset where *most* actions
+    #: require the header but a specific action (e.g. ``mine``) must not.
+    #:
+    #: Example::
+    #:
+    #:     class OrganizationViewSet(NoListVintaScheduleModelViewSet):
+    #:         active_org_optional_actions = ("mine",)
+    active_org_optional_actions: tuple[str, ...] = ()
+
+    def _is_active_org_resolution_optional(self) -> bool:
+        """Return ``True`` when strict org resolution should be skipped for this request.
+
+        Resolution is optional when either the class-level
+        ``active_org_resolution_optional`` flag is set, *or* the current action
+        name is listed in ``active_org_optional_actions``.  The latter allows a
+        single action on an otherwise strict viewset to opt out without affecting
+        the other actions.
+        """
+        if getattr(self, "active_org_resolution_optional", False):
+            return True
+        action_name = getattr(self, "action", None)
+        optional_actions: tuple[str, ...] = getattr(self, "active_org_optional_actions", ())
+        return action_name in optional_actions if action_name is not None else False
 
     def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         """Run DRF initialisation, then resolve and stash the active org."""
@@ -140,7 +179,7 @@ class TenantScopedViewMixin:
                     # it, or the membership exists but is inactive).  Raise 403
                     # unless the concrete view opted out of strict resolution
                     # (active_org_resolution_optional = True).
-                    if not getattr(self, "active_org_resolution_optional", False):
+                    if not self._is_active_org_resolution_optional():
                         logger.debug(
                             "X-Organization-Id header '%s' did not match any active membership for "
                             "user %s; raising PermissionDenied (403).",
@@ -177,7 +216,7 @@ class TenantScopedViewMixin:
                     # Reject with 400 so we never silently pick one — unless the
                     # concrete view opted out (org discovery / onboarding), in which
                     # case resolution falls through to gated (None).
-                    if not getattr(self, "active_org_resolution_optional", False):
+                    if not self._is_active_org_resolution_optional():
                         raise ValidationError(
                             {"detail": "X-Organization-Id header required."},
                         )

--- a/organizations/managers.py
+++ b/organizations/managers.py
@@ -1,6 +1,22 @@
 from django.db.models import Manager
 
-from organizations.querysets import BaseOrganizationModelQuerySet
+from organizations.querysets import BaseOrganizationModelQuerySet, OrganizationMembershipQuerySet
+
+
+class OrganizationMembershipManager(Manager):
+    """Manager for OrganizationMembership with domain-specific query methods."""
+
+    def get_queryset(self) -> OrganizationMembershipQuerySet:
+        return OrganizationMembershipQuerySet(self.model, using=self._db)
+
+    def active_for_user(self, user) -> OrganizationMembershipQuerySet:
+        """Return all active memberships for *user*, ordered by creation date.
+
+        Wraps :meth:`OrganizationMembershipQuerySet.active_for_user` so callers
+        can write ``OrganizationMembership.objects.active_for_user(user)`` without
+        first obtaining a queryset themselves.
+        """
+        return self.get_queryset().active_for_user(user)
 
 
 class BaseOrganizationModelManager(Manager):

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -8,7 +8,7 @@ from django.db import models
 
 from common.fields import TenantSafeForeignKey, TenantSafeOneToOneField
 from common.models import BaseModel
-from organizations.managers import BaseOrganizationModelManager
+from organizations.managers import BaseOrganizationModelManager, OrganizationMembershipManager
 
 
 if TYPE_CHECKING:
@@ -203,6 +203,8 @@ class OrganizationMembership(BaseModel):
             "read unchanged."
         ),
     )
+
+    objects: OrganizationMembershipManager = OrganizationMembershipManager()
 
     class Meta:
         constraints: ClassVar = [

--- a/organizations/querysets.py
+++ b/organizations/querysets.py
@@ -1,5 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.query import QuerySet
+
+
+if TYPE_CHECKING:
+    from users.models import User
+
+
+class OrganizationMembershipQuerySet(QuerySet):
+    """QuerySet for OrganizationMembership with domain-specific filtering methods."""
+
+    def active_for_user(self, user: User) -> OrganizationMembershipQuerySet:
+        """Return all active memberships for *user*, with organization pre-fetched.
+
+        Ordered by creation date (oldest first) so the result is deterministic
+        for the org-switcher list.  ``select_related("organization")`` avoids
+        an N+1 when iterating over the returned memberships.
+        """
+        return (
+            self.filter(user=user, is_active=True)
+            .select_related("organization")
+            .order_by("created")
+        )
 
 
 class BaseOrganizationModelQuerySet(QuerySet):

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -238,6 +238,36 @@ class CurrentMembershipSerializer(serializers.ModelSerializer):
         return OrganizationSerializer(obj.organization, context=self.context).data  # type: ignore[call-arg]
 
 
+class OrganizationBriefSerializer(serializers.ModelSerializer):
+    """Lightweight read-only serializer for an Organization.
+
+    Exposes only the fields needed for the org-switcher list: ``id`` and ``name``.
+    Intentionally avoids the heavier ``OrganizationSerializer`` (which loads the
+    Google service account) to keep ``GET /organizations/mine/`` fast.
+    """
+
+    class Meta:
+        model = Organization
+        fields = ("id", "name")
+        read_only_fields = ("id", "name")
+
+
+class MyMembershipSerializer(serializers.ModelSerializer):
+    """Read-only serializer for the caller's active organization memberships.
+
+    Used by ``GET /organizations/mine/`` to power the frontend org switcher.
+    Returns a list of ``{organization: {id, name}, role}`` entries — one per
+    active membership — without requiring the ``X-Organization-Id`` header.
+    """
+
+    organization = OrganizationBriefSerializer(read_only=True)
+
+    class Meta:
+        model = OrganizationMembership
+        fields = ("organization", "role")
+        read_only_fields = ("organization", "role")
+
+
 class OrganizationMembershipSerializer(serializers.ModelSerializer):
     """
     Read-only serializer for listing and retrieving organization members.

--- a/organizations/tests/test_views.py
+++ b/organizations/tests/test_views.py
@@ -3211,4 +3211,278 @@ class TestPhase20SyncAllCalendars:
         )
 
         assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
-        mock_sync.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestOrganizationMineAction:
+    """Tests for GET /organizations/mine/ (Use-case 5 — list caller's memberships)."""
+
+    # ------------------------------------------------------------------
+    # Happy paths
+    # ------------------------------------------------------------------
+
+    def test_mine_returns_both_active_memberships_for_multi_org_user(self, user):
+        """Multi-org user without X-Organization-Id header gets 200 with all memberships."""
+        org_a = baker.make(Organization, name="Alpha Corp")
+        org_b = baker.make(Organization, name="Beta LLC")
+        membership_a = OrganizationMembership.objects.create(
+            user=user,
+            organization=org_a,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        membership_b = OrganizationMembership.objects.create(
+            user=user,
+            organization=org_b,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        # No X-Organization-Id header — the endpoint must not require one.
+        url = reverse("api:Organizations-mine")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+        returned_org_ids = {item["organization"]["id"] for item in data}
+        assert returned_org_ids == {org_a.id, org_b.id}
+
+        # Verify role is reported correctly for each membership.
+        role_by_org = {item["organization"]["id"]: item["role"] for item in data}
+        assert role_by_org[org_a.id] == OrganizationRole.ADMIN
+        assert role_by_org[org_b.id] == OrganizationRole.MEMBER
+
+        # Verify the membership objects that were created match what we get back.
+        assert membership_a.id is not None  # sanity
+        assert membership_b.id is not None
+
+    def test_mine_returns_org_id_and_name(self, user):
+        """The nested organization object contains exactly id and name."""
+        org = baker.make(Organization, name="Named Org")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        url = reverse("api:Organizations-mine")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        assert len(data) == 1
+        org_data = data[0]["organization"]
+        assert org_data["id"] == org.id
+        assert org_data["name"] == "Named Org"
+        # Heavier fields from OrganizationSerializer must NOT appear.
+        assert "google_service_account" not in org_data
+        assert "should_sync_rooms" not in org_data
+
+    def test_mine_gated_user_returns_empty_list(self, auth_client):
+        """Gated user (zero memberships) gets 200 [] — not 404."""
+        url = reverse("api:Organizations-mine")
+        response = auth_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.json() == []
+
+    def test_mine_role_admin_is_reported_correctly(self, user):
+        """Admin role is serialised correctly."""
+        org = baker.make(Organization, name="Admin Org")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        url = reverse("api:Organizations-mine")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.json()[0]["role"] == OrganizationRole.ADMIN
+
+    def test_mine_role_member_is_reported_correctly(self, user):
+        """Member role is serialised correctly."""
+        org = baker.make(Organization, name="Member Org")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        url = reverse("api:Organizations-mine")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.json()[0]["role"] == OrganizationRole.MEMBER
+
+    # ------------------------------------------------------------------
+    # Inactive memberships are excluded
+    # ------------------------------------------------------------------
+
+    def test_mine_excludes_inactive_memberships(self, user):
+        """Inactive memberships are never returned in the list."""
+        active_org = baker.make(Organization, name="Active Org")
+        inactive_org = baker.make(Organization, name="Inactive Org")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=active_org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=inactive_org,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        url = reverse("api:Organizations-mine")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["organization"]["id"] == active_org.id
+
+    def test_mine_only_inactive_memberships_returns_empty_list(self, user):
+        """User with only inactive memberships gets 200 [] (same as gated)."""
+        org = baker.make(Organization, name="Dead Org")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        url = reverse("api:Organizations-mine")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert response.json() == []
+
+    # ------------------------------------------------------------------
+    # Per-action opt-out: stale/foreign X-Organization-Id is not rejected
+    # ------------------------------------------------------------------
+
+    def test_mine_with_stale_org_id_header_returns_200_not_403(self, user):
+        """A stale/foreign X-Organization-Id on mine → 200, NOT 403.
+
+        The per-action opt-out (active_org_optional_actions = ("mine",)) ensures
+        that even when the header names an org the user is not a member of, the
+        mine action still returns the list rather than raising PermissionDenied.
+        """
+        own_org = baker.make(Organization, name="Own Org")
+        other_org = baker.make(Organization, name="Foreign Org")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=own_org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        url = reverse("api:Organizations-mine")
+        # Deliberately send the foreign org id in the header.
+        response = client.get(url, HTTP_X_ORGANIZATION_ID=str(other_org.id))
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        data = response.json()
+        # Still returns the caller's actual memberships, not an error.
+        assert len(data) == 1
+        assert data[0]["organization"]["id"] == own_org.id
+
+    def test_mine_multi_org_no_header_returns_200_not_400(self, user):
+        """Multi-org caller without X-Organization-Id → 200, NOT 400.
+
+        The per-action opt-out bypasses the 400 that other viewset actions
+        would raise for multi-org callers without the header.
+        """
+        org_a = baker.make(Organization, name="Gamma A")
+        org_b = baker.make(Organization, name="Gamma B")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org_a,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org_b,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        # No header — should return the list, not 400.
+        url = reverse("api:Organizations-mine")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_200_OK)
+        assert len(response.json()) == 2
+
+    # ------------------------------------------------------------------
+    # Auth guard
+    # ------------------------------------------------------------------
+
+    def test_mine_unauthenticated_returns_401(self, anonymous_client):
+        """Unauthenticated requests get 401, not 200 or 403."""
+        url = reverse("api:Organizations-mine")
+        response = anonymous_client.get(url)
+
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+    # ------------------------------------------------------------------
+    # Per-action opt-out isolation: mine opt-out does NOT leak to current
+    # ------------------------------------------------------------------
+
+    def test_current_still_returns_400_for_multi_org_user_without_header(self, user):
+        """The mine opt-out is isolated: /organizations/current/ still returns 400
+        for a multi-org caller who omits the X-Organization-Id header.
+
+        This proves that ``active_org_optional_actions = ("mine",)`` only exempts
+        the ``mine`` action and does not accidentally make ``current`` (or any
+        other sibling action) header-optional.
+        """
+        org_a = baker.make(Organization, name="Isolation Org A")
+        org_b = baker.make(Organization, name="Isolation Org B")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org_a,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org_b,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        # No X-Organization-Id — multi-org users MUST supply the header for current.
+        url = reverse("api:Organizations-current")
+        response = client.get(url)
+
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -47,6 +47,7 @@ from organizations.serializers import (
     AcceptInvitationSerializer,
     CurrentMembershipSerializer,
     GoogleServiceAccountWriteSerializer,
+    MyMembershipSerializer,
     OrganizationInvitationSerializer,
     OrganizationMembershipSerializer,
     OrganizationSerializer,
@@ -67,6 +68,11 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
     permission_classes = (IsAuthenticated, OrganizationManagementPermission)
+    #: The ``mine`` action lists the caller's own memberships and must not require
+    #: the ``X-Organization-Id`` header — it is the endpoint the frontend uses to
+    #: *discover* which org ids are available.  All other actions on this viewset
+    #: keep the standard header enforcement (400 / 403).
+    active_org_optional_actions = ("mine",)
 
     def get_permissions(self):
         """
@@ -204,6 +210,31 @@ class OrganizationViewSet(NoListVintaScheduleModelViewSet):
         if membership is None:
             raise NotFound(detail="No organization membership.")
         serializer = CurrentMembershipSerializer(membership, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="List the authenticated user's active organization memberships",
+        responses={
+            200: MyMembershipSerializer(many=True),
+        },
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="mine",
+        permission_classes=[IsAuthenticated],
+        pagination_class=None,  # bare list — no count/next/previous envelope
+    )
+    def mine(self, request):
+        """Return all active memberships for the authenticated caller.
+
+        Designed for the frontend org switcher: the client calls this endpoint
+        *before* it knows which ``X-Organization-Id`` to send, so no header is
+        required.  The response is always HTTP 200; gated users receive an empty
+        list (``[]``).
+        """
+        memberships = OrganizationMembership.objects.active_for_user(request.user)
+        serializer = MyMembershipSerializer(memberships, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(

--- a/schema.yml
+++ b/schema.yml
@@ -5916,6 +5916,64 @@ paths:
           description: ''
         '404':
           description: No organization membership (gated user)
+  /organizations/mine/:
+    get:
+      operationId: organizations_mine_list
+      description: |-
+        Return all active memberships for the authenticated caller.
+
+        Designed for the frontend org switcher: the client calls this endpoint
+        *before* it knows which ``X-Organization-Id`` to send, so no header is
+        required.  The response is always HTTP 200; gated users receive an empty
+        list (``[]``).
+      summary: List the authenticated user's active organization memberships
+      tags:
+      - organizations
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MyMembership'
+          description: ''
+  /organizations/mine{format}:
+    get:
+      operationId: organizations_mine_formatted_list
+      description: |-
+        Return all active memberships for the authenticated caller.
+
+        Designed for the frontend org switcher: the client calls this endpoint
+        *before* it knows which ``X-Organization-Id`` to send, so no header is
+        required.  The response is always HTTP 200; gated users receive an empty
+        list (``[]``).
+      summary: List the authenticated user's active organization memberships
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - organizations
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MyMembership'
+          description: ''
   /payments/{id}/payment-update/{provider}/:
     post:
       operationId: payments_payment_update_create
@@ -9175,6 +9233,31 @@ components:
         * `WEEKLY` - Weekly
         * `MONTHLY` - Monthly
         * `YEARLY` - Yearly
+    MyMembership:
+      type: object
+      description: |-
+        Read-only serializer for the caller's active organization memberships.
+
+        Used by ``GET /organizations/mine/`` to power the frontend org switcher.
+        Returns a list of ``{organization: {id, name}, role}`` entries — one per
+        active membership — without requiring the ``X-Organization-Id`` header.
+      properties:
+        organization:
+          allOf:
+          - $ref: '#/components/schemas/OrganizationBrief'
+          readOnly: true
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          readOnly: true
+          description: |-
+            Role the user holds in this organization. Admins can manage organization-scoped resources (e.g. CalendarGroups) regardless of direct ownership.
+
+            * `member` - Member
+            * `admin` - Admin
+      required:
+      - organization
+      - role
     Organization:
       type: object
       description: |-
@@ -9216,6 +9299,24 @@ components:
       - google_service_account
       - id
       - modified
+      - name
+    OrganizationBrief:
+      type: object
+      description: |-
+        Lightweight read-only serializer for an Organization.
+
+        Exposes only the fields needed for the org-switcher list: ``id`` and ``name``.
+        Intentionally avoids the heavier ``OrganizationSerializer`` (which loads the
+        Google service account) to keep ``GET /organizations/mine/`` fast.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+      required:
+      - id
       - name
     OrganizationInvitation:
       type: object


### PR DESCRIPTION
## Summary
Phase 3 of the **Multi-Organization Membership** plan. Adds the org-switcher discovery endpoint:
`GET /organizations/mine/` returns the caller's active memberships so the frontend knows which
`X-Organization-Id` values it can send. No header required — this is what a multi-org user calls
*before* they have an id to put in the header.

## What changed
- `GET /organizations/mine/` (`mine` action on `OrganizationViewSet`): returns a bare JSON array of `{organization: {id, name}, role}` for the caller's active memberships. Gated user → `200 []`. Inactive memberships excluded. `permission_classes=[IsAuthenticated]` (so a normal member isn't blocked by the onboarding-only `OrganizationManagementPermission`).
- **Per-action opt-out** added to `TenantScopedViewMixin`: `active_org_optional_actions: tuple[str, ...]`. The resolver waives the 400/403 when `self.action` is in that tuple. `OrganizationViewSet` sets `active_org_optional_actions = ("mine",)` — so `mine` works header-less while `current`/`update`/`sync-rooms` keep full enforcement.
- New lightweight `OrganizationBriefSerializer` (`{id, name}`) + `MyMembershipSerializer` — avoids the heavier `OrganizationSerializer` (which loads the Google service account).
- New `OrganizationMembership.objects.active_for_user(user)` queryset/manager method (replaces an inline view query, per convention).
- `pagination_class=None` on the action so the response is a bare array; `schema.yml` regenerated to match (no `count/next/previous/results` envelope).

## Plan reference
Plan `ai-plans/2026-06-13-MULTI_ORG_MEMBERSHIP_IMPLEMENTATION_PLAN.md` — Phase 3 + API Design (`GET /organizations/mine/`). Use-case 5.

## Review history
Layer-3 review caught one BLOCKER: drf-spectacular inferred a paginated envelope (global `LimitOffsetPagination` + `many=True`) while the view returned a bare list — a generated client would read `.results` and break. Fixed by `pagination_class=None` + schema regen, with a test asserting the response is a bare array. Also added: a per-action-opt-out isolation test (multi-org + no header on `current` still 400), and moved the inline query to a manager method.

## Test plan
- `uv run pytest organizations/tests/test_views.py -k "Mine or mine" -vs`
- Asserts: multi-org user + no header → 200 listing both memberships (bare array); inactive excluded; gated → `200 []`; stale/foreign header on `mine` → still 200 (per-action opt-out); role reported correctly; `current` still 400 for multi-org no-header (opt-out isolation).
- Outer gate fully green: ruff, format, mypy (baseline), `makemigrations --check`, `check --deploy`, `backend-schema-local` hook, `pytest -n auto` (1594 passed, 0 failures).