### PR TITLE
fix(ci): valid origin format for CORS_ALLOWED_ORIGINS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.test"
           SECRET_KEY: ${{ steps.secret_id_generator.outputs.SECRET_KEY }}
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/vinta_schedule_test"
-          CORS_ALLOWED_ORIGINS: ".example.com"
+          CORS_ALLOWED_ORIGINS: "https://example.com"
           ALLOWED_HOSTS: ".example.com"
           SMTP_HOST: 'example.com'
           SMTP_USERNAME: "test"
@@ -102,7 +102,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.production"
           SECRET_KEY: ${{ steps.secret_id_generator.outputs.SECRET_KEY }}
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/vinta_schedule_test"
-          CORS_ALLOWED_ORIGINS: ".example.com"
+          CORS_ALLOWED_ORIGINS: "https://example.com"
           ALLOWED_HOSTS: ".example.org"
           SMTP_HOST: 'example.org'
           SMTP_USERNAME: "test"
@@ -134,7 +134,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.production"
           SECRET_KEY: ${{ steps.secret_id_generator.outputs.SECRET_KEY }}
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/vinta_schedule_test"
-          CORS_ALLOWED_ORIGINS: ".example.com"
+          CORS_ALLOWED_ORIGINS: "https://example.com"
           ALLOWED_HOSTS: ".example.org"
           SMTP_HOST: 'example.org'
           SMTP_USERNAME: "test"
@@ -166,7 +166,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.production"
           SECRET_KEY: ${{ steps.secret_id_generator.outputs.SECRET_KEY }}
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/vinta_schedule_test"
-          CORS_ALLOWED_ORIGINS: ".example.com"
+          CORS_ALLOWED_ORIGINS: "https://example.com"
           ALLOWED_HOSTS: ".example.org"
           SMTP_HOST: 'example.org'
           SMTP_USERNAME: "test"
@@ -199,7 +199,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.test"
           SECRET_KEY: ${{ steps.secret_id_generator.outputs.SECRET_KEY }}
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/vinta_schedule_test"
-          CORS_ALLOWED_ORIGINS: ".example.com"
+          CORS_ALLOWED_ORIGINS: "https://example.com"
           ALLOWED_HOSTS: ".example.com"
           SMTP_HOST: 'example.com'
           SMTP_USERNAME: "test"

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -260,15 +260,9 @@ class TestOrganizationService:
         first_name = "John"
         last_name = "Doe"
 
-        # Mock the transaction.on_commit and URL generation
-        with (
-            patch("organizations.services.transaction.on_commit") as mock_on_commit,
-            patch("organizations.services.reverse") as mock_reverse,
-            patch("organizations.services.build_absolute_uri") as mock_build_absolute_uri,
-        ):
+        # Mock the transaction.on_commit so the notification fires synchronously
+        with patch("organizations.services.transaction.on_commit") as mock_on_commit:
             mock_on_commit.side_effect = lambda func: func()
-            mock_reverse.return_value = "/invitation/test-token/"
-            mock_build_absolute_uri.return_value = "http://example.com/invitation/test-token/"
 
             # Mock the NotificationContextDict to avoid the tuple issue
             with patch("organizations.services.NotificationContextDict") as mock_context_dict:
@@ -326,15 +320,9 @@ class TestOrganizationService:
             membership=None,
         )
 
-        # Mock transaction.on_commit and URL generation
-        with (
-            patch("organizations.services.transaction.on_commit") as mock_on_commit,
-            patch("organizations.services.reverse") as mock_reverse,
-            patch("organizations.services.build_absolute_uri") as mock_build_absolute_uri,
-        ):
+        # Mock transaction.on_commit so the notification fires synchronously
+        with patch("organizations.services.transaction.on_commit") as mock_on_commit:
             mock_on_commit.side_effect = lambda func: func()
-            mock_reverse.return_value = "/invitation/test-token/"
-            mock_build_absolute_uri.return_value = "http://example.com/invitation/test-token/"
 
             # Mock the NotificationContextDict to avoid the tuple issue
             with patch("organizations.services.NotificationContextDict") as mock_context_dict:
@@ -1005,12 +993,9 @@ class TestOrganizationService:
 
         with (
             patch("organizations.services.transaction.on_commit") as mock_on_commit,
-            patch("organizations.services.reverse") as mock_reverse,
-            patch("organizations.services.build_absolute_uri"),
             patch("organizations.services.NotificationContextDict"),
         ):
             mock_on_commit.side_effect = lambda func: func()
-            mock_reverse.return_value = "/invitation/tok/"
 
             first_invitation = organization_service_with_mocks.invite_user_to_organization(
                 email=email,
@@ -1060,8 +1045,6 @@ class TestOrganizationService:
 
         with (
             patch("organizations.services.transaction.on_commit") as mock_on_commit,
-            patch("organizations.services.reverse"),
-            patch("organizations.services.build_absolute_uri"),
             patch("organizations.services.NotificationContextDict"),
         ):
             mock_on_commit.side_effect = lambda func: func()


### PR DESCRIPTION
## Problem
Build failing on `main` ([run 27580070354](https://github.com/vintasoftware/vinta-schedule-api/actions/runs/27580070354/job/81537952112)):

```
SystemCheckError: (corsheaders.E013) Origin '.example.com' in CORS_ALLOWED_ORIGINS is missing scheme or netloc
```

After `CORS_ALLOWED_ORIGINS` became an active `corsheaders` setting, the CI env value `.example.com` (bare-domain form, valid only for `ALLOWED_HOSTS`) failed corsheaders' origin validation, breaking the Django system check on every build job.

## Fix
Set `CORS_ALLOWED_ORIGINS: "https://example.com"` across all 5 CI job envs in `.github/workflows/main.yml`. corsheaders requires a scheme + netloc per origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)