### PR TITLE
refactor(calendar): extract webhook lifecycle into CalendarWebhookService

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_SERVICE_REFACTOR.md
+++ b/ai-plans/TRACKING_CALENDAR_SERVICE_REFACTOR.md
@@ -104,11 +104,28 @@
   - Phase 7 cleanup list += drop redundant facade `@transaction.atomic()` on `import_account_calendars` delegation; remove stale `_process_events_for_sync`/`_link_orphaned_recurring_instances` from the `AuthenticatedCalendarService` protocol; add a direct orphan-link unit test (currently integration-covered).
   - Checkpoint strategy (commit extraction before tests) worked well for the long extraction — reuse if Phase 6 runs long.
 
+### Phase 6 — Extract CalendarWebhookService ✅
+- **Status**: complete, PR open
+- **Model**: claude-sonnet-4-6 (Tier 3) + fixer (sonnet, guard regression)
+- **Branch**: `plan/calendar-service-refactor/phase-6` (base `…/phase-5`)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/77 (published, 3 inline comments)
+- **Files**: `calendar_integration/services/calendar_webhook_service.py` (new, ~676 lines), `calendar_integration/services/calendar_service.py` (edited, −430 lines → facade now 1618 lines), `calendar_integration/tests/services/test_calendar_webhook_service.py` (new, 12 tests)
+- **Summary**: Moved the 8 webhook methods + `WebhookHealthStatus` TypedDict into `CalendarWebhookService`. `handle_webhook` split: facade keeps org-extraction + `self.organization=` mutation (so the snapshot sees it), service does parsing/dispatch. webhook→sync routes via host; terminates.
+- **Review**: Layer-3 0 blockers, 1 should-fix (guard had been weakened to `raise_error=False` in `process_webhook_notification` — restored to immediate-raise + regression test added). Security-sensitive validation diffed byte-for-byte.
+- **Gate**: full suite 1634 passed, 0 failed. mypy 137→136 (0 new).
+
 ## Current Phase
-- Phase 6 — Extract `CalendarWebhookService` (next).
+- Phase 7 — Shrink the facade and finalize wiring (final phase).
+
+## Phase 7 cleanup checklist (accumulated across phases)
+- [ ] Drop redundant facade-level `@transaction.atomic()` on the now-1-line delegations (event create/update/delete, bundle create/update_bundle_calendar, `import_account_calendars`) — sub-service methods own atomicity.
+- [ ] Remove stale declarations from `AuthenticatedCalendarService` / `InitializedOrAuthenticatedCalendarService` protocols for methods the facade no longer implements (e.g. `_process_events_for_sync`, `_link_orphaned_recurring_instances`) — but KEEP any the facade still delegates (tests call them).
+- [ ] Export the 6 sub-services from `calendar_integration/services/__init__.py` if referenced cross-module.
+- [ ] Confirm `di_core/containers.py` `calendar_service` provider signature unchanged (still injects side_effects + permission services); `calendar_group_service` still injects `calendar_service`.
+- [ ] `grep` for stale references to migrated internals; ensure facade is delegation-only where possible (note: many private delegations are intentionally kept because `test_calendar_service.py` calls them on a facade instance — do NOT remove those).
+- [ ] Optional follow-ups noted (not blocking): direct orphan-link unit test; the `_remove_...` cast-style note; duplicated `expires_at=None` in webhook service.
 
 ## Remaining Phases
-- Phase 6 — Extract `CalendarWebhookService` (Tier 3)
 - Phase 7 — Shrink the facade and finalize wiring (Tier 2)
 
 ## Deferred Phases

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -1,30 +1,23 @@
 import datetime
-import json
 import logging
 from collections.abc import Callable, Iterable
-from typing import Annotated, TypedDict
+from typing import Annotated
 
-from django.conf import settings
 from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest
-from django.urls import reverse
 
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from dependency_injector.wiring import Provide, inject
 
 from calendar_integration.constants import (
     CalendarProvider,
-    CalendarSyncStatus,
     CalendarSyncTriggerSource,
     CalendarType,
     CalendarVisibility,
-    IncomingWebhookProcessingStatus,
 )
 from calendar_integration.exceptions import (
     InvalidCalendarTokenError,
-    ServiceNotAuthenticatedError,
-    WebhookIgnoredError,
 )
 from calendar_integration.models import (
     AvailableTime,
@@ -76,6 +69,10 @@ from calendar_integration.services.calendar_service_utils import (
 )
 from calendar_integration.services.calendar_side_effects_service import CalendarSideEffectsService
 from calendar_integration.services.calendar_sync_service import CalendarSyncService
+from calendar_integration.services.calendar_webhook_service import (
+    CalendarWebhookService,
+    WebhookHealthStatus,
+)
 from calendar_integration.services.dataclasses import (
     ApplicationCalendarData,
     AvailableTimeWindow,
@@ -101,16 +98,6 @@ from calendar_integration.services.type_guards import (
 from organizations.models import Organization
 from public_api.models import SystemUser
 from users.models import User
-
-
-class WebhookHealthStatus(TypedDict):
-    total_subscriptions: int
-    active_subscriptions: int
-    expired_subscriptions: int
-    expiring_soon_subscriptions: int
-    recent_events_count: int
-    failed_events_count: int
-    success_rate: float
 
 
 logger = logging.getLogger(__name__)
@@ -442,6 +429,22 @@ class CalendarService(BaseCalendarService):
         mutation.
         """
         return CalendarSyncService(
+            context=self._build_context_snapshot(),
+            calendar_cache=self._calendar_cache,
+            host=self,
+        )
+
+    def _get_webhook_service(self) -> CalendarWebhookService:
+        """Return the webhook sub-service bound to the facade's current auth context.
+
+        The webhook service shares the facade-owned calendar cache and routes
+        sync triggering (Phase 5 seam), adapter-class lookup, write-adapter resolution,
+        and external-id calendar lookup back through the facade (``host=self``). The
+        context is rebuilt from the live facade attributes each call (a cheap dataclass
+        construction — no network / adapter rebuild), so it never goes stale across
+        re-authentication or direct attribute mutation.
+        """
+        return CalendarWebhookService(
             context=self._build_context_snapshot(),
             calendar_cache=self._calendar_cache,
             host=self,
@@ -1500,7 +1503,7 @@ class CalendarService(BaseCalendarService):
             modification_rrule_string=modification_rrule_string,
         )
 
-    # Webhook-related methods
+    # Webhook-related methods — delegated to CalendarWebhookService
 
     def request_webhook_triggered_sync(
         self,
@@ -1508,71 +1511,19 @@ class CalendarService(BaseCalendarService):
         webhook_event: CalendarWebhookEvent,
         sync_window_hours: int = 24,
     ) -> CalendarSync | None:
+        """Request calendar sync triggered by webhook notification.
+
+        Delegates to :class:`CalendarWebhookService`. Also a ``WebhookServiceHost``
+        seam: ``CalendarWebhookService.process_webhook_notification`` calls this
+        through the host so that ``@patch.object(CalendarService,
+        "request_webhook_triggered_sync")`` in the existing test suite intercepts
+        the call before it reaches the sub-service.
         """
-        Request calendar sync triggered by webhook notification.
-        Reuses existing request_calendar_sync with webhook-specific optimizations.
-
-        Args:
-            external_calendar_id: External calendar ID from webhook
-            webhook_event: The webhook event that triggered this sync
-            sync_window_hours: Hours around current time to sync
-
-        Returns:
-            CalendarSync instance if sync was triggered, None if skipped
-        """
-        logger = logging.getLogger(__name__)
-        now = datetime.datetime.now(tz=datetime.UTC)
-
-        if not is_initialized_or_authenticated_calendar_service(self):
-            raise ValueError("Calendar service not properly initialized")
-
-        # Find calendar by external ID
-        try:
-            calendar = Calendar.objects.get(
-                organization_id=self.organization.id,
-                external_id=external_calendar_id,
-                provider=webhook_event.provider,
-            )
-        except Calendar.DoesNotExist:
-            logger.warning("Calendar not found for external_id: %s", external_calendar_id)
-            return None
-
-        # Check for recent syncs to prevent excessive syncing (deduplication)
-        recent_sync = CalendarSync.objects.filter(
-            calendar=calendar,
-            created__gte=now - datetime.timedelta(minutes=5),
-            status__in=[CalendarSyncStatus.IN_PROGRESS, CalendarSyncStatus.SUCCESS],
-        ).first()
-
-        if recent_sync:
-            logger.info(
-                "Skipping sync for calendar %s, recent sync exists: %s", calendar.id, recent_sync.id
-            )
-            webhook_event.calendar_sync = recent_sync
-            webhook_event.processing_status = IncomingWebhookProcessingStatus.PROCESSED
-            webhook_event.save()
-            return recent_sync
-
-        # Define sync window around current time
-        now = now
-        start_datetime = now - datetime.timedelta(hours=sync_window_hours // 2)
-        end_datetime = now + datetime.timedelta(hours=sync_window_hours // 2)
-
-        # Use existing request_calendar_sync method
-        calendar_sync = self.request_calendar_sync(
-            calendar=calendar,
-            start_datetime=start_datetime,
-            end_datetime=end_datetime,
-            should_update_events=True,  # Webhook implies changes, so update existing events
-            trigger_source=CalendarSyncTriggerSource.WEBHOOK,
+        return self._get_webhook_service().request_webhook_triggered_sync(
+            external_calendar_id=external_calendar_id,
+            webhook_event=webhook_event,
+            sync_window_hours=sync_window_hours,
         )
-
-        # Link webhook event to triggered sync
-        webhook_event.calendar_sync = calendar_sync
-        webhook_event.processing_status = IncomingWebhookProcessingStatus.PROCESSED
-        webhook_event.save()
-
-        return calendar_sync
 
     def create_calendar_webhook_subscription(
         self,
@@ -1580,107 +1531,12 @@ class CalendarService(BaseCalendarService):
         callback_url: str | None = None,
         expiration_hours: int = 24,
     ) -> CalendarWebhookSubscription:
-        """
-        Create webhook subscription using existing adapter methods.
-        Works for both Google and Microsoft calendars.
-
-        Args:
-            calendar: Calendar to create subscription for
-            callback_url: URL to receive webhook notifications (optional, will generate if not provided)
-            expiration_hours: Hours until subscription expires
-
-        Returns:
-            CalendarWebhookSubscription instance
-
-        Raises:
-            ValueError: If calendar service not authenticated or provider not supported
-        """
-        if not is_authenticated_calendar_service(self):
-            raise ValueError("Calendar service not authenticated")
-
-        if not self.calendar_adapter:
-            raise ValueError("Calendar adapter not available")
-
-        # Generate callback URL if not provided
-        if not callback_url:
-            if calendar.provider == CalendarProvider.GOOGLE:
-                callback_url = reverse(
-                    "calendar_integration:google_webhook",
-                    kwargs={"organization_id": calendar.organization_id},
-                )
-            elif calendar.provider == CalendarProvider.MICROSOFT:
-                callback_url = reverse(
-                    "calendar_integration:microsoft_webhook",
-                    kwargs={"organization_id": calendar.organization_id},
-                )
-            else:
-                raise ValueError(
-                    f"Webhook subscriptions not supported for provider: {calendar.provider}"
-                )
-
-            # Convert to absolute URL if needed
-            # In production, you might want to configure the domain via settings
-            if callback_url.startswith("/"):
-                domain = getattr(settings, "WEBHOOK_DOMAIN", "https://your-domain.com")
-                callback_url = f"{domain.rstrip('/')}{callback_url}"
-
-        # Use adapter-specific subscription creation
-        if calendar.provider == CalendarProvider.GOOGLE:
-            subscription_data = self.calendar_adapter.create_webhook_subscription_with_tracking(
-                resource_id=calendar.external_id,
-                callback_url=callback_url,
-                tracking_params={"ttl_seconds": expiration_hours * 3600},
-            )
-        elif calendar.provider == CalendarProvider.MICROSOFT:
-            subscription_data = self.calendar_adapter.create_webhook_subscription_with_tracking(
-                resource_id=calendar.external_id,
-                callback_url=callback_url,
-                tracking_params={"expiration_hours": expiration_hours},
-            )
-        else:
-            raise ValueError(
-                f"Webhook subscriptions not supported for provider: {calendar.provider}"
-            )
-
-        # Calculate expiration datetime
-        expiration_timestamp = subscription_data.get("expiration")
-        expires_at = None
-        if expiration_timestamp is not None:
-            try:
-                if calendar.provider == CalendarProvider.GOOGLE:
-                    # Google returns expiration as milliseconds since epoch
-                    expires_at = datetime.datetime.fromtimestamp(
-                        int(expiration_timestamp) / 1000, tz=datetime.UTC
-                    )
-                elif calendar.provider == CalendarProvider.MICROSOFT:
-                    # Microsoft returns expiration as ISO 8601 string
-                    expires_at = datetime.datetime.fromisoformat(
-                        expiration_timestamp.replace("Z", "+00:00")
-                    )
-            except (ValueError, TypeError):
-                # Log or handle malformed expiration value gracefully
-                expires_at = None
-                # Log or handle malformed expiration value gracefully
-                expires_at = None
-
-        # Create tracking record
-        webhook_subscription = CalendarWebhookSubscription.objects.create(
+        """Create webhook subscription. Delegates to :class:`CalendarWebhookService`."""
+        return self._get_webhook_service().create_calendar_webhook_subscription(
             calendar=calendar,
-            organization_id=calendar.organization_id,
-            provider=calendar.provider,
-            external_subscription_id=subscription_data.get("subscription_id")
-            or subscription_data.get("channel_id"),
-            external_resource_id=subscription_data.get("resource_id", ""),
             callback_url=callback_url,
-            channel_id=subscription_data.get("channel_id", ""),
-            resource_uri=subscription_data.get("resource_uri", ""),
-            verification_token=subscription_data.get("client_state")
-            or subscription_data.get("channel_token")
-            or "",
-            expires_at=expires_at,
+            expiration_hours=expiration_hours,
         )
-
-        return webhook_subscription
 
     def process_webhook_notification(
         self,
@@ -1690,111 +1546,29 @@ class CalendarService(BaseCalendarService):
         payload: dict | str | None = None,
         validation_token: str | None = None,
     ) -> CalendarWebhookEvent | None:
-        """
-        Process incoming webhook notification using adapter validation.
-        Returns CalendarWebhookEvent for notification
-
-        Args:
-            provider: Calendar provider (google, microsoft)
-            headers: HTTP headers from webhook request
-            payload: Webhook payload data
-            validation_token: Validation token for subscription setup
-
-        Returns:
-            CalendarWebhookEvent for notifications
-
-        Raises:
-            ValueError: If validation fails or provider not supported
-        """
-        logger = logging.getLogger(__name__)
-
-        if not is_initialized_or_authenticated_calendar_service(self):
-            # For webhook processing, we can proceed with limited functionality
-            logger.warning(
-                "Webhook received but calendar service not authenticated, webhook event recorded for later processing"
-            )
-
-        # Try to get calendar and adapter, but don't fail if not authenticated
-        calendar = None
-        calendar_adapter = None
-
-        try:
-            calendar = self._get_calendar_by_external_id(calendar_external_id)
-            calendar_adapter = self._get_write_adapter_for_calendar(calendar)
-        except (ServiceNotAuthenticatedError, Calendar.DoesNotExist):
-            # Calendar not found or not authenticated - we'll still record the webhook event
-            pass
-
-        # Handle provider-specific validation/parsing
-        # Use static validation if we don't have an authenticated adapter
-        if calendar_adapter:
-            parsed_data = calendar_adapter.validate_webhook_notification(
-                headers, json.dumps(payload) if payload else ""
-            )
-        else:
-            # Use static validation method
-            calendar_adapter_cls = self._get_calendar_adapter_cls_for_provider(
-                CalendarProvider(provider)
-            )
-            parsed_data = calendar_adapter_cls.validate_webhook_notification_static(
-                headers, json.dumps(payload) if payload else ""
-            )
-
-        if not self.organization:
-            raise ValueError("Organization context not set on calendar service")
-
-        # Create webhook event record
-        webhook_event = CalendarWebhookEvent.objects.create(
-            organization_id=self.organization.id,
+        """Process incoming webhook notification. Delegates to :class:`CalendarWebhookService`."""
+        return self._get_webhook_service().process_webhook_notification(
             provider=provider,
-            event_type=parsed_data.get("event_type", "unknown"),
-            external_calendar_id=parsed_data.get("calendar_id", ""),
-            external_event_id=parsed_data.get("event_id", ""),
-            raw_payload=payload if isinstance(payload, dict) else {"raw": str(payload or "")},
+            calendar_external_id=calendar_external_id,
             headers=headers,
+            payload=payload,
+            validation_token=validation_token,
         )
-
-        # Trigger calendar sync only if service is authenticated
-        # For webhook processing, we record the event even if sync can't be triggered immediately
-        try:
-            if is_authenticated_calendar_service(self, raise_error=False):
-                calendar_sync = self.request_webhook_triggered_sync(
-                    external_calendar_id=parsed_data["calendar_id"], webhook_event=webhook_event
-                )
-
-                if calendar_sync:
-                    logger.info(
-                        "Webhook triggered sync %s for calendar %s",
-                        calendar_sync.id,
-                        parsed_data["calendar_id"],
-                    )
-                    return webhook_event
-                else:
-                    webhook_event.processing_status = IncomingWebhookProcessingStatus.IGNORED
-                    webhook_event.save()
-            else:
-                # Service not authenticated - just record the webhook event for later processing
-                logger.warning(
-                    "Webhook received but calendar service not authenticated, webhook event recorded for later processing"
-                )
-                webhook_event.processing_status = IncomingWebhookProcessingStatus.PENDING
-                webhook_event.save()
-
-        except Exception as e:
-            webhook_event.processing_status = IncomingWebhookProcessingStatus.FAILED
-            webhook_event.save()
-            logger.exception("Failed to process webhook: %s", e)
-            # Don't re-raise the exception - webhook event is recorded
-
-        return webhook_event
 
     def handle_webhook(
         self, provider: CalendarProvider, request: HttpRequest
     ) -> CalendarWebhookEvent | None:
-        """
-        Handle Google Calendar webhook processing with organization context.
+        """Handle calendar webhook processing with organization context.
+
+        Extracts the organization from the HTTP request and writes it to
+        ``self.organization`` so that :meth:`_build_context_snapshot` picks it
+        up when the webhook sub-service calls back through the host
+        (``request_webhook_triggered_sync`` → ``request_calendar_sync``).
+        The header parsing and notification dispatching are delegated to
+        :class:`CalendarWebhookService`.
 
         Args:
+            provider: Calendar provider enum
             request: HttpRequest object containing webhook data
 
         Returns:
@@ -1804,7 +1578,6 @@ class CalendarService(BaseCalendarService):
             ValueError: If webhook validation fails or organization not found
             Exception: If processing fails
         """
-
         if not request.resolver_match:
             raise ValueError("Invalid request object")
 
@@ -1819,167 +1592,27 @@ class CalendarService(BaseCalendarService):
         except Organization.DoesNotExist as exc:
             raise ValueError(f"Organization not found: {organization_id}") from exc
 
-        calendar_adapter_cls = self._get_calendar_adapter_cls_for_provider(provider)
-
-        headers = calendar_adapter_cls.parse_webhook_headers(request.headers)
-        calendar_external_id = (
-            calendar_adapter_cls.extract_calendar_external_id_from_webhook_request(request)
-        )
-
-        # Set organization context on the service
+        # Set organization context on the facade so that _build_context_snapshot()
+        # includes it in any subsequent sub-service constructions (e.g. the
+        # request_webhook_triggered_sync callback through the host seam).
         self.organization = organization
 
-        # Process the webhook notification
-        try:
-            return self.process_webhook_notification(
-                provider=provider,
-                calendar_external_id=calendar_external_id,
-                headers=headers,
-            )
-        except WebhookIgnoredError:
-            return None
+        return self._get_webhook_service().handle_webhook(provider, request)
 
     def list_webhook_subscriptions(self) -> QuerySet[CalendarWebhookSubscription]:
-        """List all active webhook subscriptions for the organization.
-
-        Returns:
-            QuerySet of CalendarWebhookSubscription objects for the organization
-
-        Raises:
-            ValueError: If organization is not set
-        """
-        if not self.organization:
-            raise ValueError("Organization must be set")
-
-        return CalendarWebhookSubscription.objects.filter(
-            organization=self.organization, is_active=True
-        ).select_related("calendar")
+        """List active webhook subscriptions. Delegates to :class:`CalendarWebhookService`."""
+        return self._get_webhook_service().list_webhook_subscriptions()
 
     def delete_webhook_subscription(self, subscription_id: int) -> bool:
-        """Delete a webhook subscription from provider and database.
-
-        Args:
-            subscription_id: ID of the subscription to delete
-
-        Returns:
-            True if successfully deleted, False if subscription not found
-
-        Raises:
-            ValueError: If organization is not set or subscription not found
-        """
-        if not self.organization:
-            raise ValueError("Organization must be set")
-
-        try:
-            subscription = CalendarWebhookSubscription.objects.get(
-                id=subscription_id, organization=self.organization
-            )
-        except CalendarWebhookSubscription.DoesNotExist:
-            return False
-
-        # TODO: Add provider-specific subscription deletion when implementing
-        # Google Calendar and Microsoft Graph subscription deletion APIs
-        # For now, just mark as inactive
-        subscription.is_active = False
-        subscription.save(update_fields=["is_active", "modified"])
-
-        return True
+        """Delete a webhook subscription. Delegates to :class:`CalendarWebhookService`."""
+        return self._get_webhook_service().delete_webhook_subscription(subscription_id)
 
     def refresh_webhook_subscription(
         self, subscription_id: int
     ) -> CalendarWebhookSubscription | None:
-        """Refresh/renew a webhook subscription with the provider.
-
-        Args:
-            subscription_id: ID of the subscription to refresh
-
-        Returns:
-            Updated CalendarWebhookSubscription if successful, None if not found
-
-        Raises:
-            ValueError: If organization is not set
-        """
-        if not self.organization:
-            raise ValueError("Organization must be set")
-
-        try:
-            subscription = CalendarWebhookSubscription.objects.get(
-                id=subscription_id, organization=self.organization, is_active=True
-            )
-        except CalendarWebhookSubscription.DoesNotExist:
-            return None
-
-        # TODO: Implement provider-specific subscription renewal
-        # For now, extend expiration by default duration based on provider
-        now = datetime.datetime.now(tz=datetime.UTC)
-        if subscription.provider == CalendarProvider.GOOGLE:
-            # Google allows max 7 days (604800 seconds)
-            new_expiration = now + datetime.timedelta(days=7)
-        elif subscription.provider == CalendarProvider.MICROSOFT:
-            # Microsoft allows max ~70 hours (4230 minutes)
-            new_expiration = now + datetime.timedelta(minutes=4230)
-        else:
-            # Default to 1 day for other providers
-            new_expiration = now + datetime.timedelta(days=1)
-
-        subscription.expires_at = new_expiration
-        subscription.save(update_fields=["expires_at", "modified"])
-
-        return subscription
+        """Refresh a webhook subscription. Delegates to :class:`CalendarWebhookService`."""
+        return self._get_webhook_service().refresh_webhook_subscription(subscription_id)
 
     def get_webhook_health_status(self) -> WebhookHealthStatus:
-        """Get webhook system health status for the organization.
-
-        Returns:
-            WebhookHealthStatus with webhook health metrics
-
-        Raises:
-            ValueError: If organization is not set
-        """
-        if not self.organization:
-            raise ValueError("Organization must be set")
-
-        # Time boundaries
-        now = datetime.datetime.now(tz=datetime.UTC)
-        twenty_four_hours_ago = now - datetime.timedelta(hours=24)
-        expiring_soon_threshold = now + datetime.timedelta(hours=24)
-
-        # Subscription counts
-        subscriptions_qs = CalendarWebhookSubscription.objects.filter(
-            organization=self.organization
-        )
-        total_subscriptions = subscriptions_qs.count()
-        active_subscriptions = subscriptions_qs.filter(is_active=True).count()
-        expired_subscriptions = subscriptions_qs.filter(is_active=True, expires_at__lt=now).count()
-        expiring_soon_subscriptions = subscriptions_qs.filter(
-            is_active=True,
-            expires_at__gte=now,
-            expires_at__lte=expiring_soon_threshold,
-        ).count()
-
-        # Event counts in last 24 hours
-        events_qs = CalendarWebhookEvent.objects.filter(
-            organization=self.organization, created__gte=twenty_four_hours_ago
-        )
-        recent_events_count = events_qs.count()
-        failed_events_count = events_qs.filter(
-            processing_status=IncomingWebhookProcessingStatus.FAILED
-        ).count()
-
-        # Calculate success rate
-        if recent_events_count > 0:
-            success_rate = ((recent_events_count - failed_events_count) / recent_events_count) * 100
-        else:
-            success_rate = 100.0
-
-        return WebhookHealthStatus(
-            {
-                "total_subscriptions": total_subscriptions,
-                "active_subscriptions": active_subscriptions,
-                "expired_subscriptions": expired_subscriptions,
-                "expiring_soon_subscriptions": expiring_soon_subscriptions,
-                "recent_events_count": recent_events_count,
-                "failed_events_count": failed_events_count,
-                "success_rate": success_rate,
-            }
-        )
+        """Get webhook health status. Delegates to :class:`CalendarWebhookService`."""
+        return self._get_webhook_service().get_webhook_health_status()

--- a/calendar_integration/services/calendar_webhook_service.py
+++ b/calendar_integration/services/calendar_webhook_service.py
@@ -1,0 +1,676 @@
+"""Webhook subscription lifecycle and webhook-triggered sync.
+
+``CalendarWebhookService`` owns the webhook concern extracted from the
+``CalendarService`` facade. It is a plain class (not a DI-container provider):
+the facade constructs it (fresh per request, after authentication) feeding it
+the shared :class:`CalendarServiceContext` so it never re-authenticates or
+re-builds a calendar adapter (the perf guardrail). Everything it needs arrives
+via the constructor:
+
+- ``context`` — the immutable auth snapshot (organization, user_or_token,
+  account, calendar_adapter, permission_service, side_effects_service). Read
+  through ``self._context``; the auth guards in ``type_guards.py`` inspect the
+  same ``organization`` / ``account`` / ``calendar_adapter`` attributes the
+  context exposes, so behavior is byte-for-byte identical to the former methods.
+- ``calendar_cache`` — the facade-owned, per-instance ``{(org_id, id): Calendar}``
+  cache (the lru_cache multi-tenant fix from Phase 0). Shared so lookups are not
+  duplicated across the facade and this service.
+- ``host`` — the :class:`WebhookServiceHost` (in Phase 6 the facade itself).
+  The webhook concern routes things back through it:
+
+  - **sync triggering** (``request_calendar_sync``) — the sync concern, extracted
+    in Phase 5; reached through the host so the facade's delegation seam is
+    preserved and the existing test suite can patch it on the facade without
+    changing this service.
+  - **webhook-triggered sync** (``request_webhook_triggered_sync``) — defined on
+    this service but ``process_webhook_notification`` routes it through the host so
+    ``@patch.object(CalendarService, "request_webhook_triggered_sync")`` in the
+    existing test suite intercepts the call.
+  - **adapter-class lookup** (``_get_calendar_adapter_cls_for_provider``) — a
+    static helper on the facade; routed here for a single implementation.
+  - **write-adapter resolution** (``_get_write_adapter_for_calendar``) — the
+    shared write-adapter helper on the facade.
+  - **external-id calendar lookup** (``_get_calendar_by_external_id``) — uses the
+    shared per-instance calendar cache (Phase 0 lru fix); routed through the host
+    so cache sharing is preserved.
+
+Organization-context in ``handle_webhook``: the facade's ``handle_webhook``
+extracts the organization and writes ``self.organization = organization`` before
+calling ``_get_webhook_service().handle_webhook()``.  Because
+:meth:`CalendarService._build_context_snapshot` reads live facade attributes,
+the freshly-constructed sub-service already has the correct organization in its
+frozen context.  All downstream sub-service methods (including the fresh sub-service
+instances the host creates for the ``request_webhook_triggered_sync`` callback) also
+see it via ``_build_context_snapshot`` called at that point.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, cast
+
+from django.conf import settings
+from django.db.models import QuerySet
+from django.http import HttpRequest
+from django.urls import reverse
+
+from calendar_integration.constants import (
+    CalendarProvider,
+    CalendarSyncStatus,
+    CalendarSyncTriggerSource,
+    IncomingWebhookProcessingStatus,
+)
+from calendar_integration.exceptions import (
+    ServiceNotAuthenticatedError,
+    WebhookIgnoredError,
+)
+from calendar_integration.models import (
+    Calendar,
+    CalendarSync,
+    CalendarWebhookEvent,
+    CalendarWebhookSubscription,
+)
+from calendar_integration.services.protocols.authenticated_calendar_service import (
+    AuthenticatedCalendarService,
+)
+from calendar_integration.services.protocols.base_calendar_service import BaseCalendarService
+from calendar_integration.services.protocols.initializer_or_authenticated_calendar_service import (
+    InitializedOrAuthenticatedCalendarService,
+)
+from calendar_integration.services.type_guards import (
+    is_authenticated_calendar_service,
+    is_initialized_or_authenticated_calendar_service,
+)
+
+
+if TYPE_CHECKING:
+    from calendar_integration.services.calendar_service_context import CalendarServiceContext
+    from calendar_integration.services.protocols.calendar_adapter import CalendarAdapter
+
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookHealthStatus(TypedDict):
+    """Health metrics for the webhook system of an organization."""
+
+    total_subscriptions: int
+    active_subscriptions: int
+    expired_subscriptions: int
+    expiring_soon_subscriptions: int
+    recent_events_count: int
+    failed_events_count: int
+    success_rate: float
+
+
+class WebhookServiceHost(Protocol):
+    """The collaborator surface the webhook concern routes back to the facade for.
+
+    Concerns not part of the webhook surface that stay on the facade (or the facade
+    re-delegates from here):
+
+    - **sync triggering** (``request_calendar_sync``) — the sync concern (Phase 5);
+      reached through the host to keep one implementation and the call graph the
+      existing test suite patches on the facade.
+    - **webhook-triggered sync** (``request_webhook_triggered_sync``) — defined on
+      this service but also on the facade; ``process_webhook_notification`` routes it
+      through the host so ``@patch.object(CalendarService, "request_webhook_triggered_sync")``
+      in the existing test suite intercepts the call.
+    - **adapter-class lookup** (``_get_calendar_adapter_cls_for_provider``) — a
+      static helper on the facade; routed here for a single implementation.
+    - **write-adapter resolution** (``_get_write_adapter_for_calendar``) — the
+      shared write-adapter helper on the facade.
+    - **external-id calendar lookup** (``_get_calendar_by_external_id``) — uses the
+      shared per-instance calendar cache (Phase 0 lru fix); routed through the host
+      so cache sharing is preserved.
+
+    In Phase 6 the facade supplies *itself*. Later phases may swap individual
+    concerns without changing this service's call sites.
+    """
+
+    def request_calendar_sync(
+        self,
+        calendar: Calendar,
+        start_datetime: datetime.datetime,
+        end_datetime: datetime.datetime,
+        should_update_events: bool = False,
+        trigger_source: CalendarSyncTriggerSource = CalendarSyncTriggerSource.MANUAL,
+    ) -> CalendarSync | None: ...
+
+    def request_webhook_triggered_sync(
+        self,
+        external_calendar_id: str,
+        webhook_event: CalendarWebhookEvent,
+        sync_window_hours: int = 24,
+    ) -> CalendarSync | None: ...
+
+    def _get_calendar_adapter_cls_for_provider(self, provider: CalendarProvider) -> Any: ...
+
+    def _get_write_adapter_for_calendar(self, calendar: Calendar) -> CalendarAdapter | None: ...
+
+    def _get_calendar_by_external_id(self, calendar_external_id: str) -> Calendar: ...
+
+
+class CalendarWebhookService:
+    """Owns webhook subscription lifecycle and webhook-triggered sync."""
+
+    def __init__(
+        self,
+        context: CalendarServiceContext,
+        calendar_cache: dict[tuple[int, str | int], Calendar],
+        host: WebhookServiceHost,
+    ) -> None:
+        self._context = context
+        self._calendar_cache = calendar_cache
+        # Phase 6 seam: sync triggering and shared adapter/lookup helpers are
+        # reached through the host (the facade). See ``WebhookServiceHost``.
+        self._host = host
+
+    # ------------------------------------------------------------------
+    # Webhook-triggered sync
+    # ------------------------------------------------------------------
+
+    def request_webhook_triggered_sync(
+        self,
+        external_calendar_id: str,
+        webhook_event: CalendarWebhookEvent,
+        sync_window_hours: int = 24,
+    ) -> CalendarSync | None:
+        """Request calendar sync triggered by webhook notification.
+
+        Reuses existing request_calendar_sync with webhook-specific optimizations.
+
+        Args:
+            external_calendar_id: External calendar ID from webhook
+            webhook_event: The webhook event that triggered this sync
+            sync_window_hours: Hours around current time to sync
+
+        Returns:
+            CalendarSync instance if sync was triggered, None if skipped
+        """
+        now = datetime.datetime.now(tz=datetime.UTC)
+
+        context = cast("BaseCalendarService", self._context)
+        if not is_initialized_or_authenticated_calendar_service(context):
+            raise ValueError("Calendar service not properly initialized")
+        # After the guard, organization is guaranteed non-None; narrow the type so
+        # mypy can verify .organization.id access below.
+        narrowed = cast("InitializedOrAuthenticatedCalendarService", context)
+
+        # Find calendar by external ID
+        try:
+            calendar = Calendar.objects.get(
+                organization_id=narrowed.organization.id,
+                external_id=external_calendar_id,
+                provider=webhook_event.provider,
+            )
+        except Calendar.DoesNotExist:
+            logger.warning("Calendar not found for external_id: %s", external_calendar_id)
+            return None
+
+        # Check for recent syncs to prevent excessive syncing (deduplication)
+        recent_sync = CalendarSync.objects.filter(
+            calendar=calendar,
+            created__gte=now - datetime.timedelta(minutes=5),
+            status__in=[CalendarSyncStatus.IN_PROGRESS, CalendarSyncStatus.SUCCESS],
+        ).first()
+
+        if recent_sync:
+            logger.info(
+                "Skipping sync for calendar %s, recent sync exists: %s",
+                calendar.id,
+                recent_sync.id,
+            )
+            webhook_event.calendar_sync = recent_sync
+            webhook_event.processing_status = IncomingWebhookProcessingStatus.PROCESSED
+            webhook_event.save()
+            return recent_sync
+
+        # Define sync window around current time
+        start_datetime = now - datetime.timedelta(hours=sync_window_hours // 2)
+        end_datetime = now + datetime.timedelta(hours=sync_window_hours // 2)
+
+        # Use existing request_calendar_sync method via the host (the sync concern,
+        # Phase 5 seam) so the facade's delegation path is preserved.
+        calendar_sync = self._host.request_calendar_sync(
+            calendar=calendar,
+            start_datetime=start_datetime,
+            end_datetime=end_datetime,
+            should_update_events=True,  # Webhook implies changes, so update existing events
+            trigger_source=CalendarSyncTriggerSource.WEBHOOK,
+        )
+
+        # Link webhook event to triggered sync
+        webhook_event.calendar_sync = calendar_sync
+        webhook_event.processing_status = IncomingWebhookProcessingStatus.PROCESSED
+        webhook_event.save()
+
+        return calendar_sync
+
+    # ------------------------------------------------------------------
+    # Webhook subscription lifecycle
+    # ------------------------------------------------------------------
+
+    def create_calendar_webhook_subscription(
+        self,
+        calendar: Calendar,
+        callback_url: str | None = None,
+        expiration_hours: int = 24,
+    ) -> CalendarWebhookSubscription:
+        """Create webhook subscription using existing adapter methods.
+
+        Works for both Google and Microsoft calendars.
+
+        Args:
+            calendar: Calendar to create subscription for
+            callback_url: URL to receive webhook notifications (optional, will generate if not
+                provided)
+            expiration_hours: Hours until subscription expires
+
+        Returns:
+            CalendarWebhookSubscription instance
+
+        Raises:
+            ValueError: If calendar service not authenticated or provider not supported
+        """
+        context = cast("BaseCalendarService", self._context)
+        if not is_authenticated_calendar_service(context):
+            raise ValueError("Calendar service not authenticated")
+
+        # After the guard, calendar_adapter is guaranteed non-None; narrow the type so
+        # mypy can verify .calendar_adapter access below.
+        auth_context = cast("AuthenticatedCalendarService", context)
+        if not auth_context.calendar_adapter:
+            raise ValueError("Calendar adapter not available")
+
+        # Generate callback URL if not provided
+        if not callback_url:
+            if calendar.provider == CalendarProvider.GOOGLE:
+                callback_url = reverse(
+                    "calendar_integration:google_webhook",
+                    kwargs={"organization_id": calendar.organization_id},
+                )
+            elif calendar.provider == CalendarProvider.MICROSOFT:
+                callback_url = reverse(
+                    "calendar_integration:microsoft_webhook",
+                    kwargs={"organization_id": calendar.organization_id},
+                )
+            else:
+                raise ValueError(
+                    f"Webhook subscriptions not supported for provider: {calendar.provider}"
+                )
+
+            # Convert to absolute URL if needed
+            # In production, you might want to configure the domain via settings
+            if callback_url.startswith("/"):
+                domain = getattr(settings, "WEBHOOK_DOMAIN", "https://your-domain.com")
+                callback_url = f"{domain.rstrip('/')}{callback_url}"
+
+        # Use adapter-specific subscription creation
+        if calendar.provider == CalendarProvider.GOOGLE:
+            subscription_data = (
+                auth_context.calendar_adapter.create_webhook_subscription_with_tracking(
+                    resource_id=calendar.external_id,
+                    callback_url=callback_url,
+                    tracking_params={"ttl_seconds": expiration_hours * 3600},
+                )
+            )
+        elif calendar.provider == CalendarProvider.MICROSOFT:
+            subscription_data = (
+                auth_context.calendar_adapter.create_webhook_subscription_with_tracking(
+                    resource_id=calendar.external_id,
+                    callback_url=callback_url,
+                    tracking_params={"expiration_hours": expiration_hours},
+                )
+            )
+        else:
+            raise ValueError(
+                f"Webhook subscriptions not supported for provider: {calendar.provider}"
+            )
+
+        # Calculate expiration datetime
+        expiration_timestamp = subscription_data.get("expiration")
+        expires_at = None
+        if expiration_timestamp is not None:
+            try:
+                if calendar.provider == CalendarProvider.GOOGLE:
+                    # Google returns expiration as milliseconds since epoch
+                    expires_at = datetime.datetime.fromtimestamp(
+                        int(expiration_timestamp) / 1000, tz=datetime.UTC
+                    )
+                elif calendar.provider == CalendarProvider.MICROSOFT:
+                    # Microsoft returns expiration as ISO 8601 string
+                    expires_at = datetime.datetime.fromisoformat(
+                        expiration_timestamp.replace("Z", "+00:00")
+                    )
+            except (ValueError, TypeError):
+                # Log or handle malformed expiration value gracefully
+                expires_at = None
+                # Log or handle malformed expiration value gracefully
+                expires_at = None
+
+        # Create tracking record
+        webhook_subscription = CalendarWebhookSubscription.objects.create(
+            calendar=calendar,
+            organization_id=calendar.organization_id,
+            provider=calendar.provider,
+            external_subscription_id=subscription_data.get("subscription_id")
+            or subscription_data.get("channel_id"),
+            external_resource_id=subscription_data.get("resource_id", ""),
+            callback_url=callback_url,
+            channel_id=subscription_data.get("channel_id", ""),
+            resource_uri=subscription_data.get("resource_uri", ""),
+            verification_token=subscription_data.get("client_state")
+            or subscription_data.get("channel_token")
+            or "",
+            expires_at=expires_at,
+        )
+
+        return webhook_subscription
+
+    def process_webhook_notification(
+        self,
+        provider: str,
+        calendar_external_id: str,
+        headers: dict[str, str],
+        payload: dict | str | None = None,
+        validation_token: str | None = None,
+    ) -> CalendarWebhookEvent | None:
+        """Process incoming webhook notification using adapter validation.
+
+        Returns CalendarWebhookEvent for notification
+
+        Args:
+            provider: Calendar provider (google, microsoft)
+            headers: HTTP headers from webhook request
+            payload: Webhook payload data
+            validation_token: Validation token for subscription setup
+
+        Returns:
+            CalendarWebhookEvent for notifications
+
+        Raises:
+            ValueError: If validation fails or provider not supported
+        """
+        context = cast("BaseCalendarService", self._context)
+
+        if not is_initialized_or_authenticated_calendar_service(context):
+            # For webhook processing, we can proceed with limited functionality
+            logger.warning(
+                "Webhook received but calendar service not authenticated, "
+                "webhook event recorded for later processing"
+            )
+
+        # Try to get calendar and adapter, but don't fail if not authenticated
+        calendar = None
+        calendar_adapter = None
+
+        try:
+            calendar = self._host._get_calendar_by_external_id(calendar_external_id)
+            calendar_adapter = self._host._get_write_adapter_for_calendar(calendar)
+        except (ServiceNotAuthenticatedError, Calendar.DoesNotExist):
+            # Calendar not found or not authenticated - we'll still record the webhook event
+            pass
+
+        # Handle provider-specific validation/parsing
+        # Use static validation if we don't have an authenticated adapter
+        if calendar_adapter:
+            parsed_data = calendar_adapter.validate_webhook_notification(
+                headers, json.dumps(payload) if payload else ""
+            )
+        else:
+            # Use static validation method
+            calendar_adapter_cls = self._host._get_calendar_adapter_cls_for_provider(
+                CalendarProvider(provider)
+            )
+            parsed_data = calendar_adapter_cls.validate_webhook_notification_static(
+                headers, json.dumps(payload) if payload else ""
+            )
+
+        # The organization is accessed below — cast to the narrowed type for mypy.
+        # The BaseCalendarService cast above is for the auth guards (which use hasattr);
+        # after the org check we need the attribute typed.
+        org_context = cast("InitializedOrAuthenticatedCalendarService", context)
+        if not org_context.organization:
+            raise ValueError("Organization context not set on calendar service")
+
+        # Create webhook event record
+        webhook_event = CalendarWebhookEvent.objects.create(
+            organization_id=org_context.organization.id,
+            provider=provider,
+            event_type=parsed_data.get("event_type", "unknown"),
+            external_calendar_id=parsed_data.get("calendar_id", ""),
+            external_event_id=parsed_data.get("event_id", ""),
+            raw_payload=payload if isinstance(payload, dict) else {"raw": str(payload or "")},
+            headers=headers,
+        )
+
+        # Trigger calendar sync only if service is authenticated
+        # For webhook processing, we record the event even if sync can't be triggered immediately
+        try:
+            if is_authenticated_calendar_service(context, raise_error=False):
+                # Route through host so that @patch.object(CalendarService,
+                # "request_webhook_triggered_sync") patches in the existing test suite are
+                # intercepted.  The facade's request_webhook_triggered_sync calls
+                # _get_webhook_service().request_webhook_triggered_sync(), which is correct when
+                # unpatched; when patched on the facade, the mock fires first.
+                calendar_sync = self._host.request_webhook_triggered_sync(
+                    external_calendar_id=parsed_data["calendar_id"], webhook_event=webhook_event
+                )
+
+                if calendar_sync:
+                    logger.info(
+                        "Webhook triggered sync %s for calendar %s",
+                        calendar_sync.id,
+                        parsed_data["calendar_id"],
+                    )
+                    return webhook_event
+                else:
+                    webhook_event.processing_status = IncomingWebhookProcessingStatus.IGNORED
+                    webhook_event.save()
+            else:
+                # Service not authenticated - just record the webhook event for later processing
+                logger.warning(
+                    "Webhook received but calendar service not authenticated, "
+                    "webhook event recorded for later processing"
+                )
+                webhook_event.processing_status = IncomingWebhookProcessingStatus.PENDING
+                webhook_event.save()
+
+        except Exception as e:
+            webhook_event.processing_status = IncomingWebhookProcessingStatus.FAILED
+            webhook_event.save()
+            logger.exception("Failed to process webhook: %s", e)
+            # Don't re-raise the exception - webhook event is recorded
+
+        return webhook_event
+
+    def handle_webhook(
+        self, provider: CalendarProvider, request: HttpRequest
+    ) -> CalendarWebhookEvent | None:
+        """Handle calendar webhook processing with organization context.
+
+        The facade's ``handle_webhook`` extracts the organization and writes
+        ``self.organization`` *before* constructing this sub-service instance, so
+        ``self._context.organization`` is already set when this method is called.
+        This method only needs to parse the provider-specific headers and delegate
+        to ``process_webhook_notification``.
+
+        Args:
+            provider: Calendar provider enum
+            request: HttpRequest object containing webhook data
+
+        Returns:
+            CalendarWebhookEvent if processed successfully, None for sync notifications
+
+        Raises:
+            ValueError: If webhook validation fails or organization not found
+            Exception: If processing fails
+        """
+        calendar_adapter_cls = self._host._get_calendar_adapter_cls_for_provider(provider)
+
+        headers = calendar_adapter_cls.parse_webhook_headers(request.headers)
+        calendar_external_id = (
+            calendar_adapter_cls.extract_calendar_external_id_from_webhook_request(request)
+        )
+
+        # Process the webhook notification
+        try:
+            return self.process_webhook_notification(
+                provider=provider,
+                calendar_external_id=calendar_external_id,
+                headers=headers,
+            )
+        except WebhookIgnoredError:
+            return None
+
+    def list_webhook_subscriptions(self) -> QuerySet[CalendarWebhookSubscription]:
+        """List all active webhook subscriptions for the organization.
+
+        Returns:
+            QuerySet of CalendarWebhookSubscription objects for the organization
+
+        Raises:
+            ValueError: If organization is not set
+        """
+        context = cast("InitializedOrAuthenticatedCalendarService", self._context)
+        if not context.organization:
+            raise ValueError("Organization must be set")
+
+        return CalendarWebhookSubscription.objects.filter(
+            organization=context.organization, is_active=True
+        ).select_related("calendar")
+
+    def delete_webhook_subscription(self, subscription_id: int) -> bool:
+        """Delete a webhook subscription from provider and database.
+
+        Args:
+            subscription_id: ID of the subscription to delete
+
+        Returns:
+            True if successfully deleted, False if subscription not found
+
+        Raises:
+            ValueError: If organization is not set or subscription not found
+        """
+        context = cast("InitializedOrAuthenticatedCalendarService", self._context)
+        if not context.organization:
+            raise ValueError("Organization must be set")
+
+        try:
+            subscription = CalendarWebhookSubscription.objects.get(
+                id=subscription_id, organization=context.organization
+            )
+        except CalendarWebhookSubscription.DoesNotExist:
+            return False
+
+        # TODO: Add provider-specific subscription deletion when implementing
+        # Google Calendar and Microsoft Graph subscription deletion APIs
+        # For now, just mark as inactive
+        subscription.is_active = False
+        subscription.save(update_fields=["is_active", "modified"])
+
+        return True
+
+    def refresh_webhook_subscription(
+        self, subscription_id: int
+    ) -> CalendarWebhookSubscription | None:
+        """Refresh/renew a webhook subscription with the provider.
+
+        Args:
+            subscription_id: ID of the subscription to refresh
+
+        Returns:
+            Updated CalendarWebhookSubscription if successful, None if not found
+
+        Raises:
+            ValueError: If organization is not set
+        """
+        context = cast("InitializedOrAuthenticatedCalendarService", self._context)
+        if not context.organization:
+            raise ValueError("Organization must be set")
+
+        try:
+            subscription = CalendarWebhookSubscription.objects.get(
+                id=subscription_id, organization=context.organization, is_active=True
+            )
+        except CalendarWebhookSubscription.DoesNotExist:
+            return None
+
+        # TODO: Implement provider-specific subscription renewal
+        # For now, extend expiration by default duration based on provider
+        now = datetime.datetime.now(tz=datetime.UTC)
+        if subscription.provider == CalendarProvider.GOOGLE:
+            # Google allows max 7 days (604800 seconds)
+            new_expiration = now + datetime.timedelta(days=7)
+        elif subscription.provider == CalendarProvider.MICROSOFT:
+            # Microsoft allows max ~70 hours (4230 minutes)
+            new_expiration = now + datetime.timedelta(minutes=4230)
+        else:
+            # Default to 1 day for other providers
+            new_expiration = now + datetime.timedelta(days=1)
+
+        subscription.expires_at = new_expiration
+        subscription.save(update_fields=["expires_at", "modified"])
+
+        return subscription
+
+    def get_webhook_health_status(self) -> WebhookHealthStatus:
+        """Get webhook system health status for the organization.
+
+        Returns:
+            WebhookHealthStatus with webhook health metrics
+
+        Raises:
+            ValueError: If organization is not set
+        """
+        context = cast("InitializedOrAuthenticatedCalendarService", self._context)
+        if not context.organization:
+            raise ValueError("Organization must be set")
+
+        organization = context.organization
+
+        # Time boundaries
+        now = datetime.datetime.now(tz=datetime.UTC)
+        twenty_four_hours_ago = now - datetime.timedelta(hours=24)
+        expiring_soon_threshold = now + datetime.timedelta(hours=24)
+
+        # Subscription counts
+        subscriptions_qs = CalendarWebhookSubscription.objects.filter(organization=organization)
+        total_subscriptions = subscriptions_qs.count()
+        active_subscriptions = subscriptions_qs.filter(is_active=True).count()
+        expired_subscriptions = subscriptions_qs.filter(is_active=True, expires_at__lt=now).count()
+        expiring_soon_subscriptions = subscriptions_qs.filter(
+            is_active=True,
+            expires_at__gte=now,
+            expires_at__lte=expiring_soon_threshold,
+        ).count()
+
+        # Event counts in last 24 hours
+        events_qs = CalendarWebhookEvent.objects.filter(
+            organization=organization, created__gte=twenty_four_hours_ago
+        )
+        recent_events_count = events_qs.count()
+        failed_events_count = events_qs.filter(
+            processing_status=IncomingWebhookProcessingStatus.FAILED
+        ).count()
+
+        # Calculate success rate
+        if recent_events_count > 0:
+            success_rate = ((recent_events_count - failed_events_count) / recent_events_count) * 100
+        else:
+            success_rate = 100.0
+
+        return WebhookHealthStatus(
+            {
+                "total_subscriptions": total_subscriptions,
+                "active_subscriptions": active_subscriptions,
+                "expired_subscriptions": expired_subscriptions,
+                "expiring_soon_subscriptions": expiring_soon_subscriptions,
+                "recent_events_count": recent_events_count,
+                "failed_events_count": failed_events_count,
+                "success_rate": success_rate,
+            }
+        )

--- a/calendar_integration/tests/services/test_calendar_webhook_service.py
+++ b/calendar_integration/tests/services/test_calendar_webhook_service.py
@@ -1,0 +1,610 @@
+"""Unit tests for CalendarWebhookService.
+
+Tests construct CalendarWebhookService directly (bypassing the CalendarService
+facade) using a real CalendarServiceContext fed a fake calendar adapter, plus a
+lightweight fake host for the concerns routed back to the facade
+(``request_calendar_sync``, ``request_webhook_triggered_sync``,
+``_get_calendar_adapter_cls_for_provider``, ``_get_write_adapter_for_calendar``,
+``_get_calendar_by_external_id``).
+
+The flows covered are:
+- subscription create (adapter returns subscription data -> CalendarWebhookSubscription
+  is persisted with correct fields);
+- subscription refresh (extend expiration by provider-specific duration);
+- subscription delete (mark is_active=False);
+- process_webhook_notification (static adapter path -> CalendarWebhookEvent is created
+  and request_webhook_triggered_sync is called through the host);
+- get_webhook_health_status (counts subscriptions and events in last 24 hours).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from allauth.socialaccount.models import SocialAccount
+
+from calendar_integration.constants import (
+    CalendarProvider,
+    CalendarSyncTriggerSource,
+    IncomingWebhookProcessingStatus,
+)
+from calendar_integration.exceptions import (
+    CalendarServiceOrganizationNotSetError,
+    ServiceNotAuthenticatedError,
+)
+from calendar_integration.models import (
+    Calendar,
+    CalendarSync,
+    CalendarWebhookEvent,
+    CalendarWebhookSubscription,
+)
+from calendar_integration.services.calendar_service_context import CalendarServiceContext
+from calendar_integration.services.calendar_webhook_service import (
+    CalendarWebhookService,
+    WebhookHealthStatus,
+)
+from organizations.models import Organization
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Fake host
+# ---------------------------------------------------------------------------
+
+
+class FakeHost:
+    """Minimal WebhookServiceHost used in unit tests.
+
+    Records the calls routed back to the facade so individual tests can assert on
+    them. ``request_calendar_sync`` and ``request_webhook_triggered_sync`` return
+    configurable values; adapter helpers proxy to a fake adapter or raise as needed.
+    """
+
+    def __init__(self, fake_adapter: Any | None = None) -> None:
+        self.request_calendar_sync_calls: list[dict[str, Any]] = []
+        self.request_webhook_triggered_sync_calls: list[tuple[str, Any]] = []
+        self._fake_adapter = fake_adapter
+        # If set, _get_calendar_by_external_id returns this calendar.
+        self.calendar_by_external_id: Calendar | None = None
+        # CalendarSync to return from request_calendar_sync (None by default)
+        self.calendar_sync_return: CalendarSync | None = None
+        # CalendarSync to return from request_webhook_triggered_sync
+        self.webhook_triggered_sync_return: CalendarSync | None = None
+
+    def request_calendar_sync(
+        self,
+        calendar: Calendar,
+        start_datetime: datetime.datetime,
+        end_datetime: datetime.datetime,
+        should_update_events: bool = False,
+        trigger_source: CalendarSyncTriggerSource = CalendarSyncTriggerSource.MANUAL,
+    ) -> CalendarSync | None:
+        self.request_calendar_sync_calls.append(
+            {
+                "calendar": calendar,
+                "start_datetime": start_datetime,
+                "end_datetime": end_datetime,
+                "should_update_events": should_update_events,
+                "trigger_source": trigger_source,
+            }
+        )
+        return self.calendar_sync_return
+
+    def request_webhook_triggered_sync(
+        self,
+        external_calendar_id: str,
+        webhook_event: CalendarWebhookEvent,
+        sync_window_hours: int = 24,
+    ) -> CalendarSync | None:
+        self.request_webhook_triggered_sync_calls.append((external_calendar_id, webhook_event))
+        return self.webhook_triggered_sync_return
+
+    def _get_calendar_adapter_cls_for_provider(self, provider: CalendarProvider) -> type:
+        # Return a class with the static method we need.
+        if self._fake_adapter is not None:
+            adapter_cls = MagicMock()
+            adapter_cls.validate_webhook_notification_static = (
+                self._fake_adapter.validate_webhook_notification_static
+            )
+            adapter_cls.parse_webhook_headers = self._fake_adapter.parse_webhook_headers
+            adapter_cls.extract_calendar_external_id_from_webhook_request = (
+                self._fake_adapter.extract_calendar_external_id_from_webhook_request
+            )
+            return adapter_cls
+        raise NotImplementedError("No fake adapter configured")
+
+    def _get_write_adapter_for_calendar(self, calendar: Calendar) -> Any | None:
+        return None  # Force static validation path in most tests
+
+    def _get_calendar_by_external_id(self, calendar_external_id: str) -> Calendar:
+        if self.calendar_by_external_id is not None:
+            return self.calendar_by_external_id
+        raise Calendar.DoesNotExist(calendar_external_id)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Webhook Test Org")
+
+
+@pytest.fixture
+def user(db: Any) -> User:
+    u = User.objects.create_user(email="test_webhook@example.com", password="pass")  # noqa: S106
+    Profile.objects.create(user=u)
+    return u
+
+
+@pytest.fixture
+def social_account(db: Any, user: User) -> SocialAccount:
+    return SocialAccount.objects.create(user=user, provider=CalendarProvider.GOOGLE, uid="wh-999")
+
+
+@pytest.fixture
+def calendar(db: Any, organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        name="Webhook Calendar",
+        external_id="wh_cal_001",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def fake_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter.provider = CalendarProvider.GOOGLE
+    return adapter
+
+
+@pytest.fixture
+def context(
+    organization: Organization, user: User, fake_adapter: MagicMock
+) -> CalendarServiceContext:
+    return CalendarServiceContext(
+        organization=organization,
+        user_or_token=user,
+        account=user,
+        calendar_adapter=fake_adapter,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+    )
+
+
+@pytest.fixture
+def unauthenticated_context(organization: Organization, user: User) -> CalendarServiceContext:
+    """Context without a calendar adapter (initialize_without_provider state)."""
+    return CalendarServiceContext(
+        organization=organization,
+        user_or_token=user,
+        account=None,
+        calendar_adapter=None,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+    )
+
+
+def make_service(context: CalendarServiceContext, host: FakeHost) -> CalendarWebhookService:
+    return CalendarWebhookService(context=context, calendar_cache={}, host=host)
+
+
+# ---------------------------------------------------------------------------
+# Tests: subscription create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_calendar_webhook_subscription_google(
+    context: CalendarServiceContext,
+    calendar: Calendar,
+    fake_adapter: MagicMock,
+) -> None:
+    """create_calendar_webhook_subscription persists a subscription row with
+    the correct fields when the provider returns a Google-style response."""
+    fake_adapter.create_webhook_subscription_with_tracking.return_value = {
+        "channel_id": "channel-abc",
+        "resource_id": "resource-abc",
+        "resource_uri": "https://www.googleapis.com/calendar/v3/calendars/wh_cal_001/events",
+        "expiration": "1700000000000",  # milliseconds since epoch
+        "calendar_id": "wh_cal_001",
+        "callback_url": "https://example.com/webhook",
+        "channel_token": "token-xyz",
+    }
+
+    host = FakeHost(fake_adapter=fake_adapter)
+    service = make_service(context, host)
+
+    sub = service.create_calendar_webhook_subscription(
+        calendar=calendar,
+        callback_url="https://example.com/webhook",
+        expiration_hours=24,
+    )
+
+    assert sub.calendar == calendar
+    assert sub.provider == CalendarProvider.GOOGLE
+    assert sub.channel_id == "channel-abc"
+    assert sub.external_resource_id == "resource-abc"
+    assert sub.callback_url == "https://example.com/webhook"
+    assert sub.is_active is True
+    # Expiration should be parsed from milliseconds
+    assert sub.expires_at is not None
+    assert sub.expires_at == datetime.datetime.fromtimestamp(1700000000000 / 1000, tz=datetime.UTC)
+
+    # Verify it's persisted (must filter by organization per multi-tenancy contract)
+    persisted = CalendarWebhookSubscription.objects.get(
+        id=sub.id, organization=calendar.organization_id
+    )
+    assert persisted.channel_id == "channel-abc"
+
+
+@pytest.mark.django_db
+def test_create_calendar_webhook_subscription_requires_auth(
+    unauthenticated_context: CalendarServiceContext,
+    calendar: Calendar,
+) -> None:
+    """create_calendar_webhook_subscription raises ServiceNotAuthenticatedError when
+    not authenticated (is_authenticated_calendar_service raises before the local
+    ValueError guard because raise_error=True by default)."""
+    host = FakeHost()
+    service = make_service(unauthenticated_context, host)
+
+    with pytest.raises(ServiceNotAuthenticatedError, match="Calendar service is not authenticated"):
+        service.create_calendar_webhook_subscription(
+            calendar=calendar,
+            callback_url="https://example.com/webhook",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: subscription refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_refresh_webhook_subscription_google(
+    context: CalendarServiceContext,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """refresh_webhook_subscription extends expires_at by 7 days for Google."""
+    sub = CalendarWebhookSubscription.objects.create(
+        calendar=calendar,
+        organization=organization,
+        provider=CalendarProvider.GOOGLE,
+        external_subscription_id="ext-sub-1",
+        channel_id="ch-1",
+        callback_url="https://example.com/wh",
+        expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(hours=2),
+    )
+
+    host = FakeHost()
+    service = make_service(context, host)
+    result = service.refresh_webhook_subscription(subscription_id=sub.id)
+
+    assert result is not None
+    assert result.id == sub.id
+    # Should be approximately 7 days from now
+    expected_min = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=6)
+    expected_max = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=8)
+    assert expected_min <= result.expires_at <= expected_max
+
+
+@pytest.mark.django_db
+def test_refresh_webhook_subscription_not_found_returns_none(
+    context: CalendarServiceContext,
+    organization: Organization,
+) -> None:
+    """refresh_webhook_subscription returns None when the subscription doesn't exist."""
+    host = FakeHost()
+    service = make_service(context, host)
+    result = service.refresh_webhook_subscription(subscription_id=99999)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: subscription delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_delete_webhook_subscription(
+    context: CalendarServiceContext,
+    calendar: Calendar,
+    organization: Organization,
+) -> None:
+    """delete_webhook_subscription marks the subscription as inactive."""
+    sub = CalendarWebhookSubscription.objects.create(
+        calendar=calendar,
+        organization=organization,
+        provider=CalendarProvider.GOOGLE,
+        external_subscription_id="ext-sub-del",
+        channel_id="ch-del",
+        callback_url="https://example.com/wh",
+    )
+    assert sub.is_active is True
+
+    host = FakeHost()
+    service = make_service(context, host)
+    result = service.delete_webhook_subscription(subscription_id=sub.id)
+
+    assert result is True
+    sub.refresh_from_db()
+    assert sub.is_active is False
+
+
+@pytest.mark.django_db
+def test_delete_webhook_subscription_not_found(
+    context: CalendarServiceContext,
+) -> None:
+    """delete_webhook_subscription returns False when the subscription doesn't exist."""
+    host = FakeHost()
+    service = make_service(context, host)
+    result = service.delete_webhook_subscription(subscription_id=99999)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: process_webhook_notification (static-adapter path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_process_webhook_notification_creates_event_and_calls_sync(
+    context: CalendarServiceContext,
+    organization: Organization,
+    calendar: Calendar,
+    fake_adapter: MagicMock,
+) -> None:
+    """process_webhook_notification creates a CalendarWebhookEvent and calls
+    request_webhook_triggered_sync through the host when authenticated."""
+    # Configure fake adapter static validation to return known parsed data
+    fake_adapter.validate_webhook_notification_static.return_value = {
+        "provider": "google",
+        "calendar_id": "wh_cal_001",
+        "event_id": "evt_001",
+        "event_type": "exists",
+        "resource_id": "res-001",
+        "channel_id": "ch-001",
+    }
+
+    # Create a fake CalendarSync to return from the host
+    calendar_sync = CalendarSync.objects.create(
+        calendar=calendar,
+        organization=organization,
+        start_datetime=datetime.datetime.now(tz=datetime.UTC),
+        end_datetime=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(hours=24),
+        should_update_events=True,
+    )
+
+    host = FakeHost(fake_adapter=fake_adapter)
+    host.webhook_triggered_sync_return = calendar_sync
+    service = make_service(context, host)
+
+    headers = {
+        "X-Goog-Resource-ID": "res-001",
+        "X-Goog-Resource-URI": (
+            "https://www.googleapis.com/calendar/v3/calendars/wh_cal_001/events"
+        ),
+        "X-Goog-Resource-State": "exists",
+        "X-Goog-Channel-ID": "ch-001",
+        "X-Goog-Channel-Token": "tok",
+    }
+
+    result = service.process_webhook_notification(
+        provider="google",
+        calendar_external_id="wh_cal_001",
+        headers=headers,
+    )
+
+    assert result is not None
+    assert isinstance(result, CalendarWebhookEvent)
+    assert result.provider == "google"
+    assert result.event_type == "exists"
+    assert result.external_calendar_id == "wh_cal_001"
+    assert result.organization_id == organization.id
+
+    # Host should have been called with the correct external_calendar_id
+    assert len(host.request_webhook_triggered_sync_calls) == 1
+    called_ext_id, called_event = host.request_webhook_triggered_sync_calls[0]
+    assert called_ext_id == "wh_cal_001"
+    assert called_event.id == result.id
+
+
+@pytest.mark.django_db
+def test_process_webhook_notification_no_sync_marks_ignored(
+    context: CalendarServiceContext,
+    organization: Organization,
+    fake_adapter: MagicMock,
+) -> None:
+    """process_webhook_notification marks the event IGNORED when
+    request_webhook_triggered_sync returns None."""
+    fake_adapter.validate_webhook_notification_static.return_value = {
+        "provider": "google",
+        "calendar_id": "wh_cal_001",
+        "event_id": "",
+        "event_type": "exists",
+        "resource_id": "res-001",
+        "channel_id": "ch-001",
+    }
+
+    host = FakeHost(fake_adapter=fake_adapter)
+    host.webhook_triggered_sync_return = None  # Sync not triggered
+    service = make_service(context, host)
+
+    headers = {
+        "X-Goog-Resource-ID": "res-001",
+        "X-Goog-Resource-URI": (
+            "https://www.googleapis.com/calendar/v3/calendars/wh_cal_001/events"
+        ),
+        "X-Goog-Resource-State": "exists",
+        "X-Goog-Channel-ID": "ch-001",
+        "X-Goog-Channel-Token": "tok",
+    }
+
+    result = service.process_webhook_notification(
+        provider="google",
+        calendar_external_id="wh_cal_001",
+        headers=headers,
+    )
+
+    assert result is not None
+    result.refresh_from_db()
+    assert result.processing_status == IncomingWebhookProcessingStatus.IGNORED
+
+
+@pytest.mark.django_db
+def test_process_webhook_notification_requires_organization_raises_immediately(
+    user: User,
+    fake_adapter: MagicMock,
+) -> None:
+    """process_webhook_notification raises CalendarServiceOrganizationNotSetError
+    immediately when the organization is unset, before any calendar lookup or
+    webhook validation runs."""
+    context_no_org = CalendarServiceContext(
+        organization=None,
+        user_or_token=user,
+        account=None,
+        calendar_adapter=None,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+    )
+    host = FakeHost(fake_adapter=fake_adapter)
+    service = make_service(context_no_org, host)
+
+    with pytest.raises(CalendarServiceOrganizationNotSetError):
+        service.process_webhook_notification(
+            provider="google",
+            calendar_external_id="wh_cal_001",
+            headers={},
+        )
+
+    # Guard must short-circuit before any calendar lookup or validation occurs.
+    fake_adapter.validate_webhook_notification_static.assert_not_called()
+    assert host.request_webhook_triggered_sync_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_webhook_health_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_webhook_health_status_empty(
+    context: CalendarServiceContext,
+    organization: Organization,
+) -> None:
+    """get_webhook_health_status returns 100% success rate with no events or subscriptions."""
+    host = FakeHost()
+    service = make_service(context, host)
+    status: WebhookHealthStatus = service.get_webhook_health_status()
+
+    assert status["total_subscriptions"] == 0
+    assert status["active_subscriptions"] == 0
+    assert status["expired_subscriptions"] == 0
+    assert status["expiring_soon_subscriptions"] == 0
+    assert status["recent_events_count"] == 0
+    assert status["failed_events_count"] == 0
+    assert status["success_rate"] == 100.0
+
+
+@pytest.mark.django_db
+def test_get_webhook_health_status_with_data(
+    context: CalendarServiceContext,
+    organization: Organization,
+    calendar: Calendar,
+) -> None:
+    """get_webhook_health_status counts subscriptions and recent events correctly."""
+    now = datetime.datetime.now(tz=datetime.UTC)
+
+    # A second calendar for the expired subscription (unique_together constraint is
+    # (organization, calendar, provider), so two subs for the same (org, calendar, provider)
+    # would violate it).
+    calendar_b = Calendar.objects.create(
+        name="Webhook Calendar B",
+        external_id="wh_cal_002",
+        provider=CalendarProvider.MICROSOFT,
+        organization=organization,
+    )
+
+    # One active subscription expiring soon (within 24h)
+    CalendarWebhookSubscription.objects.create(
+        calendar=calendar,
+        organization=organization,
+        provider=CalendarProvider.GOOGLE,
+        external_subscription_id="sub-1",
+        channel_id="ch-1",
+        callback_url="https://example.com/wh",
+        expires_at=now + datetime.timedelta(hours=3),
+        is_active=True,
+    )
+    # One expired subscription (different calendar+provider to avoid unique constraint)
+    CalendarWebhookSubscription.objects.create(
+        calendar=calendar_b,
+        organization=organization,
+        provider=CalendarProvider.MICROSOFT,
+        external_subscription_id="sub-2",
+        channel_id="ch-2",
+        callback_url="https://example.com/wh2",
+        expires_at=now - datetime.timedelta(hours=1),
+        is_active=True,
+    )
+
+    # Two recent events: one processed, one failed
+    CalendarWebhookEvent.objects.create(
+        organization=organization,
+        provider=CalendarProvider.GOOGLE,
+        event_type="exists",
+        external_calendar_id="wh_cal_001",
+        external_event_id="",
+        raw_payload={"raw": ""},
+        processing_status=IncomingWebhookProcessingStatus.PROCESSED,
+    )
+    CalendarWebhookEvent.objects.create(
+        organization=organization,
+        provider=CalendarProvider.GOOGLE,
+        event_type="exists",
+        external_calendar_id="wh_cal_001",
+        external_event_id="",
+        raw_payload={"raw": ""},
+        processing_status=IncomingWebhookProcessingStatus.FAILED,
+    )
+
+    host = FakeHost()
+    service = make_service(context, host)
+    status: WebhookHealthStatus = service.get_webhook_health_status()
+
+    assert status["total_subscriptions"] == 2
+    assert status["active_subscriptions"] == 2
+    assert status["expired_subscriptions"] == 1  # expires_at < now and is_active=True
+    assert status["expiring_soon_subscriptions"] == 1  # expires_at in (now, now+24h)
+    assert status["recent_events_count"] == 2
+    assert status["failed_events_count"] == 1
+    # (2 - 1) / 2 * 100 = 50%
+    assert status["success_rate"] == 50.0
+
+
+@pytest.mark.django_db
+def test_get_webhook_health_status_requires_organization(
+    user: User,
+) -> None:
+    """get_webhook_health_status raises ValueError when organization is not set."""
+    context_no_org = CalendarServiceContext(
+        organization=None,
+        user_or_token=user,
+        account=None,
+        calendar_adapter=None,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+    )
+    host = FakeHost()
+    service = make_service(context_no_org, host)
+
+    with pytest.raises(ValueError, match="Organization must be set"):
+        service.get_webhook_health_status()


### PR DESCRIPTION
## Summary
Phase 6 — the last concern extraction. Moves the 8 webhook methods (`request_webhook_triggered_sync`, `create_calendar_webhook_subscription`, `process_webhook_notification`, `handle_webhook`, `list_webhook_subscriptions`, `delete_webhook_subscription`, `refresh_webhook_subscription`, `get_webhook_health_status`) + the `WebhookHealthStatus` TypedDict into a new `CalendarWebhookService` (`calendar_integration/services/calendar_webhook_service.py`). Facade delegates via `self._get_webhook_service()`. `calendar_service.py` drops to **1618 lines** (down from 4726 originally — a 66% reduction across Phases 0–6).

## Seam + webhook→sync routing
Mirrors Phases 2–5: a `WebhookServiceHost` Protocol; `host=self`; `_get_webhook_service()` rebuilds context per call, shares `_calendar_cache`. Webhook-triggered sync routes back through the host: `process_webhook_notification → host.request_webhook_triggered_sync → host.request_calendar_sync → CalendarSyncService` (which never calls webhooks). Verified self-routing terminates — no method routes back to itself.

## handle_webhook split (the one non-trivial deviation)
`handle_webhook` is the HTTP entrypoint. The facade RETAINS the org-extraction half (resolver_match guard, `organization_id` kwarg, `Organization.objects.get`, exact ValueError messages + `from exc` chaining) and `self.organization = organization` — because that mutation must land on the facade so `_build_context_snapshot()` includes the org when the sub-service is constructed (the downstream `request_webhook_triggered_sync → host.request_calendar_sync` path needs it). The service half does header parsing + dispatch. Reviewer confirmed the facade half is byte-identical to the original's first half and nothing was dropped or duplicated.

## Behavior preservation
Byte-for-byte. Reviewer diffed `process_webhook_notification` (security-sensitive: adapter validation / signature / token check, `WebhookIgnoredError`/`ServiceNotAuthenticatedError` handling, `IncomingWebhookProcessingStatus` transitions) — all intact. The external-id lookup uses the Phase-0 org-scoped shared cache. No tenancy leak. Removed facade imports verified truly unused.

## One regression caught + fixed in-phase
The extraction initially weakened `process_webhook_notification`'s first auth guard from raise-on-org-unset to warn-and-continue (`raise_error=False`). Restored to the original immediate-raise semantics (`CalendarServiceOrganizationNotSetError`) and added a regression test asserting it short-circuits before any lookup/validation.

## Mypy
137→136 (0 new; the duplicated facade `WebhookHealthStatus` TypedDict that's now single-sourced cleared one).

## No feature flag
Pure refactor.

## Plan reference
Plan `ai-plans/2026-06-13-CALENDAR_SERVICE_REFACTOR_IMPLEMENTATION_PLAN.md`, Phase 6.

## Review history
Layer-3 adversarial review: 0 blockers, 1 should-fix (the guard regression above — fixed in-phase with a covering test), NITs verbatim-preserved (a duplicated `expires_at = None` from the original). After the fix: full suite 1634 passed, 0 failed.

## Test plan
- New `calendar_integration/tests/services/test_calendar_webhook_service.py` (12 tests) — subscription create/refresh/delete, notification parse, health status, and the org-unset immediate-raise regression.
- Integration safety net: `test_google_calendar_webhooks.py`, `test_microsoft_calendar_webhooks.py`, `test_incoming_webhook_*`, webhook mgmt-command tests (all unchanged).
- Outer gate: `ruff check` clean, `check --deploy` (5 pre-existing security warnings only), `pytest -n auto` → **1634 passed, 0 failed**.