### PR TITLE
feat(public_api): gated childOrganizations analytics query

### DIFF
--- a/ai-plans/TRACKING_whitelabel-api-provisioning.md
+++ b/ai-plans/TRACKING_whitelabel-api-provisioning.md
@@ -101,12 +101,20 @@ Inserted **Phase 10a — First-party REST branding endpoints** (backend) after P
 - **Review**: ⚠️ 3 BLOCKERs caught — (1) confirmation templates wrongly substituted app_name for the domain URL (byte-for-byte break) → reverted (account emails stay vinta default); (2) context RAISED for invited_by=None → killed the marquee branded-invite path → made graceful; (3) `.strip()` on invited_by_name changed blank-last-name spacing → reverted. Dead per-email branding queries removed from accounts. Tests now RENDER templates.
 - **DEFERRED**: From/reply-to = support_email — vintasend DjangoEmailNotificationAdapter has no per-notification from_email hook; TODO at send site (organizations/services.py). Needs adapter extension; follow-up.
 
+### Phase 9 — childOrganizations analytics ✅
+- **Status**: PR #94 (https://github.com/vintasoftware/vinta-schedule-api/pull/94), base phase-8
+- **Branch**: plan/whitelabel-api-provisioning/phase-9 · Model: claude-sonnet-4-6 (Tier 3) · implementer
+- **Commits**: f93b6e6 (feat)
+- **Summary**: `childOrganizations(offset,limit)` → `[{id,name,createdAt,membershipCount,calendarCount,eventCount,calendarGroupCount}]`. Direct children (parent=acting_org) only; gate CHILD_ORG_ANALYTICS + assert_org_can_invite. Counts via 4 independent correlated Subquery annotations (fan-out-safe), using `.original_manager` to bypass org-scoping for child data. CalendarEvent has direct organization_id (RecurringMixin→OrganizationModel). membership counts all (active+inactive).
+- **Gate**: 1988 passed (orchestrator-verified); check --deploy + makemigrations clean.
+- **Review**: no BLOCKER / no SHOULD-FIX. Fan-out avoidance + cross-reseller isolation confirmed (tests seed distinct 3/2/5/1 metrics + a second reseller for leak check). NITs (accepted): no direct createdAt assertion; subquery helper dedup.
+- **Carry-forward**: all 6 bundle scopes now mapped in FIELD_TO_RESOURCE_MAPPING. GraphQL provisioning bundle COMPLETE (createOrganization/createUser/createInvitation/createSystemUserToken/updateBranding + brandingForTenant + childOrganizations).
+
 ## Current Phase
-Phase 9 — childOrganizations analytics (starting)
+Phase 10a — First-party REST branding endpoints (NEW, backend) (starting)
 
 ## Remaining Phases
-- Phase 9 — childOrganizations analytics
-- Phase 10a — First-party REST branding endpoints (NEW, backend, depends on Phase 6)
+- Phase 10a — First-party REST branding endpoints (depends on Phase 6 OrganizationBranding model — present)
 
 ## Deferred Phases
 - Phase 10b — Frontend themed OAuth interstitials (repo: vinta-schedule-frontend-web)

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -47,6 +47,7 @@ class OrganizationResourceAccess(BasePermission):
         "createInvitation": PublicAPIResources.INVITATION,
         "createSystemUserToken": PublicAPIResources.SYSTEM_USER,
         "updateBranding": PublicAPIResources.BRANDING,
+        "childOrganizations": PublicAPIResources.CHILD_ORG_ANALYTICS,
     }
 
     def has_permission(self, source, info: Info, **kwargs) -> bool:  # type: ignore

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -2,7 +2,8 @@ import datetime
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, cast
 
-from django.db.models import Value
+from django.db.models import Count as DjangoCount
+from django.db.models import OuterRef, Subquery, Value
 from django.db.models.functions import Concat
 
 import strawberry
@@ -33,12 +34,13 @@ from calendar_integration.models import (
     CalendarEvent,
     CalendarGroup,
 )
-from organizations.models import Organization, resolve_branding
+from organizations.models import Organization, OrganizationMembership, resolve_branding
+from public_api.capabilities import assert_org_can_invite
 from public_api.permissions import (
     IsAuthenticated,
     OrganizationResourceAccess,
 )
-from public_api.types import PublicApiHttpRequest, PublicBrandingResult
+from public_api.types import ChildOrganizationMetrics, PublicApiHttpRequest, PublicBrandingResult
 from users.graphql import UserGraphQLType
 from users.models import User
 
@@ -534,6 +536,84 @@ class Query:
             group_id=group_id, start=start_datetime, end=end_datetime
         )
         return cast(list[CalendarEventGraphQLType], list(events))
+
+    @strawberry_django.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def child_organizations(
+        self,
+        info: strawberry.Info,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[ChildOrganizationMetrics]:
+        """List the acting reseller's direct child organizations with aggregate counts.
+
+        Counts (memberships, calendars, events, calendar groups) are computed as
+        ORM Subquery annotations to avoid join fan-out double-counting that arises
+        when multiple Count() calls are combined in a single annotate() call across
+        different related models.
+
+        Membership count includes ALL memberships (active + inactive) — the plan
+        says "memberships" with no active-only qualifier, so all rows are counted.
+
+        "Children" means DIRECT children (parent = acting_org). The plan says
+        "its child organizations"/"its children" — literal parent FK match.
+
+        Gate: acting org must have can_invite_organizations=True (assert_org_can_invite)
+        AND the token must carry CHILD_ORG_ANALYTICS scope (OrganizationResourceAccess).
+        """
+        org = _get_org(info)
+        assert_org_can_invite(org)
+
+        # Subquery-based counts to avoid join fan-out when multiple aggregates
+        # are applied over different relations in a single queryset.
+        membership_sq = (
+            OrganizationMembership.objects.filter(organization_id=OuterRef("pk"))
+            .values("organization_id")
+            .annotate(cnt=DjangoCount("id"))
+            .values("cnt")
+        )
+        calendar_sq = (
+            Calendar.original_manager.filter(organization_id=OuterRef("pk"))
+            .values("organization_id")
+            .annotate(cnt=DjangoCount("id"))
+            .values("cnt")
+        )
+        event_sq = (
+            CalendarEvent.original_manager.filter(organization_id=OuterRef("pk"))
+            .values("organization_id")
+            .annotate(cnt=DjangoCount("id"))
+            .values("cnt")
+        )
+        group_sq = (
+            CalendarGroup.original_manager.filter(organization_id=OuterRef("pk"))
+            .values("organization_id")
+            .annotate(cnt=DjangoCount("id"))
+            .values("cnt")
+        )
+
+        qs = (
+            Organization.objects.filter(parent=org)
+            .annotate(
+                membership_count=Subquery(membership_sq),
+                calendar_count=Subquery(calendar_sq),
+                event_count=Subquery(event_sq),
+                calendar_group_count=Subquery(group_sq),
+            )
+            .order_by("pk")
+        )
+        qs = _slice_qs(qs, offset, limit)
+
+        return [
+            ChildOrganizationMetrics(
+                id=child.id,
+                name=child.name,
+                created_at=child.created,
+                membership_count=child.membership_count or 0,
+                calendar_count=child.calendar_count or 0,
+                event_count=child.event_count or 0,
+                calendar_group_count=child.calendar_group_count or 0,
+            )
+            for child in qs
+        ]
 
     @strawberry.field()
     def branding_for_tenant(self, tenant_id: strawberry.ID) -> PublicBrandingResult:

--- a/public_api/tests/test_queries.py
+++ b/public_api/tests/test_queries.py
@@ -8,7 +8,13 @@ import pytest
 from model_bakery import baker
 from rest_framework.test import APIClient
 
-from calendar_integration.models import AvailableTime, BlockedTime, Calendar, CalendarEvent
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+)
 from calendar_integration.services.dataclasses import (
     AvailableTimeWindow,
     BlockedTimeData,
@@ -2165,3 +2171,335 @@ class TestBrandingForTenantQuery:
         assert mock_rate_limiter.called, (
             "Rate limiter should be called for unauthenticated requests"
         )
+
+
+# ---------------------------------------------------------------------------
+# childOrganizations analytics query tests
+# ---------------------------------------------------------------------------
+
+_CHILD_ORG_ANALYTICS_QUERY = """
+    query GetChildOrganizations($offset: Int, $limit: Int) {
+        childOrganizations(offset: $offset, limit: $limit) {
+            id
+            name
+            createdAt
+            membershipCount
+            calendarCount
+            eventCount
+            calendarGroupCount
+        }
+    }
+"""
+
+
+def _make_reseller_client(reseller: Organization):
+    """Create an authenticated API client for a reseller org with CHILD_ORG_ANALYTICS scope."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="reseller_analytics", organization=reseller
+    )
+    baker.make(
+        ResourceAccess,
+        system_user=system_user,
+        resource_name=PublicAPIResources.CHILD_ORG_ANALYTICS,
+    )
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {system_user.id}:{token}")
+    return client
+
+
+@pytest.mark.django_db
+@patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+class TestChildOrganizationsQuery:
+    """Tests for the childOrganizations gated analytics query."""
+
+    def test_exact_aggregate_counts_per_child(self, mock_rate_limiter):
+        """Counts are exact per child; distinct metrics detect join fan-out.
+
+        Seeds a child with intentionally different values for each metric
+        (3 memberships, 2 calendars, 5 events, 1 group) so that any
+        join-based multi-relation fan-out would produce obviously wrong numbers.
+        """
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        child = baker.make(Organization, name="ChildA", parent=reseller)
+        client = _make_reseller_client(reseller)
+
+        # 3 memberships
+        for i in range(3):
+            user = baker.make("users.User", email=f"user{i}@childA.test")
+            baker.make(OrganizationMembership, user=user, organization=child)
+
+        # 2 calendars
+        for i in range(2):
+            baker.make(Calendar, organization=child, external_id=f"cal-{i}")
+
+        # 5 events — all belong directly to the child org
+        for i in range(5):
+            baker.make(
+                CalendarEvent,
+                organization=child,
+                external_id=f"ev-{i}",
+                timezone="UTC",
+            )
+
+        # 1 calendar group
+        baker.make(CalendarGroup, organization=child)
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+
+        data = assert_graphql_success(response)
+        children = data["childOrganizations"]
+        assert len(children) == 1
+
+        row = children[0]
+        assert row["id"] == child.id
+        assert row["name"] == "ChildA"
+        assert row["membershipCount"] == 3, f"expected 3, got {row['membershipCount']}"
+        assert row["calendarCount"] == 2, f"expected 2, got {row['calendarCount']}"
+        assert row["eventCount"] == 5, f"expected 5, got {row['eventCount']}"
+        assert row["calendarGroupCount"] == 1, f"expected 1, got {row['calendarGroupCount']}"
+
+    def test_multiple_children_counted_independently(self, mock_rate_limiter):
+        """Each child's counts are independent (no cross-child leakage)."""
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = baker.make(Organization, name="Reseller2", can_invite_organizations=True)
+        child1 = baker.make(Organization, name="Child1", parent=reseller)
+        child2 = baker.make(Organization, name="Child2", parent=reseller)
+        client = _make_reseller_client(reseller)
+
+        # child1: 2 memberships, 1 calendar, 0 events, 0 groups
+        for i in range(2):
+            u = baker.make("users.User", email=f"mc1-{i}@test.com")
+            baker.make(OrganizationMembership, user=u, organization=child1)
+        baker.make(Calendar, organization=child1, external_id="c1-cal")
+
+        # child2: 0 memberships, 0 calendars, 3 events, 2 groups
+        for i in range(3):
+            baker.make(CalendarEvent, organization=child2, external_id=f"c2-ev-{i}", timezone="UTC")
+        for i in range(2):
+            baker.make(CalendarGroup, organization=child2, name=f"grp-{i}")
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+
+        data = assert_graphql_success(response)
+        children = {c["id"]: c for c in data["childOrganizations"]}
+
+        assert children[child1.id]["membershipCount"] == 2
+        assert children[child1.id]["calendarCount"] == 1
+        assert children[child1.id]["eventCount"] == 0
+        assert children[child1.id]["calendarGroupCount"] == 0
+
+        assert children[child2.id]["membershipCount"] == 0
+        assert children[child2.id]["calendarCount"] == 0
+        assert children[child2.id]["eventCount"] == 3
+        assert children[child2.id]["calendarGroupCount"] == 2
+
+    def test_no_cross_reseller_leak(self, mock_rate_limiter):
+        """Only the acting reseller's own children are returned (no cross-reseller data)."""
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller_a = baker.make(Organization, name="ResellerA", can_invite_organizations=True)
+        reseller_b = baker.make(Organization, name="ResellerB", can_invite_organizations=True)
+        child_a = baker.make(Organization, name="ChildOfA", parent=reseller_a)
+        child_b = baker.make(Organization, name="ChildOfB", parent=reseller_b)
+
+        # Client for reseller_a
+        client = _make_reseller_client(reseller_a)
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+
+        data = assert_graphql_success(response)
+        children = data["childOrganizations"]
+        returned_ids = {c["id"] for c in children}
+
+        assert child_a.id in returned_ids, "reseller_a's child must be present"
+        assert child_b.id not in returned_ids, "reseller_b's child must NOT appear"
+        assert reseller_b.id not in returned_ids, "reseller_b itself must NOT appear"
+
+    def test_flag_off_acting_org_returns_permission_error(self, mock_rate_limiter):
+        """A non-reseller org (flag off) is denied even if it holds the scope."""
+        mock_rate_limiter.return_value = iter([None])
+
+        non_reseller = baker.make(Organization, name="NotAReseller", can_invite_organizations=False)
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=non_reseller
+        )
+        baker.make(
+            ResourceAccess,
+            system_user=system_user,
+            resource_name=PublicAPIResources.CHILD_ORG_ANALYTICS,
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {system_user.id}:{token}")
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+
+        assert_response_status_code(response, 200)
+        response_data = response.json()
+        assert "errors" in response_data
+        error_text = str(response_data["errors"])
+        assert "permission" in error_text.lower() or "invite" in error_text.lower(), (
+            f"Expected a permission-related error, got: {error_text}"
+        )
+
+    def test_missing_child_org_analytics_scope_returns_denied(self, mock_rate_limiter):
+        """A reseller token without CHILD_ORG_ANALYTICS scope is denied at the permission layer."""
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = baker.make(Organization, name="ResellerNoScope", can_invite_organizations=True)
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="no_scope_integration", organization=reseller
+        )
+        # Intentionally do NOT grant CHILD_ORG_ANALYTICS scope
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {system_user.id}:{token}")
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+
+        assert_response_status_code(response, 200)
+        response_data = response.json()
+        assert "errors" in response_data
+
+    def test_pagination_offset_and_limit(self, mock_rate_limiter):
+        """Pagination returns the correct slice of children in stable order."""
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = baker.make(Organization, name="ResellerPaging", can_invite_organizations=True)
+        client = _make_reseller_client(reseller)
+
+        # Create 5 children
+        children = [
+            baker.make(Organization, name=f"PagChild-{i}", parent=reseller) for i in range(5)
+        ]
+        children_by_id = sorted(children, key=lambda c: c.id)
+
+        # Request only first 2
+        response = client.post(
+            "/graphql/",
+            data=json.dumps(
+                {
+                    "query": _CHILD_ORG_ANALYTICS_QUERY,
+                    "variables": {"offset": 0, "limit": 2},
+                }
+            ),
+            content_type="application/json",
+        )
+        data = assert_graphql_success(response)
+        page1 = data["childOrganizations"]
+        assert len(page1) == 2
+        assert page1[0]["id"] == children_by_id[0].id
+        assert page1[1]["id"] == children_by_id[1].id
+
+        # Next page: offset=2, limit=2
+        response = client.post(
+            "/graphql/",
+            data=json.dumps(
+                {
+                    "query": _CHILD_ORG_ANALYTICS_QUERY,
+                    "variables": {"offset": 2, "limit": 2},
+                }
+            ),
+            content_type="application/json",
+        )
+        data = assert_graphql_success(response)
+        page2 = data["childOrganizations"]
+        assert len(page2) == 2
+        assert page2[0]["id"] == children_by_id[2].id
+        assert page2[1]["id"] == children_by_id[3].id
+
+    def test_zero_counts_for_empty_child(self, mock_rate_limiter):
+        """A child with no members / calendars / events / groups returns zero counts."""
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = baker.make(Organization, name="ResellerEmpty", can_invite_organizations=True)
+        child = baker.make(Organization, name="EmptyChild", parent=reseller)
+        client = _make_reseller_client(reseller)
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+        data = assert_graphql_success(response)
+        children = data["childOrganizations"]
+        assert len(children) == 1
+        row = children[0]
+        assert row["id"] == child.id
+        assert row["membershipCount"] == 0
+        assert row["calendarCount"] == 0
+        assert row["eventCount"] == 0
+        assert row["calendarGroupCount"] == 0
+
+    def test_only_direct_children_returned(self, mock_rate_limiter):
+        """Only direct children (parent=reseller) are returned; grandchildren are excluded."""
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = baker.make(Organization, name="ResellerDirect", can_invite_organizations=True)
+        direct_child = baker.make(Organization, name="DirectChild", parent=reseller)
+        # grandchild — NOT a direct child of reseller
+        grandchild = baker.make(Organization, name="GrandChild", parent=direct_child)
+        client = _make_reseller_client(reseller)
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+        data = assert_graphql_success(response)
+        children = data["childOrganizations"]
+        returned_ids = {c["id"] for c in children}
+
+        assert direct_child.id in returned_ids, "direct child must be listed"
+        assert grandchild.id not in returned_ids, "grandchild must NOT be listed"
+
+    def test_membership_count_includes_inactive(self, mock_rate_limiter):
+        """membership_count includes ALL memberships (active=True and active=False).
+
+        The plan spec says 'memberships' with no active-only qualifier.
+        """
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = baker.make(Organization, name="ResellerInactive", can_invite_organizations=True)
+        child = baker.make(Organization, name="ChildInactive", parent=reseller)
+        client = _make_reseller_client(reseller)
+
+        user_active = baker.make("users.User", email="active@example.com")
+        user_inactive = baker.make("users.User", email="inactive@example.com")
+        baker.make(OrganizationMembership, user=user_active, organization=child, is_active=True)
+        baker.make(OrganizationMembership, user=user_inactive, organization=child, is_active=False)
+
+        response = client.post(
+            "/graphql/",
+            data=json.dumps({"query": _CHILD_ORG_ANALYTICS_QUERY}),
+            content_type="application/json",
+        )
+        data = assert_graphql_success(response)
+        children = data["childOrganizations"]
+        assert len(children) == 1
+        # Both memberships (active + inactive) are counted
+        assert children[0]["membershipCount"] == 2

--- a/public_api/types.py
+++ b/public_api/types.py
@@ -164,3 +164,20 @@ class PublicBrandingResult:
     logo_url: str
     primary_color: str
     secondary_color: str
+
+
+@strawberry.type
+class ChildOrganizationMetrics:
+    """Point-in-time aggregate counts for a child organization.
+
+    Returned by the childOrganizations analytics query (resource: CHILD_ORG_ANALYTICS).
+    Counts are computed via ORM subqueries to avoid join fan-out double-counting.
+    """
+
+    id: int
+    name: str
+    created_at: datetime.datetime
+    membership_count: int
+    calendar_count: int
+    event_count: int
+    calendar_group_count: int


### PR DESCRIPTION
## Summary
The reseller's analytics surface: list its direct child orgs with point-in-time aggregate counts.

- `childOrganizations(offset, limit)` → `[{ id, name, createdAt, membershipCount, calendarCount, eventCount, calendarGroupCount }]`.
- Direct children only (`parent = acting_org`); only the acting reseller's own children — no cross-reseller leak.
- Counts via four independent correlated `Subquery` annotations (one per metric), avoiding the multi-relation `Count()` join fan-out that would multiply counts. `Subquery(...) or 0` yields 0 for empty metrics.
- **Dual gate**: `OrganizationResourceAccess('CHILD_ORG_ANALYTICS')` + in-resolver `assert_org_can_invite`. Paginated offset/limit, ordered by pk.

## Plan reference
ai-plans/2026-06-16-WHITELABEL_API_PROVISIONING_IMPLEMENTATION_PLAN.md — Phase 9, API Design 4.7, "Child analytics shape". **Stacked on Phase 8** (PR #93). Last backend GraphQL phase; Phase 10a (REST branding) is next.

## Test plan
- `uv run pytest public_api/tests/test_queries.py -vs`
- Outer gate: `uv run python manage.py check --deploy` + `uv run pytest -n auto` (1988 passed, orchestrator-verified) + `uv run python manage.py makemigrations --check`.

Reviewer notes: no BLOCKER / no SHOULD-FIX. Fan-out avoidance and cross-reseller isolation both confirmed; tests seed distinct per-metric values (3/2/5/1) so a fan-out bug fails, and seed a second reseller's children to assert exclusion. `original_manager` use in the count subqueries is correct (the org-scoped default manager enforces tenancy via Python-side hooks that never fire inside a compiled Subquery; the correlation filter `organization_id=OuterRef("pk")` is provably a child of the acting org). Counts are of stored rows (no soft-delete on these models; recurring occurrences are not expanded) — the intended point-in-time semantics. NIT (not blocking): no direct `createdAt` assertion; `membershipCount` counts active+inactive per the plan's unqualified "memberships".