### PR TITLE
feat(public_api): self-managed invitations — suppress email and return raw token once

### DIFF
--- a/ai-plans/TRACKING_whitelabel-api-provisioning.md
+++ b/ai-plans/TRACKING_whitelabel-api-provisioning.md
@@ -52,8 +52,18 @@ None (capability switch `can_invite_organizations`, DB-only, default off — not
 - **DEVIATION (acknowledged)**: plan 4.3 named INVITATION+MEMBERSHIP; `FIELD_TO_RESOURCE_MAPPING` is one-resource-per-field by design — gated on INVITATION + DB flag, MEMBERSHIP implied. Not re-architected (out of scope). Documented in PR #88.
 - **Carry-forward**: `assert_target_in_subtree(acting_org, target_org)` in public_api/capabilities.py — reuse for Phases 5 & 9 (raises GraphQLError, cycle-guarded). `OrganizationService.invite_user_to_organization(email,first_name,last_name,organization,invited_by=None,role=...)` DI-injected via `organization_service` provider (now a required dep in get_mutation_dependencies). OrgRole strawberry enum (`@strawberry.enum class OrgRole(enum.Enum)`, `.to_model_role()`) in public_api/types.py. organizations migrations now at 0010.
 
+### Phase 4 — Self-managed invitations (email suppression + token return) ✅
+- **Status**: PR #89 (https://github.com/vintasoftware/vinta-schedule-api/pull/89), base phase-3
+- **Branch**: plan/whitelabel-api-provisioning/phase-4
+- **Model**: claude-sonnet-4-6 (Tier 3) · implementer
+- **Commits**: 2ba6070 (feat)
+- **Summary**: `createInvitation` sendEmail=false branch. `invite_user_to_organization` gained `send_email: bool = True` (guards the on_commit email dispatch; existing callers default True = unchanged) and attaches the raw token as transient `invitation._raw_token` (set after save, never persisted — only token_hash/SHA-256 stored). Mutation: false → returns raw token + inviteUrl (from `HEADLESS_FRONTEND_URLS["account_accept_invitation"]`, same as email; test.py adds the test key) once; true → null (Phase 3 unchanged). Returned token validates via accept_invitation (tested end-to-end).
+- **Gate**: 1929 passed; check --deploy + makemigrations --check clean.
+- **Review**: no BLOCKER — all security invariants confirmed (no plaintext persistence; token validates; email truly suppressed; flag/scope/subtree gate holds on false path; true path returns null). Low-value test-convention SHOULD-FIX accepted as-is.
+- **Future hardening (noted, out of scope)**: `accept_invitation` scans invitations cross-org (email__iexact + per-row verify) — latent timing/DoS surface as volume grows.
+
 ## Current Phase
-Phase 4 — Self-managed invitations (email suppression + token return) (starting)
+Phase 5 — createSystemUserToken (token delegation) (starting)
 
 ## Remaining Phases
 - Phase 3 — createInvitation (branded email)

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -206,10 +206,17 @@ class OrganizationService:
         organization: Organization,
         invited_by: User | None = None,
         role: str = OrganizationRole.MEMBER,
+        send_email: bool = True,
     ) -> OrganizationInvitation:
         """
         Invite a user to join the organization. if the invitation already exists, resets the token
         and the expiration date.
+
+        The raw token is attached to the returned invitation as ``invitation._raw_token`` (a
+        transient, non-persisted attribute) so callers that need it (e.g. the public-API
+        self-managed-invitation path) can surface it once without it ever being stored in
+        plaintext. Only ``token_hash`` is persisted.
+
         :param email: Email of the user to invite.
         :param organization: Organization the user is being invited to.
         :param invited_by: User who is sending the invitation. May be None when the invitation is
@@ -217,6 +224,10 @@ class OrganizationService:
             corresponding Django User.
         :param role: Role the invited user should receive on accepting the invitation. Defaults to
             MEMBER. Use OrganizationRole.ADMIN for admin invitations.
+        :param send_email: When True (default) the invitation email is dispatched via the
+            notification service. When False the email is suppressed — the caller is responsible
+            for delivering the invite link using the raw token attached to the returned instance
+            as ``_raw_token``.
         """
         token = generate_long_lived_token()
         token_hash = hash_long_lived_token(token)
@@ -252,27 +263,32 @@ class OrganizationService:
             invitation.membership = None
             invitation.save()
 
-        transaction.on_commit(
-            lambda: self.notification_service.create_one_off_notification(
-                email_or_phone=email,
-                first_name=first_name,
-                last_name=last_name,
-                notification_type=NotificationTypes.EMAIL.value,
-                title="Invitation to join organization",
-                body_template="organizations/emails/organization_invitation.body.html",
-                context_name="organization_invitation_context",
-                context_kwargs=NotificationContextDict(
-                    {
-                        "organization_invitation_id": invitation.id,
-                        "invitation_url": (getattr(settings, "HEADLESS_FRONTEND_URLS", {}))
-                        .get("account_accept_invitation", "")
-                        .format(token=token),
-                    }
-                ),
-                subject_template="organizations/emails/organization_invitation.subject.txt",
-                preheader_template="organizations/emails/organization_invitation.pre_header.txt",
+        # Attach the raw token as a transient attribute so the caller can surface it once.
+        # It is never persisted — only token_hash is stored in the DB row.
+        invitation._raw_token = token  # type: ignore[attr-defined]
+
+        if send_email:
+            transaction.on_commit(
+                lambda: self.notification_service.create_one_off_notification(
+                    email_or_phone=email,
+                    first_name=first_name,
+                    last_name=last_name,
+                    notification_type=NotificationTypes.EMAIL.value,
+                    title="Invitation to join organization",
+                    body_template="organizations/emails/organization_invitation.body.html",
+                    context_name="organization_invitation_context",
+                    context_kwargs=NotificationContextDict(
+                        {
+                            "organization_invitation_id": invitation.id,
+                            "invitation_url": (getattr(settings, "HEADLESS_FRONTEND_URLS", {}))
+                            .get("account_accept_invitation", "")
+                            .format(token=token),
+                        }
+                    ),
+                    subject_template="organizations/emails/organization_invitation.subject.txt",
+                    preheader_template="organizations/emails/organization_invitation.pre_header.txt",
+                )
             )
-        )
         return invitation
 
     def accept_invitation(self, token: str, user: User) -> OrganizationMembership:

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Annotated, cast
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.utils import timezone
@@ -228,6 +229,9 @@ class Mutation(CalendarGroupMutations):
         # invited_by=None because the public-API caller is a SystemUser, not a Django User.
         # first_name/last_name are empty strings — invite_user_to_organization creates (or
         # reuses) the user and stores names for email rendering only.
+        #
+        # Phase 4: when send_email=False the service suppresses the email and attaches the raw
+        # token as invitation._raw_token (transient, never persisted in plaintext).
         invitation = deps.organization_service.invite_user_to_organization(
             email=input.user_email,
             first_name="",
@@ -235,11 +239,23 @@ class Mutation(CalendarGroupMutations):
             organization=target_org,
             invited_by=None,
             role=input.role.to_model_role(),
+            send_email=input.send_email,
         )
 
-        # Phase 4: sendEmail=false returns raw token. For now (Phase 3), sendEmail is always true
-        # and the invitation email is sent by invite_user_to_organization above.
-        # token and invite_url remain null in the sendEmail=true path.
+        raw_token: str | None = None
+        invite_url: str | None = None
+
+        if not input.send_email:
+            # The service always attaches _raw_token; retrieve it once so it is not
+            # inadvertently retained beyond this scope.
+            raw_token = invitation._raw_token  # type: ignore[attr-defined]
+            # Build the invite URL using the same template the branded email uses.
+            # Phase 6+ may refine this URL from the reseller's return_url_allowlist once
+            # OrganizationBranding is available; for now we use the same base as the email.
+            url_template: str = getattr(settings, "HEADLESS_FRONTEND_URLS", {}).get(
+                "account_accept_invitation", ""
+            )
+            invite_url = url_template.format(token=raw_token) if url_template else None
 
         return CreateInvitationResult(
             invitation=InvitationResult(
@@ -247,6 +263,6 @@ class Mutation(CalendarGroupMutations):
                 email=invitation.email,
                 expires_at=invitation.expires_at,
             ),
-            token=None,
-            invite_url=None,
+            token=raw_token,
+            invite_url=invite_url,
         )

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -753,3 +753,211 @@ class TestCreateInvitationMutation:
         assert not OrganizationInvitation.objects.filter(
             email=target_email, organization=r2_child
         ).exists()
+
+    # -------------------------------------------------------------------------
+    # Phase 4: self-managed invitations (sendEmail=false path)
+    # -------------------------------------------------------------------------
+
+    def test_send_email_false_no_email_sent_returns_token_and_invite_url(self):
+        """sendEmail=false sends no email and returns a non-null token + inviteUrl.
+
+        This is the core Phase-4 happy path: the reseller opts out of vinta's invitation
+        email and receives the raw token + invite URL once so it can render the link in
+        its own UI.
+
+        Asserts:
+        - transaction.on_commit is NOT called (no email scheduled).
+        - token and inviteUrl are non-null in the response.
+        - inviteUrl contains the raw token.
+        """
+        reseller_org, system_user, token, auth_service = self._setup_reseller()
+        child_org = baker.make(Organization, name="Child Org", parent=reseller_org)
+        user_email = "self_managed@example.com"
+
+        from di_core.containers import container
+
+        with (
+            container.public_api_auth_service.override(auth_service),
+            patch("organizations.services.transaction.on_commit") as mock_on_commit,
+        ):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_INVITATION_MUTATION,
+                    "variables": {
+                        "input": {
+                            "userEmail": user_email,
+                            "organizationId": str(child_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        # token and invite_url must be non-null in the sendEmail=false path
+        returned_token = data["data"]["createInvitation"]["token"]
+        invite_url = data["data"]["createInvitation"]["inviteUrl"]
+        assert returned_token is not None, "token must be non-null when sendEmail=false"
+        assert invite_url is not None, "inviteUrl must be non-null when sendEmail=false"
+        # inviteUrl must embed the raw token
+        assert returned_token in invite_url
+
+        # transaction.on_commit must NOT have been called — no email was scheduled
+        mock_on_commit.assert_not_called()
+
+    def test_send_email_false_returned_token_validates_via_accept_invitation(self):
+        """The raw token returned when sendEmail=false must be usable with accept_invitation.
+
+        This is the security-critical proof: the plaintext token the mutation returned
+        matches the stored hash and drives a successful accept → active membership.
+
+        Asserts:
+        - Calling OrganizationService.accept_invitation(returned_token, user) succeeds.
+        - An active OrganizationMembership is created for the user in the target org.
+        """
+        from common.utils.authentication_utils import verify_long_lived_token
+        from di_core.containers import container
+        from organizations.services import OrganizationService
+
+        reseller_org, system_user, api_token, auth_service = self._setup_reseller()
+        child_org = baker.make(Organization, name="Child Org", parent=reseller_org)
+        user_email = "token_validate@example.com"
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_INVITATION_MUTATION,
+                    "variables": {
+                        "input": {
+                            "userEmail": user_email,
+                            "organizationId": str(child_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{api_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        returned_token = data["data"]["createInvitation"]["token"]
+        assert returned_token is not None
+
+        # Retrieve the DB row and verify the plaintext was NOT persisted
+        invitation = OrganizationInvitation.objects.get(email=user_email, organization=child_org)
+        assert invitation.token_hash != returned_token, (
+            "Plaintext token must not equal the stored hash — only the hash is persisted"
+        )
+        # Confirm the hash matches the returned token (proves token_hash is derived from token)
+        assert verify_long_lived_token(returned_token, invitation.token_hash), (
+            "The returned token must verify against the stored hash"
+        )
+
+        # Accept the invitation using the raw token — proves end-to-end correctness
+        user_model = get_user_model()
+        accepting_user = user_model.objects.create(email=user_email)
+
+        org_service = OrganizationService()
+        membership = org_service.accept_invitation(returned_token, accepting_user)
+
+        assert membership is not None
+        assert membership.organization == child_org
+        assert OrganizationMembership.objects.filter(
+            user=accepting_user, organization=child_org
+        ).exists()
+
+    def test_send_email_false_no_plaintext_in_db(self):
+        """No plaintext token is stored in the OrganizationInvitation row.
+
+        The raw token returned by sendEmail=false must not appear verbatim in any
+        DB column — only the derived token_hash is stored.
+        """
+        from di_core.containers import container
+
+        reseller_org, system_user, api_token, auth_service = self._setup_reseller()
+        child_org = baker.make(Organization, name="Child Org", parent=reseller_org)
+        user_email = "no_plaintext@example.com"
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_INVITATION_MUTATION,
+                    "variables": {
+                        "input": {
+                            "userEmail": user_email,
+                            "organizationId": str(child_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{api_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_token = data["data"]["createInvitation"]["token"]
+        assert returned_token is not None
+
+        invitation = OrganizationInvitation.objects.get(email=user_email, organization=child_org)
+
+        # The plaintext token must not appear in any DB-backed field
+        assert invitation.token_hash != returned_token
+        # email, first_name, last_name, role are unrelated; verify the hash column is distinct
+        assert returned_token not in (
+            invitation.token_hash,
+            invitation.email,
+            invitation.first_name,
+            invitation.last_name,
+        )
+
+    def test_send_email_false_flag_off_acting_org_rejected(self):
+        """sendEmail=false is denied when the acting org's can_invite_organizations flag is off.
+
+        The flag gate applies regardless of the sendEmail value; a non-reseller cannot
+        suppress the email to bypass any constraint.
+        """
+        from di_core.containers import container
+
+        non_reseller_org = baker.make(Organization, name="Non-Reseller")
+        auth_service = PublicAPIAuthService()
+        system_user, api_token = auth_service.create_system_user(
+            integration_name="test_integration", organization=non_reseller_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="invitation")
+
+        child_org = baker.make(Organization, name="Child Org")
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_INVITATION_MUTATION,
+                    "variables": {
+                        "input": {
+                            "userEmail": "someone@example.com",
+                            "organizationId": str(child_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{api_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "does not have permission to invite or create" in str(data["errors"]).lower()

--- a/public_api/tests/test_provisioning_flow.py
+++ b/public_api/tests/test_provisioning_flow.py
@@ -415,3 +415,140 @@ class TestCreateInvitationProvisioning:
         invite = OrganizationInvitation.objects.get(email=invited_email, organization=child_org)
         assert invite.accepted_at is not None
         assert invite.membership_id == membership.pk
+
+    # -------------------------------------------------------------------------
+    # Phase 4: self-managed invitation (sendEmail=false) integration tests
+    # -------------------------------------------------------------------------
+
+    def test_send_email_false_token_drives_successful_accept_auto_join(self):
+        """A token obtained via sendEmail=false drives a successful accept_invitation / auto-join.
+
+        Full integration: call the mutation with sendEmail=false, then use the returned raw
+        token to call accept_invitation, assert an active membership in the target org,
+        and confirm no plaintext token is stored in the DB row.
+        """
+        from common.utils.authentication_utils import verify_long_lived_token
+        from di_core.containers import container
+        from organizations.services import OrganizationService
+
+        # Setup reseller + child org
+        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="invitation")
+
+        child_org = baker.make(Organization, name="Child Org", parent=reseller_org)
+        invited_email = "self_managed_join@example.com"
+
+        create_invitation_mutation = """
+        mutation CreateInvitation($input: CreateInvitationInput!) {
+            createInvitation(input: $input) {
+                invitation { id email expiresAt }
+                token
+                inviteUrl
+            }
+        }
+        """
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": create_invitation_mutation,
+                    "variables": {
+                        "input": {
+                            "userEmail": invited_email,
+                            "organizationId": str(child_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        raw_token = data["data"]["createInvitation"]["token"]
+        invite_url = data["data"]["createInvitation"]["inviteUrl"]
+        assert raw_token is not None, "sendEmail=false must return a non-null token"
+        assert invite_url is not None, "sendEmail=false must return a non-null inviteUrl"
+        assert raw_token in invite_url, "inviteUrl must embed the raw token"
+
+        # Verify no plaintext token is in the DB
+        invitation = OrganizationInvitation.objects.get(email=invited_email, organization=child_org)
+        assert invitation.token_hash != raw_token, "Plaintext must not be stored in token_hash"
+        assert verify_long_lived_token(raw_token, invitation.token_hash), (
+            "Stored hash must verify against the raw token"
+        )
+
+        # Use the raw token to accept the invitation
+        user_model = get_user_model()
+        accepting_user = user_model.objects.create(email=invited_email)
+
+        org_service = OrganizationService()
+        membership = org_service.accept_invitation(raw_token, accepting_user)
+
+        assert membership is not None
+        assert membership.organization == child_org
+
+        # Invitation is now accepted
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is not None
+
+    def test_send_email_false_no_email_sent(self):
+        """sendEmail=false suppresses the invitation email entirely.
+
+        Asserts the notification service is not invoked when the reseller opts out of the
+        vinta-managed email.  Also confirms that sendEmail=true (default) still sends.
+        """
+        from di_core.containers import container
+
+        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="invitation")
+
+        child_org = baker.make(Organization, name="Child Org", parent=reseller_org)
+
+        create_invitation_mutation = """
+        mutation CreateInvitation($input: CreateInvitationInput!) {
+            createInvitation(input: $input) {
+                invitation { id email expiresAt }
+                token
+                inviteUrl
+            }
+        }
+        """
+
+        with (
+            container.public_api_auth_service.override(auth_service),
+            patch("organizations.services.transaction.on_commit") as mock_on_commit,
+        ):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": create_invitation_mutation,
+                    "variables": {
+                        "input": {
+                            "userEmail": "no_email@example.com",
+                            "organizationId": str(child_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        # transaction.on_commit must NOT have been called — no email was scheduled
+        mock_on_commit.assert_not_called()

--- a/public_api/tests/test_provisioning_flow.py
+++ b/public_api/tests/test_provisioning_flow.py
@@ -3,6 +3,8 @@
 import datetime
 from unittest.mock import MagicMock, patch
 
+from django.contrib.auth import get_user_model
+
 import pytest
 from allauth.socialaccount.models import SocialLogin
 from model_bakery import baker

--- a/vinta_schedule_api/settings/test.py
+++ b/vinta_schedule_api/settings/test.py
@@ -5,6 +5,13 @@ from .base import *
 # and N+1 regressions fail the suite instead of only surfacing on the dev runtime.
 DEBUG = True
 
+# Add the invitation-accept URL so sendEmail=false tests receive a non-null inviteUrl.
+# The base settings omit this key; staging/production set it against FRONTEND_BASE_URL.
+HEADLESS_FRONTEND_URLS = {
+    **HEADLESS_FRONTEND_URLS,
+    "account_accept_invitation": "http://localhost:3000/auth/accept-invite/?token={token}",
+}
+
 SECRET_KEY = "test-secret-key-not-for-production-use-only-0123456789"  # nosec
 
 STATIC_ROOT = base_dir_join("staticfiles")


### PR DESCRIPTION
## Summary
Completes `createInvitation` with the `sendEmail=false` branch so a reseller can render the invite link in its own UI.

- `sendEmail=false` (gated by `can_invite_organizations` + INVITATION scope + subtree guard): no email is sent; returns the raw invitation token + a constructed `inviteUrl` **once**. The reseller delivers the link itself.
- `sendEmail=true` (default): unchanged Phase 3 behavior — email sent, `token`/`inviteUrl` null.
- **Security**: only `token_hash` (SHA-256) is ever persisted. The raw token is surfaced via a transient `invitation._raw_token` Python attribute set after `save()` and never re-saved — no plaintext column exists. The returned token validates end-to-end through `accept_invitation` (proven by test).
- `inviteUrl` is built from the same `HEADLESS_FRONTEND_URLS["account_accept_invitation"]` template the branded email uses (present in staging/production; test-only addition in settings/test.py). Phase 6+ may refine it from the reseller's `return_url_allowlist` once `OrganizationBranding` exists.

## Plan reference
ai-plans/2026-06-16-WHITELABEL_API_PROVISIONING_IMPLEMENTATION_PLAN.md — Phase 4, API Design 4.3. **Stacked on Phase 3** (PR #88).

## Test plan
- `uv run pytest public_api/tests/test_mutations.py public_api/tests/test_provisioning_flow.py -vs`
- Outer gate: `uv run python manage.py check --deploy` + `uv run pytest -n auto` (1929 passed) + `uv run python manage.py makemigrations --check`.

Reviewer notes (security-sensitive phase, reviewed adversarially): no BLOCKER — all critical invariants confirmed (no plaintext persistence; returned token validates via accept_invitation; email truly suppressed on false with both existing callers unchanged at default True; the flag/scope/subtree gate still applies on the false path; true-path returns null token even though `_raw_token` is attached). Accepted low-value test-convention SHOULD-FIX (tests use `OrganizationService()` directly vs DI) as-is. Pre-existing cross-org token-scan in `accept_invitation` noted for a future hardening pass (out of scope).