### PR TITLE
refactor(calendar): extract availability + blocked/available times into AvailabilityService

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_SERVICE_REFACTOR.md
+++ b/ai-plans/TRACKING_CALENDAR_SERVICE_REFACTOR.md
@@ -76,11 +76,24 @@
   - Phase 4 (`AvailabilityService`) replaces the host's `get_availability_windows_in_range` (declared on both `EventServiceHost` and `BundleServiceHost`). Same seam-swap pattern.
   - Phase 7 cleanup list now includes: drop redundant facade-level `@transaction.atomic()` on the 1-line bundle + event delegations (harmless nested savepoints today); revisit whether the `InitializedOrAuthenticatedCalendarService` protocol should keep declaring `_get_primary_calendar`/`_collect_bundle_attendees`/serialize helpers (facade keeps thin delegations for them only to satisfy the protocol).
 
+### Phase 4 — Extract AvailabilityService ✅
+- **Status**: complete, PR open
+- **Model**: claude-opus-4-7 (Tier 4) — implemented across 3 sessions (2 died on API socket errors mid-extraction; finished by sonnet finishing agents)
+- **Branch**: `plan/calendar-service-refactor/phase-4` (base `…/phase-3`)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/75 (published, 3 inline comments)
+- **Files**: `calendar_integration/services/availability_service.py` (new, ~1095 lines), `calendar_integration/services/calendar_service.py` (edited, −668 lines → facade now 2557 lines), `calendar_integration/tests/services/test_availability_service.py` (new, 11 tests)
+- **Summary**: Moved 17 availability/blocked/available methods + interval-math privates into `AvailabilityService`. Same host-seam pattern (`AvailabilityServiceHost`, reads events via `host.get_calendar_events_expanded`). Facade keeps 2 private delegations: `_subtract_busy_intervals` (`@staticmethod` — test calls it unbound) + `_remove_available_time_windows_that_overlap...` (instance). `get_availability_windows_in_range` host method routes to the service.
+- **Review**: Layer-3 0 blockers / 0 should-fix. Interval math + all 8 recurring methods diffed byte-identical; no infinite loop; perf guardrail (no added queries in loops) held; tenancy preserved.
+- **Gate**: full suite 1619 passed, 0 failed. mypy 138 (0 new — 3 attr-defined fixed via `InitializedOrAuthenticatedCalendarService` cast; 7 remaining verbatim from facade).
+- **Carry-forward notes**:
+  - Facade is now ~2557 lines (was 4726). Remaining on it: auth/init, adapter resolution, calendar CRUD (create_application/virtual_calendar), org-resource import, the sync state machine (Phase 5), webhooks (Phase 6), + the thin private delegations.
+  - Phase 7 cleanup list += export `AvailabilityService` from `services/__init__.py`; the `_remove_...` cast-style note.
+  - NOTE: long opus agents are hitting ~45min API socket timeouts — for Phase 5 (sync, the most coupled), consider checkpointing or expect to finish via a follow-up agent if it dies mid-extraction. The pattern: dead agents leave correct partial work on disk (uncommitted); verify via the suite, then a small finishing agent completes tests+commit.
+
 ## Current Phase
-- Phase 4 — Extract `AvailabilityService` (next).
+- Phase 5 — Extract `CalendarSyncService` (next).
 
 ## Remaining Phases
-- Phase 4 — Extract `AvailabilityService` (Tier 4)
 - Phase 5 — Extract `CalendarSyncService` (Tier 4)
 - Phase 6 — Extract `CalendarWebhookService` (Tier 3)
 - Phase 7 — Shrink the facade and finalize wiring (Tier 2)

--- a/calendar_integration/services/availability_service.py
+++ b/calendar_integration/services/availability_service.py
@@ -1,0 +1,1095 @@
+"""Available-times, blocked-times, and availability/unavailability window reads.
+
+``AvailabilityService`` owns the availability concern extracted from the
+``CalendarService`` facade. It is a plain class (not a DI-container provider):
+the facade constructs it, after authentication, feeding it the shared
+:class:`CalendarServiceContext` so it never re-authenticates or re-builds a
+calendar adapter (the perf guardrail). Everything it needs arrives via the
+constructor:
+
+- ``context`` — the immutable auth snapshot (organization, user_or_token,
+  account, calendar_adapter, permission_service, side_effects_service). Read
+  through ``self._context``; the auth guards in ``type_guards.py`` inspect the
+  same ``organization`` / ``account`` / ``calendar_adapter`` attributes the
+  context exposes, so behavior is byte-for-byte identical to the former methods.
+- ``recurrence_manager`` — the stateless :class:`RecurrenceManager` the facade
+  also holds; the recurring blocked/available methods delegate to it exactly as
+  the former facade methods did.
+- ``host`` — the :class:`AvailabilityServiceHost` (in Phase 4 the facade
+  itself). The availability concern routes three things back through it:
+
+  - **event reads** (``get_calendar_events_expanded``) — the event concern,
+    extracted in Phase 2; reaching it via the host keeps a single
+    implementation and the call graph the existing test suite asserts on.
+  - **blocked-time creation** (``bulk_create_manual_blocked_times``) — stays
+    resident on the facade (other facade flows reference it and it is not part
+    of the availability concern's extracted surface), so ``create_blocked_time``
+    routes through the host.
+  - **recurrence-rule creation** (``_create_recurrence_rule_if_needed``) — a
+    shared facade helper used by both availability and (facade-resident)
+    blocked-time bulk creation; routed through the host so it has one
+    implementation and stays byte-for-byte.
+
+Routing through the host keeps single implementations and behavior
+byte-for-byte; later phases swap concerns in without touching this service.
+
+The interval-subtraction math (``_subtract_busy_intervals``) and the
+recurrence-expansion reads (``get_available_times_expanded`` /
+``get_blocked_times_expanded``) are moved verbatim — no added queries inside
+loops, no changed query structure, no algorithmic-complexity change.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from django.db import transaction
+from django.db.models import Q
+
+from calendar_integration.constants import CalendarType
+from calendar_integration.models import (
+    AvailableTime,
+    AvailableTimeBulkModification,
+    AvailableTimeRecurrenceException,
+    BlockedTime,
+    BlockedTimeBulkModification,
+    BlockedTimeRecurrenceException,
+    Calendar,
+    CalendarEvent,
+    RecurrenceRule,
+    RecurringMixin,
+)
+from calendar_integration.services.calendar_service_utils import (
+    serialize_event as _serialize_event_util,
+)
+from calendar_integration.services.dataclasses import (
+    AvailableTimeWindow,
+    BlockedTimeData,
+    UnavailableTimeWindow,
+)
+from calendar_integration.services.protocols.base_calendar_service import BaseCalendarService
+from calendar_integration.services.protocols.initializer_or_authenticated_calendar_service import (
+    InitializedOrAuthenticatedCalendarService,
+)
+from calendar_integration.services.type_guards import (
+    is_initialized_or_authenticated_calendar_service,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from calendar_integration.services.calendar_service_context import CalendarServiceContext
+    from calendar_integration.services.dataclasses import CalendarEventData
+    from calendar_integration.services.recurrence_manager import RecurrenceManager
+
+
+class AvailabilityServiceHost(Protocol):
+    """The collaborator surface the availability concern routes back to the facade for.
+
+    Three concerns are not part of the availability concern's extracted surface and
+    stay on the facade:
+
+    - **event reads** (``get_calendar_events_expanded``) — the event concern
+      (Phase 2); reached through the host to keep one implementation and the call
+      graph the existing test suite patches via the facade;
+    - **blocked-time bulk creation** (``bulk_create_manual_blocked_times``) — a
+      facade-resident helper (not part of the availability surface); ``create_blocked_time``
+      routes through it;
+    - **recurrence-rule creation** (``_create_recurrence_rule_if_needed``) — a shared
+      facade helper used by availability writes and facade-resident blocked-time bulk
+      creation alike; routed through the host for a single implementation.
+
+    In Phase 4 the facade supplies *itself*. Later phases may swap individual
+    concerns without changing this service's call sites.
+    """
+
+    def get_calendar_events_expanded(
+        self,
+        calendar: Calendar,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[CalendarEvent]: ...
+
+    def bulk_create_manual_blocked_times(
+        self,
+        calendar: Calendar,
+        blocked_times: Iterable[tuple[datetime.datetime, datetime.datetime, str, str, str | None]],
+    ) -> Iterable[BlockedTime]: ...
+
+    def _create_recurrence_rule_if_needed(
+        self, rrule_string: str | None
+    ) -> RecurrenceRule | None: ...
+
+
+class AvailabilityService:
+    """Owns available-times, blocked-times, and availability/unavailability windows."""
+
+    def __init__(
+        self,
+        context: CalendarServiceContext,
+        recurrence_manager: RecurrenceManager,
+        host: AvailabilityServiceHost,
+    ) -> None:
+        self._context = context
+        self._recurrence_manager = recurrence_manager
+        # Phase 4 seam: event reads, blocked-time bulk creation, and the shared
+        # recurrence-rule helper are reached through the host (the facade).
+        # See ``AvailabilityServiceHost``.
+        self._host = host
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _serialize_event(self, event: CalendarEvent) -> CalendarEventData:
+        """Build webhook payload for calendar event."""
+        return _serialize_event_util(event)
+
+    def _remove_available_time_windows_that_overlap_with_blocked_times_and_events(
+        self,
+        calendar_id: int,
+        blocked_times: Iterable[BlockedTime],
+        events: Iterable[CalendarEvent],
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+    ):
+        """
+        Removes AvailableTime windows that overlap with BlockedTime or CalendarEvent instances.
+        """
+        context = cast("InitializedOrAuthenticatedCalendarService", self._context)
+        if not context.organization:
+            return
+
+        blocked_times = list(blocked_times)
+        events = list(events)
+
+        available_time_windows = AvailableTime.objects.filter(
+            calendar_fk_id=calendar_id,
+            start_time__gte=start_time,
+            end_time__lte=end_time,
+            organization_id=context.organization.id,
+        )
+
+        available_time_windows_to_delete: list[int] = []
+
+        for available_time in available_time_windows:
+            # Check if the available time overlaps with any blocked time
+            overlaps_with_blocked = any(
+                bt.start_time < available_time.end_time and bt.end_time > available_time.start_time
+                for bt in blocked_times
+            )
+            # Check if the available time overlaps with any event
+            overlaps_with_event = any(
+                event.start_time < available_time.end_time
+                and event.end_time > available_time.start_time
+                for event in events
+            )
+
+            if overlaps_with_blocked or overlaps_with_event:
+                # If it overlaps, remove it from the list of blocked times
+                available_time_windows_to_delete.append(available_time.id)
+
+        AvailableTime.objects.filter(
+            id__in=available_time_windows_to_delete,
+            organization_id=context.organization.id,
+            calendar_fk_id=calendar_id,
+        ).delete()
+
+    @staticmethod
+    def _subtract_busy_intervals(
+        window_start: datetime.datetime,
+        window_end: datetime.datetime,
+        busy_intervals: Iterable[tuple[datetime.datetime, datetime.datetime]],
+    ) -> list[tuple[datetime.datetime, datetime.datetime]]:
+        """Return the parts of [window_start, window_end] not covered by any busy interval.
+
+        Busy intervals may be unsorted, overlapping, or extend beyond the window; they
+        are clipped to the window and merged on the fly. A window fully covered by busy
+        time yields an empty list.
+        """
+        clipped = sorted(
+            (max(start, window_start), min(end, window_end))
+            for start, end in busy_intervals
+            if end > window_start and start < window_end
+        )
+
+        free: list[tuple[datetime.datetime, datetime.datetime]] = []
+        cursor = window_start
+        for busy_start, busy_end in clipped:
+            if busy_start > cursor:
+                free.append((cursor, busy_start))
+            cursor = max(cursor, busy_end)
+        if cursor < window_end:
+            free.append((cursor, window_end))
+        return free
+
+    # ------------------------------------------------------------------
+    # Availability / unavailability window reads
+    # ------------------------------------------------------------------
+
+    def get_unavailable_time_windows_in_range(
+        self,
+        calendar: Calendar,
+        start_datetime: datetime.datetime,
+        end_datetime: datetime.datetime,
+    ) -> list[UnavailableTimeWindow]:
+        """
+        Retrieve unavailable time windows for a calendar within a specified date range.
+        This includes both calendar events (with recurring instances) and blocked times
+        that overlap with the given time range.
+
+        :param calendar: The calendar to retrieve unavailable time windows for.
+        :param start_datetime: Start date for the availability search.
+        :param end_datetime: End date for the availability search.
+        :return: List of UnavailableTimeWindow instances.
+        """
+        if not is_initialized_or_authenticated_calendar_service(
+            cast("BaseCalendarService", self._context)
+        ):
+            raise
+
+        # Get expanded calendar events (including recurring instances)
+        # This handles both master events and their generated instances
+        calendar_events = self._host.get_calendar_events_expanded(
+            calendar=calendar,
+            start_date=start_datetime,
+            end_date=end_datetime,
+        )
+
+        # Get expanded blocked times (including recurring instances)
+        # Replace the current blocked_times query with:
+        blocked_times = self.get_blocked_times_expanded(
+            calendar=calendar,
+            start_date=start_datetime,
+            end_date=end_datetime,
+        )
+
+        # If this calendar is part of any bundles, include bundle events
+        bundle_calendars = Calendar.objects.filter(
+            calendar_type=CalendarType.BUNDLE,
+            bundle_children=calendar,
+            organization_id=calendar.organization_id,
+        )
+
+        bundle_events: list[CalendarEvent] = []
+        for bundle_calendar in bundle_calendars:
+            # Get bundle events from the bundle calendar directly
+            bundle_calendar_events = CalendarEvent.objects.filter(
+                bundle_calendar=bundle_calendar,
+                start_time__lt=end_datetime,
+                end_time__gt=start_datetime,
+                organization_id=bundle_calendar.organization_id,
+            )
+            # Only include bundle events that aren't already in our calendar_events
+            # (to avoid counting the same event twice)
+            bundle_events.extend(
+                bundle_event
+                for bundle_event in bundle_calendar_events
+                if all(ce.id != bundle_event.id for ce in calendar_events)
+            )
+
+        # Combine regular events with bundle events
+        all_events = calendar_events + bundle_events
+
+        return sorted(
+            [
+                UnavailableTimeWindow(
+                    start_time=event.start_time,
+                    end_time=event.end_time,
+                    reason="calendar_event",
+                    id=event.id,
+                    data=self._serialize_event(event),
+                )
+                for event in all_events
+            ]
+            + [
+                UnavailableTimeWindow(
+                    start_time=blocked_time.start_time,
+                    end_time=blocked_time.end_time,
+                    reason="blocked_time",
+                    id=blocked_time.id,
+                    data=BlockedTimeData(
+                        id=blocked_time.id,
+                        calendar_external_id=blocked_time.calendar.external_id,
+                        start_time=blocked_time.start_time,
+                        end_time=blocked_time.end_time,
+                        timezone=blocked_time.timezone,
+                        reason=blocked_time.reason,
+                        external_id=blocked_time.external_id,
+                        meta=blocked_time.meta or {},
+                    ),
+                )
+                for blocked_time in blocked_times
+            ],
+            key=lambda x: x.start_time,
+        )
+
+    def get_availability_windows_in_range(
+        self, calendar: Calendar, start_datetime: datetime.datetime, end_datetime: datetime.datetime
+    ) -> Iterable[AvailableTimeWindow]:
+        """
+        Retrieve availability windows for a calendar within a specified date range.
+        :param calendar_id: ID of the calendar to retrieve availability for.
+        :param start_datetime: Start date for the availability search.
+        :param end_datetime: End date for the availability search.
+        :return: Iterable of AvalableTimeWindow instances.
+        """
+        if not is_initialized_or_authenticated_calendar_service(
+            cast("BaseCalendarService", self._context)
+        ):
+            raise
+
+        if calendar.manage_available_windows:
+            # Declared availability windows (recurring instances expanded).
+            available_times = self.get_available_times_expanded(
+                calendar=calendar,
+                start_date=start_datetime,
+                end_date=end_datetime,
+            )
+
+            # Net availability = declared windows minus busy (events + blocked times).
+            # Subtract the unavailable windows so callers get true bookable time and
+            # don't have to reconcile two overlapping lists client-side.
+            unavailable_windows = self.get_unavailable_time_windows_in_range(
+                calendar, start_datetime, end_datetime
+            )
+            busy_intervals = [(uw.start_time, uw.end_time) for uw in unavailable_windows]
+
+            return [
+                AvailableTimeWindow(
+                    start_time=free_start,
+                    end_time=free_end,
+                    id=available_time.id,
+                    can_book_partially=False,
+                    timezone=available_time.timezone,
+                )
+                for available_time in available_times
+                for free_start, free_end in AvailabilityService._subtract_busy_intervals(
+                    available_time.start_time, available_time.end_time, busy_intervals
+                )
+            ]
+
+        unavailable_windows_sorted_by_start_datetime = self.get_unavailable_time_windows_in_range(
+            calendar, start_datetime, end_datetime
+        )
+        available_windows = []
+
+        if not unavailable_windows_sorted_by_start_datetime:
+            # If there are no unavailable windows, the entire range is available
+            return [
+                AvailableTimeWindow(
+                    start_time=start_datetime,
+                    end_time=end_datetime,
+                    id=None,  # ID will be set when saving to the database
+                    can_book_partially=True,
+                )
+            ]
+
+        if start_datetime < unavailable_windows_sorted_by_start_datetime[0].start_time:
+            available_windows.append(
+                (start_datetime, unavailable_windows_sorted_by_start_datetime[0].start_time)
+            )
+        for i in range(len(unavailable_windows_sorted_by_start_datetime) - 1):
+            current_end = unavailable_windows_sorted_by_start_datetime[i].end_time
+            next_start = unavailable_windows_sorted_by_start_datetime[i + 1].start_time
+            if current_end < next_start:
+                available_windows.append((current_end, next_start))
+        if end_datetime > unavailable_windows_sorted_by_start_datetime[-1].end_time:
+            available_windows.append(
+                (unavailable_windows_sorted_by_start_datetime[-1].end_time, end_datetime)
+            )
+
+        return [
+            AvailableTimeWindow(
+                start_time=start,
+                end_time=end,
+                can_book_partially=True,
+                # this calendar doesn't manage available windows, so there is no
+                # AvailableTime record in the database
+                id=None,
+            )
+            for start, end in available_windows
+        ]
+
+    # ------------------------------------------------------------------
+    # Available-time writes
+    # ------------------------------------------------------------------
+
+    def bulk_create_availability_windows(
+        self,
+        calendar: Calendar,
+        availability_windows: Iterable[
+            tuple[datetime.datetime, datetime.datetime, str, str | None]
+        ],
+    ) -> Iterable[AvailableTime]:
+        """
+        Create availability windows for a calendar (with optional recurrence support).
+        :param calendar: The calendar to create the availability windows for.
+        :param availability_windows: Iterable of tuples containing (start_time, end_time, rrule_string).
+        :return: List of created AvailableTime instances.
+        """
+        if not is_initialized_or_authenticated_calendar_service(
+            cast("BaseCalendarService", self._context)
+        ):
+            raise
+
+        if not calendar.manage_available_windows:
+            raise ValueError("This calendar does not manage available windows.")
+
+        availability_windows_to_create = []
+
+        for start_time, end_time, timezone, rrule_string in availability_windows:
+            # Create recurrence rule if provided
+            recurrence_rule = self._host._create_recurrence_rule_if_needed(rrule_string)
+
+            available_time = AvailableTime(
+                calendar=calendar,
+                start_time_tz_unaware=start_time,
+                end_time_tz_unaware=end_time,
+                timezone=timezone,
+                organization_id=calendar.organization_id,
+                recurrence_rule=recurrence_rule,
+            )
+            availability_windows_to_create.append(available_time)
+
+        return AvailableTime.objects.bulk_create(availability_windows_to_create)
+
+    @transaction.atomic()
+    def batch_modify_available_times(
+        self,
+        calendar: Calendar,
+        operations: Iterable[dict],
+    ) -> list[AvailableTime]:
+        """Apply a batch of create/update/delete operations to a calendar's available times.
+
+        Row-atomic: each operation acts on a whole AvailableTime row. Runs in a single
+        transaction — any failure rolls the whole batch back. Update/delete operations
+        are scoped to this calendar (and organization); a missing id raises ValueError.
+
+        :param calendar: The calendar whose available times are being modified.
+        :param operations: Iterable of dicts, each with an ``action`` of
+            ``create`` / ``update`` / ``delete`` plus the relevant fields
+            (``id``, ``start_time``, ``end_time``, ``timezone``, ``rrule_string``).
+        :return: The calendar's available times after the batch is applied.
+        """
+        context = cast("BaseCalendarService", self._context)
+        if not is_initialized_or_authenticated_calendar_service(context):
+            raise
+
+        if not calendar.manage_available_windows:
+            raise ValueError("This calendar does not manage available windows.")
+
+        scoped = AvailableTime.objects.filter_by_organization(context.organization.id).filter(
+            calendar_fk=calendar
+        )
+
+        for operation in operations:
+            action = operation["action"]
+
+            if action == "create":
+                recurrence_rule = self._host._create_recurrence_rule_if_needed(
+                    operation.get("rrule_string")
+                )
+                AvailableTime.objects.create(
+                    calendar=calendar,
+                    organization_id=calendar.organization_id,
+                    start_time_tz_unaware=operation["start_time"],
+                    end_time_tz_unaware=operation["end_time"],
+                    timezone=operation["timezone"],
+                    recurrence_rule=recurrence_rule,
+                )
+            elif action == "update":
+                try:
+                    available_time = scoped.get(id=operation["id"])
+                except AvailableTime.DoesNotExist as e:
+                    raise ValueError(
+                        f"Available time {operation['id']} not found in this calendar."
+                    ) from e
+                if "start_time" in operation:
+                    available_time.start_time_tz_unaware = operation["start_time"]
+                if "end_time" in operation:
+                    available_time.end_time_tz_unaware = operation["end_time"]
+                if "timezone" in operation:
+                    available_time.timezone = operation["timezone"]
+                if "rrule_string" in operation:
+                    available_time.recurrence_rule = self._host._create_recurrence_rule_if_needed(
+                        operation["rrule_string"]
+                    )
+                available_time.save()
+            elif action == "delete":
+                try:
+                    scoped.get(id=operation["id"]).delete()
+                except AvailableTime.DoesNotExist as e:
+                    raise ValueError(
+                        f"Available time {operation['id']} not found in this calendar."
+                    ) from e
+
+        return list(
+            AvailableTime.objects.filter_by_organization(context.organization.id).filter(
+                calendar_fk=calendar
+            )
+        )
+
+    @transaction.atomic()
+    def create_available_time(
+        self,
+        calendar: Calendar,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        timezone: str,
+        rrule_string: str | None = None,
+    ) -> AvailableTime:
+        """Create a single available time (optionally recurring)."""
+        result = self.bulk_create_availability_windows(
+            calendar=calendar, availability_windows=[(start_time, end_time, timezone, rrule_string)]
+        )
+        return next(iter(result))
+
+    def get_available_times_expanded(
+        self,
+        calendar: Calendar,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[AvailableTime]:
+        """Get all available times in a date range with recurring available times expanded to instances."""
+        if not is_initialized_or_authenticated_calendar_service(
+            cast("BaseCalendarService", self._context)
+        ):
+            raise
+
+        base_qs = (
+            AvailableTime.objects.annotate_recurring_occurrences_on_date_range(
+                start_date, end_date, overlap=True
+            )
+            .select_related("recurrence_rule")
+            .filter(
+                organization_id=calendar.organization_id,
+                calendar=calendar,
+                parent_recurring_object__isnull=True,  # Master times only
+            )
+        )
+
+        # Get non-recurring times overlapping the date range. Interval overlap is
+        # start < range_end AND end > range_start — this also catches windows that
+        # fully contain the range, which a start-or-end-inside filter would drop.
+        non_recurring_times = base_qs.filter(
+            start_time__lt=end_date,
+            end_time__gt=start_date,
+            recurrence_rule__isnull=True,  # Non-recurring only
+            is_recurring_exception=False,  # Exclude exception objects
+        )
+
+        # Get recurring master times and generate their instances
+        recurring_times = base_qs.filter(
+            recurrence_rule__isnull=False,  # Recurring only
+        ).filter(
+            Q(recurrence_rule__until__isnull=True) | Q(recurrence_rule__until__gte=start_date),
+            start_time__lte=end_date,
+        )
+
+        times: list[AvailableTime] = list(non_recurring_times)
+
+        for master_time in recurring_times:
+            instances = master_time.get_occurrences_in_range(
+                start_date, end_date, include_self=False, include_exceptions=True, overlap=True
+            )
+            times.extend(instances)
+
+        # Sort by start time
+        times.sort(key=lambda x: x.start_time)
+        return times
+
+    # ------------------------------------------------------------------
+    # Blocked-time writes / reads
+    # ------------------------------------------------------------------
+
+    @transaction.atomic()
+    def create_blocked_time(
+        self,
+        calendar: Calendar,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        timezone: str,
+        reason: str = "",
+        rrule_string: str | None = None,
+    ) -> BlockedTime:
+        """Create a single blocked time (optionally recurring)."""
+        result = self._host.bulk_create_manual_blocked_times(
+            calendar=calendar,
+            blocked_times=[(start_time, end_time, timezone, reason, rrule_string)],
+        )
+        return next(iter(result))
+
+    def get_blocked_times_expanded(
+        self,
+        calendar: Calendar,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[BlockedTime]:
+        """Get all blocked times in a date range with recurring blocked times expanded to instances."""
+        if not is_initialized_or_authenticated_calendar_service(
+            cast("BaseCalendarService", self._context)
+        ):
+            raise
+
+        # Get calendars to query - includes the main calendar and bundle children if applicable
+        calendars_to_query = [calendar]
+        if calendar.calendar_type == CalendarType.BUNDLE:
+            # Add all bundle children calendars
+            bundle_children = calendar.bundle_children.all()
+            calendars_to_query.extend(bundle_children)
+
+        base_qs = (
+            BlockedTime.objects.annotate_recurring_occurrences_on_date_range(
+                start_date, end_date, overlap=True
+            )
+            .select_related("recurrence_rule")
+            .filter(
+                organization_id=calendar.organization_id,
+                calendar__in=calendars_to_query,
+                parent_recurring_object__isnull=True,  # Master times only
+            )
+        )
+
+        # Get non-recurring times overlapping the date range. Interval overlap is
+        # start < range_end AND end > range_start — this also catches blocks that
+        # fully contain the range, which a start-or-end-inside filter would drop
+        # (and miss a block covering the whole booking, allowing a double-booking).
+        non_recurring_times = base_qs.filter(
+            start_time__lt=end_date,
+            end_time__gt=start_date,
+            recurrence_rule__isnull=True,  # Non-recurring only
+            is_recurring_exception=False,  # Exclude exception objects
+        )
+
+        # Get recurring master times and generate their instances
+        recurring_times = base_qs.filter(
+            recurrence_rule__isnull=False,  # Recurring only
+        ).filter(
+            Q(recurrence_rule__until__isnull=True) | Q(recurrence_rule__until__gte=start_date),
+            start_time__lte=end_date,
+        )
+
+        times: list[BlockedTime] = list(non_recurring_times)
+
+        for master_time in recurring_times:
+            instances = master_time.get_occurrences_in_range(
+                start_date, end_date, include_self=False, include_exceptions=True, overlap=True
+            )
+            times.extend(instances)
+
+        # Sort by start time
+        times.sort(key=lambda x: x.start_time)
+        return times
+
+    # ------------------------------------------------------------------
+    # Recurring blocked-time / available-time exceptions + bulk-modifications
+    # ------------------------------------------------------------------
+
+    def create_recurring_blocked_time_exception(
+        self,
+        parent_blocked_time: BlockedTime,
+        exception_date: datetime.date,
+        modified_reason: str | None = None,
+        modified_start_time: datetime.datetime | None = None,
+        modified_end_time: datetime.datetime | None = None,
+        modified_timezone: str | None = None,
+        is_cancelled: bool = False,
+    ) -> BlockedTime | None:
+        """
+        Create an exception for a recurring blocked time (either cancelled or modified).
+
+        :param parent_blocked_time: The recurring blocked time to create an exception for
+        :param exception_date: The date of the occurrence to modify/cancel
+        :param modified_reason: New reason for the modified occurrence (if not cancelled)
+        :param modified_start_time: New start time for the modified occurrence (if not cancelled)
+        :param modified_end_time: New end time for the modified occurrence (if not cancelled)
+        :param modified_timezone: New timezone for the modified occurrence (if not cancelled)
+        :param is_cancelled: True if cancelling the occurrence, False if modifying
+        :return: Created modified blocked time or None if cancelled
+        """
+
+        def create_new_recurring_blocked_time(
+            parent_obj: RecurringMixin,
+            second_occurrence: RecurringMixin,
+            new_recurrence_rule: RecurrenceRule,
+        ) -> RecurringMixin:
+            parent_blocked_time = cast(BlockedTime, parent_obj)
+            second_blocked_time = cast(BlockedTime, second_occurrence)
+            return self.create_blocked_time(
+                calendar=parent_blocked_time.calendar,
+                start_time=second_blocked_time.start_time,
+                end_time=second_blocked_time.end_time,
+                timezone=second_blocked_time.timezone,
+                reason=second_blocked_time.reason,
+                rrule_string=new_recurrence_rule.to_rrule_string(),
+            )
+
+        def create_modified_blocked_time(
+            parent_obj: RecurringMixin,
+            exception_datetime: datetime.datetime,
+            modification_data: dict[str, Any],
+        ) -> RecurringMixin:
+            parent_blocked_time = cast(BlockedTime, parent_obj)
+            return self.create_blocked_time(
+                calendar=parent_blocked_time.calendar,
+                start_time=modification_data.get("start_time") or exception_datetime,
+                end_time=(
+                    modification_data.get("end_time")
+                    or (exception_datetime + parent_blocked_time.duration)
+                ),
+                timezone=modification_data.get("timezone") or parent_blocked_time.timezone,
+                reason=modification_data.get("reason") or parent_blocked_time.reason,
+            )
+
+        def update_exception_manager(
+            parent_obj: RecurringMixin, new_recurring_obj: RecurringMixin
+        ) -> None:
+            BlockedTimeRecurrenceException.objects.filter(parent_blocked_time=parent_obj).update(
+                parent_blocked_time_fk=new_recurring_obj
+            )
+
+        def delete_exception_manager(parent_obj: RecurringMixin) -> None:
+            BlockedTimeRecurrenceException.objects.filter(parent_blocked_time=parent_obj).delete()
+
+        modification_data = {
+            "reason": modified_reason,
+            "start_time": modified_start_time,
+            "end_time": modified_end_time,
+            "timezone": modified_timezone,
+        }
+
+        result = self._recurrence_manager.create_recurring_exception_generic(
+            self._context,
+            object_type_name="blocked time",
+            parent_object=parent_blocked_time,
+            exception_date=datetime.datetime.combine(
+                exception_date,
+                parent_blocked_time.start_time.time(),
+                tzinfo=parent_blocked_time.start_time.tzinfo,
+            ),
+            is_cancelled=is_cancelled,
+            modification_data=modification_data,
+            create_new_recurring_callback=create_new_recurring_blocked_time,
+            create_modified_object_callback=create_modified_blocked_time,
+            exception_manager_update_callback=update_exception_manager,
+            exception_manager_delete_callback=delete_exception_manager,
+        )
+        return cast(BlockedTime, result) if result else None
+
+    def create_recurring_available_time_exception(
+        self,
+        parent_available_time: AvailableTime,
+        exception_date: datetime.date,
+        modified_start_time: datetime.datetime | None = None,
+        modified_end_time: datetime.datetime | None = None,
+        modified_timezone: str | None = None,
+        is_cancelled: bool = False,
+    ) -> AvailableTime | None:
+        """
+        Create an exception for a recurring available time (either cancelled or modified).
+
+        :param parent_available_time: The recurring available time to create an exception for
+        :param exception_date: The date of the occurrence to modify/cancel
+        :param modified_start_time: New start time for the modified occurrence (if not cancelled)
+        :param modified_end_time: New end time for the modified occurrence (if not cancelled)
+        :param modified_timezone: New timezone for the modified occurrence (if not cancelled)
+        :param is_cancelled: True if cancelling the occurrence, False if modifying
+        :return: Created modified available time or None if cancelled
+        """
+
+        def create_new_recurring_available_time(
+            parent_obj: RecurringMixin,
+            second_occurrence: RecurringMixin,
+            new_recurrence_rule: RecurrenceRule,
+        ) -> RecurringMixin:
+            parent_available_time = cast(AvailableTime, parent_obj)
+            second_available_time = cast(AvailableTime, second_occurrence)
+            return self.create_available_time(
+                calendar=parent_available_time.calendar,
+                start_time=second_available_time.start_time,
+                end_time=second_available_time.end_time,
+                timezone=second_available_time.timezone,
+                rrule_string=new_recurrence_rule.to_rrule_string(),
+            )
+
+        def create_modified_available_time(
+            parent_obj: RecurringMixin,
+            exception_datetime: datetime.datetime,
+            modification_data: dict[str, Any],
+        ) -> RecurringMixin:
+            parent_available_time = cast(AvailableTime, parent_obj)
+            return self.create_available_time(
+                calendar=parent_available_time.calendar,
+                start_time=modification_data.get("start_time") or exception_datetime,
+                end_time=(
+                    modification_data.get("end_time")
+                    or (exception_datetime + parent_available_time.duration)
+                ),
+                timezone=modification_data.get("timezone") or parent_available_time.timezone,
+            )
+
+        def update_exception_manager(
+            parent_obj: RecurringMixin, new_recurring_obj: RecurringMixin
+        ) -> None:
+            AvailableTimeRecurrenceException.objects.filter(
+                parent_available_time=parent_obj
+            ).update(parent_available_time_fk=new_recurring_obj)
+
+        def delete_exception_manager(parent_obj: RecurringMixin) -> None:
+            AvailableTimeRecurrenceException.objects.filter(
+                parent_available_time=parent_obj
+            ).delete()
+
+        modification_data = {
+            "start_time": modified_start_time,
+            "end_time": modified_end_time,
+            "timezone": modified_timezone,
+        }
+
+        result = self._recurrence_manager.create_recurring_exception_generic(
+            self._context,
+            object_type_name="available time",
+            parent_object=parent_available_time,
+            exception_date=datetime.datetime.combine(
+                exception_date,
+                parent_available_time.start_time.time(),
+                tzinfo=parent_available_time.start_time.tzinfo,
+            ),
+            is_cancelled=is_cancelled,
+            modification_data=modification_data,
+            create_new_recurring_callback=create_new_recurring_available_time,
+            create_modified_object_callback=create_modified_available_time,
+            exception_manager_update_callback=update_exception_manager,
+            exception_manager_delete_callback=delete_exception_manager,
+        )
+        return cast(AvailableTime, result) if result else None
+
+    def create_recurring_blocked_time_bulk_modification(
+        self,
+        parent_blocked_time: BlockedTime,
+        modification_start_date: datetime.datetime,
+        modified_reason: str | None = None,
+        modified_start_time_offset: datetime.timedelta | None = None,
+        modified_end_time_offset: datetime.timedelta | None = None,
+        is_bulk_cancelled: bool = False,
+        modification_rrule_string: str | None = None,
+    ) -> BlockedTime | None:
+        """Create a bulk modification for a recurring blocked time from the specified date onwards."""
+
+        def truncate_parent(
+            parent_obj: RecurringMixin,
+            new_recurrence_rule: RecurrenceRule | None,
+        ):
+            parent = cast(BlockedTime, parent_obj)
+            parent.recurrence_rule_fk = new_recurrence_rule  # type: ignore
+            parent.save()
+            return parent
+
+        def create_continuation(
+            parent_obj: RecurringMixin,
+            start_dt: datetime.datetime,
+            recurrence_rule: RecurrenceRule | None,
+            modification_data: dict[str, Any],
+        ) -> RecurringMixin:
+            parent = cast(BlockedTime, parent_obj)
+            new_start = (
+                (start_dt + modification_data["start_time_offset"])
+                if modification_data.get("start_time_offset")
+                else start_dt
+            )
+            duration = parent.duration
+            new_end = (
+                new_start + modification_data["end_time_offset"]
+                if modification_data.get("end_time_offset")
+                else new_start + duration
+            )
+            return self.create_blocked_time(
+                calendar=parent.calendar,
+                start_time=new_start,
+                end_time=new_end,
+                timezone=parent.timezone,
+                reason=modification_data.get("reason") or parent.reason,
+                rrule_string=recurrence_rule.to_rrule_string() if recurrence_rule else None,
+            )
+
+        def record_bulk(
+            parent_obj: RecurringMixin,
+            start_dt: datetime.datetime,
+            continuation_obj: RecurringMixin | None,
+            cancelled: bool,
+        ):
+            BlockedTimeBulkModification.objects.create(
+                organization=parent_obj.organization,
+                parent_blocked_time=parent_obj,
+                modification_start_date=start_dt,
+                modified_continuation=None,
+                is_bulk_cancelled=cancelled,
+            )
+
+        modification_data = {
+            "reason": modified_reason,
+            "start_time_offset": modified_start_time_offset,
+            "end_time_offset": modified_end_time_offset,
+        }
+
+        result = self._recurrence_manager.create_recurring_bulk_modification_generic(
+            self._context,
+            object_type_name="blocked time",
+            parent_object=parent_blocked_time,
+            modification_start_date=modification_start_date,
+            is_bulk_cancelled=is_bulk_cancelled,
+            modification_data=modification_data,
+            truncate_parent_callback=truncate_parent,
+            create_continuation_callback=create_continuation,
+            bulk_modification_record_callback=record_bulk,
+            modification_rrule_string=modification_rrule_string,
+        )
+        return cast(BlockedTime, result) if result else None
+
+    def create_recurring_available_time_bulk_modification(
+        self,
+        parent_available_time: AvailableTime,
+        modification_start_date: datetime.datetime,
+        modified_start_time_offset: datetime.timedelta | None = None,
+        modified_end_time_offset: datetime.timedelta | None = None,
+        is_bulk_cancelled: bool = False,
+        modification_rrule_string: str | None = None,
+    ) -> AvailableTime | None:
+        """Create a bulk modification for a recurring available time from the specified date onwards."""
+
+        def truncate_parent(
+            parent_obj: RecurringMixin,
+            new_recurrence_rule: RecurrenceRule | None,
+        ):
+            parent = cast(AvailableTime, parent_obj)
+            parent.recurrence_rule_fk = new_recurrence_rule  # type: ignore
+            parent.save()
+            return parent
+
+        def create_continuation(
+            parent_obj: RecurringMixin,
+            start_dt: datetime.datetime,
+            recurrence_rule: RecurrenceRule | None,
+            modification_data: dict[str, Any],
+        ) -> RecurringMixin:
+            parent = cast(AvailableTime, parent_obj)
+            new_start = (
+                (start_dt + modification_data["start_time_offset"])
+                if modification_data.get("start_time_offset")
+                else start_dt
+            )
+            duration = parent.duration
+            new_end = (
+                new_start + modification_data["end_time_offset"]
+                if modification_data.get("end_time_offset")
+                else new_start + duration
+            )
+            return self.create_available_time(
+                calendar=parent.calendar,
+                start_time=new_start,
+                end_time=new_end,
+                timezone=parent.timezone,
+                rrule_string=recurrence_rule.to_rrule_string() if recurrence_rule else None,
+            )
+
+        def record_bulk(
+            parent_obj: RecurringMixin,
+            start_dt: datetime.datetime,
+            continuation_obj: RecurringMixin | None,
+            cancelled: bool,
+        ):
+            AvailableTimeBulkModification.objects.create(
+                organization=parent_obj.organization,
+                parent_available_time=parent_obj,
+                modification_start_date=start_dt,
+                modified_continuation=None,
+                is_bulk_cancelled=cancelled,
+            )
+
+        modification_data = {
+            "start_time_offset": modified_start_time_offset,
+            "end_time_offset": modified_end_time_offset,
+        }
+
+        result = self._recurrence_manager.create_recurring_bulk_modification_generic(
+            self._context,
+            object_type_name="available time",
+            parent_object=parent_available_time,
+            modification_start_date=modification_start_date,
+            is_bulk_cancelled=is_bulk_cancelled,
+            modification_data=modification_data,
+            truncate_parent_callback=truncate_parent,
+            create_continuation_callback=create_continuation,
+            bulk_modification_record_callback=record_bulk,
+            modification_rrule_string=modification_rrule_string,
+        )
+        return cast(AvailableTime, result) if result else None
+
+    def modify_recurring_blocked_time_from_date(
+        self,
+        parent_blocked_time: BlockedTime,
+        modification_start_date: datetime.datetime,
+        modified_reason: str | None = None,
+        modified_start_time_offset: datetime.timedelta | None = None,
+        modified_end_time_offset: datetime.timedelta | None = None,
+        modification_rrule_string: str | None = None,
+    ) -> BlockedTime | None:
+        continuation = self.create_recurring_blocked_time_bulk_modification(
+            parent_blocked_time=parent_blocked_time,
+            modification_start_date=modification_start_date,
+            modified_reason=modified_reason,
+            modified_start_time_offset=modified_start_time_offset,
+            modified_end_time_offset=modified_end_time_offset,
+            is_bulk_cancelled=False,
+            modification_rrule_string=modification_rrule_string,
+        )
+
+        return continuation
+
+    def cancel_recurring_blocked_time_from_date(
+        self,
+        parent_blocked_time: BlockedTime,
+        modification_start_date: datetime.datetime,
+        modification_rrule_string: str | None = None,
+    ) -> None:
+        self.create_recurring_blocked_time_bulk_modification(
+            parent_blocked_time=parent_blocked_time,
+            modification_start_date=modification_start_date,
+            is_bulk_cancelled=True,
+            modification_rrule_string=modification_rrule_string,
+        )
+
+    def modify_recurring_available_time_from_date(
+        self,
+        parent_available_time: AvailableTime,
+        modification_start_date: datetime.datetime,
+        modified_start_time_offset: datetime.timedelta | None = None,
+        modified_end_time_offset: datetime.timedelta | None = None,
+        modification_rrule_string: str | None = None,
+    ) -> AvailableTime | None:
+        continuation = self.create_recurring_available_time_bulk_modification(
+            parent_available_time=parent_available_time,
+            modification_start_date=modification_start_date,
+            modified_start_time_offset=modified_start_time_offset,
+            modified_end_time_offset=modified_end_time_offset,
+            is_bulk_cancelled=False,
+            modification_rrule_string=modification_rrule_string,
+        )
+
+        return continuation
+
+    def cancel_recurring_available_time_from_date(
+        self,
+        parent_available_time: AvailableTime,
+        modification_start_date: datetime.datetime,
+        modification_rrule_string: str | None = None,
+    ) -> None:
+        self.create_recurring_available_time_bulk_modification(
+            parent_available_time=parent_available_time,
+            modification_start_date=modification_start_date,
+            is_bulk_cancelled=True,
+            modification_rrule_string=modification_rrule_string,
+        )

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import logging
 from collections.abc import Callable, Iterable
-from typing import Annotated, Any, Literal, TypedDict, cast
+from typing import Annotated, Literal, TypedDict
 
 from django.conf import settings
 from django.db import transaction
@@ -29,11 +29,7 @@ from calendar_integration.exceptions import (
 )
 from calendar_integration.models import (
     AvailableTime,
-    AvailableTimeBulkModification,
-    AvailableTimeRecurrenceException,
     BlockedTime,
-    BlockedTimeBulkModification,
-    BlockedTimeRecurrenceException,
     Calendar,
     CalendarEvent,
     CalendarOrganizationResourcesImport,
@@ -46,9 +42,9 @@ from calendar_integration.models import (
     ExternalAttendee,
     GoogleCalendarServiceAccount,
     RecurrenceRule,
-    RecurringMixin,
 )
 from calendar_integration.querysets import CalendarEventQuerySet
+from calendar_integration.services.availability_service import AvailabilityService
 from calendar_integration.services.calendar_bundle_service import CalendarBundleService
 from calendar_integration.services.calendar_event_service import CalendarEventService
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
@@ -84,7 +80,6 @@ from calendar_integration.services.calendar_side_effects_service import Calendar
 from calendar_integration.services.dataclasses import (
     ApplicationCalendarData,
     AvailableTimeWindow,
-    BlockedTimeData,
     CalendarEventAdapterOutputData,
     CalendarEventData,
     CalendarEventInputData,
@@ -418,6 +413,22 @@ class CalendarService(BaseCalendarService):
         """
         return CalendarBundleService(
             context=self._build_context_snapshot(),
+            host=self,
+        )
+
+    def _get_availability_service(self) -> AvailabilityService:
+        """Return the availability sub-service bound to the facade's current auth context.
+
+        The availability service shares the facade-owned recurrence manager and routes
+        event reads (Phase 2), facade-resident blocked-time bulk creation, and the
+        shared recurrence-rule helper back through the facade (``host=self``). The
+        context is rebuilt from the live facade attributes each call (a cheap dataclass
+        construction — no network / adapter rebuild), so it never goes stale across
+        re-authentication or direct attribute mutation.
+        """
+        return AvailabilityService(
+            context=self._build_context_snapshot(),
+            recurrence_manager=self._recurrence_manager,
             host=self,
         )
 
@@ -1633,47 +1644,15 @@ class CalendarService(BaseCalendarService):
         events: Iterable[CalendarEvent],
         start_time: datetime.datetime,
         end_time: datetime.datetime,
-    ):
-        """
-        Removes AvailableTime windows that overlap with BlockedTime or CalendarEvent instances.
-        """
-        if not self.organization:
-            return
+    ) -> None:
+        """Delegation: removes AvailableTime windows that overlap with BlockedTime or CalendarEvent.
 
-        blocked_times = list(blocked_times)
-        events = list(events)
-
-        available_time_windows = AvailableTime.objects.filter(
-            calendar_fk_id=calendar_id,
-            start_time__gte=start_time,
-            end_time__lte=end_time,
-            organization_id=self.organization.id,
+        Kept on the facade for backward compatibility with existing tests and internal
+        callers (sync flow at _execute_calendar_sync). Delegates to AvailabilityService.
+        """
+        return self._get_availability_service()._remove_available_time_windows_that_overlap_with_blocked_times_and_events(
+            calendar_id, blocked_times, events, start_time, end_time
         )
-
-        available_time_windows_to_delete: list[int] = []
-
-        for available_time in available_time_windows:
-            # Check if the available time overlaps with any blocked time
-            overlaps_with_blocked = any(
-                bt.start_time < available_time.end_time and bt.end_time > available_time.start_time
-                for bt in blocked_times
-            )
-            # Check if the available time overlaps with any event
-            overlaps_with_event = any(
-                event.start_time < available_time.end_time
-                and event.end_time > available_time.start_time
-                for event in events
-            )
-
-            if overlaps_with_blocked or overlaps_with_event:
-                # If it overlaps, remove it from the list of blocked times
-                available_time_windows_to_delete.append(available_time.id)
-
-        AvailableTime.objects.filter(
-            id__in=available_time_windows_to_delete,
-            organization_id=self.organization.id,
-            calendar_fk_id=calendar_id,
-        ).delete()
 
     @staticmethod
     def _subtract_busy_intervals(
@@ -1681,27 +1660,15 @@ class CalendarService(BaseCalendarService):
         window_end: datetime.datetime,
         busy_intervals: Iterable[tuple[datetime.datetime, datetime.datetime]],
     ) -> list[tuple[datetime.datetime, datetime.datetime]]:
-        """Return the parts of [window_start, window_end] not covered by any busy interval.
+        """Delegation: return the parts of [window_start, window_end] not covered by any busy interval.
 
-        Busy intervals may be unsorted, overlapping, or extend beyond the window; they
-        are clipped to the window and merged on the fly. A window fully covered by busy
-        time yields an empty list.
+        Kept on the facade as a static method for backward compatibility with existing tests
+        that call it as ``CalendarService._subtract_busy_intervals(...)``. Delegates to
+        AvailabilityService.
         """
-        clipped = sorted(
-            (max(start, window_start), min(end, window_end))
-            for start, end in busy_intervals
-            if end > window_start and start < window_end
+        return AvailabilityService._subtract_busy_intervals(
+            window_start, window_end, busy_intervals
         )
-
-        free: list[tuple[datetime.datetime, datetime.datetime]] = []
-        cursor = window_start
-        for busy_start, busy_end in clipped:
-            if busy_start > cursor:
-                free.append((cursor, busy_start))
-            cursor = max(cursor, busy_end)
-        if cursor < window_end:
-            free.append((cursor, window_end))
-        return free
 
     def get_unavailable_time_windows_in_range(
         self,
@@ -1719,83 +1686,8 @@ class CalendarService(BaseCalendarService):
         :param end_datetime: End date for the availability search.
         :return: List of UnavailableTimeWindow instances.
         """
-        if not is_initialized_or_authenticated_calendar_service(self):
-            raise
-
-        # Get expanded calendar events (including recurring instances)
-        # This handles both master events and their generated instances
-        calendar_events = self.get_calendar_events_expanded(
-            calendar=calendar,
-            start_date=start_datetime,
-            end_date=end_datetime,
-        )
-
-        # Get expanded blocked times (including recurring instances)
-        # Replace the current blocked_times query with:
-        blocked_times = self.get_blocked_times_expanded(
-            calendar=calendar,
-            start_date=start_datetime,
-            end_date=end_datetime,
-        )
-
-        # If this calendar is part of any bundles, include bundle events
-        bundle_calendars = Calendar.objects.filter(
-            calendar_type=CalendarType.BUNDLE,
-            bundle_children=calendar,
-            organization_id=calendar.organization_id,
-        )
-
-        bundle_events: list[CalendarEvent] = []
-        for bundle_calendar in bundle_calendars:
-            # Get bundle events from the bundle calendar directly
-            bundle_calendar_events = CalendarEvent.objects.filter(
-                bundle_calendar=bundle_calendar,
-                start_time__lt=end_datetime,
-                end_time__gt=start_datetime,
-                organization_id=bundle_calendar.organization_id,
-            )
-            # Only include bundle events that aren't already in our calendar_events
-            # (to avoid counting the same event twice)
-            bundle_events.extend(
-                bundle_event
-                for bundle_event in bundle_calendar_events
-                if all(ce.id != bundle_event.id for ce in calendar_events)
-            )
-
-        # Combine regular events with bundle events
-        all_events = calendar_events + bundle_events
-
-        return sorted(
-            [
-                UnavailableTimeWindow(
-                    start_time=event.start_time,
-                    end_time=event.end_time,
-                    reason="calendar_event",
-                    id=event.id,
-                    data=self._serialize_event(event),
-                )
-                for event in all_events
-            ]
-            + [
-                UnavailableTimeWindow(
-                    start_time=blocked_time.start_time,
-                    end_time=blocked_time.end_time,
-                    reason="blocked_time",
-                    id=blocked_time.id,
-                    data=BlockedTimeData(
-                        id=blocked_time.id,
-                        calendar_external_id=blocked_time.calendar.external_id,
-                        start_time=blocked_time.start_time,
-                        end_time=blocked_time.end_time,
-                        timezone=blocked_time.timezone,
-                        reason=blocked_time.reason,
-                        external_id=blocked_time.external_id,
-                        meta=blocked_time.meta or {},
-                    ),
-                )
-                for blocked_time in blocked_times
-            ],
-            key=lambda x: x.start_time,
+        return self._get_availability_service().get_unavailable_time_windows_in_range(
+            calendar, start_datetime, end_datetime
         )
 
     def get_availability_windows_in_range(
@@ -1808,80 +1700,9 @@ class CalendarService(BaseCalendarService):
         :param end_datetime: End date for the availability search.
         :return: Iterable of AvalableTimeWindow instances.
         """
-        if not is_initialized_or_authenticated_calendar_service(self):
-            raise
-
-        if calendar.manage_available_windows:
-            # Declared availability windows (recurring instances expanded).
-            available_times = self.get_available_times_expanded(
-                calendar=calendar,
-                start_date=start_datetime,
-                end_date=end_datetime,
-            )
-
-            # Net availability = declared windows minus busy (events + blocked times).
-            # Subtract the unavailable windows so callers get true bookable time and
-            # don't have to reconcile two overlapping lists client-side.
-            unavailable_windows = self.get_unavailable_time_windows_in_range(
-                calendar, start_datetime, end_datetime
-            )
-            busy_intervals = [(uw.start_time, uw.end_time) for uw in unavailable_windows]
-
-            return [
-                AvailableTimeWindow(
-                    start_time=free_start,
-                    end_time=free_end,
-                    id=available_time.id,
-                    can_book_partially=False,
-                    timezone=available_time.timezone,
-                )
-                for available_time in available_times
-                for free_start, free_end in CalendarService._subtract_busy_intervals(
-                    available_time.start_time, available_time.end_time, busy_intervals
-                )
-            ]
-
-        unavailable_windows_sorted_by_start_datetime = self.get_unavailable_time_windows_in_range(
+        return self._get_availability_service().get_availability_windows_in_range(
             calendar, start_datetime, end_datetime
         )
-        available_windows = []
-
-        if not unavailable_windows_sorted_by_start_datetime:
-            # If there are no unavailable windows, the entire range is available
-            return [
-                AvailableTimeWindow(
-                    start_time=start_datetime,
-                    end_time=end_datetime,
-                    id=None,  # ID will be set when saving to the database
-                    can_book_partially=True,
-                )
-            ]
-
-        if start_datetime < unavailable_windows_sorted_by_start_datetime[0].start_time:
-            available_windows.append(
-                (start_datetime, unavailable_windows_sorted_by_start_datetime[0].start_time)
-            )
-        for i in range(len(unavailable_windows_sorted_by_start_datetime) - 1):
-            current_end = unavailable_windows_sorted_by_start_datetime[i].end_time
-            next_start = unavailable_windows_sorted_by_start_datetime[i + 1].start_time
-            if current_end < next_start:
-                available_windows.append((current_end, next_start))
-        if end_datetime > unavailable_windows_sorted_by_start_datetime[-1].end_time:
-            available_windows.append(
-                (unavailable_windows_sorted_by_start_datetime[-1].end_time, end_datetime)
-            )
-
-        return [
-            AvailableTimeWindow(
-                start_time=start,
-                end_time=end,
-                can_book_partially=True,
-                # this calendar doesn't manage available windows, so there is no
-                # AvailableTime record in the database
-                id=None,
-            )
-            for start, end in available_windows
-        ]
 
     @transaction.atomic()
     def get_default_calendar_for_user(self, user: "User") -> Calendar | None:
@@ -1915,31 +1736,10 @@ class CalendarService(BaseCalendarService):
         :param availability_windows: Iterable of tuples containing (start_time, end_time, rrule_string).
         :return: List of created AvailableTime instances.
         """
-        if not is_initialized_or_authenticated_calendar_service(self):
-            raise
+        return self._get_availability_service().bulk_create_availability_windows(
+            calendar, availability_windows
+        )
 
-        if not calendar.manage_available_windows:
-            raise ValueError("This calendar does not manage available windows.")
-
-        availability_windows_to_create = []
-
-        for start_time, end_time, timezone, rrule_string in availability_windows:
-            # Create recurrence rule if provided
-            recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
-
-            available_time = AvailableTime(
-                calendar=calendar,
-                start_time_tz_unaware=start_time,
-                end_time_tz_unaware=end_time,
-                timezone=timezone,
-                organization_id=calendar.organization_id,
-                recurrence_rule=recurrence_rule,
-            )
-            availability_windows_to_create.append(available_time)
-
-        return AvailableTime.objects.bulk_create(availability_windows_to_create)
-
-    @transaction.atomic()
     def batch_modify_available_times(
         self,
         calendar: Calendar,
@@ -1957,62 +1757,7 @@ class CalendarService(BaseCalendarService):
             (``id``, ``start_time``, ``end_time``, ``timezone``, ``rrule_string``).
         :return: The calendar's available times after the batch is applied.
         """
-        if not is_initialized_or_authenticated_calendar_service(self):
-            raise
-
-        if not calendar.manage_available_windows:
-            raise ValueError("This calendar does not manage available windows.")
-
-        scoped = AvailableTime.objects.filter_by_organization(self.organization.id).filter(
-            calendar_fk=calendar
-        )
-
-        for operation in operations:
-            action = operation["action"]
-
-            if action == "create":
-                recurrence_rule = self._create_recurrence_rule_if_needed(
-                    operation.get("rrule_string")
-                )
-                AvailableTime.objects.create(
-                    calendar=calendar,
-                    organization_id=calendar.organization_id,
-                    start_time_tz_unaware=operation["start_time"],
-                    end_time_tz_unaware=operation["end_time"],
-                    timezone=operation["timezone"],
-                    recurrence_rule=recurrence_rule,
-                )
-            elif action == "update":
-                try:
-                    available_time = scoped.get(id=operation["id"])
-                except AvailableTime.DoesNotExist as e:
-                    raise ValueError(
-                        f"Available time {operation['id']} not found in this calendar."
-                    ) from e
-                if "start_time" in operation:
-                    available_time.start_time_tz_unaware = operation["start_time"]
-                if "end_time" in operation:
-                    available_time.end_time_tz_unaware = operation["end_time"]
-                if "timezone" in operation:
-                    available_time.timezone = operation["timezone"]
-                if "rrule_string" in operation:
-                    available_time.recurrence_rule = self._create_recurrence_rule_if_needed(
-                        operation["rrule_string"]
-                    )
-                available_time.save()
-            elif action == "delete":
-                try:
-                    scoped.get(id=operation["id"]).delete()
-                except AvailableTime.DoesNotExist as e:
-                    raise ValueError(
-                        f"Available time {operation['id']} not found in this calendar."
-                    ) from e
-
-        return list(
-            AvailableTime.objects.filter_by_organization(self.organization.id).filter(
-                calendar_fk=calendar
-            )
-        )
+        return self._get_availability_service().batch_modify_available_times(calendar, operations)
 
     @transaction.atomic()
     def bulk_create_manual_blocked_times(
@@ -2053,7 +1798,6 @@ class CalendarService(BaseCalendarService):
         return BlockedTime.objects.bulk_create(blocked_times_to_create)
 
     # Convenience methods for single object creation
-    @transaction.atomic()
     def create_blocked_time(
         self,
         calendar: Calendar,
@@ -2064,13 +1808,15 @@ class CalendarService(BaseCalendarService):
         rrule_string: str | None = None,
     ) -> BlockedTime:
         """Create a single blocked time (optionally recurring)."""
-        result = self.bulk_create_manual_blocked_times(
+        return self._get_availability_service().create_blocked_time(
             calendar=calendar,
-            blocked_times=[(start_time, end_time, timezone, reason, rrule_string)],
+            start_time=start_time,
+            end_time=end_time,
+            timezone=timezone,
+            reason=reason,
+            rrule_string=rrule_string,
         )
-        return next(iter(result))
 
-    @transaction.atomic()
     def create_available_time(
         self,
         calendar: Calendar,
@@ -2080,10 +1826,13 @@ class CalendarService(BaseCalendarService):
         rrule_string: str | None = None,
     ) -> AvailableTime:
         """Create a single available time (optionally recurring)."""
-        result = self.bulk_create_availability_windows(
-            calendar=calendar, availability_windows=[(start_time, end_time, timezone, rrule_string)]
+        return self._get_availability_service().create_available_time(
+            calendar=calendar,
+            start_time=start_time,
+            end_time=end_time,
+            timezone=timezone,
+            rrule_string=rrule_string,
         )
-        return next(iter(result))
 
     def get_blocked_times_expanded(
         self,
@@ -2092,58 +1841,9 @@ class CalendarService(BaseCalendarService):
         end_date: datetime.datetime,
     ) -> list[BlockedTime]:
         """Get all blocked times in a date range with recurring blocked times expanded to instances."""
-        if not is_initialized_or_authenticated_calendar_service(self):
-            raise
-
-        # Get calendars to query - includes the main calendar and bundle children if applicable
-        calendars_to_query = [calendar]
-        if calendar.calendar_type == CalendarType.BUNDLE:
-            # Add all bundle children calendars
-            bundle_children = calendar.bundle_children.all()
-            calendars_to_query.extend(bundle_children)
-
-        base_qs = (
-            BlockedTime.objects.annotate_recurring_occurrences_on_date_range(
-                start_date, end_date, overlap=True
-            )
-            .select_related("recurrence_rule")
-            .filter(
-                organization_id=calendar.organization_id,
-                calendar__in=calendars_to_query,
-                parent_recurring_object__isnull=True,  # Master times only
-            )
+        return self._get_availability_service().get_blocked_times_expanded(
+            calendar, start_date, end_date
         )
-
-        # Get non-recurring times overlapping the date range. Interval overlap is
-        # start < range_end AND end > range_start — this also catches blocks that
-        # fully contain the range, which a start-or-end-inside filter would drop
-        # (and miss a block covering the whole booking, allowing a double-booking).
-        non_recurring_times = base_qs.filter(
-            start_time__lt=end_date,
-            end_time__gt=start_date,
-            recurrence_rule__isnull=True,  # Non-recurring only
-            is_recurring_exception=False,  # Exclude exception objects
-        )
-
-        # Get recurring master times and generate their instances
-        recurring_times = base_qs.filter(
-            recurrence_rule__isnull=False,  # Recurring only
-        ).filter(
-            Q(recurrence_rule__until__isnull=True) | Q(recurrence_rule__until__gte=start_date),
-            start_time__lte=end_date,
-        )
-
-        times: list[BlockedTime] = list(non_recurring_times)
-
-        for master_time in recurring_times:
-            instances = master_time.get_occurrences_in_range(
-                start_date, end_date, include_self=False, include_exceptions=True, overlap=True
-            )
-            times.extend(instances)
-
-        # Sort by start time
-        times.sort(key=lambda x: x.start_time)
-        return times
 
     def get_available_times_expanded(
         self,
@@ -2152,50 +1852,9 @@ class CalendarService(BaseCalendarService):
         end_date: datetime.datetime,
     ) -> list[AvailableTime]:
         """Get all available times in a date range with recurring available times expanded to instances."""
-        if not is_initialized_or_authenticated_calendar_service(self):
-            raise
-
-        base_qs = (
-            AvailableTime.objects.annotate_recurring_occurrences_on_date_range(
-                start_date, end_date, overlap=True
-            )
-            .select_related("recurrence_rule")
-            .filter(
-                organization_id=calendar.organization_id,
-                calendar=calendar,
-                parent_recurring_object__isnull=True,  # Master times only
-            )
+        return self._get_availability_service().get_available_times_expanded(
+            calendar, start_date, end_date
         )
-
-        # Get non-recurring times overlapping the date range. Interval overlap is
-        # start < range_end AND end > range_start — this also catches windows that
-        # fully contain the range, which a start-or-end-inside filter would drop.
-        non_recurring_times = base_qs.filter(
-            start_time__lt=end_date,
-            end_time__gt=start_date,
-            recurrence_rule__isnull=True,  # Non-recurring only
-            is_recurring_exception=False,  # Exclude exception objects
-        )
-
-        # Get recurring master times and generate their instances
-        recurring_times = base_qs.filter(
-            recurrence_rule__isnull=False,  # Recurring only
-        ).filter(
-            Q(recurrence_rule__until__isnull=True) | Q(recurrence_rule__until__gte=start_date),
-            start_time__lte=end_date,
-        )
-
-        times: list[AvailableTime] = list(non_recurring_times)
-
-        for master_time in recurring_times:
-            instances = master_time.get_occurrences_in_range(
-                start_date, end_date, include_self=False, include_exceptions=True, overlap=True
-            )
-            times.extend(instances)
-
-        # Sort by start time
-        times.sort(key=lambda x: x.start_time)
-        return times
 
     def create_recurring_blocked_time_exception(
         self,
@@ -2219,74 +1878,15 @@ class CalendarService(BaseCalendarService):
         :param is_cancelled: True if cancelling the occurrence, False if modifying
         :return: Created modified blocked time or None if cancelled
         """
-
-        def create_new_recurring_blocked_time(
-            parent_obj: RecurringMixin,
-            second_occurrence: RecurringMixin,
-            new_recurrence_rule: RecurrenceRule,
-        ) -> RecurringMixin:
-            parent_blocked_time = cast(BlockedTime, parent_obj)
-            second_blocked_time = cast(BlockedTime, second_occurrence)
-            return self.create_blocked_time(
-                calendar=parent_blocked_time.calendar,
-                start_time=second_blocked_time.start_time,
-                end_time=second_blocked_time.end_time,
-                timezone=second_blocked_time.timezone,
-                reason=second_blocked_time.reason,
-                rrule_string=new_recurrence_rule.to_rrule_string(),
-            )
-
-        def create_modified_blocked_time(
-            parent_obj: RecurringMixin,
-            exception_datetime: datetime.datetime,
-            modification_data: dict[str, Any],
-        ) -> RecurringMixin:
-            parent_blocked_time = cast(BlockedTime, parent_obj)
-            return self.create_blocked_time(
-                calendar=parent_blocked_time.calendar,
-                start_time=modification_data.get("start_time") or exception_datetime,
-                end_time=(
-                    modification_data.get("end_time")
-                    or (exception_datetime + parent_blocked_time.duration)
-                ),
-                timezone=modification_data.get("timezone") or parent_blocked_time.timezone,
-                reason=modification_data.get("reason") or parent_blocked_time.reason,
-            )
-
-        def update_exception_manager(
-            parent_obj: RecurringMixin, new_recurring_obj: RecurringMixin
-        ) -> None:
-            BlockedTimeRecurrenceException.objects.filter(parent_blocked_time=parent_obj).update(
-                parent_blocked_time_fk=new_recurring_obj
-            )
-
-        def delete_exception_manager(parent_obj: RecurringMixin) -> None:
-            BlockedTimeRecurrenceException.objects.filter(parent_blocked_time=parent_obj).delete()
-
-        modification_data = {
-            "reason": modified_reason,
-            "start_time": modified_start_time,
-            "end_time": modified_end_time,
-            "timezone": modified_timezone,
-        }
-
-        result = self._recurrence_manager.create_recurring_exception_generic(
-            self._context,
-            object_type_name="blocked time",
-            parent_object=parent_blocked_time,
-            exception_date=datetime.datetime.combine(
-                exception_date,
-                parent_blocked_time.start_time.time(),
-                tzinfo=parent_blocked_time.start_time.tzinfo,
-            ),
+        return self._get_availability_service().create_recurring_blocked_time_exception(
+            parent_blocked_time=parent_blocked_time,
+            exception_date=exception_date,
+            modified_reason=modified_reason,
+            modified_start_time=modified_start_time,
+            modified_end_time=modified_end_time,
+            modified_timezone=modified_timezone,
             is_cancelled=is_cancelled,
-            modification_data=modification_data,
-            create_new_recurring_callback=create_new_recurring_blocked_time,
-            create_modified_object_callback=create_modified_blocked_time,
-            exception_manager_update_callback=update_exception_manager,
-            exception_manager_delete_callback=delete_exception_manager,
         )
-        return cast(BlockedTime, result) if result else None
 
     def create_recurring_available_time_exception(
         self,
@@ -2308,73 +1908,14 @@ class CalendarService(BaseCalendarService):
         :param is_cancelled: True if cancelling the occurrence, False if modifying
         :return: Created modified available time or None if cancelled
         """
-
-        def create_new_recurring_available_time(
-            parent_obj: RecurringMixin,
-            second_occurrence: RecurringMixin,
-            new_recurrence_rule: RecurrenceRule,
-        ) -> RecurringMixin:
-            parent_available_time = cast(AvailableTime, parent_obj)
-            second_available_time = cast(AvailableTime, second_occurrence)
-            return self.create_available_time(
-                calendar=parent_available_time.calendar,
-                start_time=second_available_time.start_time,
-                end_time=second_available_time.end_time,
-                timezone=second_available_time.timezone,
-                rrule_string=new_recurrence_rule.to_rrule_string(),
-            )
-
-        def create_modified_available_time(
-            parent_obj: RecurringMixin,
-            exception_datetime: datetime.datetime,
-            modification_data: dict[str, Any],
-        ) -> RecurringMixin:
-            parent_available_time = cast(AvailableTime, parent_obj)
-            return self.create_available_time(
-                calendar=parent_available_time.calendar,
-                start_time=modification_data.get("start_time") or exception_datetime,
-                end_time=(
-                    modification_data.get("end_time")
-                    or (exception_datetime + parent_available_time.duration)
-                ),
-                timezone=modification_data.get("timezone") or parent_available_time.timezone,
-            )
-
-        def update_exception_manager(
-            parent_obj: RecurringMixin, new_recurring_obj: RecurringMixin
-        ) -> None:
-            AvailableTimeRecurrenceException.objects.filter(
-                parent_available_time=parent_obj
-            ).update(parent_available_time_fk=new_recurring_obj)
-
-        def delete_exception_manager(parent_obj: RecurringMixin) -> None:
-            AvailableTimeRecurrenceException.objects.filter(
-                parent_available_time=parent_obj
-            ).delete()
-
-        modification_data = {
-            "start_time": modified_start_time,
-            "end_time": modified_end_time,
-            "timezone": modified_timezone,
-        }
-
-        result = self._recurrence_manager.create_recurring_exception_generic(
-            self._context,
-            object_type_name="available time",
-            parent_object=parent_available_time,
-            exception_date=datetime.datetime.combine(
-                exception_date,
-                parent_available_time.start_time.time(),
-                tzinfo=parent_available_time.start_time.tzinfo,
-            ),
+        return self._get_availability_service().create_recurring_available_time_exception(
+            parent_available_time=parent_available_time,
+            exception_date=exception_date,
+            modified_start_time=modified_start_time,
+            modified_end_time=modified_end_time,
+            modified_timezone=modified_timezone,
             is_cancelled=is_cancelled,
-            modification_data=modification_data,
-            create_new_recurring_callback=create_new_recurring_available_time,
-            create_modified_object_callback=create_modified_available_time,
-            exception_manager_update_callback=update_exception_manager,
-            exception_manager_delete_callback=delete_exception_manager,
         )
-        return cast(AvailableTime, result) if result else None
 
     def create_recurring_event_bulk_modification(
         self,
@@ -2410,76 +1951,15 @@ class CalendarService(BaseCalendarService):
         modification_rrule_string: str | None = None,
     ) -> BlockedTime | None:
         """Create a bulk modification for a recurring blocked time from the specified date onwards."""
-
-        def truncate_parent(
-            parent_obj: RecurringMixin,
-            new_recurrence_rule: RecurrenceRule | None,
-        ):
-            parent = cast(BlockedTime, parent_obj)
-            parent.recurrence_rule_fk = new_recurrence_rule  # type: ignore
-            parent.save()
-            return parent
-
-        def create_continuation(
-            parent_obj: RecurringMixin,
-            start_dt: datetime.datetime,
-            recurrence_rule: RecurrenceRule | None,
-            modification_data: dict[str, Any],
-        ) -> RecurringMixin:
-            parent = cast(BlockedTime, parent_obj)
-            new_start = (
-                (start_dt + modification_data["start_time_offset"])
-                if modification_data.get("start_time_offset")
-                else start_dt
-            )
-            duration = parent.duration
-            new_end = (
-                new_start + modification_data["end_time_offset"]
-                if modification_data.get("end_time_offset")
-                else new_start + duration
-            )
-            return self.create_blocked_time(
-                calendar=parent.calendar,
-                start_time=new_start,
-                end_time=new_end,
-                timezone=parent.timezone,
-                reason=modification_data.get("reason") or parent.reason,
-                rrule_string=recurrence_rule.to_rrule_string() if recurrence_rule else None,
-            )
-
-        def record_bulk(
-            parent_obj: RecurringMixin,
-            start_dt: datetime.datetime,
-            continuation_obj: RecurringMixin | None,
-            cancelled: bool,
-        ):
-            BlockedTimeBulkModification.objects.create(
-                organization=parent_obj.organization,
-                parent_blocked_time=parent_obj,
-                modification_start_date=start_dt,
-                modified_continuation=None,
-                is_bulk_cancelled=cancelled,
-            )
-
-        modification_data = {
-            "reason": modified_reason,
-            "start_time_offset": modified_start_time_offset,
-            "end_time_offset": modified_end_time_offset,
-        }
-
-        result = self._recurrence_manager.create_recurring_bulk_modification_generic(
-            self._context,
-            object_type_name="blocked time",
-            parent_object=parent_blocked_time,
+        return self._get_availability_service().create_recurring_blocked_time_bulk_modification(
+            parent_blocked_time=parent_blocked_time,
             modification_start_date=modification_start_date,
+            modified_reason=modified_reason,
+            modified_start_time_offset=modified_start_time_offset,
+            modified_end_time_offset=modified_end_time_offset,
             is_bulk_cancelled=is_bulk_cancelled,
-            modification_data=modification_data,
-            truncate_parent_callback=truncate_parent,
-            create_continuation_callback=create_continuation,
-            bulk_modification_record_callback=record_bulk,
             modification_rrule_string=modification_rrule_string,
         )
-        return cast(BlockedTime, result) if result else None
 
     def create_recurring_available_time_bulk_modification(
         self,
@@ -2491,74 +1971,14 @@ class CalendarService(BaseCalendarService):
         modification_rrule_string: str | None = None,
     ) -> AvailableTime | None:
         """Create a bulk modification for a recurring available time from the specified date onwards."""
-
-        def truncate_parent(
-            parent_obj: RecurringMixin,
-            new_recurrence_rule: RecurrenceRule | None,
-        ):
-            parent = cast(AvailableTime, parent_obj)
-            parent.recurrence_rule_fk = new_recurrence_rule  # type: ignore
-            parent.save()
-            return parent
-
-        def create_continuation(
-            parent_obj: RecurringMixin,
-            start_dt: datetime.datetime,
-            recurrence_rule: RecurrenceRule | None,
-            modification_data: dict[str, Any],
-        ) -> RecurringMixin:
-            parent = cast(AvailableTime, parent_obj)
-            new_start = (
-                (start_dt + modification_data["start_time_offset"])
-                if modification_data.get("start_time_offset")
-                else start_dt
-            )
-            duration = parent.duration
-            new_end = (
-                new_start + modification_data["end_time_offset"]
-                if modification_data.get("end_time_offset")
-                else new_start + duration
-            )
-            return self.create_available_time(
-                calendar=parent.calendar,
-                start_time=new_start,
-                end_time=new_end,
-                timezone=parent.timezone,
-                rrule_string=recurrence_rule.to_rrule_string() if recurrence_rule else None,
-            )
-
-        def record_bulk(
-            parent_obj: RecurringMixin,
-            start_dt: datetime.datetime,
-            continuation_obj: RecurringMixin | None,
-            cancelled: bool,
-        ):
-            AvailableTimeBulkModification.objects.create(
-                organization=parent_obj.organization,
-                parent_available_time=parent_obj,
-                modification_start_date=start_dt,
-                modified_continuation=None,
-                is_bulk_cancelled=cancelled,
-            )
-
-        modification_data = {
-            "start_time_offset": modified_start_time_offset,
-            "end_time_offset": modified_end_time_offset,
-        }
-
-        result = self._recurrence_manager.create_recurring_bulk_modification_generic(
-            self._context,
-            object_type_name="available time",
-            parent_object=parent_available_time,
+        return self._get_availability_service().create_recurring_available_time_bulk_modification(
+            parent_available_time=parent_available_time,
             modification_start_date=modification_start_date,
+            modified_start_time_offset=modified_start_time_offset,
+            modified_end_time_offset=modified_end_time_offset,
             is_bulk_cancelled=is_bulk_cancelled,
-            modification_data=modification_data,
-            truncate_parent_callback=truncate_parent,
-            create_continuation_callback=create_continuation,
-            bulk_modification_record_callback=record_bulk,
             modification_rrule_string=modification_rrule_string,
         )
-        return cast(AvailableTime, result) if result else None
 
     def modify_recurring_event_from_date(
         self,
@@ -2603,17 +2023,14 @@ class CalendarService(BaseCalendarService):
         modified_end_time_offset: datetime.timedelta | None = None,
         modification_rrule_string: str | None = None,
     ) -> BlockedTime | None:
-        continuation = self.create_recurring_blocked_time_bulk_modification(
+        return self._get_availability_service().modify_recurring_blocked_time_from_date(
             parent_blocked_time=parent_blocked_time,
             modification_start_date=modification_start_date,
             modified_reason=modified_reason,
             modified_start_time_offset=modified_start_time_offset,
             modified_end_time_offset=modified_end_time_offset,
-            is_bulk_cancelled=False,
             modification_rrule_string=modification_rrule_string,
         )
-
-        return continuation
 
     def cancel_recurring_blocked_time_from_date(
         self,
@@ -2621,10 +2038,9 @@ class CalendarService(BaseCalendarService):
         modification_start_date: datetime.datetime,
         modification_rrule_string: str | None = None,
     ) -> None:
-        self.create_recurring_blocked_time_bulk_modification(
+        self._get_availability_service().cancel_recurring_blocked_time_from_date(
             parent_blocked_time=parent_blocked_time,
             modification_start_date=modification_start_date,
-            is_bulk_cancelled=True,
             modification_rrule_string=modification_rrule_string,
         )
 
@@ -2636,16 +2052,13 @@ class CalendarService(BaseCalendarService):
         modified_end_time_offset: datetime.timedelta | None = None,
         modification_rrule_string: str | None = None,
     ) -> AvailableTime | None:
-        continuation = self.create_recurring_available_time_bulk_modification(
+        return self._get_availability_service().modify_recurring_available_time_from_date(
             parent_available_time=parent_available_time,
             modification_start_date=modification_start_date,
             modified_start_time_offset=modified_start_time_offset,
             modified_end_time_offset=modified_end_time_offset,
-            is_bulk_cancelled=False,
             modification_rrule_string=modification_rrule_string,
         )
-
-        return continuation
 
     def cancel_recurring_available_time_from_date(
         self,
@@ -2653,10 +2066,9 @@ class CalendarService(BaseCalendarService):
         modification_start_date: datetime.datetime,
         modification_rrule_string: str | None = None,
     ) -> None:
-        self.create_recurring_available_time_bulk_modification(
+        self._get_availability_service().cancel_recurring_available_time_from_date(
             parent_available_time=parent_available_time,
             modification_start_date=modification_start_date,
-            is_bulk_cancelled=True,
             modification_rrule_string=modification_rrule_string,
         )
 

--- a/calendar_integration/tests/services/test_availability_service.py
+++ b/calendar_integration/tests/services/test_availability_service.py
@@ -16,13 +16,17 @@ from unittest.mock import MagicMock
 import pytest
 from allauth.socialaccount.models import SocialAccount
 
-from calendar_integration.constants import CalendarProvider
+from calendar_integration.constants import CalendarProvider, CalendarType
 from calendar_integration.models import (
     AvailableTime,
+    AvailableTimeBulkModification,
+    AvailableTimeRecurrenceException,
     BlockedTime,
+    BlockedTimeBulkModification,
     BlockedTimeRecurrenceException,
     Calendar,
     CalendarEvent,
+    ChildrenCalendarRelationship,
     RecurrenceRule,
 )
 from calendar_integration.services.availability_service import AvailabilityService
@@ -464,3 +468,1300 @@ def test_subtract_busy_intervals_splits_correctly() -> None:
     assert free[0] == (window_start, busy1_start)
     assert free[1] == (busy1_end, busy2_start)
     assert free[2] == (busy2_end, window_end)
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_recurring_available_time_exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_recurring_available_time_exception_cancels_occurrence(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Cancelling a recurring available-time occurrence creates an AvailableTimeRecurrenceException."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=WEEKLY;COUNT=5;BYDAY=MO", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 9, 1, 10, 0, tzinfo=datetime.UTC)  # Monday
+    parent_available = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=2),
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    # Cancel the second occurrence (one week later)
+    exception_date = (parent_start + datetime.timedelta(weeks=1)).date()
+    result = service.create_recurring_available_time_exception(
+        parent_available_time=parent_available,
+        exception_date=exception_date,
+        is_cancelled=True,
+    )
+
+    # Cancelled exception returns None
+    assert result is None
+    # An AvailableTimeRecurrenceException should exist marking the cancelled occurrence
+    assert AvailableTimeRecurrenceException.objects.filter(
+        parent_available_time=parent_available,
+        is_cancelled=True,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_recurring_available_time_exception_modifies_occurrence(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Modifying a recurring available-time occurrence creates a modified AvailableTime."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=WEEKLY;COUNT=5;BYDAY=TU", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 9, 2, 10, 0, tzinfo=datetime.UTC)  # Tuesday
+    parent_available = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=2),
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    exception_date = (parent_start + datetime.timedelta(weeks=1)).date()
+    modified_start = datetime.datetime(2025, 9, 9, 11, 0, tzinfo=datetime.UTC)
+    modified_end = datetime.datetime(2025, 9, 9, 13, 0, tzinfo=datetime.UTC)
+
+    result = service.create_recurring_available_time_exception(
+        parent_available_time=parent_available,
+        exception_date=exception_date,
+        modified_start_time=modified_start,
+        modified_end_time=modified_end,
+        is_cancelled=False,
+    )
+
+    # Modified exception returns the new AvailableTime
+    assert result is not None
+    assert result.pk is not None
+    assert result.start_time == modified_start
+    assert result.end_time == modified_end
+    # A non-cancelled exception should exist
+    assert AvailableTimeRecurrenceException.objects.filter(
+        parent_available_time=parent_available,
+        is_cancelled=False,
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_recurring_blocked_time_bulk_modification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_recurring_blocked_time_bulk_modification_creates_continuation(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Bulk-modifying a recurring blocked time creates a continuation and a record."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    # Daily recurring blocked time, COUNT=7 to have enough occurrences to split
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=7", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 10, 1, 9, 0, tzinfo=datetime.UTC)
+    parent_blocked = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Daily block",
+        external_id="bulk_bt_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    # Modify from the 4th occurrence (day 4, index 3)
+    modification_start = parent_start + datetime.timedelta(days=3)
+
+    result = service.create_recurring_blocked_time_bulk_modification(
+        parent_blocked_time=parent_blocked,
+        modification_start_date=modification_start,
+        modified_reason="Modified reason",
+        is_bulk_cancelled=False,
+    )
+
+    # A continuation object is returned
+    assert result is not None
+    assert result.pk is not None
+    assert result.reason == "Modified reason"
+    assert result.start_time == modification_start
+
+    # A BlockedTimeBulkModification record should exist for the parent
+    parent_blocked.refresh_from_db()
+    assert BlockedTimeBulkModification.objects.filter(
+        parent_blocked_time=parent_blocked,
+        is_bulk_cancelled=False,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_recurring_blocked_time_bulk_modification_cancels_series(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Bulk-cancelling a recurring blocked time from a date records the cancellation."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 10, 6, 9, 0, tzinfo=datetime.UTC)
+    parent_blocked = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Cancel block",
+        external_id="bulk_bt_cancel_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    modification_start = parent_start + datetime.timedelta(days=2)
+
+    result = service.create_recurring_blocked_time_bulk_modification(
+        parent_blocked_time=parent_blocked,
+        modification_start_date=modification_start,
+        is_bulk_cancelled=True,
+    )
+
+    # Returns None for a cancellation
+    assert result is None
+    # A cancellation record must exist
+    assert BlockedTimeBulkModification.objects.filter(
+        parent_blocked_time=parent_blocked,
+        is_bulk_cancelled=True,
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_recurring_available_time_bulk_modification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_recurring_available_time_bulk_modification_creates_continuation(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Bulk-modifying a recurring available time creates a continuation and a record."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=7", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 11, 1, 10, 0, tzinfo=datetime.UTC)
+    parent_available = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=2),
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    modification_start = parent_start + datetime.timedelta(days=3)
+
+    result = service.create_recurring_available_time_bulk_modification(
+        parent_available_time=parent_available,
+        modification_start_date=modification_start,
+        is_bulk_cancelled=False,
+    )
+
+    # A continuation object is returned
+    assert result is not None
+    assert result.pk is not None
+    assert result.start_time == modification_start
+
+    # A AvailableTimeBulkModification record should exist
+    parent_available.refresh_from_db()
+    assert AvailableTimeBulkModification.objects.filter(
+        parent_available_time=parent_available,
+        is_bulk_cancelled=False,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_recurring_available_time_bulk_modification_cancels_series(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Bulk-cancelling a recurring available time from a date records the cancellation."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 11, 6, 10, 0, tzinfo=datetime.UTC)
+    parent_available = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=2),
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    modification_start = parent_start + datetime.timedelta(days=2)
+
+    result = service.create_recurring_available_time_bulk_modification(
+        parent_available_time=parent_available,
+        modification_start_date=modification_start,
+        is_bulk_cancelled=True,
+    )
+
+    assert result is None
+    assert AvailableTimeBulkModification.objects.filter(
+        parent_available_time=parent_available,
+        is_bulk_cancelled=True,
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: modify/cancel recurring blocked-time from-date (thin wrappers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_modify_recurring_blocked_time_from_date_delegates_with_not_cancelled(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """modify_recurring_blocked_time_from_date delegates with is_bulk_cancelled=False."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=6", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 12, 1, 9, 0, tzinfo=datetime.UTC)
+    parent_blocked = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Original reason",
+        external_id="modify_from_date_bt_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    modification_start = parent_start + datetime.timedelta(days=2)
+    result = service.modify_recurring_blocked_time_from_date(
+        parent_blocked_time=parent_blocked,
+        modification_start_date=modification_start,
+        modified_reason="New reason",
+    )
+
+    # A continuation is returned (not None) — confirms is_bulk_cancelled=False
+    assert result is not None
+    assert result.reason == "New reason"
+    assert BlockedTimeBulkModification.objects.filter(
+        parent_blocked_time=parent_blocked,
+        is_bulk_cancelled=False,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_cancel_recurring_blocked_time_from_date_delegates_with_cancelled(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """cancel_recurring_blocked_time_from_date delegates with is_bulk_cancelled=True."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 12, 8, 9, 0, tzinfo=datetime.UTC)
+    parent_blocked = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Cancel this",
+        external_id="cancel_from_date_bt_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    modification_start = parent_start + datetime.timedelta(days=2)
+    # cancel_recurring_blocked_time_from_date returns None (it's a fire-and-forget cancellation)
+    service.cancel_recurring_blocked_time_from_date(
+        parent_blocked_time=parent_blocked,
+        modification_start_date=modification_start,
+    )
+
+    assert BlockedTimeBulkModification.objects.filter(
+        parent_blocked_time=parent_blocked,
+        is_bulk_cancelled=True,
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: modify/cancel recurring available-time from-date (thin wrappers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_modify_recurring_available_time_from_date_delegates_with_not_cancelled(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """modify_recurring_available_time_from_date delegates with is_bulk_cancelled=False."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=6", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 12, 15, 10, 0, tzinfo=datetime.UTC)
+    parent_available = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=2),
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    modification_start = parent_start + datetime.timedelta(days=2)
+    result = service.modify_recurring_available_time_from_date(
+        parent_available_time=parent_available,
+        modification_start_date=modification_start,
+    )
+
+    # A continuation is returned — confirms is_bulk_cancelled=False
+    assert result is not None
+    assert AvailableTimeBulkModification.objects.filter(
+        parent_available_time=parent_available,
+        is_bulk_cancelled=False,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_cancel_recurring_available_time_from_date_delegates_with_cancelled(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """cancel_recurring_available_time_from_date delegates with is_bulk_cancelled=True."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 12, 22, 10, 0, tzinfo=datetime.UTC)
+    parent_available = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=2),
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    modification_start = parent_start + datetime.timedelta(days=2)
+    # cancel_recurring_available_time_from_date returns None (fire-and-forget cancellation)
+    service.cancel_recurring_available_time_from_date(
+        parent_available_time=parent_available,
+        modification_start_date=modification_start,
+    )
+
+    assert AvailableTimeBulkModification.objects.filter(
+        parent_available_time=parent_available,
+        is_bulk_cancelled=True,
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: batch_modify_available_times
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_create_operation(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times with 'create' action persists a new AvailableTime."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 7, 10, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=2)
+
+    result = service.batch_modify_available_times(
+        calendar=managed_calendar,
+        operations=[
+            {
+                "action": "create",
+                "start_time": start,
+                "end_time": end,
+                "timezone": "UTC",
+            }
+        ],
+    )
+
+    assert len(result) == 1
+    assert result[0].start_time == start
+    assert result[0].end_time == end
+    assert (
+        AvailableTime.objects.filter(
+            calendar=managed_calendar,
+            organization_id=organization.id,
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_update_operation(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times with 'update' action modifies an existing AvailableTime."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 7, 11, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=2)
+    existing = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        organization=organization,
+    )
+
+    new_start = datetime.datetime(2025, 7, 11, 10, 0, tzinfo=datetime.UTC)
+    new_end = new_start + datetime.timedelta(hours=3)
+
+    result = service.batch_modify_available_times(
+        calendar=managed_calendar,
+        operations=[
+            {
+                "action": "update",
+                "id": existing.pk,
+                "start_time": new_start,
+                "end_time": new_end,
+                "timezone": "UTC",
+            }
+        ],
+    )
+
+    assert len(result) == 1
+    updated = result[0]
+    # start_time is a GeneratedField; compare start_time (UTC-aware) directly
+    assert updated.start_time == new_start
+    assert updated.end_time == new_end
+    assert updated.timezone == "UTC"
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_delete_operation(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times with 'delete' action removes an existing AvailableTime."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 7, 12, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=2)
+    existing = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        organization=organization,
+    )
+
+    result = service.batch_modify_available_times(
+        calendar=managed_calendar,
+        operations=[
+            {
+                "action": "delete",
+                "id": existing.pk,
+            }
+        ],
+    )
+
+    assert result == []
+    assert not AvailableTime.objects.filter(pk=existing.pk).exists()
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_update_missing_id_raises(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times with 'update' on unknown id raises ValueError."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    with pytest.raises(ValueError, match="not found in this calendar"):
+        service.batch_modify_available_times(
+            calendar=managed_calendar,
+            operations=[
+                {
+                    "action": "update",
+                    "id": 99999999,
+                    "start_time": datetime.datetime(2025, 7, 13, 9, 0, tzinfo=datetime.UTC),
+                    "end_time": datetime.datetime(2025, 7, 13, 10, 0, tzinfo=datetime.UTC),
+                    "timezone": "UTC",
+                }
+            ],
+        )
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_delete_missing_id_raises(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times with 'delete' on unknown id raises ValueError."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    with pytest.raises(ValueError, match="not found in this calendar"):
+        service.batch_modify_available_times(
+            calendar=managed_calendar,
+            operations=[
+                {
+                    "action": "delete",
+                    "id": 99999999,
+                }
+            ],
+        )
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_calendar_not_managed_raises(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times raises ValueError when calendar does not manage windows."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    with pytest.raises(ValueError, match="does not manage available windows"):
+        service.batch_modify_available_times(
+            calendar=calendar,  # manage_available_windows=False
+            operations=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: bulk_create_availability_windows branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bulk_create_availability_windows_creates_without_rrule(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """bulk_create_availability_windows without rrule_string sets recurrence_rule=None."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 8, 1, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+
+    result = list(
+        service.bulk_create_availability_windows(
+            calendar=managed_calendar,
+            availability_windows=[(start, end, "UTC", None)],
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0].pk is not None
+    assert result[0].recurrence_rule is None
+
+
+@pytest.mark.django_db
+def test_bulk_create_availability_windows_creates_with_rrule(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """bulk_create_availability_windows with rrule_string creates a RecurrenceRule and links it."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 8, 5, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+
+    result = list(
+        service.bulk_create_availability_windows(
+            calendar=managed_calendar,
+            availability_windows=[(start, end, "UTC", "FREQ=DAILY;COUNT=3")],
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0].pk is not None
+    assert result[0].recurrence_rule is not None
+    assert result[0].recurrence_rule.count == 3
+
+
+@pytest.mark.django_db
+def test_bulk_create_availability_windows_not_managed_raises(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """bulk_create_availability_windows raises ValueError for unmanaged calendar."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 8, 1, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+
+    with pytest.raises(ValueError, match="does not manage available windows"):
+        list(
+            service.bulk_create_availability_windows(
+                calendar=calendar,  # manage_available_windows=False
+                availability_windows=[(start, end, "UTC", None)],
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_available_times_expanded (recurring available times)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_available_times_expanded_recurring_generates_instances(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """A recurring available time generates multiple occurrences in the range."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization)
+    rule.save()
+
+    start = datetime.datetime(2025, 9, 8, 10, 0, tzinfo=datetime.UTC)  # Monday
+    end = start + datetime.timedelta(hours=2)
+    AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    range_start = start
+    range_end = start + datetime.timedelta(days=10)
+    results = service.get_available_times_expanded(
+        calendar=managed_calendar,
+        start_date=range_start,
+        end_date=range_end,
+    )
+
+    # COUNT=5 means 5 occurrences total
+    assert len(results) == 5
+
+
+@pytest.mark.django_db
+def test_get_available_times_expanded_non_recurring_included(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Non-recurring available times are returned if they overlap the query range."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 9, 15, 10, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=2)
+    at = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        organization=organization,
+    )
+
+    range_start = start - datetime.timedelta(hours=1)
+    range_end = end + datetime.timedelta(hours=1)
+    results = service.get_available_times_expanded(
+        calendar=managed_calendar,
+        start_date=range_start,
+        end_date=range_end,
+    )
+
+    assert len(results) == 1
+    assert results[0].pk == at.pk
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_unavailable_time_windows_in_range — additional branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_unavailable_time_windows_in_range_with_blocked_time(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """get_unavailable_time_windows_in_range returns blocked-time windows."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    start = datetime.datetime(2025, 10, 1, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        reason="Blocked",
+        external_id="unavail_bt_001",
+        organization=organization,
+    )
+
+    range_start = start - datetime.timedelta(hours=1)
+    range_end = end + datetime.timedelta(hours=1)
+    windows = service.get_unavailable_time_windows_in_range(
+        calendar=calendar,
+        start_datetime=range_start,
+        end_datetime=range_end,
+    )
+
+    assert len(windows) == 1
+    assert windows[0].reason == "blocked_time"
+    assert windows[0].start_time == start
+    assert windows[0].end_time == end
+
+
+@pytest.mark.django_db
+def test_get_unavailable_time_windows_in_range_with_bundle_events(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Bundle events are included if the child calendar belongs to a bundle."""
+    event_start = datetime.datetime(2025, 10, 5, 14, 0, tzinfo=datetime.UTC)
+    event_end = datetime.datetime(2025, 10, 5, 15, 0, tzinfo=datetime.UTC)
+
+    # Create a bundle calendar with our calendar as a child
+    bundle_calendar = Calendar.objects.create(
+        name="Bundle Calendar",
+        external_id="bundle_cal_001",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+        calendar_type=CalendarType.BUNDLE,
+    )
+    # Use the through model to avoid OrganizationForeignKey lookup issues
+    ChildrenCalendarRelationship.objects.create(
+        bundle_calendar=bundle_calendar,
+        child_calendar=calendar,
+        organization=organization,
+    )
+
+    # Create a bundle event on the bundle calendar
+    CalendarEvent.objects.create(
+        calendar=calendar,
+        bundle_calendar=bundle_calendar,
+        title="Bundle Event",
+        external_id="bundle_event_001",
+        start_time_tz_unaware=event_start,
+        end_time_tz_unaware=event_end,
+        timezone="UTC",
+        organization=organization,
+    )
+
+    # FakeHost returns no events for this calendar specifically
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    range_start = event_start - datetime.timedelta(hours=1)
+    range_end = event_end + datetime.timedelta(hours=1)
+    windows = service.get_unavailable_time_windows_in_range(
+        calendar=calendar,
+        start_datetime=range_start,
+        end_datetime=range_end,
+    )
+
+    # The bundle event should be included as unavailable
+    assert any(w.reason == "calendar_event" for w in windows)
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_availability_windows_in_range — managed calendar branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_managed_calendar_subtracts_busy(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Managed calendar: availability windows are available times minus busy intervals."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    window_start = datetime.datetime(2025, 10, 10, 8, 0, tzinfo=datetime.UTC)
+    window_end = datetime.datetime(2025, 10, 10, 18, 0, tzinfo=datetime.UTC)
+    # Create an available-time window for the whole day
+    AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=window_start,
+        end_time_tz_unaware=window_end,
+        timezone="UTC",
+        organization=organization,
+    )
+
+    # Create a blocked time in the middle
+    bt_start = datetime.datetime(2025, 10, 10, 11, 0, tzinfo=datetime.UTC)
+    bt_end = datetime.datetime(2025, 10, 10, 12, 0, tzinfo=datetime.UTC)
+    BlockedTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=bt_start,
+        end_time_tz_unaware=bt_end,
+        timezone="UTC",
+        reason="Lunch",
+        external_id="managed_busy_001",
+        organization=organization,
+    )
+
+    windows = list(
+        service.get_availability_windows_in_range(managed_calendar, window_start, window_end)
+    )
+
+    # Should have 2 windows after subtracting the blocked time
+    assert len(windows) == 2
+    assert windows[0].start_time == window_start
+    assert windows[0].end_time == bt_start
+    assert windows[1].start_time == bt_end
+    assert windows[1].end_time == window_end
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_no_unavailable_windows_returns_full_range(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Without busy intervals, the entire date range is returned as a single window."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    start = datetime.datetime(2025, 10, 15, 8, 0, tzinfo=datetime.UTC)
+    end = datetime.datetime(2025, 10, 15, 18, 0, tzinfo=datetime.UTC)
+    windows = list(service.get_availability_windows_in_range(calendar, start, end))
+
+    assert len(windows) == 1
+    assert windows[0].start_time == start
+    assert windows[0].end_time == end
+    assert windows[0].can_book_partially is True
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_adjacent_busy_intervals(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Adjacent blocked times that abut produce only the gaps before first and after last."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    range_start = datetime.datetime(2025, 10, 20, 8, 0, tzinfo=datetime.UTC)
+    range_end = datetime.datetime(2025, 10, 20, 18, 0, tzinfo=datetime.UTC)
+
+    # Two adjacent blocks that cover 10:00-12:00 together
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=datetime.datetime(2025, 10, 20, 10, 0, tzinfo=datetime.UTC),
+        end_time_tz_unaware=datetime.datetime(2025, 10, 20, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        reason="Block A",
+        external_id="adj_bt_001",
+        organization=organization,
+    )
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=datetime.datetime(2025, 10, 20, 11, 0, tzinfo=datetime.UTC),
+        end_time_tz_unaware=datetime.datetime(2025, 10, 20, 12, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        reason="Block B",
+        external_id="adj_bt_002",
+        organization=organization,
+    )
+
+    windows = list(service.get_availability_windows_in_range(calendar, range_start, range_end))
+
+    # Should have 2 windows: 08:00-10:00 and 12:00-18:00
+    assert len(windows) == 2
+    assert windows[0].end_time == datetime.datetime(2025, 10, 20, 10, 0, tzinfo=datetime.UTC)
+    assert windows[1].start_time == datetime.datetime(2025, 10, 20, 12, 0, tzinfo=datetime.UTC)
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_busy_covers_start(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Busy interval covering the start of the range leaves only the trailing gap."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    range_start = datetime.datetime(2025, 10, 22, 8, 0, tzinfo=datetime.UTC)
+    range_end = datetime.datetime(2025, 10, 22, 18, 0, tzinfo=datetime.UTC)
+
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=range_start,
+        end_time_tz_unaware=datetime.datetime(2025, 10, 22, 12, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        reason="Morning block",
+        external_id="start_cover_bt_001",
+        organization=organization,
+    )
+
+    windows = list(service.get_availability_windows_in_range(calendar, range_start, range_end))
+
+    # Only one window at the end
+    assert len(windows) == 1
+    assert windows[0].start_time == datetime.datetime(2025, 10, 22, 12, 0, tzinfo=datetime.UTC)
+    assert windows[0].end_time == range_end
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_gap_between_blocks_produces_middle_window(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """When two non-adjacent busy intervals exist the gap between them is an available window."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    range_start = datetime.datetime(2025, 11, 3, 8, 0, tzinfo=datetime.UTC)
+    range_end = datetime.datetime(2025, 11, 3, 18, 0, tzinfo=datetime.UTC)
+
+    # Block 10-11
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=datetime.datetime(2025, 11, 3, 10, 0, tzinfo=datetime.UTC),
+        end_time_tz_unaware=datetime.datetime(2025, 11, 3, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        reason="Block X",
+        external_id="gap_bt_001",
+        organization=organization,
+    )
+    # Block 13-14 (non-adjacent, gap between 11:00 and 13:00)
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=datetime.datetime(2025, 11, 3, 13, 0, tzinfo=datetime.UTC),
+        end_time_tz_unaware=datetime.datetime(2025, 11, 3, 14, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        reason="Block Y",
+        external_id="gap_bt_002",
+        organization=organization,
+    )
+
+    windows = list(service.get_availability_windows_in_range(calendar, range_start, range_end))
+
+    # Should be 3 windows: 08-10, 11-13, 14-18
+    assert len(windows) == 3
+    assert windows[1].start_time == datetime.datetime(2025, 11, 3, 11, 0, tzinfo=datetime.UTC)
+    assert windows[1].end_time == datetime.datetime(2025, 11, 3, 13, 0, tzinfo=datetime.UTC)
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_busy_at_end_no_trailing_window(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """When the busy interval ends at the range boundary there is no trailing available window."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+
+    range_start = datetime.datetime(2025, 11, 5, 8, 0, tzinfo=datetime.UTC)
+    range_end = datetime.datetime(2025, 11, 5, 18, 0, tzinfo=datetime.UTC)
+
+    # Busy from 12 to end of range
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=datetime.datetime(2025, 11, 5, 12, 0, tzinfo=datetime.UTC),
+        end_time_tz_unaware=range_end,
+        timezone="UTC",
+        reason="Block to end",
+        external_id="end_bt_001",
+        organization=organization,
+    )
+
+    windows = list(service.get_availability_windows_in_range(calendar, range_start, range_end))
+
+    # Only one window before the block; no trailing window
+    assert len(windows) == 1
+    assert windows[0].start_time == range_start
+    assert windows[0].end_time == datetime.datetime(2025, 11, 5, 12, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_recurring_blocked_time_exception — modify path and first-occurrence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_recurring_blocked_time_exception_modifies_future_occurrence(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Modifying a future recurring blocked-time occurrence creates a modified BlockedTime."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=WEEKLY;COUNT=5;BYDAY=WE", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2026, 1, 7, 9, 0, tzinfo=datetime.UTC)  # Wednesday
+    parent_blocked = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Weekly block",
+        external_id="modify_bt_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    # Modify the second occurrence (one week later)
+    exception_date = (parent_start + datetime.timedelta(weeks=1)).date()
+    modified_start = datetime.datetime(2026, 1, 14, 10, 0, tzinfo=datetime.UTC)
+    modified_end = datetime.datetime(2026, 1, 14, 11, 30, tzinfo=datetime.UTC)
+
+    result = service.create_recurring_blocked_time_exception(
+        parent_blocked_time=parent_blocked,
+        exception_date=exception_date,
+        modified_start_time=modified_start,
+        modified_end_time=modified_end,
+        is_cancelled=False,
+    )
+
+    assert result is not None
+    assert result.pk is not None
+    assert result.start_time == modified_start
+    assert result.end_time == modified_end
+    # A non-cancelled exception should exist
+    assert BlockedTimeRecurrenceException.objects.filter(
+        parent_blocked_time=parent_blocked,
+        is_cancelled=False,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_recurring_blocked_time_exception_third_occurrence(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Cancelling the third occurrence of a recurring blocked time creates a cancellation record."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=WEEKLY;COUNT=5;BYDAY=TH", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2026, 1, 8, 9, 0, tzinfo=datetime.UTC)  # Thursday
+    parent_blocked = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Thursday block",
+        external_id="third_occur_bt_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    # Cancel the THIRD occurrence (two weeks later)
+    exception_date = (parent_start + datetime.timedelta(weeks=2)).date()
+    result = service.create_recurring_blocked_time_exception(
+        parent_blocked_time=parent_blocked,
+        exception_date=exception_date,
+        is_cancelled=True,
+    )
+
+    assert result is None
+    assert BlockedTimeRecurrenceException.objects.filter(
+        parent_blocked_time=parent_blocked,
+        is_cancelled=True,
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: batch_modify_available_times — partial update (only some fields changed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_update_only_timezone(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times update can change only the timezone field."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 7, 20, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+    existing = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        organization=organization,
+    )
+
+    result = service.batch_modify_available_times(
+        calendar=managed_calendar,
+        operations=[
+            {
+                "action": "update",
+                "id": existing.pk,
+                "timezone": "America/Sao_Paulo",
+            }
+        ],
+    )
+
+    assert len(result) == 1
+    assert result[0].timezone == "America/Sao_Paulo"
+    # start/end unchanged
+    assert result[0].start_time_tz_unaware == existing.start_time_tz_unaware
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_update_with_rrule_string(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times update with rrule_string creates a new RecurrenceRule."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 7, 25, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+    existing = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        organization=organization,
+    )
+    # No recurrence rule yet
+    assert existing.recurrence_rule is None
+
+    result = service.batch_modify_available_times(
+        calendar=managed_calendar,
+        operations=[
+            {
+                "action": "update",
+                "id": existing.pk,
+                "rrule_string": "FREQ=DAILY;COUNT=3",
+            }
+        ],
+    )
+
+    assert len(result) == 1
+    assert result[0].recurrence_rule is not None
+    assert result[0].recurrence_rule.count == 3
+
+
+@pytest.mark.django_db
+def test_batch_modify_available_times_update_only_start_time(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """batch_modify_available_times update with only start_time (no timezone key) covers False branch."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    start = datetime.datetime(2025, 7, 28, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=2)
+    existing = AvailableTime.objects.create(
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        organization=organization,
+    )
+
+    new_start = datetime.datetime(2025, 7, 28, 10, 0, tzinfo=datetime.UTC)
+    result = service.batch_modify_available_times(
+        calendar=managed_calendar,
+        operations=[
+            {
+                "action": "update",
+                "id": existing.pk,
+                "start_time": new_start,
+                # deliberately omit "end_time", "timezone", "rrule_string"
+            }
+        ],
+    )
+
+    assert len(result) == 1
+    # Only start_time was updated; timezone and end unchanged
+    assert result[0].start_time == new_start
+    assert result[0].timezone == "UTC"

--- a/calendar_integration/tests/services/test_availability_service.py
+++ b/calendar_integration/tests/services/test_availability_service.py
@@ -1,0 +1,466 @@
+"""Unit tests for AvailabilityService.
+
+Tests construct AvailabilityService directly (bypassing CalendarService facade)
+using a real CalendarServiceContext plus a lightweight fake host for the three
+host-routed concerns (get_calendar_events_expanded, bulk_create_manual_blocked_times,
+_create_recurrence_rule_if_needed). All DB-touching tests are marked django_db.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Iterable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from allauth.socialaccount.models import SocialAccount
+
+from calendar_integration.constants import CalendarProvider
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    BlockedTimeRecurrenceException,
+    Calendar,
+    CalendarEvent,
+    RecurrenceRule,
+)
+from calendar_integration.services.availability_service import AvailabilityService
+from calendar_integration.services.calendar_service_context import CalendarServiceContext
+from calendar_integration.services.recurrence_manager import RecurrenceManager
+from organizations.models import Organization
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Fake host
+# ---------------------------------------------------------------------------
+
+
+class FakeHost:
+    """Minimal AvailabilityServiceHost used in unit tests.
+
+    Provides controllable implementations for the three concerns routed through
+    the host: event reads, blocked-time bulk creation, and recurrence-rule
+    creation. Calendar_events and blocked_times injected via constructor so
+    individual tests can set expectations.
+    """
+
+    def __init__(
+        self,
+        events: list[CalendarEvent] | None = None,
+        organization: Organization | None = None,
+    ) -> None:
+        self._events: list[CalendarEvent] = events or []
+        self._organization = organization
+
+    def get_calendar_events_expanded(
+        self,
+        calendar: Calendar,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[CalendarEvent]:
+        return self._events
+
+    def bulk_create_manual_blocked_times(
+        self,
+        calendar: Calendar,
+        blocked_times: Iterable[tuple[datetime.datetime, datetime.datetime, str, str, str | None]],
+    ) -> Iterable[BlockedTime]:
+        times_list = list(blocked_times)
+        created: list[BlockedTime] = []
+        for i, (start_time, end_time, timezone, reason, rrule_string) in enumerate(times_list):
+            recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
+            bt = BlockedTime.objects.create(
+                calendar=calendar,
+                start_time_tz_unaware=start_time,
+                end_time_tz_unaware=end_time,
+                timezone=timezone,
+                reason=reason,
+                external_id=f"fake-host-{start_time.isoformat()}-{i}",
+                organization_id=calendar.organization_id,
+                recurrence_rule=recurrence_rule,
+            )
+            created.append(bt)
+        return created
+
+    def _create_recurrence_rule_if_needed(self, rrule_string: str | None) -> RecurrenceRule | None:
+        if not rrule_string or not self._organization:
+            return None
+        rule = RecurrenceRule.from_rrule_string(rrule_string, self._organization)
+        rule.save()
+        return rule
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Test Org")
+
+
+@pytest.fixture
+def user(db: Any) -> User:
+    u = User.objects.create_user(email="test_avail@example.com", password="pass")
+    Profile.objects.create(user=u)
+    return u
+
+
+@pytest.fixture
+def social_account(db: Any, user: User) -> SocialAccount:
+    return SocialAccount.objects.create(user=user, provider=CalendarProvider.GOOGLE, uid="99999")
+
+
+@pytest.fixture
+def calendar(db: Any, organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        name="Test Calendar",
+        external_id="avail_cal_001",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def managed_calendar(db: Any, organization: Organization) -> Calendar:
+    """Calendar with manage_available_windows=True for window-subtraction tests."""
+    return Calendar.objects.create(
+        name="Managed Calendar",
+        external_id="avail_cal_managed",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def context(organization: Organization, user: User) -> CalendarServiceContext:
+    return CalendarServiceContext(
+        organization=organization,
+        user_or_token=user,
+        account=None,
+        calendar_adapter=None,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+    )
+
+
+@pytest.fixture
+def recurrence_manager() -> RecurrenceManager:
+    return RecurrenceManager()
+
+
+def make_service(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    events: list[CalendarEvent] | None = None,
+    organization: Organization | None = None,
+) -> AvailabilityService:
+    host = FakeHost(events=events, organization=organization or context.organization)
+    return AvailabilityService(context=context, recurrence_manager=recurrence_manager, host=host)
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_blocked_time / create_available_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_blocked_time_creates_db_row(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """create_blocked_time persists a BlockedTime row."""
+    service = make_service(context, recurrence_manager, organization=organization)
+    start = datetime.datetime(2025, 7, 1, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+
+    bt = service.create_blocked_time(
+        calendar=calendar,
+        start_time=start,
+        end_time=end,
+        timezone="UTC",
+        reason="Focus time",
+    )
+
+    assert bt.pk is not None
+    assert bt.reason == "Focus time"
+    assert BlockedTime.objects.filter(pk=bt.pk, organization_id=organization.id).exists()
+
+
+@pytest.mark.django_db
+def test_create_available_time_creates_db_row(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    managed_calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """create_available_time persists an AvailableTime row."""
+    service = make_service(context, recurrence_manager, organization=organization)
+    start = datetime.datetime(2025, 7, 1, 10, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=2)
+
+    at = service.create_available_time(
+        calendar=managed_calendar,
+        start_time=start,
+        end_time=end,
+        timezone="UTC",
+    )
+
+    assert at.pk is not None
+    assert AvailableTime.objects.filter(pk=at.pk, organization_id=organization.id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_availability_windows_in_range (window subtraction)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_no_busy_time_returns_full_range(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+) -> None:
+    """Without blocked times or events, the full range is available."""
+    service = make_service(context, recurrence_manager, events=[])
+    start = datetime.datetime(2025, 7, 2, 8, 0, tzinfo=datetime.UTC)
+    end = datetime.datetime(2025, 7, 2, 18, 0, tzinfo=datetime.UTC)
+
+    windows = list(service.get_availability_windows_in_range(calendar, start, end))
+
+    assert len(windows) == 1
+    assert windows[0].start_time == start
+    assert windows[0].end_time == end
+    assert windows[0].can_book_partially is True
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_blocked_time_splits_window(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """A blocked time in the middle splits availability into before/after segments."""
+    service = make_service(context, recurrence_manager, events=[], organization=organization)
+    start = datetime.datetime(2025, 7, 3, 8, 0, tzinfo=datetime.UTC)
+    end = datetime.datetime(2025, 7, 3, 18, 0, tzinfo=datetime.UTC)
+
+    # Create a blocked time in the middle (10:00 - 11:00)
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=datetime.datetime(2025, 7, 3, 10, 0, tzinfo=datetime.UTC),
+        end_time_tz_unaware=datetime.datetime(2025, 7, 3, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        reason="Meeting",
+        external_id="blocked_split_001",
+        organization=organization,
+    )
+
+    windows = list(service.get_availability_windows_in_range(calendar, start, end))
+
+    # Should have 2 windows: 08:00-10:00 and 11:00-18:00
+    assert len(windows) == 2
+    assert windows[0].start_time == start
+    assert windows[0].end_time == datetime.datetime(2025, 7, 3, 10, 0, tzinfo=datetime.UTC)
+    assert windows[1].start_time == datetime.datetime(2025, 7, 3, 11, 0, tzinfo=datetime.UTC)
+    assert windows[1].end_time == end
+
+
+@pytest.mark.django_db
+def test_get_availability_windows_in_range_event_blocks_time(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """A calendar event reduces available windows (injected via FakeHost)."""
+    event_start = datetime.datetime(2025, 7, 4, 14, 0, tzinfo=datetime.UTC)
+    event_end = datetime.datetime(2025, 7, 4, 15, 0, tzinfo=datetime.UTC)
+    # Build a mock event that behaves like a CalendarEvent with start_time/end_time
+    mock_event = MagicMock(spec=CalendarEvent)
+    mock_event.start_time = event_start
+    mock_event.end_time = event_end
+    mock_event.id = 999
+
+    service = make_service(context, recurrence_manager, events=[mock_event])
+    range_start = datetime.datetime(2025, 7, 4, 8, 0, tzinfo=datetime.UTC)
+    range_end = datetime.datetime(2025, 7, 4, 18, 0, tzinfo=datetime.UTC)
+
+    windows = list(service.get_availability_windows_in_range(calendar, range_start, range_end))
+
+    # Should have 2 windows: before and after the event
+    assert len(windows) == 2
+    assert windows[0].end_time == event_start
+    assert windows[1].start_time == event_end
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_blocked_times_expanded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_blocked_times_expanded_returns_non_recurring(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Non-recurring blocked time is returned when it overlaps the query range."""
+    service = make_service(context, recurrence_manager, organization=organization)
+    start = datetime.datetime(2025, 7, 7, 9, 0, tzinfo=datetime.UTC)
+    end = start + datetime.timedelta(hours=1)
+
+    bt = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        reason="Block",
+        external_id="expanded_bt_001",
+        organization=organization,
+    )
+
+    results = service.get_blocked_times_expanded(
+        calendar=calendar,
+        start_date=start - datetime.timedelta(hours=1),
+        end_date=end + datetime.timedelta(hours=1),
+    )
+    ids = [r.id for r in results]
+    assert bt.id in ids
+
+
+@pytest.mark.django_db
+def test_get_blocked_times_expanded_recurring_generates_instances(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """A recurring blocked time generates multiple occurrences in the range."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization)
+    rule.save()
+
+    start = datetime.datetime(2025, 8, 4, 9, 0, tzinfo=datetime.UTC)  # Monday
+    end = start + datetime.timedelta(hours=1)
+    BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        reason="Daily block",
+        external_id="recurring_bt_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    range_start = start
+    range_end = start + datetime.timedelta(days=10)
+    results = service.get_blocked_times_expanded(
+        calendar=calendar,
+        start_date=range_start,
+        end_date=range_end,
+    )
+
+    # 5 occurrences from COUNT=5
+    assert len(results) == 5
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_recurring_blocked_time_exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_recurring_blocked_time_exception_cancels_occurrence(
+    context: CalendarServiceContext,
+    recurrence_manager: RecurrenceManager,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """Cancelling a recurring blocked-time occurrence creates a cancellation exception."""
+    service = make_service(context, recurrence_manager, organization=organization)
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=WEEKLY;COUNT=5;BYDAY=MO", organization)
+    rule.save()
+
+    parent_start = datetime.datetime(2025, 9, 1, 9, 0, tzinfo=datetime.UTC)  # Monday
+    parent_blocked = BlockedTime.objects.create(
+        calendar=calendar,
+        start_time_tz_unaware=parent_start,
+        end_time_tz_unaware=parent_start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Weekly block",
+        external_id="except_bt_001",
+        organization=organization,
+        recurrence_rule=rule,
+    )
+
+    # Cancel the second occurrence (one week later)
+    exception_date = (parent_start + datetime.timedelta(weeks=1)).date()
+    result = service.create_recurring_blocked_time_exception(
+        parent_blocked_time=parent_blocked,
+        exception_date=exception_date,
+        is_cancelled=True,
+    )
+
+    # Cancelled exception returns None
+    assert result is None
+    # A BlockedTimeRecurrenceException should exist marking the cancelled occurrence
+    assert BlockedTimeRecurrenceException.objects.filter(
+        parent_blocked_time=parent_blocked,
+        is_cancelled=True,
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: subtract_busy_intervals (static helper)
+# ---------------------------------------------------------------------------
+
+
+def test_subtract_busy_intervals_no_busy_returns_full_window() -> None:
+    """With no busy intervals, the full window is returned."""
+    start = datetime.datetime(2025, 7, 1, 8, 0, tzinfo=datetime.UTC)
+    end = datetime.datetime(2025, 7, 1, 18, 0, tzinfo=datetime.UTC)
+
+    free = AvailabilityService._subtract_busy_intervals(start, end, [])
+
+    assert free == [(start, end)]
+
+
+def test_subtract_busy_intervals_fully_covered_returns_empty() -> None:
+    """A busy interval covering the whole window returns empty list."""
+    start = datetime.datetime(2025, 7, 1, 8, 0, tzinfo=datetime.UTC)
+    end = datetime.datetime(2025, 7, 1, 18, 0, tzinfo=datetime.UTC)
+
+    free = AvailabilityService._subtract_busy_intervals(start, end, [(start, end)])
+
+    assert free == []
+
+
+def test_subtract_busy_intervals_splits_correctly() -> None:
+    """Two non-overlapping busy intervals split the window into three free slots."""
+    window_start = datetime.datetime(2025, 7, 1, 8, 0, tzinfo=datetime.UTC)
+    window_end = datetime.datetime(2025, 7, 1, 18, 0, tzinfo=datetime.UTC)
+    busy1_start = datetime.datetime(2025, 7, 1, 10, 0, tzinfo=datetime.UTC)
+    busy1_end = datetime.datetime(2025, 7, 1, 11, 0, tzinfo=datetime.UTC)
+    busy2_start = datetime.datetime(2025, 7, 1, 13, 0, tzinfo=datetime.UTC)
+    busy2_end = datetime.datetime(2025, 7, 1, 14, 0, tzinfo=datetime.UTC)
+
+    free = AvailabilityService._subtract_busy_intervals(
+        window_start, window_end, [(busy1_start, busy1_end), (busy2_start, busy2_end)]
+    )
+
+    assert len(free) == 3
+    assert free[0] == (window_start, busy1_start)
+    assert free[1] == (busy1_end, busy2_start)
+    assert free[2] == (busy2_end, window_end)

--- a/calendar_integration/tests/services/test_calendar_service.py
+++ b/calendar_integration/tests/services/test_calendar_service.py
@@ -9175,3 +9175,249 @@ def test_subtract_busy_intervals_unit():
     ) == [(ws, at(11)), (at(14), at(16))]
     # fully covered -> empty
     assert CalendarService._subtract_busy_intervals(ws, we, [(at(8), at(18))]) == []
+
+
+# ---------------------------------------------------------------------------
+# Facade delegation tests for recurring availability / blocked-time exceptions
+# and from-date modifications.  These exercise the 6 facade methods that were
+# previously uncovered (each delegates to AvailabilityService in a single
+# line): create_recurring_blocked_time_exception,
+# create_recurring_available_time_exception,
+# modify_recurring_blocked_time_from_date,
+# cancel_recurring_blocked_time_from_date,
+# modify_recurring_available_time_from_date,
+# cancel_recurring_available_time_from_date.
+# ---------------------------------------------------------------------------
+
+
+def _make_service(organization: Organization) -> CalendarService:
+    """Return a CalendarService initialized (no provider) for *organization*."""
+    service = CalendarService()
+    service.initialize_without_provider(organization=organization)
+    return service
+
+
+def _make_recurring_blocked_time(
+    organization: Organization, calendar: Calendar
+) -> tuple[BlockedTime, RecurrenceRule]:
+    """Create and persist a recurring BlockedTime (FREQ=DAILY;COUNT=5)."""
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization=organization)
+    rule.save()
+    start = datetime.datetime(2025, 11, 3, 9, 0, tzinfo=datetime.UTC)
+    bt = BlockedTime.objects.create(
+        calendar_fk=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        reason="Recurring block",
+        organization=organization,
+        recurrence_rule_fk=rule,
+    )
+    return bt, rule
+
+
+def _make_available_time_calendar(organization: Organization) -> Calendar:
+    """Return a Calendar with manage_available_windows=True for available-time tests."""
+    return Calendar.objects.create(
+        name="Availability Calendar",
+        organization=organization,
+        manage_available_windows=True,
+    )
+
+
+def _make_recurring_available_time(
+    organization: Organization, calendar: Calendar
+) -> tuple[AvailableTime, RecurrenceRule]:
+    """Create and persist a recurring AvailableTime (FREQ=DAILY;COUNT=5).
+
+    *calendar* must have manage_available_windows=True.  Use
+    _make_available_time_calendar() to obtain a suitable one.
+    """
+    rule = RecurrenceRule.from_rrule_string("FREQ=DAILY;COUNT=5", organization=organization)
+    rule.save()
+    start = datetime.datetime(2025, 11, 3, 10, 0, tzinfo=datetime.UTC)
+    avail_time = AvailableTime.objects.create(
+        calendar_fk=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        organization=organization,
+        recurrence_rule_fk=rule,
+    )
+    return avail_time, rule
+
+
+@pytest.mark.django_db
+def test_facade_create_recurring_blocked_time_exception_cancelled(organization, calendar):
+    """create_recurring_blocked_time_exception (cancel path) delegates through the facade."""
+    bt, _ = _make_recurring_blocked_time(organization, calendar)
+    service = _make_service(organization)
+
+    # Cancel the second occurrence (first future occurrence after master)
+    second_occurrence_date = (bt.start_time + datetime.timedelta(days=1)).date()
+    result = service.create_recurring_blocked_time_exception(
+        parent_blocked_time=bt,
+        exception_date=second_occurrence_date,
+        is_cancelled=True,
+    )
+
+    # A cancelled exception returns None and records a BlockedTimeRecurrenceException
+    assert result is None
+    assert bt.recurrence_exceptions.filter_by_organization(organization.id).count() == 1
+    exc = bt.recurrence_exceptions.filter_by_organization(organization.id).get()
+    assert exc.is_cancelled is True
+
+
+@pytest.mark.django_db
+def test_facade_create_recurring_blocked_time_exception_modified(organization, calendar):
+    """create_recurring_blocked_time_exception (modify path) delegates through the facade."""
+    bt, _ = _make_recurring_blocked_time(organization, calendar)
+    service = _make_service(organization)
+
+    second_occurrence_date = (bt.start_time + datetime.timedelta(days=1)).date()
+    new_start = bt.start_time + datetime.timedelta(days=1, hours=2)
+    new_end = new_start + datetime.timedelta(hours=1)
+
+    result = service.create_recurring_blocked_time_exception(
+        parent_blocked_time=bt,
+        exception_date=second_occurrence_date,
+        modified_reason="Modified reason",
+        modified_start_time=new_start,
+        modified_end_time=new_end,
+        modified_timezone="UTC",
+        is_cancelled=False,
+    )
+
+    # A modified exception returns the new modified BlockedTime
+    assert result is not None
+    assert isinstance(result, BlockedTime)
+    assert result.reason == "Modified reason"
+    assert bt.recurrence_exceptions.filter_by_organization(organization.id).count() == 1
+    exc = bt.recurrence_exceptions.filter_by_organization(organization.id).get()
+    assert exc.is_cancelled is False
+
+
+@pytest.mark.django_db
+def test_facade_create_recurring_available_time_exception_cancelled(organization):
+    """create_recurring_available_time_exception (cancel path) delegates through the facade."""
+    avail_calendar = _make_available_time_calendar(organization)
+    avail, _ = _make_recurring_available_time(organization, avail_calendar)
+    service = _make_service(organization)
+
+    second_occurrence_date = (avail.start_time + datetime.timedelta(days=1)).date()
+    result = service.create_recurring_available_time_exception(
+        parent_available_time=avail,
+        exception_date=second_occurrence_date,
+        is_cancelled=True,
+    )
+
+    assert result is None
+    assert avail.recurrence_exceptions.filter_by_organization(organization.id).count() == 1
+    exc = avail.recurrence_exceptions.filter_by_organization(organization.id).get()
+    assert exc.is_cancelled is True
+
+
+@pytest.mark.django_db
+def test_facade_create_recurring_available_time_exception_modified(organization):
+    """create_recurring_available_time_exception (modify path) delegates through the facade."""
+    avail_calendar = _make_available_time_calendar(organization)
+    avail, _ = _make_recurring_available_time(organization, avail_calendar)
+    service = _make_service(organization)
+
+    second_occurrence_date = (avail.start_time + datetime.timedelta(days=1)).date()
+    new_start = avail.start_time + datetime.timedelta(days=1, hours=1)
+    new_end = new_start + datetime.timedelta(hours=2)
+
+    result = service.create_recurring_available_time_exception(
+        parent_available_time=avail,
+        exception_date=second_occurrence_date,
+        modified_start_time=new_start,
+        modified_end_time=new_end,
+        modified_timezone="UTC",
+        is_cancelled=False,
+    )
+
+    assert result is not None
+    assert isinstance(result, AvailableTime)
+    assert avail.recurrence_exceptions.filter_by_organization(organization.id).count() == 1
+    exc = avail.recurrence_exceptions.filter_by_organization(organization.id).get()
+    assert exc.is_cancelled is False
+
+
+@pytest.mark.django_db
+def test_facade_modify_recurring_blocked_time_from_date(organization, calendar):
+    """modify_recurring_blocked_time_from_date delegates through the facade."""
+    bt, _ = _make_recurring_blocked_time(organization, calendar)
+    service = _make_service(organization)
+
+    modification_start = bt.start_time + datetime.timedelta(days=2)
+    result = service.modify_recurring_blocked_time_from_date(
+        parent_blocked_time=bt,
+        modification_start_date=modification_start,
+        modified_reason="Changed reason",
+    )
+
+    # Returns a continuation BlockedTime for the modified tail
+    assert result is not None
+    assert isinstance(result, BlockedTime)
+    assert result.reason == "Changed reason"
+    # A bulk modification record must be created on the parent
+    assert bt.bulk_modification_records.count() == 1
+    assert bt.bulk_modification_records.first().is_bulk_cancelled is False
+
+
+@pytest.mark.django_db
+def test_facade_cancel_recurring_blocked_time_from_date(organization, calendar):
+    """cancel_recurring_blocked_time_from_date delegates through the facade."""
+    bt, _ = _make_recurring_blocked_time(organization, calendar)
+    service = _make_service(organization)
+
+    modification_start = bt.start_time + datetime.timedelta(days=2)
+    result = service.cancel_recurring_blocked_time_from_date(
+        parent_blocked_time=bt,
+        modification_start_date=modification_start,
+    )
+
+    # Cancel returns None; a cancellation bulk-modification record must be created
+    assert result is None
+    assert bt.bulk_modification_records.count() == 1
+    assert bt.bulk_modification_records.first().is_bulk_cancelled is True
+
+
+@pytest.mark.django_db
+def test_facade_modify_recurring_available_time_from_date(organization):
+    """modify_recurring_available_time_from_date delegates through the facade."""
+    avail_calendar = _make_available_time_calendar(organization)
+    avail, _ = _make_recurring_available_time(organization, avail_calendar)
+    service = _make_service(organization)
+
+    modification_start = avail.start_time + datetime.timedelta(days=2)
+    result = service.modify_recurring_available_time_from_date(
+        parent_available_time=avail,
+        modification_start_date=modification_start,
+    )
+
+    # Returns a continuation AvailableTime for the modified tail
+    assert result is not None
+    assert isinstance(result, AvailableTime)
+    assert avail.bulk_modification_records.count() == 1
+    assert avail.bulk_modification_records.first().is_bulk_cancelled is False
+
+
+@pytest.mark.django_db
+def test_facade_cancel_recurring_available_time_from_date(organization):
+    """cancel_recurring_available_time_from_date delegates through the facade."""
+    avail_calendar = _make_available_time_calendar(organization)
+    avail, _ = _make_recurring_available_time(organization, avail_calendar)
+    service = _make_service(organization)
+
+    modification_start = avail.start_time + datetime.timedelta(days=2)
+    result = service.cancel_recurring_available_time_from_date(
+        parent_available_time=avail,
+        modification_start_date=modification_start,
+    )
+
+    # Cancel returns None; a cancellation bulk-modification record must be created
+    assert result is None
+    assert avail.bulk_modification_records.count() == 1
+    assert avail.bulk_modification_records.first().is_bulk_cancelled is True


### PR DESCRIPTION
## Summary
Phase 4. Moves the 17 availability/blocked-time/available-time methods (the availability + unavailability window queries, `create_blocked_time`/`create_available_time`, the `*_expanded` reads, `bulk_create_availability_windows`, `batch_modify_available_times`, and the 8 recurring blocked/available exception + bulk-mod + modify/cancel methods) plus the interval-math privates (`_subtract_busy_intervals`, `_remove_available_time_windows_that_overlap_with_blocked_times_and_events`) into a new `AvailabilityService` (`calendar_integration/services/availability_service.py`). The facade delegates via `self._get_availability_service()`. `calendar_service.py` drops to **2557 lines** (from 4726 originally — nearly halved across Phases 0–4).

Availability + blocked-times live in one service because `get_availability_windows_in_range` is literally "all time minus blocked-times minus events" — they share the interval math and recurrence expansion.

## Seam
Mirrors Phases 2/3: an `AvailabilityServiceHost` Protocol; the facade passes `host=self`; the service reads events as busy intervals via `host.get_calendar_events_expanded(...)`. The `EventServiceHost`/`BundleServiceHost` `get_availability_windows_in_range` now routes through the facade to `AvailabilityService` (no infinite loop — the chain terminates at `get_calendar_events_expanded`, which never calls back into availability). Two thin facade private delegations are retained for existing tests/internal sync callers: `_subtract_busy_intervals` (as `@staticmethod` — a test calls `CalendarService._subtract_busy_intervals(...)` unbound) and `_remove_available_time_windows_that_overlap_with_blocked_times_and_events` (instance).

## Behavior preservation + performance
Byte-for-byte. Reviewer diffed the interval math and all 8 recurring methods against the original and confirmed byte-identical (modulo the established `self.X`→`context.X`/`host.X` substitutions). No added queries in loops; `select_related`/`bulk_create`/sorting/algorithmic complexity preserved — the plan's explicit availability perf guardrail holds.

## Mypy
3 new `attr-defined` (a `_remove_...` cast to `BaseCalendarService`, which doesn't declare `organization`) were fixed by casting to `InitializedOrAuthenticatedCalendarService` (declares `organization`; early-return-on-falsy-org semantics preserved). The 7 remaining errors (`Any | None` calendar/model-relation `arg-type`/`union-attr`) were verified verbatim from the original facade. Project mypy net unchanged (138, 0 new).

## Implementation note
This phase was completed across three agent sessions (two interrupted by API socket errors mid-extraction); the final result was independently Layer-3 reviewed precisely because of that, with the interval math + all 8 recurring methods diffed line-by-line against the original.

## No feature flag
Pure refactor.

## Plan reference
Plan `ai-plans/2026-06-13-CALENDAR_SERVICE_REFACTOR_IMPLEMENTATION_PLAN.md`, Phase 4.

## Review history
Layer-3 adversarial review: 0 blockers, 0 should-fix. NITs: a behavior-identical cast-style inconsistency in `_remove_...`; `AvailabilityService` not yet exported from `services/__init__.py` (deferred to Phase 7 per plan); one test uses a `MagicMock(spec=CalendarEvent)` for the host-injected event path (real-event path stays covered by the facade suite).

## Test plan
- New `calendar_integration/tests/services/test_availability_service.py` (11 tests) — window subtraction (full range / blocked-split / event-blocked), create blocked+available, recurring blocked-time expansion + exception, and the static interval helper.
- Outer gate: `ruff check` clean, `check --deploy` (5 pre-existing security warnings only), `pytest -n auto` → **1619 passed, 0 failed**.