### PR TITLE
feat(public_api): gated passwordless createUser mutation

### DIFF
--- a/ai-plans/TRACKING_whitelabel-api-provisioning.md
+++ b/ai-plans/TRACKING_whitelabel-api-provisioning.md
@@ -41,11 +41,20 @@ None (capability switch `can_invite_organizations`, DB-only, default off — not
 - **Review**: no BLOCKER; SHOULD-FIX (TOCTOU race → unique constraint; weak security asserts → specific gate/scope message + no-creation; flag-injection test behavioral) all fixed.
 - **Carry-forward**: gated-public-mutation pattern — register field in `FIELD_TO_RESOURCE_MAPPING` (public_api/permissions.py), permission_classes=[IsAuthenticated, OrganizationResourceAccess], acting org via `info.context.request.public_api_organization`, `assert_org_can_invite` in-resolver after scope. Types in public_api/types.py. organizations migrations now at 0009.
 
+### Phase 2 — createUser (passwordless shell) ✅
+- **Status**: PR #87 (https://github.com/vintasoftware/vinta-schedule-api/pull/87), base phase-1
+- **Branch**: plan/whitelabel-api-provisioning/phase-2
+- **Model**: claude-haiku-4-5 (Tier 2) · agent implementer
+- **Commits**: 95c6a04 (feat) + f190440 (fix BLOCKER + tests)
+- **Summary**: `createUser(input:{email,firstName,lastName})` → `{user{id email firstName lastName}}`. Gate+scope (USER). Idempotent on email via `get_user_model().objects.get_or_create(email=...)`. New user: `set_unusable_password()` + allauth `EmailAddress(verified=False)` (passwordless, unverified). Profile guaranteed on BOTH paths (no signal exists). No membership created.
+- **Gate**: 1904 passed; check --deploy + makemigrations --check clean.
+- **Review**: BLOCKER — idempotent return dereferenced `user.profile` but no auto-create signal ⇒ 500 on profile-less existing user; fixed (Profile.get_or_create moved before return, defensive read). SHOULD-FIX: no-membership assert, profile-less regression test, behavioral `authenticate()` rejection test, honored plan's test_provisioning_flow.py placement — all done.
+- **Carry-forward**: email verification = allauth `EmailAddress.verified` (django-allauth). User model = `get_user_model()` (users app); Profile at `users.models.Profile` (OneToOne, NO post_save signal — always get_or_create). Provisioned users are passwordless+unverified until social login + invite auto-join.
+
 ## Current Phase
-Phase 2 — createUser (starting)
+Phase 3 — createInvitation (branded-email path) (starting)
 
 ## Remaining Phases
-- Phase 3 — createInvitation (branded email)
 - Phase 4 — Self-managed invitations
 - Phase 5 — createSystemUserToken
 - Phase 6 — Branding storage + updateBranding

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
 from typing import Annotated, cast
 
+from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.utils import timezone
 
 import strawberry
+from allauth.account.models import EmailAddress
 from dependency_injector.wiring import Provide, inject
 from graphql import GraphQLError
 
@@ -14,7 +16,15 @@ from public_api.capabilities import assert_org_can_invite
 from public_api.models import SystemUser
 from public_api.permissions import IsAuthenticated, OrganizationResourceAccess
 from public_api.services import PublicAPIAuthService
-from public_api.types import CreateOrganizationInput, CreateOrganizationResult, OrganizationResult
+from public_api.types import (
+    CreateOrganizationInput,
+    CreateOrganizationResult,
+    CreateUserInput,
+    CreateUserResult,
+    OrganizationResult,
+    UserResult,
+)
+from users.models import Profile
 
 
 @dataclass
@@ -150,4 +160,66 @@ class Mutation(CalendarGroupMutations):
 
         return CreateOrganizationResult(
             organization=OrganizationResult(id=child_org.id, name=child_org.name)
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_user(
+        self,
+        info: strawberry.Info,
+        input: CreateUserInput,  # noqa: A002
+    ) -> CreateUserResult:
+        """
+        Create a passwordless end-user (provisioned by a reseller).
+
+        The mutation:
+        1. Checks that the acting org has the can_invite_organizations flag (via assert_org_can_invite).
+        2. Idempotent on email: if a User with that email exists, returns it (does NOT duplicate).
+        3. Creates User + Profile with set_unusable_password() and email left UNVERIFIED.
+        4. Returns the created user with id, email, first_name, and last_name.
+
+        The token's OrganizationResourceAccess must include the USER resource.
+        """
+        user_model = get_user_model()
+
+        acting_org = info.context.request.public_api_organization
+        if not acting_org:
+            raise GraphQLError("Organization not found")
+
+        # Gate: check the org can invite before proceeding
+        assert_org_can_invite(acting_org)
+
+        # Idempotent on email: get-or-create pattern
+        user, created = user_model.objects.get_or_create(
+            email=input.email,
+            defaults={},
+        )
+
+        if created:
+            # Only set unusable password and create profile if the user is newly created
+            user.set_unusable_password()
+            user.save(update_fields=["password"])
+
+            # Create the associated Profile with first_name and last_name
+            profile, _ = Profile.objects.get_or_create(user=user)
+            if input.first_name is not None:
+                profile.first_name = input.first_name
+            if input.last_name is not None:
+                profile.last_name = input.last_name
+            profile.save()
+
+            # Create an EmailAddress entry with verified=False (email is unverified)
+            EmailAddress.objects.create(
+                user=user,
+                email=user.email,
+                verified=False,
+                primary=True,
+            )
+
+        return CreateUserResult(
+            user=UserResult(
+                id=user.id,
+                email=user.email,
+                first_name=user.profile.first_name or None,
+                last_name=user.profile.last_name or None,
+            )
         )

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -194,13 +194,15 @@ class Mutation(CalendarGroupMutations):
             defaults={},
         )
 
+        # Guarantee a Profile exists (handles both newly created and profile-less existing users)
+        profile, _ = Profile.objects.get_or_create(user=user)
+
         if created:
-            # Only set unusable password and create profile if the user is newly created
+            # Only set unusable password and email if the user is newly created
             user.set_unusable_password()
             user.save(update_fields=["password"])
 
-            # Create the associated Profile with first_name and last_name
-            profile, _ = Profile.objects.get_or_create(user=user)
+            # Set first_name and last_name on the Profile for the new user
             if input.first_name is not None:
                 profile.first_name = input.first_name
             if input.last_name is not None:
@@ -219,7 +221,7 @@ class Mutation(CalendarGroupMutations):
             user=UserResult(
                 id=user.id,
                 email=user.email,
-                first_name=user.profile.first_name or None,
-                last_name=user.profile.last_name or None,
+                first_name=profile.first_name or None,
+                last_name=profile.last_name or None,
             )
         )

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -41,6 +41,7 @@ class OrganizationResourceAccess(BasePermission):
         "calendarGroupEvents": PublicAPIResources.CALENDAR_GROUP,
         "deleteSystemUser": PublicAPIResources.SYSTEM_USER,
         "createOrganization": PublicAPIResources.ORGANIZATION,
+        "createUser": PublicAPIResources.USER,
     }
 
     def has_permission(self, source, info: Info, **kwargs) -> bool:  # type: ignore

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -362,3 +362,317 @@ class TestGraphQLMutations:
         response_data = response.json()
         assert "errors" in response_data
         assert len(response_data["errors"]) > 0
+
+    def test_create_user_success_reseller(self):
+        """Test successful creation of a passwordless user by a reseller."""
+        from allauth.account.models import EmailAddress
+
+        from di_core.containers import container
+
+        # Create a reseller org with the can_invite_organizations flag
+        reseller_org = baker.make(Organization, name="Reseller Org", can_invite_organizations=True)
+
+        # Create a system user for the reseller with USER resource access
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(
+            ResourceAccess,
+            system_user=system_user,
+            resource_name="user",
+        )
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                    firstName
+                    lastName
+                }
+            }
+        }
+        """
+
+        user_email = "newuser@example.com"
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": user_email,
+                            "firstName": "John",
+                            "lastName": "Doe",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "data" in data
+        assert data["data"]["createUser"]["user"]["email"] == user_email
+        assert data["data"]["createUser"]["user"]["firstName"] == "John"
+        assert data["data"]["createUser"]["user"]["lastName"] == "Doe"
+
+        # Verify the user was created with correct properties
+        user_model = get_user_model()
+        created_user = user_model.objects.get(email=user_email)
+        assert created_user.has_usable_password() is False
+        assert created_user.profile.first_name == "John"
+        assert created_user.profile.last_name == "Doe"
+
+        # Verify email is unverified
+        email_address = EmailAddress.objects.get(user=created_user)
+        assert email_address.verified is False
+        assert email_address.primary is True
+
+    def test_create_user_idempotent_on_email(self):
+        """Test that createUser is idempotent on email (returns existing user)."""
+        from di_core.containers import container
+
+        # Create a reseller org
+        reseller_org = baker.make(Organization, name="Reseller Org", can_invite_organizations=True)
+
+        # Create a system user with USER resource access
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(
+            ResourceAccess,
+            system_user=system_user,
+            resource_name="user",
+        )
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                    firstName
+                    lastName
+                }
+            }
+        }
+        """
+
+        user_email = "idempotent@example.com"
+        with container.public_api_auth_service.override(auth_service):
+            # First call
+            response1 = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": user_email,
+                            "firstName": "Jane",
+                            "lastName": "Smith",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+            assert response1.status_code == 200
+            data1 = response1.json()
+            user_id_1 = data1["data"]["createUser"]["user"]["id"]
+
+            # Second call with the same email - should return the same user
+            response2 = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": user_email,
+                            "firstName": "Different",
+                            "lastName": "Name",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+            assert response2.status_code == 200
+            data2 = response2.json()
+            user_id_2 = data2["data"]["createUser"]["user"]["id"]
+
+        # Verify same user id returned
+        assert user_id_1 == user_id_2
+
+        # Verify only one user exists with this email
+        user_model = get_user_model()
+        assert user_model.objects.filter(email=user_email).count() == 1
+
+    def test_create_user_fails_flag_off(self):
+        """Test that createUser fails when acting org has flag off."""
+        from di_core.containers import container
+
+        # Create a non-reseller org (flag is False by default)
+        non_reseller_org = baker.make(Organization, name="Non-Reseller Org")
+
+        # Create a system user with USER resource access
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=non_reseller_org
+        )
+        baker.make(
+            ResourceAccess,
+            system_user=system_user,
+            resource_name="user",
+        )
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                }
+            }
+        }
+        """
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": "user@example.com",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        # Should get a GraphQL error with the permission message
+        assert "errors" in response_data
+        assert len(response_data["errors"]) > 0
+        assert (
+            "does not have permission to invite or create" in str(response_data["errors"]).lower()
+        )
+        # Verify no user was created
+        user_model = get_user_model()
+        assert not user_model.objects.filter(email="user@example.com").exists()
+
+    def test_create_user_fails_no_scope(self):
+        """Test that createUser fails without USER scope."""
+        from di_core.containers import container
+
+        # Create a reseller org
+        reseller_org = baker.make(Organization, name="Reseller Org", can_invite_organizations=True)
+
+        # Create a system user without USER resource access
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        # Don't grant USER resource
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                }
+            }
+        }
+        """
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": "user@example.com",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        # Should get a GraphQL error for permission denied
+        assert "errors" in response_data
+        assert len(response_data["errors"]) > 0
+        # Verify the OrganizationResourceAccess permission message
+        assert "don't have access" in str(response_data["errors"]).lower()
+        # Verify no user was created
+        user_model = get_user_model()
+        assert not user_model.objects.filter(email="user@example.com").exists()
+
+    def test_create_user_optional_names(self):
+        """Test that firstName and lastName are optional."""
+        from di_core.containers import container
+
+        # Create a reseller org
+        reseller_org = baker.make(Organization, name="Reseller Org", can_invite_organizations=True)
+
+        # Create a system user with USER resource access
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(
+            ResourceAccess,
+            system_user=system_user,
+            resource_name="user",
+        )
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                    firstName
+                    lastName
+                }
+            }
+        }
+        """
+
+        user_email = "nonames@example.com"
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": user_email,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "data" in data
+        assert data["data"]["createUser"]["user"]["email"] == user_email
+        # Names should be None when not provided
+        assert data["data"]["createUser"]["user"]["firstName"] is None
+        assert data["data"]["createUser"]["user"]["lastName"] is None

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -433,6 +433,9 @@ class TestGraphQLMutations:
         assert email_address.verified is False
         assert email_address.primary is True
 
+        # Verify the user is membership-less (no organization membership)
+        assert not OrganizationMembership.objects.filter(user=created_user).exists()
+
     def test_create_user_idempotent_on_email(self):
         """Test that createUser is idempotent on email (returns existing user)."""
         from di_core.containers import container
@@ -676,3 +679,89 @@ class TestGraphQLMutations:
         # Names should be None when not provided
         assert data["data"]["createUser"]["user"]["firstName"] is None
         assert data["data"]["createUser"]["user"]["lastName"] is None
+
+    def test_create_user_idempotent_on_existing_profileless_user(self):
+        """Test that createUser handles existing users without a Profile (regression test for BLOCKER)."""
+        from allauth.account.models import EmailAddress
+
+        from di_core.containers import container
+
+        # Create a reseller org
+        reseller_org = baker.make(Organization, name="Reseller Org", can_invite_organizations=True)
+
+        # Create a system user with USER resource access
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(
+            ResourceAccess,
+            system_user=system_user,
+            resource_name="user",
+        )
+
+        # Create a User without a Profile (mimic a user created by another path)
+        user_model = get_user_model()
+        pre_existing_user = user_model.objects.create(email="profileless@example.com")
+        # Set unusable password to mimic an existing user from another auth pathway
+        pre_existing_user.set_unusable_password()
+        pre_existing_user.save(update_fields=["password"])
+
+        # Verify the pre-existing user has no Profile and no EmailAddress
+        from django.core.exceptions import ObjectDoesNotExist
+
+        try:
+            _ = pre_existing_user.profile
+            has_profile = True
+        except ObjectDoesNotExist:
+            has_profile = False
+        assert not has_profile
+        assert EmailAddress.objects.filter(user=pre_existing_user).count() == 0
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                    firstName
+                    lastName
+                }
+            }
+        }
+        """
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": "profileless@example.com",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        # Should succeed with no GraphQL errors
+        assert response.status_code == 200
+        data = response.json()
+        assert "data" in data
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        # Verify the returned user has the pre-existing user's id
+        returned_user_id = data["data"]["createUser"]["user"]["id"]
+        assert int(returned_user_id) == pre_existing_user.id
+
+        # Verify exactly one User with this email exists
+        assert user_model.objects.filter(email="profileless@example.com").count() == 1
+
+        # Verify no EmailAddress was created (idempotent path must not create one)
+        assert EmailAddress.objects.filter(user=pre_existing_user).count() == 0
+
+        # Verify the user still has no usable password
+        pre_existing_user.refresh_from_db()
+        assert pre_existing_user.has_usable_password() is False

--- a/public_api/tests/test_provisioning_flow.py
+++ b/public_api/tests/test_provisioning_flow.py
@@ -1,4 +1,6 @@
-"""Integration tests for the provisioning flow (Phase 1: createOrganization)."""
+"""Integration tests for the provisioning flow (Phase 1: createOrganization; Phase 2: createUser)."""
+
+from django.contrib.auth import authenticate, get_user_model
 
 import pytest
 from model_bakery import baker
@@ -222,3 +224,122 @@ class TestCreateOrganizationProvisioning:
         assert child_a.parent_id == reseller_org.id
         assert child_b.parent_id == reseller_org.id
         assert child_a.id != child_b.id
+
+
+@pytest.mark.django_db
+class TestCreateUserProvisioning:
+    """Integration tests for the createUser mutation in the provisioning flow (Phase 2)."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def test_provisioned_user_cannot_password_authenticate(self):
+        """Test that a provisioned user cannot password-authenticate (behavioral test)."""
+        from di_core.containers import container
+
+        # Create a reseller org
+        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+
+        # Create a system user for the reseller with USER scope
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="reseller_integration", organization=reseller_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="user")
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                }
+            }
+        }
+        """
+
+        user_email = "provisioned@example.com"
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": user_email,
+                            "firstName": "Provisioned",
+                            "lastName": "User",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "data" in data
+        assert data["data"]["createUser"]["user"]["email"] == user_email
+
+        # Get the provisioned user
+        user_model = get_user_model()
+        provisioned_user = user_model.objects.get(email=user_email)
+
+        # Assert user has no usable password
+        assert provisioned_user.has_usable_password() is False
+
+        # Behaviorally assert the user cannot password-authenticate
+        # The USERNAME_FIELD for User is "email"
+        authenticated_user = authenticate(username=user_email, password="anything")
+        assert authenticated_user is None
+
+    def test_token_without_user_scope_is_denied(self):
+        """Test that a token without USER scope cannot call createUser."""
+        from di_core.containers import container
+
+        # Create a reseller org
+        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+
+        # Create a system user WITHOUT USER scope
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="reseller_integration", organization=reseller_org
+        )
+        # Grant a different resource instead (e.g., ORGANIZATION)
+        baker.make(ResourceAccess, system_user=system_user, resource_name="organization")
+
+        mutation = """
+        mutation CreateUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+                user {
+                    id
+                    email
+                }
+            }
+        }
+        """
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {
+                        "input": {
+                            "email": "denied@example.com",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        response_data = response.json()
+        # Should get permission denied
+        assert "errors" in response_data
+        assert len(response_data["errors"]) > 0
+
+        # Verify no user was created
+        user_model = get_user_model()
+        assert not user_model.objects.filter(email="denied@example.com").exists()

--- a/public_api/types.py
+++ b/public_api/types.py
@@ -31,3 +31,29 @@ class CreateOrganizationResult:
     """Result of creating an organization."""
 
     organization: OrganizationResult
+
+
+@strawberry.input
+class CreateUserInput:
+    """Input for creating a passwordless user."""
+
+    email: str
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+@strawberry.type
+class UserResult:
+    """Represents a user in the API response."""
+
+    id: int
+    email: str
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+@strawberry.type
+class CreateUserResult:
+    """Result of creating a user."""
+
+    user: UserResult


### PR DESCRIPTION
## Summary
Second reseller-bundle mutation: provision a passwordless end-user by email.

- `createUser(input: { email, firstName, lastName })` → `{ user { id email firstName lastName } }`.
- New user: `set_unusable_password()` + an allauth `EmailAddress(verified=False)` — passwordless and email-unverified. The user only becomes usable after the themed Google login (Google verifies the email) + the existing social-adapter invite auto-join. Vinta's verification posture is preserved, not bypassed.
- **Idempotent on email**: a repeat call returns the existing user without re-mutating it (no second EmailAddress, no password reset). A `Profile` is guaranteed on both paths so the idempotent return never crashes on a profile-less pre-existing user.
- **Dual gate**: `OrganizationResourceAccess('USER')` + in-resolver `assert_org_can_invite(acting_org)`. No `OrganizationMembership` is created here (membership arrives via Phase 3's invitation).

## Plan reference
ai-plans/2026-06-16-WHITELABEL_API_PROVISIONING_IMPLEMENTATION_PLAN.md — Phase 2, API Design 4.2. **Stacked on Phase 1** (PR #86).

## Test plan
- `uv run pytest public_api/tests/test_mutations.py public_api/tests/test_provisioning_flow.py -vs`
- Outer gate: `uv run python manage.py check --deploy` + `uv run pytest -n auto` (1904 passed) + `uv run python manage.py makemigrations --check`.

Reviewer notes: review caught a BLOCKER — the original idempotent return dereferenced `user.profile` while Profile has no auto-create signal, so an email mapping to a profile-less user would 500. Fixed by guaranteeing the Profile before return; a regression test exercises that exact path. A behavioral test now asserts `authenticate(...)` rejects the provisioned user (not just `has_usable_password() is False`).