### PR TITLE
Phase 0 — Shared calendar mutation DI scaffolding (public_api)

### DIFF
--- a/ai-plans/2026-06-17-PUBLIC_GRAPHQL_SERVICE_WRAPPERS_IMPLEMENTATION_PLAN.md
+++ b/ai-plans/2026-06-17-PUBLIC_GRAPHQL_SERVICE_WRAPPERS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,540 @@
+# Public GraphQL Service Wrappers — Implementation Plan
+
+Thin Public GraphQL wrappers over already-existing calendar/availability/bundle services, following the `create-graphql-public-query` pattern. Source of proposed signatures: [building-blocks-integration-v2.md](../docs/building-blocks-integration-v2.md), "What needs to be done → A. Thin GraphQL wrappers". This plan covers **only** section A (the 🔶 items) plus the true service gaps those wrappers expose.
+
+## 1. Goals
+
+1. Expose the existing single-calendar event, resource-calendar, availability/blocked-time, and bundle services through the Public GraphQL API as `IsAuthenticated` + `OrganizationResourceAccess`-guarded fields, each delegating to a DI-injected service and returning the project's `success` / `errorMessage` / payload result shape.
+2. Give every new field its **own** `PublicAPIResources` value and `FIELD_TO_RESOURCE_MAPPING` entry, so a token can be granted each query/mutation independently (per the chosen granular-permission model).
+3. Add the small service methods the wrappers require but that do **not** exist today: `disable_resource_calendar`, `disable_bundle_calendar`, `update_blocked_time`, `delete_blocked_time`, and `reschedule_grouped_event`.
+4. Add a `CalendarBundleGraphQLType` + `calendarBundles` query so bundles (Calendars with `calendar_type=BUNDLE`) become a first-class Public API read surface.
+
+**Non-goals** (each is a separate, independently-planned change — explicitly out of scope here):
+- The `is_private` / restricted flag on calendars / groups / bundles.
+- The `owners` field on `CalendarGraphQLType`.
+- The `userId` argument on the `calendarEvents` query.
+- Single-use scheduling / booking codes and the `*WithCode` patient mutations (see [2026-06-17-SINGLE_USE_SCHEDULING_CODES_SPEC.md](2026-06-17-SINGLE_USE_SCHEDULING_CODES_SPEC.md)).
+- Per-user / patient-scoped Public API tokens (see [2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md](2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md)).
+- `updateResourceCalendar` / `editResourceCalendar` — not requested; also a true service gap (no `update_resource_calendar`). Left out deliberately.
+- No new UI — this is API surface for external integrators (Medplum / Building Blocks). No E2E phases.
+
+## 2. Guiding Decisions
+
+| Decision | Resolution |
+|---|---|
+| **Surface** | Public GraphQL only, wired on `@public_api/queries.py` and `@public_api/mutations.py`. No REST, no internal schema changes. |
+| **Auth** | Existing Public API org token (`Authorization: Bearer {system_user.id}:{token}`), enforced by `IsAuthenticated` + `OrganizationResourceAccess`. No new auth path (that's the codes/scoped-token specs). |
+| **Permission granularity** | **One dedicated `PublicAPIResources` value per new field** (e.g. `CREATE_CALENDAR_EVENT`, `RESCHEDULE_CALENDAR_EVENT`, `CANCEL_EVENT`, …). Chosen over reusing the read resources so a token can grant each mutation independently and read grants never imply write. Each value added in the phase that introduces its field. |
+| **Service delegation** | Reuse the `calendar_service` DI provider (the facade already exposes events CRUD, `create_resource_calendar`, bundle create/update, `create_available_time`, `create_blocked_time`, `batch_modify_available_times`). `calendar_group_service` for group reschedule. No new DI registrations needed — sub-services (`CalendarEventService`, `CalendarBundleService`, `AvailabilityService`, `CalendarSyncService`) are owned by the facade. |
+| **Init pattern** | Mutations resolve org from `info.context.request.public_api_organization`, then `calendar_service.initialize_without_provider(user_or_token=request.public_api_system_user, organization=org)` — mirroring `_prepare_service_and_calendar` in queries and `create_calendar_group_event` in mutations. |
+| **Result shape** | Per-field `@strawberry.type` results with `success: bool`, `error_message: str | None`, and an optional payload field (`event` / `calendar` / `bundle` / `available_time` / `blocked_time`). Service exceptions caught → `success=False`. Matches existing `CalendarGroupResult` / `WebhookSubscriptionResult`. |
+| **True gaps build in-plan** | `disable_resource_calendar`, `disable_bundle_calendar`, `update_blocked_time`, `delete_blocked_time` added as small service methods folded into their wrapper phase. `reschedule_grouped_event` is architectural → its own foundation phase before the wrapper. |
+| **No feature flag** | Purely additive new GraphQL fields no existing code reads/writes; exposure is already opt-in per token via the new resource grants. No flag, no flag-removal phase. (Confirmed in Step 0.) |
+| **Disable semantics** | "Disable" = set `Calendar.visibility = INACTIVE` (org-scoped, validated) via a service method. No row deletion. |
+
+### Doc discrepancies flagged (signatures that differ from the v2 doc)
+
+- **Batch op key**: `batch_modify_available_times` operations use `"action"` (`create`/`update`/`delete`), **not** `"op"` as the doc shows. Also only available times are batchable — there is **no** batch path for blocked times.
+- **Event resource allocations**: `CalendarEventInputData.resource_allocations` items are `ResourceAllocationInputData(resource_id: int)`, **not** `{ calendarId }` as the doc's `createCalendarEvent` example implies.
+- **`rescheduleCalendarGroupEvent`**: doc tags it 🔶 (service ready). **Reality: ❌** — `CalendarGroupService` has no reschedule/update-group-event method. New service method required (Phase 5a).
+- **`updateBlockedTime` / `deleteBlockedTime`**: doc tags 🔶. **Reality: ❌** — `AvailabilityService` has `create_blocked_time` + recurring-exception methods only; no single update/delete. New methods required (Phases 3g/3h).
+- **`disableResourceCalendar` / `disableCalendarBundle`**: no service method exists; only the `visibility` field. New methods added (Phases 2b/4d).
+
+## 3. Data Model Changes
+
+No new tables, columns, or migrations. The only "model layer" work is **service methods** (Python, no schema change):
+
+### 3.1 New service methods (added in their phases)
+- `CalendarService.disable_resource_calendar(calendar_id) -> Calendar` — Phase 2b.
+- `CalendarService.disable_bundle_calendar(bundle_id) -> Calendar` — Phase 4d.
+- `AvailabilityService.update_blocked_time(calendar, blocked_time_id, ...)` + facade delegate — Phase 3g.
+- `AvailabilityService.delete_blocked_time(calendar, blocked_time_id, delete_series=False)` + facade delegate — Phase 3h.
+- `CalendarGroupService.reschedule_grouped_event(...)` — Phase 5a.
+
+### 3.2 New constants
+- New `PublicAPIResources` values in [public_api/constants.py](../public_api/constants.py), one per field — added incrementally per phase. Full list in Touch List.
+
+### 3.3 Type plumbing
+- `CalendarBundleGraphQLType` (new) in `@calendar_integration/graphql.py` — Phase 4a.
+- Reuse existing `CalendarEventGraphQLType`, `CalendarGraphQLType`, `AvailableTimeGraphQLType`, `BlockedTimeGraphQLType` for payloads.
+- Mutation input `@strawberry.input` types per field (mirroring `CalendarGroupInput` etc.).
+
+## 4. API Design
+
+All fields follow the same contract: `permission_classes=[IsAuthenticated, OrganizationResourceAccess]`, a single `input` argument (mutations) or scalar args (queries), org resolved from request context, service delegation, `{ success, errorMessage, <payload> }` result. Concrete proposed signatures live in [building-blocks-integration-v2.md](../docs/building-blocks-integration-v2.md) ("Integration touch-points per screen"); this plan implements them with the corrections noted in Guiding Decisions.
+
+Mutations to add: `createCalendarEvent`, `rescheduleCalendarEvent`, `cancelEvent`, `createResourceCalendar`, `disableResourceCalendar`, `importResourceCalendars`, `createAvailabilityWindow`, `updateAvailabilityWindow`, `deleteAvailabilityWindow`, `batchUpdateAvailabilityWindows`, `createBlockedTime`, `updateBlockedTime`, `deleteBlockedTime`, `createCalendarBundle`, `updateCalendarBundle`, `disableCalendarBundle`, `rescheduleCalendarGroupEvent`.
+
+Queries to add: `calendarBundles`.
+
+## 5. Phased Rollout
+
+Phases are MR-sized, one use-case each, independently mergeable, each with its own tests. Ordering: shared scaffolding first, then by resource area; within an area, foundation service methods land before the wrapper that needs them. No flag → no removal phase.
+
+---
+
+### Phase 0 — Shared mutation scaffolding
+
+**Goal**: Ship value: none on its own. Provide the reusable DI deps getter + org/init helper that every wrapper phase consumes, so each later phase is a thin field addition.
+
+Changes:
+1. [public_api/mutations.py](../public_api/mutations.py): add a `CalendarMutationDependencies` dataclass + `get_calendar_mutation_dependencies()` (`@inject`, `Provide["calendar_service"]`, `Provide["calendar_group_service"]`), mirroring the existing `get_calendar_group_mutation_dependencies`.
+2. Add a module-level helper `_get_org_and_init_calendar_service(info)` returning `(calendar_service, org)` initialized via `initialize_without_provider(user_or_token=request.public_api_system_user, organization=org)`; raise/return-error consistently with existing resolvers.
+3. No new fields registered yet.
+
+Spec use-case: shared scaffolding — no use-case yet.
+
+Tests:
+- **Unit**: [public_api/tests/test_mutations.py](../public_api/tests/test_mutations.py) — `get_calendar_mutation_dependencies` raises `GraphQLError` when the provider is missing; helper raises on missing org.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`. Pattern copy of existing deps getter, no business logic.
+
+**Reusable skills**: none.
+
+Acceptance: `get_calendar_mutation_dependencies()` returns the facade + group service from the DI container, and the schema still builds (`python manage.py graphql_schema`/existing schema test passes) with no new fields.
+
+---
+
+### Phase 1a — `createCalendarEvent` mutation
+
+**Goal**: External integrators can create a single-calendar event via the Public API.
+
+Changes:
+1. [public_api/constants.py](../public_api/constants.py): add `CREATE_CALENDAR_EVENT`.
+2. [public_api/permissions.py](../public_api/permissions.py): add `"createCalendarEvent": PublicAPIResources.CREATE_CALENDAR_EVENT` to `FIELD_TO_RESOURCE_MAPPING`.
+3. [public_api/mutations.py](../public_api/mutations.py): `CreateCalendarEventInput` (+ nested attendance/external-attendance/resource-allocation inputs — reuse the ones already defined for group events where possible) → build `CalendarEventInputData` (note `resource_allocations` use `resource_id`) → `calendar_service.create_event(calendar_id, event_data)`. Return `CreateCalendarEventResult { success, errorMessage, event }`.
+
+Spec use-case: Create Appointment Modal → `createCalendarEvent`.
+
+Tests:
+- **Integration**: [public_api/tests/test_mutations.py](../public_api/tests/test_mutations.py) — happy path creates event; unauthorized token (no `CREATE_CALENDAR_EVENT` grant) is denied; cross-org calendar id rejected; service `ValueError` → `success=False`.
+
+**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. Nested input mapping + recurrence/attendees plumbing.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A token granted `CREATE_CALENDAR_EVENT` creates an event on an org calendar; a token without it gets a permission error.
+
+---
+
+### Phase 1b — `rescheduleCalendarEvent` mutation
+
+**Goal**: Move an existing event's start/end via the Public API.
+
+Changes:
+1. constants: add `RESCHEDULE_CALENDAR_EVENT`; permissions mapping entry.
+2. mutations: `RescheduleCalendarEventInput { organizationId, calendarId, eventId, startTime, endTime, timezone }` → load current event data, apply new times into `CalendarEventInputData` → `calendar_service.update_event(calendar_id, event_id, event_data)`. Return `{ success, errorMessage, event }`.
+
+Spec use-case: Reschedule / Cancel Modal → `rescheduleCalendarEvent`.
+
+Tests:
+- **Integration**: happy path updates times; missing event → `success=False`; cross-org event rejected; permission denied without grant.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` (iterate) / `gpt-5-mini` / `gemini-2.5-flash`. Reuses 1a plumbing.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token reschedules an event; the stored event reflects new start/end.
+
+---
+
+### Phase 1c — `cancelEvent` mutation
+
+**Goal**: Cancel/delete an event (optionally the series) via the Public API.
+
+Changes:
+1. constants: add `CANCEL_EVENT`; permissions mapping entry.
+2. mutations: `CancelEventInput { organizationId, calendarId, eventId, deleteSeries }` → `calendar_service.delete_event(calendar_id, event_id, delete_series)`. Return `{ success, errorMessage }`.
+
+Spec use-case: Reschedule / Cancel Modal → `cancelEvent`.
+
+Tests:
+- **Integration**: deletes single occurrence; `deleteSeries=true` deletes series; missing/cross-org event → `success=False`; permission denied without grant.
+
+**Suggested AI model**: Tier 1 — `claude-haiku-4-5` / `gpt-5-nano` / `gemini-2.5-flash-lite`. Thin delegate, boolean flag.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token cancels an event; the event no longer appears in `calendarEvents`.
+
+---
+
+### Phase 2a — `createResourceCalendar` mutation
+
+**Goal**: Admin integrators can create a manual resource (room/equipment) calendar.
+
+Changes:
+1. constants: add `CREATE_RESOURCE_CALENDAR`; permissions mapping entry.
+2. mutations: `CreateResourceCalendarInput { organizationId, name, description, capacity, manageAvailableWindows }` → `calendar_service.create_resource_calendar(name, description, capacity, manage_available_windows)`. Return `{ success, errorMessage, calendar }`.
+
+Spec use-case: Location Page → `createResourceCalendar`.
+
+Tests:
+- **Integration**: creates a resource calendar scoped to org; permission denied without grant; resulting calendar has `calendar_type=resource`.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token creates a resource calendar returned by `calendars(calendarType: "resource")`.
+
+---
+
+### Phase 2b — `disableResourceCalendar` mutation + `disable_resource_calendar` service method
+
+**Goal**: Admin integrators can disable a resource calendar.
+
+Changes:
+1. [calendar_integration/services/calendar_service.py](../calendar_integration/services/calendar_service.py): add `disable_resource_calendar(calendar_id) -> Calendar` — org-scoped fetch, validate it is a resource calendar, set `visibility = INACTIVE`, save. (Small, testable in the service.)
+2. constants: add `DISABLE_RESOURCE_CALENDAR`; permissions mapping entry.
+3. mutations: `DisableResourceCalendarInput { organizationId, calendarId }` → service call. Return `{ success, errorMessage }`.
+
+Spec use-case: Location Page → `disableResourceCalendar`.
+
+Tests:
+- **Unit**: service test — sets `visibility=INACTIVE`; rejects cross-org id; rejects non-resource calendar.
+- **Integration**: mutation happy path + permission denied without grant.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`. One service method + thin wrapper.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token disables a resource calendar; it drops out of `calendars().only_listed()`.
+
+---
+
+### Phase 2c — `importResourceCalendars` mutation
+
+**Goal**: Admin integrators can trigger a Google Workspace resource import for the org.
+
+Changes:
+1. constants: add `IMPORT_RESOURCE_CALENDARS`; permissions mapping entry.
+2. mutations: `ImportResourceCalendarsInput { organizationId, startTime, endTime }` → init `calendar_service` → `calendar_sync_service.request_organization_calendar_resources_import(start_time, end_time)` (accessed via the facade's sync sub-service). Return `{ success, errorMessage }` (async request — no payload).
+
+Spec use-case: Location Page → `importResourceCalendars` (optional in doc; included).
+
+Tests:
+- **Integration**: enqueues import (assert the request method is invoked / workflow row created, mock external); permission denied without grant; missing org → error.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`. Verify how the facade exposes the sync sub-service during implementation.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token triggers `request_organization_calendar_resources_import` with the supplied window.
+
+---
+
+### Phase 3a — `createAvailabilityWindow` mutation
+
+**Goal**: Create a single (optionally recurring) available time on a calendar.
+
+Changes:
+1. constants: add `CREATE_AVAILABILITY_WINDOW`; permissions mapping entry.
+2. mutations: `CreateAvailableTimeInput { organizationId, calendarId, startTime, endTime, timezone, rruleString }` → `calendar_service.create_available_time(calendar, start_time, end_time, timezone, rrule_string)`. Return `{ success, errorMessage, availableTime }`. Note service raises if `calendar.manage_available_windows` is false → map to `success=False`.
+
+Spec use-case: Provider Availability → `createAvailabilityWindow`.
+
+Tests:
+- **Integration**: creates window; non-managing calendar → `success=False`; permission denied without grant; cross-org calendar rejected.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token creates an available time returned by `availableTimes`.
+
+---
+
+### Phase 3b — `updateAvailabilityWindow` mutation
+
+**Goal**: Update one available time via the existing batch path.
+
+Changes:
+1. constants: add `UPDATE_AVAILABILITY_WINDOW`; permissions mapping entry.
+2. mutations: `UpdateAvailableTimeInput { organizationId, calendarId, availableTimeId, startTime, endTime, timezone, rruleString }` → `calendar_service.batch_modify_available_times(calendar, [{"action": "update", "id": ..., ...}])` (single-op). Return `{ success, errorMessage, availableTime }` (the matching row from the returned list).
+
+Spec use-case: Provider Availability → `updateAvailabilityWindow`.
+
+Tests:
+- **Integration**: updates fields; missing id → `success=False` (service raises `ValueError`); permission denied without grant.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`. Note the `action` key (not `op`).
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token updates an available time's start/end/rrule.
+
+---
+
+### Phase 3c — `deleteAvailabilityWindow` mutation
+
+**Goal**: Delete one available time via the batch path.
+
+Changes:
+1. constants: add `DELETE_AVAILABILITY_WINDOW`; permissions mapping entry.
+2. mutations: `DeleteAvailableTimeInput { organizationId, calendarId, availableTimeId }` → `batch_modify_available_times(calendar, [{"action": "delete", "id": ...}])`. Return `{ success, errorMessage }`. (Note: the v2 doc's `deleteSeries` arg has no backing — single-row delete only; omit `deleteSeries` and document the limitation.)
+
+Spec use-case: Provider Availability → `deleteAvailabilityWindow`.
+
+Tests:
+- **Integration**: deletes row; missing id → `success=False`; permission denied without grant.
+
+**Suggested AI model**: Tier 1 — `claude-haiku-4-5` / `gpt-5-nano` / `gemini-2.5-flash-lite`.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token deletes an available time; it no longer appears in `availableTimes`.
+
+---
+
+### Phase 3d — `batchUpdateAvailabilityWindows` mutation
+
+**Goal**: Apply an atomic create/update/delete batch of available times.
+
+Changes:
+1. constants: add `BATCH_UPDATE_AVAILABILITY_WINDOWS`; permissions mapping entry.
+2. mutations: `BatchAvailabilityInput { organizationId, calendarId, operations: [{ action, availableTimeId, startTime, endTime, timezone, rruleString }] }` → translate each op to the service dict shape (map `availableTimeId`→`id`, validate `action ∈ {create,update,delete}`) → `batch_modify_available_times`. Return `{ success, errorMessage, availableTimes }`. Whole batch rolls back on any failure (service is row-atomic in one transaction).
+
+Spec use-case: Provider Availability → `batchUpdateAvailabilityWindows`.
+
+Tests:
+- **Integration**: mixed batch applies; one bad id rolls the whole batch back (assert no partial writes); invalid `action` rejected; permission denied without grant.
+
+**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. Atomic-batch edge cases.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token applies a create+update+delete batch atomically; a failing op leaves state unchanged.
+
+---
+
+### Phase 3e — `createBlockedTime` mutation
+
+**Goal**: Create a single (optionally recurring) blocked time.
+
+Changes:
+1. constants: add `CREATE_BLOCKED_TIME`; permissions mapping entry.
+2. mutations: `CreateBlockedTimeInput { organizationId, calendarId, startTime, endTime, timezone, reason, rruleString }` → `calendar_service.create_blocked_time(calendar, start_time, end_time, timezone, reason, rrule_string)`. Return `{ success, errorMessage, blockedTime }`.
+
+Spec use-case: Provider Availability → `createBlockedTime`.
+
+Tests:
+- **Integration**: creates blocked time; permission denied without grant; cross-org calendar rejected.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token creates a blocked time returned by `blockedTimes`.
+
+---
+
+### Phase 3f — `updateBlockedTime` mutation + `update_blocked_time` service method
+
+**Goal**: Update one blocked time (true gap — no service method today).
+
+Changes:
+1. [calendar_integration/services/availability_service.py](../calendar_integration/services/availability_service.py): add `update_blocked_time(calendar, blocked_time_id, start_time=None, end_time=None, timezone=None, reason=None, rrule_string=None) -> BlockedTime` — org-scoped + calendar-scoped fetch (mirror the `scoped` filter in `batch_modify_available_times`), apply provided fields, save; raise `ValueError` on missing id. Add facade delegate on `CalendarService`.
+2. constants: add `UPDATE_BLOCKED_TIME`; permissions mapping entry.
+3. mutations: `UpdateBlockedTimeInput { organizationId, calendarId, blockedTimeId, startTime, endTime, timezone, reason, rruleString }` → service call. Return `{ success, errorMessage, blockedTime }`.
+
+Spec use-case: Provider Availability → `updateBlockedTime`.
+
+Tests:
+- **Unit**: service test — updates fields, org/calendar scoping, missing id raises `ValueError`.
+- **Integration**: mutation happy path; missing id → `success=False`; permission denied without grant.
+
+**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. New service method + scoping + wrapper.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token updates a blocked time's fields; cross-calendar/cross-org ids rejected.
+
+---
+
+### Phase 3g — `deleteBlockedTime` mutation + `delete_blocked_time` service method
+
+**Goal**: Delete one blocked time (true gap — no service method today).
+
+Changes:
+1. [calendar_integration/services/availability_service.py](../calendar_integration/services/availability_service.py): add `delete_blocked_time(calendar, blocked_time_id, delete_series=False) -> None` — org/calendar-scoped delete; `delete_series` deletes the recurring parent + children consistent with how blocked-time recurrence is modeled (confirm during impl); raise `ValueError` on missing id. Add facade delegate.
+2. constants: add `DELETE_BLOCKED_TIME`; permissions mapping entry.
+3. mutations: `DeleteBlockedTimeInput { organizationId, calendarId, blockedTimeId, deleteSeries }` → service call. Return `{ success, errorMessage }`.
+
+Spec use-case: Provider Availability → `deleteBlockedTime`.
+
+Tests:
+- **Unit**: service test — deletes single + series, org/calendar scoping, missing id raises.
+- **Integration**: mutation happy path; permission denied without grant.
+
+**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. Series-delete semantics need care.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token deletes a blocked time (and series when requested); it no longer appears in `blockedTimes`.
+
+---
+
+### Phase 4a — `CalendarBundleGraphQLType` + `calendarBundles` query
+
+**Goal**: Bundles become a first-class Public API read surface.
+
+Changes:
+1. [calendar_integration/graphql.py](../calendar_integration/graphql.py): add `CalendarBundleGraphQLType` over `Calendar` (filtered to `calendar_type=BUNDLE`), exposing `id, name, description, children { id name }` (children via `ChildrenCalendarRelationship`). No `isPrivate`/`owners` (non-goals).
+2. constants: add `CALENDAR_BUNDLE` (new resource category); permissions mapping entries for `calendarBundles` (and reuse for the bundle mutations in 4b–4d, each still getting its own value — see Open Questions if a single category is preferred).
+3. [public_api/queries.py](../public_api/queries.py): `calendarBundles(offset, limit)` → `Calendar.objects.filter_by_organization(org.id).filter(calendar_type=BUNDLE)`, paginated via `_slice_qs`. Address child prefetch to avoid N+1.
+
+Spec use-case: Appointment Types & Calendar Groups & Bundles → List calendar bundles.
+
+Tests:
+- **Integration**: lists bundles for org only (cross-org isolation); children resolve; pagination bounds; permission denied without `CALENDAR_BUNDLE` grant.
+
+**Suggested AI model**: Tier 3 — `claude-sonnet-4-6` / `gpt-5` / `gemini-2.5-pro`. New type + query + prefetch.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token lists the org's bundle calendars with their children; other orgs' bundles never appear.
+
+---
+
+### Phase 4b — `createCalendarBundle` mutation
+
+**Goal**: Create a bundle calendar from child calendars.
+
+Changes:
+1. constants: add `CREATE_CALENDAR_BUNDLE`; permissions mapping entry.
+2. mutations: `CreateCalendarBundleInput { organizationId, name, description, childrenIds, primaryCalendarId }` → resolve child Calendars (org-scoped) + primary → `calendar_service.create_bundle_calendar(name, description, child_calendars, primary_calendar)`. Return `{ success, errorMessage, bundle }`. (No `isPrivate` — non-goal.)
+
+Spec use-case: Appointment Types & Calendar Groups & Bundles → `createCalendarBundle`.
+
+Tests:
+- **Integration**: creates bundle with children; cross-org child id rejected; permission denied without grant.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token creates a bundle returned by `calendarBundles`.
+
+---
+
+### Phase 4c — `updateCalendarBundle` mutation
+
+**Goal**: Update a bundle's children/primary.
+
+Changes:
+1. constants: add `UPDATE_CALENDAR_BUNDLE`; permissions mapping entry.
+2. mutations: `UpdateCalendarBundleInput { organizationId, bundleId, name, description, childrenIds, primaryCalendarId }` → org-scoped fetch of the bundle Calendar + resolve children → `calendar_service.update_bundle_calendar(bundle_calendar, child_calendars, primary_calendar)`. Return `{ success, errorMessage, bundle }`. (`name`/`description` update applied on the bundle Calendar if the service does not — confirm during impl.)
+
+Spec use-case: Appointment Types & Calendar Groups & Bundles → `updateCalendarBundle`.
+
+Tests:
+- **Integration**: updates children set; missing/cross-org bundle → `success=False`; permission denied without grant.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token replaces a bundle's children; `calendarBundles` reflects the change.
+
+---
+
+### Phase 4d — `disableCalendarBundle` mutation + `disable_bundle_calendar` service method
+
+**Goal**: Disable a bundle calendar.
+
+Changes:
+1. [calendar_integration/services/calendar_service.py](../calendar_integration/services/calendar_service.py): add `disable_bundle_calendar(bundle_id) -> Calendar` — org-scoped fetch, validate `calendar_type=BUNDLE`, set `visibility=INACTIVE`, save.
+2. constants: add `DISABLE_CALENDAR_BUNDLE`; permissions mapping entry.
+3. mutations: `DisableCalendarBundleInput { organizationId, bundleId }` → service call. Return `{ success, errorMessage }`.
+
+Spec use-case: Appointment Types & Calendar Groups & Bundles → `disableCalendarBundle`.
+
+Tests:
+- **Unit**: service test — sets `visibility=INACTIVE`; rejects non-bundle / cross-org id.
+- **Integration**: mutation happy path; permission denied without grant.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token disables a bundle; it drops out of the listed bundles.
+
+---
+
+### Phase 5a — `reschedule_grouped_event` service method (foundation)
+
+**Goal**: Ship value: none on its own. Add the missing `CalendarGroupService` method that moves a grouped event's start/end (and optionally re-selects slot calendars), coordinating the change across the grouped event's child events. **True gap** — no reschedule path exists today; `create_grouped_event` is the only write.
+
+Changes:
+1. [calendar_integration/services/calendar_group_service.py](../calendar_integration/services/calendar_group_service.py): add `reschedule_grouped_event(event_id, start_time, end_time, timezone, slot_selections=None) -> CalendarEvent`. Design notes for the implementer: a grouped event is a `CalendarEvent` spanning multiple slot-selected child calendars; rescheduling must (a) validate the new window against availability for the selected calendars (reuse `check_group_availability` / `find_bookable_slots`), (b) update the parent grouped event times, (c) update/re-create the per-slot child events consistently, in one transaction. Confirm the exact child-event model relationship before coding. Compare with `CalendarBundleService.update_bundle_event` (lines ~409–475) as a precedent for multi-calendar event updates.
+2. Raise typed errors (`CalendarGroupError`) for invalid group/event/slot states.
+
+Spec use-case: shared scaffolding for `rescheduleCalendarGroupEvent` — no GraphQL field yet.
+
+Tests:
+- **Unit**: service tests — reschedule keeps group invariants (required_count per slot still satisfied); rejects unavailable new window; transactional rollback on partial failure; cross-org event rejected.
+
+**Suggested AI model**: Tier 4 — `claude-opus-4-7[1m]` / `gpt-5` (extended thinking) / `gemini-3-pro`. Architectural multi-calendar transactional logic with availability validation.
+
+**Reusable skills**: `write-tests`.
+
+Acceptance: `reschedule_grouped_event` moves a grouped event and all its child events atomically, validating availability; full service test suite green.
+
+---
+
+### Phase 5b — `rescheduleCalendarGroupEvent` mutation
+
+**Goal**: Reschedule a grouped event via the Public API.
+
+Changes:
+1. constants: add `RESCHEDULE_CALENDAR_GROUP_EVENT`; permissions mapping entry.
+2. mutations (in `CalendarGroupMutations` or alongside): `RescheduleGroupEventInput { organizationId, groupId, eventId, startTime, endTime, timezone, slotSelections: [{ slotId, calendarIds }] }` → init `calendar_group_service` → `reschedule_grouped_event(...)`. Return `{ success, errorMessage, event }`.
+
+Spec use-case: Reschedule / Cancel Modal → `rescheduleCalendarGroupEvent`.
+
+Tests:
+- **Integration**: reschedules a grouped event; unavailable window → `success=False`; missing event/group → `success=False`; permission denied without grant.
+
+**Suggested AI model**: Tier 2 — `claude-haiku-4-5` / `gpt-5-mini` / `gemini-2.5-flash`. Thin wrapper over 5a.
+
+**Reusable skills**: `create-graphql-public-query`; `write-tests`.
+
+Acceptance: A granted token reschedules a grouped event; the change is reflected across its child events.
+
+---
+
+## 6. Risk & Rollout Notes
+
+- **No feature flag**: brand-new GraphQL fields, no existing caller touched; per-token `PublicAPIResources` grants are the access gate. A token sees a new field only after an admin grants the matching resource (REST `POST /public-api-tokens/` with `available_resources`).
+- **No migrations**: no schema/locks/partition concerns. All new server work is Python service methods.
+- **Permission-matrix growth**: ~17 new `PublicAPIResources` values. Document them so admins know what to grant; ensure the REST token-creation surface accepts the new values (it reads `PublicAPIResources`, so additions are automatic — verify in Phase 0/2a).
+- **Org isolation**: every resolver must `filter_by_organization(org.id)` before touching a row; tests assert cross-org ids are rejected (recurring bug source).
+- **Batch atomicity**: `batchUpdateAvailabilityWindows` relies on the service's single-transaction row-atomic guarantee; test asserts rollback on a bad op.
+- **Group reschedule (5a) is the only real risk**: multi-calendar transactional update + availability validation. Land + soak its service tests before wiring 5b. If 5a proves larger than ~300 LoC, split into `5a-i` (times-only reschedule) and `5a-ii` (slot re-selection).
+- **Rollback**: any phase reverts cleanly by removing its field + resource value + mapping entry (and service method for gap phases); no data migration to undo.
+
+## 7. Open Questions
+
+| Question | Recommended default |
+|---|---|
+| Should the three bundle mutations + `calendarBundles` query each get a distinct `PublicAPIResources` value, or share one `CALENDAR_BUNDLE` category? | Per the Step 0 decision, **distinct value per field** (`CALENDAR_BUNDLE` for the read, `CREATE/UPDATE/DISABLE_CALENDAR_BUNDLE` for writes). Revisit only if the token-grant UX becomes unwieldy. |
+| `deleteAvailabilityWindow` / `deleteBlockedTime` `deleteSeries` semantics for recurring rows — what exactly does "series" mean against the recurring-exception model? | Confirm during Phase 3c/3g against the recurrence model; default to single-row delete + document the limitation if series delete is non-trivial, and split a follow-up phase. |
+| Does `update_bundle_calendar` persist `name`/`description`, or only children/primary? | Confirm in Phase 4c; if not, set them on the bundle Calendar in the resolver. |
+| Exact child-event relationship for grouped events (for 5a). | Resolve during Phase 5a design before coding; precedent in `CalendarBundleService.update_bundle_event`. |
+
+## 8. Touch List
+
+**Phase 0**: edit [public_api/mutations.py](../public_api/mutations.py); test [public_api/tests/test_mutations.py](../public_api/tests/test_mutations.py).
+
+**Phase 1a–1c** (events): edit [public_api/constants.py](../public_api/constants.py), [public_api/permissions.py](../public_api/permissions.py), [public_api/mutations.py](../public_api/mutations.py); tests in [public_api/tests/test_mutations.py](../public_api/tests/test_mutations.py).
+
+**Phase 2a–2c** (resource calendars): edit constants, permissions, mutations; `@calendar_integration/services/calendar_service.py` (`disable_resource_calendar`, Phase 2b); tests in test_mutations.py + a calendar-service test module for the new method.
+
+**Phase 3a–3g** (availability/blocked): edit constants, permissions, mutations; `@calendar_integration/services/availability_service.py` + facade delegates in `@calendar_integration/services/calendar_service.py` (`update_blocked_time` Phase 3f, `delete_blocked_time` Phase 3g); tests in test_mutations.py + availability-service test module.
+
+**Phase 4a–4d** (bundles): new `CalendarBundleGraphQLType` in `@calendar_integration/graphql.py`; edit [public_api/queries.py](../public_api/queries.py) (`calendarBundles`), constants, permissions, mutations; `@calendar_integration/services/calendar_service.py` (`disable_bundle_calendar`, Phase 4d); tests in [public_api/tests/test_queries.py](../public_api/tests/test_queries.py) (4a) + test_mutations.py (4b–4d).
+
+**Phase 5a–5b** (group reschedule): `@calendar_integration/services/calendar_group_service.py` (`reschedule_grouped_event`, Phase 5a); edit constants, permissions, mutations (5b); tests in the calendar-group-service test module (5a) + test_mutations.py (5b).
+
+**Schema**: no edits to [public_api/schema.py](../public_api/schema.py) needed — it imports `Query`/`Mutation` whole.

--- a/ai-plans/TRACKING_PUBLIC_GRAPHQL_SERVICE_WRAPPERS.md
+++ b/ai-plans/TRACKING_PUBLIC_GRAPHQL_SERVICE_WRAPPERS.md
@@ -1,0 +1,45 @@
+# Tracking — Public GraphQL Service Wrappers
+
+- **Feature**: Public GraphQL Service Wrappers
+- **Plan**: ai-plans/2026-06-17-PUBLIC_GRAPHQL_SERVICE_WRAPPERS_IMPLEMENTATION_PLAN.md
+- **Started**: 2026-06-17
+- **Last updated**: 2026-06-17
+- **Feature flag**: none (purely additive surface; per-token PublicAPIResources grants gate exposure)
+
+## Run options
+- `commit_strategy_resolved`: stacked-branches
+- `pause_between_phases`: false (auto-flow)
+- `generate_inline_comments`: true
+- `use_worktree`: true
+  - `worktree_path`: /Users/hugobessa/Workspaces/vinta-schedule/.claude/worktrees/plan-public-graphql-service-wrappers
+  - `worktree_branch`: plan/public-graphql-service-wrappers/wt
+  - `worktree_summary`: .vinta-ai-workflows/worktrees/plan-public-graphql-service-wrappers.yaml
+- `pr_creation`: agents-create
+- branch pattern: `plan/public-graphql-service-wrappers/phase-{id}`
+
+## Gate execution (IMPORTANT for resume)
+Tests/lint/build run INSIDE docker compose (per skills updated on main @868627d — "use docker compose for environment consistency"). Host Postgres is NOT used (host ephemeral-port exhaustion). Recipe, from the worktree dir:
+```
+COMPOSE_PROJECT_NAME=vinta-schedule docker compose run --rm api uv run <cmd>
+```
+- Reuses the shared `vinta-schedule` stack (db/broker/redis already up); mounts worktree code; DB over docker network.
+- `vinta_schedule_api/settings/local.py` is a real COPY in the worktree (NOT a symlink) — a symlink breaks inside the container (`ModuleNotFoundError: settings.local`).
+- Branch base rebased onto origin/main @868627d.
+
+## Completed Phases
+### Phase 0 — Shared mutation scaffolding ✅
+- Branch: `plan/public-graphql-service-wrappers/phase-0` (base: origin/main @868627d)
+- Model: claude-haiku-4-5 (plan tier 2). Fixer: haiku. Reviewer: sonnet.
+- Files: `public_api/mutations.py`, `public_api/tests/test_mutations.py`.
+- Added `CalendarMutationDependencies` + `get_calendar_mutation_dependencies()` (DI getter) and `_get_org_and_init_calendar_service(info)` helper (resolves org from request context, inits `calendar_service` via `initialize_without_provider`). No GraphQL fields/constants/permissions yet — pure scaffolding consumed by later phases.
+- Review: no BLOCKERs. SHOULD-FIX applied — reverted unrelated `get_mutation_dependencies` message (scope creep); tightened tests (`pytest.raises(GraphQLError)`, behavioral assertions on `calendar_service.organization`/`user_or_token`, top-level imports).
+- Outer gate (docker compose): ruff ✅, format ✅, check --deploy ✅, pytest -n auto = 2004 passed.
+
+## Current Phase
+- Phase 1a — createCalendarEvent (next)
+
+## Remaining Phases
+1a, 1b, 1c, 2a, 2b, 2c, 3a, 3b, 3c, 3d, 3e, 3f, 3g, 4a, 4b, 4c, 4d, 5a, 5b
+
+## Deferred Phases
+_(none — no cross-repo, no flag-removal phases in this plan)_

--- a/docs/building-blocks-integration-v2.md
+++ b/docs/building-blocks-integration-v2.md
@@ -1,0 +1,813 @@
+# BuildingBlocks \<-\> Vinta-Schedule Integration Project
+
+The objective of this document is to explain how the integration is going to work and what parts are still missing in the Vinta-Schedule APIs to make sure the integration is covered.
+
+## Status legend
+
+Each API call below is tagged with one of:
+
+| Tag | Meaning |
+| :---- | :---- |
+| ✅ **Ready** | Query/mutation already exists in the Public GraphQL API. |
+| 🔶 **Service ready / GraphQL missing** | Business logic exists in a service, but there is **no** Public GraphQL field exposing it — only a thin GraphQL wrapper \+ permission mapping is needed. |
+| ❌ **Missing** | Neither GraphQL nor service support exists; net-new work. |
+
+### Schema conventions (important)
+
+- The Public API uses **plain lists with `offset`/`limit` pagination**, *not* Relay `connection { nodes { ... } }` envelopes. The `nodes { ... }` syntax used in v1 of this doc does **not** match the real schema — examples below are rewritten to the real shape.  
+- Strawberry auto-camelCases fields, so Python `start_datetime` is `startDatetime` in GraphQL.  
+- Every Public API field is guarded by `IsAuthenticated` \+ `OrganizationResourceAccess`. Adding a new field **also** requires adding it to `OrganizationResourceAccess.FIELD_TO_RESOURCE_MAPPING` (`public_api/permissions.py`) and, for genuinely new resource categories, adding a value to `PublicAPIResources` (`public_api/constants.py`).  
+- The current auth model is **org-wide \+ resource-type-scoped only**. There is no per-user / per-object scoping (see §3.2 / §3.3 gaps).
+
+---
+
+# Integration setup questions
+
+## 1\. How are admins going to connect to vinta-schedule?
+
+### 1.1. create an account in vinta-schedule — ✅ Ready
+
+Sign up and create an organization using email/password or social login (Google).
+
+### 1.2. configure the service accounts — ✅ Ready (admin UI / existing flows)
+
+Service accounts are necessary to sync room/resource calendars with Google Calendar and do some admin operations on Google Calendar integration.
+
+### 1.3. \[optional\] import resource calendars — 🔶 Service ready / GraphQL missing
+
+Resource import from Google Workspace exists as a service (`CalendarSyncService.request_organization_calendar_resources_import` / `import_organization_calendar_resources`) but is **not** exposed through the Public GraphQL API. If admins must trigger it from the integration, a mutation is needed (see Location Page).
+
+## 2\. How do admins invite team members to vinta-schedule?
+
+### 2.1. Automatically link vinta-schedule users with Medplum providers — ❌ Missing
+
+Admins need to create a webhook for the "user created" event in vinta-schedule to notify a medplum bot about the new user, so it can link the identifier with their provider.
+
+#### Observation
+
+The **"user created" webhook event doesn't exist yet.** Outgoing webhooks *do* exist (`webhooks/` app — `WebhookConfiguration` \+ `WebhookEvent`, managed over **REST** at `/webhooks/` and `/webhook-events/`), but the only event types defined (`webhooks/constants.py`) are calendar-event / attendee events: `calendar_event_created`, `calendar_event_updated`, `calendar_event_deleted`, `calendar_event_attendee_added/removed/updated`. **To do:** add a `user_created` event type and emit it on user creation.
+
+### 2.2. invite the user on vinta-schedule — ✅ Ready (existing invite flow)
+
+Providers need to be invited to Vinta Schedule so they authorize it to look at their calendars in Google Calendar.
+
+### 2.3. user accepts the invitation — ✅ Ready (will trigger the new webhook once 2.1 ships)
+
+Users will create their account in the Vinta Schedule and that will trigger the "user created" webhook.
+
+### 2.4. user id is linked to the medplum provider — ❌ Missing (depends on 2.1 \+ 3.2)
+
+A Medplum bot will be triggered on user creation and that bot needs to add a vinta-schedule identifier to the Provider (so they are linked) and generate a Public API token to give the provider ability to make the necessary queries and mutations to Vinta Schedule.
+
+### 2.5. user configures their calendars — ✅ mostly Ready
+
+They'll be able to configure their default calendar, which calendars are listed and which sync automatically. Backing concepts already exist: `Calendar.visibility` (`ACTIVE`/`UNLISTED`/`INACTIVE`), `Calendar.sync_enabled`, `accepts_public_scheduling`, and `CalendarOwnership.is_default` (`CalendarService.get_default_calendar_for_user`). Exposure of the *mutations* to change these from the integration may still be needed.
+
+## 3\. How does the admin integrate medplum with vinta-schedule?
+
+### 3.1. Create an admin Public API token — ✅ Ready (REST, not GraphQL)
+
+Tokens are created via **REST** `POST /public-api-tokens/` (`integration_name` \+ `available_resources: [...]`), gated by `IsOrganizationAdmin`. The plaintext token is returned **once** as `{system_user.id}:{token}`. Resource grants come from `PublicAPIResources`. This token can be granted resource access (calendars, calendar groups, system users, etc.).
+
+### 3.2. Create webhooks for generating user tokens — ❌ Missing
+
+On "user creation", generate a new provider token that only has access to manage that provider's data (manage recurring availability, manage specific availability dates, manage blocked times, free/busy checks, list events, list blocked times, schedule events).
+
+#### Observation
+
+vinta-schedule **does not** have user-specific Public API tokens restricted to what one user can access. Today `SystemUser` \+ `ResourceAccess` give **org-wide, resource-type-level** access only — there is no per-user / per-owner scoping. To enable §3.2 we need:
+
+- a per-owner scope on the token (e.g. a `SystemUser.scoped_to_user` FK or a `ResourceAccess` object-level constraint), and the permission classes (`OrganizationResourceAccess`) updated to filter querysets/mutations by that owner;  
+- a way for the bot to mint that token (REST endpoint already exists for org tokens — extend it to accept an owner scope, **or** add a GraphQL mutation `createScopedSystemUser`).
+
+### 3.3. Create Patient token — ❌ Missing (depends on 3.4 \+ visibility work)
+
+Create a patient token that's only able to check availability and create an appointment (passing the scheduling code or not depending if the calendars/calendar-groups/calendar-bundles are restricted).
+
+#### Observation
+
+vinta-schedule **does not** differentiate restricted/public calendars/calendar-groups/ calendar-bundles in a single uniform way:
+
+- `Calendar` has `visibility` \+ `accepts_public_scheduling` (closest existing knob).  
+- `CalendarGroup` has **no** privacy/visibility field.  
+- Bundles (modeled as `Calendar` with `calendar_type=BUNDLE`) only have `visibility`.
+
+We need a consistent `is_private` (restricted) concept across calendars / groups / bundles, plus the single-use code mutations:
+
+- a mutation to generate a single-use **scheduling** code,  
+- a mutation to generate a single-use **rescheduling** code (one specific event),  
+- a mutation to generate a single-use **cancel** code (one specific event),  
+- a mutation to **create** an event passing a single-use scheduling code,  
+- a mutation to **reschedule** an event passing a single-use code.
+
+Note: the data model already has `CalendarManagementToken` \+ `CalendarManagementTokenPermission` (permissions: create, update\_attendees, update\_self\_rsvp, update\_details, cancel, reschedule) plus `CalendarPermissionService.create_attendee_token()` / `create_external_attendee_update_token()`. **The model layer for single-use codes mostly exists — the gap is GraphQL mutations to mint standalone codes and to act with a code.**
+
+### 3.4. Implement single-use scheduling codes for Patients — ❌ Missing (GraphQL surface)
+
+Generate appointment-type unique, single-use scheduling code so patients can schedule an appointment on restricted calendars/calendar-groups/calendar-bundles. Backed by `CalendarManagementToken`; needs the GraphQL mutations from §3.3.
+
+## 4\. How do the events get synchronized between VintaSchedule and the Building Blocks?
+
+When we create an appointment on the Building Blocks we also need to create a CalendarEvent on VintaSchedule so we save the CalendarEvent id in the Appointment (as an identifier).
+
+We also need webhooks so updates in VintaSchedule are automatically cascaded into the Appointment. Outgoing webhooks already exist for `calendar_event_created/updated/deleted` and attendee changes (REST `/webhooks/`), so Medplum Bots can subscribe today for event sync. The **remaining gap** is the `user_created` event (§2.1) and, optionally, exposing webhook config management over GraphQL (currently REST-only).
+
+---
+
+# Integration touch-points per screen
+
+Each call lists its **status tag** and a concrete GraphQL signature. Signatures tagged 🔶/❌ are **proposed** (to be implemented); ✅ ones reflect the current schema.
+
+## Provider/Admin App
+
+### Login / SSO
+
+- **Maybe List calendars** — ✅ Ready
+
+```
+query Calendars($userId: Int, $calendarType: String, $offset: Int! = 0, $limit: Int! = 100) {
+  calendars(userId: $userId, calendarType: $calendarType, offset: $offset, limit: $limit) {
+    id name description email calendarType capacity visibility syncEnabled
+  }
+}
+```
+
+### Location Page
+
+- **List resources (id, name, description, capacity)** — ✅ Ready (filter by type)
+
+```
+query Resources($offset: Int! = 0, $limit: Int! = 100) {
+  calendars(calendarType: "resource", offset: $offset, limit: $limit) {
+    id name description capacity calendarType
+  }
+}
+```
+
+- **createResourceCalendar(name, description, capacity)** — 🔶 Service ready / GraphQL missing Backed by `CalendarService.create_resource_calendar(name, description, capacity, manage_available_windows)`.
+
+```
+mutation CreateResourceCalendar($input: CreateResourceCalendarInput!) {
+  createResourceCalendar(input: $input) {   # input: { organizationId, name, description, capacity, manageAvailableWindows }
+    success errorMessage calendar { id name description capacity calendarType }
+  }
+}
+```
+
+- **editResourceCalendar(name, description, capacity)** — ❌ Missing (No dedicated `update_resource_calendar` service method found; needs a service method \+ mutation. Works only for manual `provider=INTERNAL` resource calendars, not Google-synced ones.)
+
+```
+mutation UpdateResourceCalendar($input: UpdateResourceCalendarInput!) {
+  updateResourceCalendar(input: $input) {   # input: { organizationId, calendarId, name, description, capacity }
+    success errorMessage calendar { id name description capacity }
+  }
+}
+```
+
+- **disableResourceCalendar(id)** — 🔶 Service ready / GraphQL missing (Backed by `Calendar.visibility = INACTIVE`; expose a mutation.)
+
+```
+mutation DisableResourceCalendar($input: DisableResourceCalendarInput!) {
+  disableResourceCalendar(input: $input) {  # input: { organizationId, calendarId }
+    success errorMessage
+  }
+}
+```
+
+- *(optional)* **importResourceCalendars** — 🔶 Service ready / GraphQL missing (Wraps `CalendarSyncService.request_organization_calendar_resources_import(start_time, end_time)`.)
+
+### Appointment Types & Calendar Groups & Bundles (Admin)
+
+- **List calendar groups** — ✅ Ready (but see gaps: no `isPrivate`, no `owners`) Real shape (lists, not `nodes`):
+
+```
+query CalendarGroups($offset: Int! = 0, $limit: Int! = 100) {
+  calendarGroups(offset: $offset, limit: $limit) {
+    id name description
+    slots {
+      id name requiredCount order
+      calendars {
+        id name
+        # owners { ... }   # ❌ Missing: CalendarGraphQLType has no `owners` field yet
+      }
+    }
+    # isPrivate            # ❌ Missing: no privacy field on CalendarGroup
+  }
+}
+```
+
+  **Gaps:** add `isPrivate` to `CalendarGroup` (model \+ type), and add an `owners` field to `CalendarGraphQLType` (data exists via `CalendarOwnership` / `ownerships` related name, resolving to `{ id, user { id, email, profile { firstName lastName profilePicture } } }`).
+
+
+- **List calendar bundles** — ❌ Missing (GraphQL surface) Bundles exist as `Calendar` with `calendar_type=BUNDLE` \+ `ChildrenCalendarRelationship`, and `CalendarBundleService` has full CRUD, but there is **no** GraphQL query/type for them. Proposed:
+
+```
+query CalendarBundles($offset: Int! = 0, $limit: Int! = 100) {
+  calendarBundles(offset: $offset, limit: $limit) {
+    id name description isPrivate     # isPrivate ❌ needs field
+    children { id name owners { id user { id email profile { firstName lastName profilePicture } } } }
+  }
+}
+```
+
+- **createCalendarGroup(name, is\_private, slots)** — ✅ Ready (⚠️ `isPrivate` not yet supported)
+
+```
+mutation CreateCalendarGroup($input: CalendarGroupInput!) {
+  # input: { organizationId, name, description, slots: [{ name, calendarIds, requiredCount, description, order }] }
+  # ❌ add `isPrivate` to CalendarGroupInput
+  createCalendarGroup(input: $input) { success errorMessage group { id name } }
+}
+```
+
+- **updateCalendarGroup(name, is\_private, slots)** — ✅ Ready (⚠️ `isPrivate` not yet supported)
+
+```
+mutation UpdateCalendarGroup($input: UpdateCalendarGroupInput!) {
+  # input: { organizationId, groupId, name, description, slots: [...] }  (+ isPrivate ❌)
+  updateCalendarGroup(input: $input) { success errorMessage group { id name } }
+}
+```
+
+- **disableCalendarGroup(id)** — ✅ Ready (as `deleteCalendarGroup`)
+
+```
+mutation DeleteCalendarGroup($input: DeleteCalendarGroupInput!) {  # { organizationId, groupId }
+  deleteCalendarGroup(input: $input) { success errorMessage }
+}
+```
+
+- **List calendars, filter by user** — ✅ Ready
+
+```
+query CalendarsByUser($userId: Int!) { calendars(userId: $userId) { id name calendarType } }
+```
+
+- **createCalendarBundle(name, is\_private, childrenIds)** — 🔶 Service ready / GraphQL missing (Backed by `CalendarBundleService.create_bundle_calendar(name, description, child_calendars, primary_calendar)`.)
+
+```
+mutation CreateCalendarBundle($input: CreateCalendarBundleInput!) {
+  # input: { organizationId, name, description, childrenIds: [Int!]!, primaryCalendarId, isPrivate }
+  createCalendarBundle(input: $input) { success errorMessage bundle { id name } }
+}
+```
+
+- **updateCalendarBundle(name, is\_private, childrenIds)** — 🔶 Service ready / GraphQL missing (Backed by `CalendarBundleService.update_bundle_calendar(bundle_calendar, child_calendars, primary_calendar)`.)
+
+```
+mutation UpdateCalendarBundle($input: UpdateCalendarBundleInput!) {
+  # input: { organizationId, bundleId, name, description, childrenIds, primaryCalendarId, isPrivate }
+  updateCalendarBundle(input: $input) { success errorMessage bundle { id name } }
+}
+```
+
+- **disableCalendarBundle(id)** — 🔶 Service ready / GraphQL missing (Set bundle `Calendar.visibility = INACTIVE`.)
+
+```
+mutation DisableCalendarBundle($input: DisableCalendarBundleInput!) {  # { organizationId, bundleId }
+  disableCalendarBundle(input: $input) { success errorMessage }
+}
+```
+
+### Provider Availability
+
+- **List available times** — ✅ Ready
+
+```
+query AvailableTimes($calendarId: Int!, $start: DateTime!, $end: DateTime!) {
+  availableTimes(calendarId: $calendarId, startDatetime: $start, endDatetime: $end) {
+    id startTime endTime recurrenceRule { rruleString }
+  }
+}
+```
+
+- **List unavailable times** — ✅ Ready
+
+```
+query UnavailableWindows($calendarId: Int!, $start: DateTime!, $end: DateTime!) {
+  unavailableWindows(calendarId: $calendarId, startDatetime: $start, endDatetime: $end) {
+    id startTime endTime reason
+  }
+}
+```
+
+- **List AvailabilityWindows** — ✅ Ready
+
+```
+query AvailabilityWindows($calendarId: Int!, $start: DateTime!, $end: DateTime!) {
+  availabilityWindows(calendarId: $calendarId, startDatetime: $start, endDatetime: $end) {
+    id startTime endTime canBookPartially
+  }
+}
+```
+
+- **List BlockedTimes** — ✅ Ready
+
+```
+query BlockedTimes($calendarId: Int!, $start: DateTime!, $end: DateTime!) {
+  blockedTimes(calendarId: $calendarId, startDatetime: $start, endDatetime: $end) {
+    id startTime endTime recurrenceRule { rruleString }
+  }
+}
+```
+
+- **createAvailabilityWindow** — 🔶 Service ready / GraphQL missing (`AvailabilityService.create_available_time(calendar, start_time, end_time, timezone, rrule_string)`.)
+
+```
+mutation CreateAvailabilityWindow($input: CreateAvailableTimeInput!) {
+  # input: { organizationId, calendarId, startTime, endTime, timezone, rruleString }
+  createAvailabilityWindow(input: $input) { success errorMessage availableTime { id startTime endTime } }
+}
+```
+
+- **createBlockedTime** — 🔶 Service ready / GraphQL missing (`AvailabilityService.create_blocked_time(calendar, start_time, end_time, timezone, reason, rrule_string)`.)
+
+```
+mutation CreateBlockedTime($input: CreateBlockedTimeInput!) {
+  # input: { organizationId, calendarId, startTime, endTime, timezone, reason, rruleString }
+  createBlockedTime(input: $input) { success errorMessage blockedTime { id startTime endTime } }
+}
+```
+
+- **updateAvailabilityWindow** — 🔶 Service ready / GraphQL missing (Via `AvailabilityService.batch_modify_available_times` / recurring-exception methods.)
+
+```
+mutation UpdateAvailabilityWindow($input: UpdateAvailableTimeInput!) {
+  # input: { organizationId, calendarId, availableTimeId, startTime, endTime, timezone, rruleString }
+  updateAvailabilityWindow(input: $input) { success errorMessage availableTime { id startTime endTime } }
+}
+```
+
+- **batchUpdateAvailabilityWindows** — 🔶 Service ready / GraphQL missing (`AvailabilityService.batch_modify_available_times(calendar, operations)` — atomic create/update/delete.)
+
+```
+mutation BatchUpdateAvailabilityWindows($input: BatchAvailabilityInput!) {
+  # input: { organizationId, calendarId, operations: [{ op: "create"|"update"|"delete", availableTimeId, startTime, endTime, timezone, rruleString }] }
+  batchUpdateAvailabilityWindows(input: $input) { success errorMessage availableTimes { id startTime endTime } }
+}
+```
+
+- **updateBlockedTime** — 🔶 Service ready / GraphQL missing
+
+```
+mutation UpdateBlockedTime($input: UpdateBlockedTimeInput!) {
+  # input: { organizationId, calendarId, blockedTimeId, startTime, endTime, timezone, reason, rruleString }
+  updateBlockedTime(input: $input) { success errorMessage blockedTime { id startTime endTime } }
+}
+```
+
+- **deleteAvailabilityWindow** — 🔶 Service ready / GraphQL missing
+
+```
+mutation DeleteAvailabilityWindow($input: DeleteAvailableTimeInput!) {  # { organizationId, calendarId, availableTimeId, deleteSeries }
+  deleteAvailabilityWindow(input: $input) { success errorMessage }
+}
+```
+
+- **deleteBlockedTime** — 🔶 Service ready / GraphQL missing
+
+```
+mutation DeleteBlockedTime($input: DeleteBlockedTimeInput!) {  # { organizationId, calendarId, blockedTimeId, deleteSeries }
+  deleteBlockedTime(input: $input) { success errorMessage }
+}
+```
+
+### Scheduler / Calendar
+
+- **List events (filter by user and calendar)** — ✅ Ready (filter by calendar \+ range)
+
+```
+query CalendarEvents($calendarId: Int!, $start: DateTime!, $end: DateTime!) {
+  calendarEvents(calendarId: $calendarId, startDatetime: $start, endDatetime: $end) {
+    id title description startTime endTime
+    attendees { id email }
+    resources { id name }
+  }
+}
+```
+
+  Note: filtering events **by user** is not a direct argument today. Resolve the user's calendars first (`calendars(userId: ...)`), then query events per calendar, **or** add a `userId` argument to `calendarEvents` (🔶 small enhancement). Matching appointments to show clinical info live on the Building Blocks side, keyed by the stored CalendarEvent id.
+
+### Create Appointment Modal
+
+- **List resources** — ✅ Ready (`calendars(calendarType: "resource")`).  
+- **List calendar available times** — ✅ Ready (`availabilityWindows`).  
+- **List user available times** — ✅ Ready (resolve user calendar → `availabilityWindows`).  
+- **List calendar group available times** — ✅ Ready
+
+```
+query GroupBookableSlots($groupId: Int!, $start: DateTime!, $end: DateTime!, $durationSeconds: Int!) {
+  calendarGroupBookableSlots(groupId: $groupId, searchWindowStart: $start,
+    searchWindowEnd: $end, durationSeconds: $durationSeconds) { startTime endTime }
+}
+```
+
+- **createCalendarEvent** — 🔶 Service ready / GraphQL missing (`CalendarEventService.create_event(calendar_id, event_data)`.)
+
+```
+mutation CreateCalendarEvent($input: CreateCalendarEventInput!) {
+  # input: { organizationId, calendarId, title, description, startTime, endTime, timezone,
+  #          attendances: [{ userId }], externalAttendances: [{ externalAttendee: { email, name } }],
+  #          resourceAllocations: [{ calendarId }], rruleString }
+  createCalendarEvent(input: $input) {
+    success errorMessage event { id title startTime endTime }
+  }
+}
+```
+
+- **createCalendarGroupEvent** — ✅ Ready
+
+```
+mutation CreateCalendarGroupEvent($input: CalendarGroupEventInput!) {
+  # input: { organizationId, groupId, title, description, startTime, endTime, timezone,
+  #          slotSelections: [{ slotId, calendarIds }], attendances: [{ userId }],
+  #          externalAttendances: [{ externalAttendee: { email, name } }] }
+  createCalendarGroupEvent(input: $input) { success errorMessage event { id title startTime endTime } }
+}
+```
+
+### Booking Link Creation
+
+All six are ❌ Missing as GraphQL mutations, but the model layer (`CalendarManagementToken`
+
++ `CalendarManagementTokenPermission`) and token-creation services already exist — these mutations are thin wrappers that mint a token with the right permission set \+ scope.  
+- **createCalendarBookingCode(calendar\_id)** — ❌ Missing
+
+```
+mutation CreateCalendarBookingCode($input: CreateBookingCodeInput!) {
+  # input: { organizationId, calendarId, appointmentTypeId, expiresAt }
+  createCalendarBookingCode(input: $input) { success errorMessage code }
+}
+```
+
+- **createCalendarGroupBookingCode(calendar\_group\_id)** — ❌ Missing
+
+```
+mutation CreateCalendarGroupBookingCode($input: CreateGroupBookingCodeInput!) {
+  # input: { organizationId, calendarGroupId, appointmentTypeId, expiresAt }
+  createCalendarGroupBookingCode(input: $input) { success errorMessage code }
+}
+```
+
+- **createCalendarRescheduleBookingCode(calendar\_id)** — ❌ Missing (Reschedule code is bound to **one specific event**, so it takes `eventId`.)
+
+```
+mutation CreateCalendarRescheduleBookingCode($input: CreateRescheduleCodeInput!) {
+  # input: { organizationId, calendarId, eventId, expiresAt }
+  createCalendarRescheduleBookingCode(input: $input) { success errorMessage code }
+}
+```
+
+- **createCalendarGroupRescheduleBookingCode(calendar\_group\_id)** — ❌ Missing
+
+```
+mutation CreateCalendarGroupRescheduleBookingCode($input: CreateGroupRescheduleCodeInput!) {
+  # input: { organizationId, calendarGroupId, eventId, expiresAt }
+  createCalendarGroupRescheduleBookingCode(input: $input) { success errorMessage code }
+}
+```
+
+- **createCalendarCancellationBookingCode(calendar\_id)** — ❌ Missing
+
+```
+mutation CreateCalendarCancellationBookingCode($input: CreateCancellationCodeInput!) {
+  # input: { organizationId, calendarId, eventId, expiresAt }
+  createCalendarCancellationBookingCode(input: $input) { success errorMessage code }
+}
+```
+
+- **createCalendarGroupCancellationBookingCode(calendar\_group\_id)** — ❌ Missing
+
+```
+mutation CreateCalendarGroupCancellationBookingCode($input: CreateGroupCancellationCodeInput!) {
+  # input: { organizationId, calendarGroupId, eventId, expiresAt }
+  createCalendarGroupCancellationBookingCode(input: $input) { success errorMessage code }
+}
+```
+
+### Appointment Details
+
+- **Get CalendarEvent** — ✅ Ready (use the `eventId` argument)
+
+```
+query GetEvent($eventId: Int!) {
+  calendarEvents(eventId: $eventId) {
+    id title description startTime endTime
+    calendar { id name }
+    attendees { id email profile { firstName lastName } }
+    externalAttendees { id email name }
+    resources { id name }
+    calendarGroup { id name }
+  }
+}
+```
+
+### Reschedule / Cancel Modal
+
+- **List resources / calendar / user / group available times** — ✅ Ready (same as Create Appointment Modal).  
+- **rescheduleCalendarEvent()** — 🔶 Service ready / GraphQL missing (`CalendarEventService.update_event(calendar_id, event_id, event_data)` with new times.)
+
+```
+mutation RescheduleCalendarEvent($input: RescheduleCalendarEventInput!) {
+  # input: { organizationId, calendarId, eventId, startTime, endTime, timezone }
+  rescheduleCalendarEvent(input: $input) { success errorMessage event { id startTime endTime } }
+}
+```
+
+- **rescheduleCalendarGroupEvent()** — 🔶 Service ready / GraphQL missing (Group event reschedule via group service \+ `update_event` on the grouped event.)
+
+```
+mutation RescheduleCalendarGroupEvent($input: RescheduleGroupEventInput!) {
+  # input: { organizationId, groupId, eventId, startTime, endTime, timezone, slotSelections: [{ slotId, calendarIds }] }
+  rescheduleCalendarGroupEvent(input: $input) { success errorMessage event { id startTime endTime } }
+}
+```
+
+- **cancelEvent()** — 🔶 Service ready / GraphQL missing (`CalendarEventService.delete_event(calendar_id, event_id, delete_series)`.)
+
+```
+mutation CancelEvent($input: CancelEventInput!) {
+  # input: { organizationId, calendarId, eventId, deleteSeries }
+  cancelEvent(input: $input) { success errorMessage }
+}
+```
+
+## Patient Portal
+
+### Login Identification — no integration.
+
+### Home / Dashboard — no integration.
+
+### Booking Calendar
+
+- **List resources** — ✅ Ready (`calendars(calendarType: "resource")`).  
+- **List calendar available times** — ✅ Ready (`availabilityWindows`).  
+- **List user available times** — ✅ Ready (resolve user calendar → `availabilityWindows`).  
+- **List calendar group available times** — ✅ Ready (`calendarGroupBookableSlots`).
+
+⚠️ For the **patient** (restricted) path, these reads should be permitted via a scheduling code / patient-scoped token rather than a full org token. That gating is part of the §3.3/§3.4 work (restricted visibility \+ single-use codes) and does not exist yet.
+
+### Booking Confirmation
+
+- **createCalendarEvent** — ❌ Missing for patients (needs the *with-code* variant) Single-calendar create exists as a service (🔶), but patient booking must accept a single-use scheduling code:
+
+```
+mutation CreateCalendarEventWithCode($input: CreateEventWithCodeInput!) {
+  # input: { code, title, description, startTime, endTime, timezone,
+  #          externalAttendee: { email, name } }
+  createCalendarEventWithCode(input: $input) { success errorMessage event { id startTime endTime } }
+}
+```
+
+- **createCalendarGroupEvent** — ❌ Missing for patients (needs the *with-code* variant)
+
+```
+mutation CreateCalendarGroupEventWithCode($input: CreateGroupEventWithCodeInput!) {
+  # input: { code, title, description, startTime, endTime, timezone,
+  #          slotSelections: [{ slotId, calendarIds }], externalAttendee: { email, name } }
+  createCalendarGroupEventWithCode(input: $input) { success errorMessage event { id startTime endTime } }
+}
+```
+
+  The authenticated (provider) variants are the existing `createCalendarEvent` (🔶) / `createCalendarGroupEvent` (✅); the patient portal needs the code-bearing variants above.
+
+### Intake Flag — no integration.
+
+### Manage Appointment
+
+- **List resources / calendar / user / group available times** — ✅ Ready (read side).  
+- **rescheduleCalendarEventWithCode()** — ❌ Missing
+
+```
+mutation RescheduleCalendarEventWithCode($input: RescheduleWithCodeInput!) {
+  # input: { code, startTime, endTime, timezone }
+  rescheduleCalendarEventWithCode(input: $input) { success errorMessage event { id startTime endTime } }
+}
+```
+
+- **rescheduleCalendarGroupEventWithCode()** — ❌ Missing
+
+```
+mutation RescheduleCalendarGroupEventWithCode($input: RescheduleGroupWithCodeInput!) {
+  # input: { code, startTime, endTime, timezone, slotSelections: [{ slotId, calendarIds }] }
+  rescheduleCalendarGroupEventWithCode(input: $input) { success errorMessage event { id startTime endTime } }
+}
+```
+
+- **cancelEventWithCode()** — ❌ Missing
+
+```
+mutation CancelEventWithCode($input: CancelWithCodeInput!) {  # { code }
+  cancelEventWithCode(input: $input) { success errorMessage }
+}
+```
+
+### Pre-visit Questionnaire — no integration.
+
+### Visit Day — no integration.
+
+---
+
+# What needs to be done (gap summary)
+
+Grouped by effort, smallest first.
+
+### A. Thin GraphQL wrappers over existing services (🔶 — low effort)
+
+Service logic exists; add mutation \+ `FIELD_TO_RESOURCE_MAPPING` entry (+ new `PublicAPIResources` value where needed):
+
+1. **Single-calendar events**: `createCalendarEvent`, `rescheduleCalendarEvent`, `cancelEvent` (`CalendarEventService.create_event` / `update_event` / `delete_event`).  
+2. **Resource calendars**: `createResourceCalendar`, `disableResourceCalendar`, *(optional)* `importResourceCalendars` (`CalendarService.create_resource_calendar`, `Calendar.visibility`, `CalendarSyncService` import).  
+3. **Availability / blocked times**: `createAvailabilityWindow`, `updateAvailabilityWindow`, `batchUpdateAvailabilityWindows`, `deleteAvailabilityWindow`, `createBlockedTime`, `updateBlockedTime`, `deleteBlockedTime` (`AvailabilityService.*`).  
+4. **Bundles GraphQL surface**: `CalendarBundleGraphQLType`, `calendarBundles` query, `createCalendarBundle`, `updateCalendarBundle`, `disableCalendarBundle` (`CalendarBundleService.*`).  
+5. **Group event reschedule**: `rescheduleCalendarGroupEvent`.
+
+### B. Schema additions (❌ small/medium)
+
+6. **`owners` field** on `CalendarGraphQLType` (data via `CalendarOwnership` / `ownerships`).  
+7. **`isPrivate` (restricted) concept** uniformly across `Calendar`, `CalendarGroup`, and bundle calendars — new model field(s) \+ expose on types \+ accept in create/update inputs. `Calendar.accepts_public_scheduling` / `visibility` partially cover Calendar already.  
+8. **`userId` argument** on `calendarEvents` query for direct per-user filtering.
+
+### C. Net-new building blocks (❌ medium/large)
+
+9. **Single-use booking codes (GraphQL)**: the six `create*BookingCode` / `*RescheduleBookingCode` / `*CancellationBookingCode` mutations, plus the patient *with-code* action mutations (`createCalendarEventWithCode`, `createCalendarGroupEventWithCode`, `reschedule*WithCode`, `cancelEventWithCode`). Model layer (`CalendarManagementToken` \+ permissions \+ `CalendarPermissionService`) mostly exists; build the GraphQL surface \+ the "act with a code" auth path (no org token required).  
+10. **Per-user / patient-scoped Public API tokens** (§3.2/§3.3): add owner scoping to `SystemUser`/`ResourceAccess`, enforce it in `OrganizationResourceAccess`, and provide a way for a bot to mint such tokens (extend REST `/public-api-tokens/` or add a GraphQL `createScopedSystemUser` mutation).  
+11. **`user_created` outgoing webhook** (§2.1): add the event type to `webhooks/constants.py` and emit it on user creation; optionally expose webhook config management over GraphQL (currently REST-only at `/webhooks/`).
+
+### Already done (✅ — no work)
+
+- Calendar / event / availability / blocked-time / user **read** queries.  
+- Calendar group CRUD \+ grouped-event creation \+ group availability/bookable-slots/events.  
+- Org-wide admin Public API token creation (REST) \+ token check / delete mutations.  
+- Outgoing webhooks for `calendar_event_*` and attendee changes (REST), usable for event sync.  
+- Incoming Google-provider webhook subscription management (GraphQL).
+
+---
+
+# Next-step prompts
+
+Copy/paste prompts to drive the spec & planning skills. The `create-spec` and `plan-feature`
+skills both interview you before drafting, so each prompt is a self-contained brief — answer
+any follow-up questions the skill asks.
+
+## `create-spec` prompts — "Net-new building blocks" (section C)
+
+### Prompt C-9 — Single-use booking / scheduling codes (GraphQL surface)
+
+> Write a spec for adding **single-use scheduling codes** to the Vinta-Schedule Public
+> GraphQL API so external integrators (Medplum / Building Blocks patient portal) can let
+> unauthenticated patients book, reschedule, and cancel appointments on restricted
+> calendars, calendar-groups, and calendar-bundles.
+>
+> Context: the data model mostly exists — `CalendarManagementToken` +
+> `CalendarManagementTokenPermission` (permissions: create, update_attendees,
+> update_self_rsvp, update_details, cancel, reschedule) and
+> `CalendarPermissionService.create_attendee_token()` /
+> `create_external_attendee_update_token()`. The gap is (a) GraphQL mutations to **mint
+> standalone codes**, and (b) GraphQL mutations to **act with a code** without an org token.
+>
+> Scope the following mutations (see `docs/building-blocks-integration-v2.md` for proposed
+> signatures): `createCalendarBookingCode`, `createCalendarGroupBookingCode`,
+> `createCalendarRescheduleBookingCode`, `createCalendarGroupRescheduleBookingCode`,
+> `createCalendarCancellationBookingCode`, `createCalendarGroupCancellationBookingCode`
+> (admin/provider-minted, org-token-gated); and the code-bearing patient actions
+> `createCalendarEventWithCode`, `createCalendarGroupEventWithCode`,
+> `rescheduleCalendarEventWithCode`, `rescheduleCalendarGroupEventWithCode`,
+> `cancelEventWithCode`.
+>
+> Decide and document: code lifecycle (single-use, expiry, revocation, what "used" means);
+> how a code binds to an appointment type vs a specific event; the auth path for codeless
+> patient calls (a code must authorize an action without `IsAuthenticated` /
+> `OrganizationResourceAccess`); how codes interact with restricted-visibility booking — note
+> that a separate effort introduces a uniform `is_private` (restricted) flag across
+> `Calendar`, `CalendarGroup`, and bundle calendars, and codes are the mechanism that lets
+> patients book on restricted ones, so design the code flow assuming that flag will exist;
+> abuse/rate-limiting; and the success/error result shape. Negative scope: do not build the
+> patient portal UI; do not build the `is_private` field/flag itself (that is a separate,
+> independently-planned change).
+
+### Prompt C-10 — Per-user / patient-scoped Public API tokens
+
+> Write a spec for **per-owner-scoped Public API tokens** in Vinta-Schedule so a Medplum bot
+> can mint, on user creation, a token that only manages **one specific provider's** data
+> (their recurring availability, specific availability dates, blocked times, free/busy checks,
+> list events, list blocked times, schedule events) — and, separately, a **patient** token
+> able only to check availability and create appointments.
+>
+> Context: today `SystemUser` + `ResourceAccess` (`public_api/models.py`) grant **org-wide,
+> resource-type-level** access only — no per-user / per-object scoping. The permission
+> classes `IsAuthenticated` + `OrganizationResourceAccess` (`public_api/permissions.py`) map
+> a GraphQL field to a `PublicAPIResources` value and check the system user has that resource.
+>
+> Decide and document: the data-model change (e.g. a `SystemUser.scoped_to_user` FK vs an
+> object-level constraint on `ResourceAccess`); how `OrganizationResourceAccess` must filter
+> querysets AND guard mutations by that owner so a scoped token cannot read/write other users'
+> data; how the bot mints such a token (extend REST `POST /public-api-tokens/` with an owner
+> scope vs a new GraphQL `createScopedSystemUser` mutation); how the patient-token variant
+> differs (very narrow resource set + likely tied to a single-use scheduling-code flow that is
+> being designed separately); migration / backward-compat for existing org-wide tokens; and the
+> security review of the scope-bypass surface. Negative scope: do not build the single-use
+> scheduling/booking codes, and do not build the `user_created` outgoing webhook — both are
+> separate, independently-planned changes.
+
+### Prompt C-11 — `user_created` outgoing webhook event
+
+> Write a spec for adding a **`user_created` outgoing webhook event** to Vinta-Schedule so a
+> Medplum bot is notified when a user is created and can link the vinta-schedule identifier to
+> its Provider and mint a scoped token.
+>
+> Context: outgoing webhooks already exist (`webhooks/` app — `WebhookConfiguration` +
+> `WebhookEvent`, managed over REST at `/webhooks/` and `/webhook-events/`, async delivery
+> with exponential backoff). Current event types (`webhooks/constants.py`) are calendar-event
+> and attendee events only — there is no user event.
+>
+> Decide and document: the new event-type constant; the trigger point on user creation (and
+> whether org-membership creation vs user creation is the right signal in a multi-tenant
+> model); the payload shape (what user fields a Medplum bot needs to link the provider — id,
+> email, profile name, organization, identifiers); idempotency / retry semantics reusing the
+> existing delivery machinery; and whether webhook-config management should also be exposed
+> over GraphQL (currently REST-only) or stay REST. Negative scope: do not build per-user/
+> patient-scoped tokens or single-use scheduling codes — both are separate, independently-
+> planned changes that merely consume this webhook.
+
+## `plan-feature` prompt — "Thin GraphQL wrappers" (section A, all items)
+
+### Prompt A — Expose existing calendar services through the Public GraphQL API
+
+> Plan a feature that adds **thin Public GraphQL wrappers over already-existing services** in
+> Vinta-Schedule. Each mutation/query must follow the `create-graphql-public-query` skill
+> pattern: register the field on `public_api/queries.py` / `public_api/mutations.py`, apply
+> `IsAuthenticated` + `OrganizationResourceAccess`, add a `FIELD_TO_RESOURCE_MAPPING` entry in
+> `public_api/permissions.py` (and a new `PublicAPIResources` value in
+> `public_api/constants.py` where a new resource category is needed, e.g. calendar bundles),
+> delegate to DI-injected services, and return the project's `success`/`errorMessage`/payload
+> result shape. Proposed signatures live in `docs/building-blocks-integration-v2.md`.
+>
+> The wrappers to expose (backing service shown):
+> 1. **Single-calendar events**: `createCalendarEvent`, `rescheduleCalendarEvent`,
+>    `cancelEvent` — `CalendarEventService.create_event` / `update_event` / `delete_event`.
+> 2. **Resource calendars**: `createResourceCalendar`, `disableResourceCalendar`, and
+>    (optional) `importResourceCalendars` — `CalendarService.create_resource_calendar`,
+>    `Calendar.visibility = INACTIVE`, `CalendarSyncService.request_organization_calendar_resources_import`.
+> 3. **Availability / blocked times**: `createAvailabilityWindow`, `updateAvailabilityWindow`,
+>    `batchUpdateAvailabilityWindows`, `deleteAvailabilityWindow`, `createBlockedTime`,
+>    `updateBlockedTime`, `deleteBlockedTime` — `AvailabilityService.*` (incl.
+>    `batch_modify_available_times`).
+> 4. **Bundles GraphQL surface**: `CalendarBundleGraphQLType`, `calendarBundles` query,
+>    `createCalendarBundle`, `updateCalendarBundle`, `disableCalendarBundle` —
+>    `CalendarBundleService.*` (bundles are `Calendar` with `calendar_type=BUNDLE` +
+>    `ChildrenCalendarRelationship`).
+> 5. **Group event reschedule**: `rescheduleCalendarGroupEvent`.
+>
+> Phase the plan sensibly (e.g. by resource area), with tests per phase. Flag any service
+> method that turns out NOT to exist or whose signature differs from the doc (e.g. there is no
+> dedicated `update_resource_calendar` — that one is a true gap and may need a small service
+> method). Negative scope (all separate, independently-planned changes — do NOT include them):
+> the `is_private`/restricted flag on calendars/groups/bundles, the `owners` field on
+> `CalendarGraphQLType`, the `userId` argument on the `calendarEvents` query, single-use
+> scheduling/booking codes, and per-user/patient-scoped Public API tokens.
+
+## `plan-feature` prompts — "Schema additions" (section B, one per item)
+
+### Prompt B-6 — `owners` field on `CalendarGraphQLType`
+
+> Plan adding an **`owners` field to `CalendarGraphQLType`** in the Public GraphQL API. The
+> data already exists via `CalendarOwnership` (related name `ownerships` on `Calendar`). The
+> field should resolve to a list of owners shaped
+> `{ id, user { id, email, profile { firstName lastName profilePicture } } }`, so the
+> Provider/Admin app can show calendar/group/bundle owners (see the calendar-groups and
+> bundles queries in `docs/building-blocks-integration-v2.md`). Address N+1 / prefetching for
+> nested `user.profile`, and confirm the existing `OrganizationResourceAccess` mapping for
+> `calendars` already covers it (no new resource). Include tests asserting owner data is
+> org-scoped and not leaked across organizations.
+
+### Prompt B-7 — Uniform `is_private` (restricted) concept across calendars, groups, bundles
+
+> Plan introducing a **uniform `is_private` (restricted) concept** across `Calendar`,
+> `CalendarGroup`, and bundle calendars in Vinta-Schedule, plus exposing it through the Public
+> GraphQL API. Today this is inconsistent: `Calendar` has `visibility`
+> (`ACTIVE`/`UNLISTED`/`INACTIVE`) + `accepts_public_scheduling`; `CalendarGroup` has **no**
+> privacy field; bundles (a `Calendar` with `calendar_type=BUNDLE`) only have `visibility`.
+>
+> Decide and document: whether `is_private` is a new field or a derived semantic over the
+> existing `visibility` / `accepts_public_scheduling` knobs; the model + migration changes
+> (use the `add-migration` / `migration-author` flow, multi-tenant `OrganizationModel`); how
+> `is_private` is surfaced on `CalendarGraphQLType`, `CalendarGroupGraphQLType`, and the
+> new bundle type, and accepted on the create/update inputs
+> (`CalendarGroupInput`/`UpdateCalendarGroupInput`, and bundle inputs); and how `is_private`
+> gates public vs scheduling-code-required booking. Note this flag is a prerequisite for a
+> separately-planned single-use scheduling-codes feature (codes let patients book on private
+> calendars/groups/bundles) — call out that downstream dependency so the field's semantics
+> support it. Phase with tests covering private/public booking behavior. Negative scope: do not
+> build the scheduling-code mutations themselves (separate change).
+
+### Prompt B-8 — `userId` argument on the `calendarEvents` query
+
+> Plan adding a **`userId` argument to the `calendarEvents` query** in `public_api/queries.py`
+> so the Scheduler/Calendar screen can list a single provider's events directly instead of
+> resolving the user's calendars first and querying per calendar. The filter should match
+> events on calendars owned by that user (via `CalendarOwnership`) within the existing
+> `startDatetime`/`endDatetime` range, stay org-scoped under `OrganizationResourceAccess`, and
+> compose with the existing `calendarId` filter. Confirm interaction with the
+> `get_calendar_events_expanded` service path (recurring expansion) and add tests that a user
+> filter returns only that user's events and respects organization boundaries.

--- a/docs/building-blocks-integration.md
+++ b/docs/building-blocks-integration.md
@@ -1,0 +1,208 @@
+# BuildingBlocks \<-\> Vinta-Schedule Integration Project
+
+The objective of this document is to explain how the integration is going to work and what parts are still missing in the Vinta-Schedule APIs to make sure the integration is covered.
+
+# Integration setup questions
+
+## 1\. How are admins going to connect to vinta-schedule?
+
+### 1.1. create an account in vinta-schedule
+
+You can sign up and create an organization using email/password or social login (Google).
+
+### 1.2. configure the service accounts
+
+Service accounts are necessary to sync room/resource calendars with Google Calendar and do some admin operations on Google Calendar integration.
+
+### 1.3. \[optional\] import resource calendars
+
+You can get your Rooms/Resources from Google Workspace and link them to the events to manage availability.
+
+## 2\. How do admins invite team members to vinta-schedule?
+
+### 2.1. Automatically link vinta-schedule users with Medplum providers
+
+Admins need to create a webhook for the "user created" event in vinta-schedule to notify a medplum bot about the new user, so it can link the identifier with their provider
+
+#### Observation
+
+The "user created" webhook event doesn't exist yet. This needs to be included on vinta-schedule API and frontend
+
+### 2.2. invite the user on vinta-schedule
+
+Providers need to be invited to Vinta Schedule so they authorize it to look at their calendars in Google Calendar.
+
+### 2.3. user accepts the invitation
+
+Users will create their account in the Vinta Schedule and that will trigger the "user created" webhook.
+
+### 2.4. user id is linked to the medplum provider
+
+A Medplum bot will be triggered on user creation and that bot needs to add a vinta-schedule identifier to the Provider (so they are linked) and generate a Public API token to give the provider ability to make the necessary queries and mutations to Vinta Schedule.
+
+### 2.5. user configures their calendars
+
+They'll be able to configure what's their default calendar, what of their calendar should be listed and what calendars sync automatically, for instance. This way we ensure we're checking their availability correctly.
+
+## 3\. How does the admin integrate medplum with vinta-schedule?
+
+### 3.1. Create an admin Public API token
+
+This token needs to allow resources management, calendar groups management, and calendar bundles management, and Public API tokens management.
+
+### 3.2. Create webhooks for generating user tokens
+
+On "user creation", generate a new provider token that only has access to manage that provider's data (manage recurring availability, manage specific availability dates, manage blocked times, free/busy checks, list events, list blocked times, schedule events)
+
+#### Observation:
+
+vinta-schedule doesn't have user-specific Public API tokens that are restricted to what the user has access to. This needs to be implemented to enable ([3.2](#32-on-user-creation-generate-a-new-provider-token-that-only-has-access-to-manage-that-providers-data-manage-recurring-availability-manage-specific-availability-dates-manage-blocked-times-freebusy-checks-list-events-list-blocked-times-schedule-events)).
+
+### 3.3. Create Patient token
+
+Create patient token that's only able to check availability and create appointment (passing the scheduling code or not depending if the calendars/calendar-groups/calendar-bundles is restricted)
+
+#### Observation:
+
+vinta-schedule doesn't differentiate restricted/public calendars/calendar-groups/calendar-bundles. This needs to be implemented before creating tokens for patients ([3.3](#33-generate-patient-token-thats-only-able-to-check-availability-and-create-appointment-passing-the-scheduling-code-or-not-depending-if-the-calendarscalendar-groupscalendar-bundles-is-restricted)). We also need:
+
+* a mutation to generate a single-use scheduling code.  
+* a mutation to generate a single-use rescheduling code (that only allow rescheduling one specific event).  
+* a mutation to generate a single-use cancel code (that only allow cancelling one specific event).  
+* a mutation to create an event passing a single-use scheduling code.  
+* a mutation to reschedule an event passing a single-use scheduling code.
+
+### 3.4. Implement single-use scheduling codes for Patients
+
+Generate appointment type unique, single-use scheduling code so patients can schedule an appointment on restricted calendars/calendar-groups/calendar-bundles
+
+## 4\. How do the events get synchronized between VintaSchedule and the Building Blocks?
+
+When we create an appointment on the Building Blocks we also need to create a CalendarEvent on VintaSchedule so we save the CalendarEvent id in the Appointment (as an identifier)
+
+We also need to create webhooks so updates in VintaSchedule are automatically cascaded into the Appointment. We'll need Medplum Bots to receive the webhooks and sync the Appointments.
+
+# Integration touch-points per screen
+
+Here we're going to describe which queries and mutations are going to be necessary for each page in the Provider/Admin App and in the Patient Portal. This will help us understand the gaps we have on the Public API.
+
+## Provider/Admin App
+
+### Login / SSO
+
+* Maybe List calendars
+
+### Location Page
+
+* List resources (id, name, description, capacity)  
+* createResourceCalendar(name, description, capacity)  
+* disableResourceCalendar(id)  
+* editResourceCalendar(name, description, capacity)  
+  * This one only works with manual resource calendars, not with the ones synced with Google Calendar.
+
+### Appointment Types & Calendar Groups & Bundles (Admin)
+
+* List calendar groups (name, is\_private, slots { nodes { id, calendars { nodes { id, owners { nodes { id, user { id, email, profile { first\_name, last\_name, profile\_picture } } } } } })  
+* List calendar bundles (name, is\_private, children { nodes { id, owners { nodes { id, user { id, email, profile { first\_name, last\_name, profile\_picture } } } } } })  
+* createCalendarGroup(name, is\_private, slots)  
+* updateCalendarGroup(name, is\_private, slots)  
+* disableCalendarGroup(id)  
+* List calendars, filter by user  
+* createCalendarBundle(name, is\_private, childrenIds)  
+* updateCalendarBundle(name, is\_private, childrenIds)  
+* disableCalendarBundle(id)
+
+### Provider Availability
+
+* List available times  
+* List unavailable times  
+* List AvailabilityWindows  
+* List BlockedTimes  
+* createAvailabilityWindow  
+* createBlockedTime  
+* updateAvailabilityWindow  
+* batchUpdateAvailabilityWindows  
+* updateBlockedTime  
+* deleteAvailabilityWindow  
+* deleteBlockedTime
+
+### Scheduler / Calendar
+
+* List events (filter by user and calendar)  
+  * We'll need to get matching appointments to display clinical information that won't be on Vinta Schedule
+
+### Create Appointment Modal
+
+* List resources  
+* List calendar available times  
+* List user available times  
+* List calendar group available times  
+* createCalendarEvent  
+* createCalendarGroupEvent
+
+### Booking Link Creation
+
+* createCalendarBookingCode(calendar\_id)  
+* createCalendarGroupBookingCode(calendar\_group\_id)  
+* createCalendarRescheduleBookingCode(calendar\_id)  
+* createCalendarGroupRescheduleBookingCode(calendar\_group\_id)  
+* createCalendarCancellationBookingCode(calendar\_id)  
+* createCalendarGroupCancellationBookingCode(calendar\_group\_id)
+
+### Appointment Details
+
+* Get CalendarEvent
+
+### Reschedule / Cancel Modal
+
+* List resources  
+* List calendar available times  
+* List user available times  
+* List calendar group available times  
+* rescheduleCalendarEvent()  
+* rescheduleCalendarGroupEvent()  
+* cancelEvent()
+
+## Patient Portal
+
+### Login Identification
+
+Doesn't have integration
+
+### Home / Dashboard
+
+Doesn't have integration
+
+### Booking Calendar
+
+* List resources  
+* List calendar available times  
+* List user available times  
+* List calendar group available times
+
+### Booking Confirmation
+
+* createCalendarEvent  
+* createCalendarGroupEvent
+
+### Intake Flag
+
+Doesn't have integration
+
+### Manage Appointment
+
+* List resources  
+* List calendar available times  
+* List user available times  
+* List calendar group available times  
+* rescheduleCalendarEventWithCode()  
+* rescheduleCalendarGroupEventWithCode()  
+* cancelEventWithCode()
+
+### Pre-visit Questionnaire
+
+Doesn't have integration
+
+### Visit Day
+
+Doesn't have integration

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -65,8 +65,9 @@ def get_mutation_dependencies(
 ) -> MutationDependencies:
     required_dependencies = [public_api_auth_service, organization_service]
     if any(dep is None for dep in required_dependencies):
-        missing = [d for d in required_dependencies if d is None]
-        raise GraphQLError(f"Missing required dependencies: {missing}")
+        raise GraphQLError(
+            f"Missing required dependency {', '.join([str(dep) for dep in required_dependencies if dep is None])}"
+        )
 
     return MutationDependencies(
         public_api_auth_service=cast(PublicAPIAuthService, public_api_auth_service),

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Annotated, cast
+from typing import TYPE_CHECKING, Annotated, cast
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -32,9 +32,15 @@ from public_api.types import (
     CreateSystemUserTokenResult,
     InvitationResult,
     OrganizationResult,
+    PublicApiHttpRequest,
     UpdateBrandingInput,
     UpdateBrandingResult,
 )
+
+
+if TYPE_CHECKING:
+    from calendar_integration.services.calendar_group_service import CalendarGroupService
+    from calendar_integration.services.calendar_service import CalendarService
 
 
 # Module-scope constants for validation
@@ -59,14 +65,64 @@ def get_mutation_dependencies(
 ) -> MutationDependencies:
     required_dependencies = [public_api_auth_service, organization_service]
     if any(dep is None for dep in required_dependencies):
-        raise GraphQLError(
-            f"Missing required dependency {', '.join([str(dep) for dep in required_dependencies if dep is None])}"
-        )
+        missing = [d for d in required_dependencies if d is None]
+        raise GraphQLError(f"Missing required dependencies: {missing}")
 
     return MutationDependencies(
         public_api_auth_service=cast(PublicAPIAuthService, public_api_auth_service),
         organization_service=cast(OrganizationService, organization_service),
     )
+
+
+@dataclass
+class CalendarMutationDependencies:
+    """Dependencies for calendar mutations."""
+
+    calendar_service: "CalendarService"
+    calendar_group_service: "CalendarGroupService"
+
+
+@inject
+def get_calendar_mutation_dependencies(
+    calendar_service: Annotated["CalendarService | None", Provide["calendar_service"]] = None,
+    calendar_group_service: Annotated[
+        "CalendarGroupService | None", Provide["calendar_group_service"]
+    ] = None,
+) -> CalendarMutationDependencies:
+    """Get calendar mutation dependencies from DI container."""
+    required_dependencies = [calendar_service, calendar_group_service]
+    if any(dep is None for dep in required_dependencies):
+        missing = [d for d in required_dependencies if d is None]
+        raise GraphQLError(f"Missing required dependencies: {missing}")
+
+    return CalendarMutationDependencies(
+        calendar_service=cast("CalendarService", calendar_service),
+        calendar_group_service=cast("CalendarGroupService", calendar_group_service),
+    )
+
+
+def _get_org_and_init_calendar_service(
+    info: strawberry.Info,
+) -> tuple["CalendarService", Organization]:
+    """Resolve org from request context and initialize calendar service.
+
+    Returns:
+        Tuple of (initialized calendar_service, organization)
+
+    Raises:
+        GraphQLError: If organization is not found in request context
+    """
+    org = info.context.request.public_api_organization
+    if not org:
+        raise GraphQLError("Organization not found in request context")
+
+    deps = get_calendar_mutation_dependencies()
+    request: PublicApiHttpRequest = info.context.request
+    deps.calendar_service.initialize_without_provider(
+        user_or_token=request.public_api_system_user, organization=org
+    )
+
+    return deps.calendar_service, org
 
 
 @strawberry.type

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -15,6 +15,10 @@ from organizations.models import (
 )
 from public_api.constants import PublicAPIResources
 from public_api.models import ResourceAccess
+from public_api.mutations import (
+    _get_org_and_init_calendar_service,
+    get_calendar_mutation_dependencies,
+)
 from public_api.services import PublicAPIAuthService
 
 
@@ -1844,8 +1848,6 @@ class TestGetCalendarMutationDependencies:
 
     def test_get_calendar_mutation_dependencies_success(self):
         """Happy path: get_calendar_mutation_dependencies returns both services."""
-        from public_api.mutations import get_calendar_mutation_dependencies
-
         deps = get_calendar_mutation_dependencies()
         assert deps is not None
         assert deps.calendar_service is not None
@@ -1854,35 +1856,27 @@ class TestGetCalendarMutationDependencies:
     def test_get_calendar_mutation_dependencies_missing_calendar_service(self):
         """Missing calendar_service raises GraphQLError."""
         from di_core.containers import container
-        from public_api.mutations import get_calendar_mutation_dependencies
 
         # Override with None to simulate missing dependency
         with container.calendar_service.override(None):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(GraphQLError) as exc_info:
                 get_calendar_mutation_dependencies()
-            # The error should mention the missing dependency
-            assert "Missing required dependency" in str(exc_info.value) or "None" in str(
-                exc_info.value
-            )
+            # The error should mention the missing dependencies
+            assert "Missing required dependencies" in str(exc_info.value)
 
     def test_get_calendar_mutation_dependencies_missing_calendar_group_service(self):
         """Missing calendar_group_service raises GraphQLError."""
         from di_core.containers import container
-        from public_api.mutations import get_calendar_mutation_dependencies
 
         # Override with None to simulate missing dependency
         with container.calendar_group_service.override(None):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(GraphQLError) as exc_info:
                 get_calendar_mutation_dependencies()
-            # The error should mention the missing dependency
-            assert "Missing required dependency" in str(exc_info.value) or "None" in str(
-                exc_info.value
-            )
+            # The error should mention the missing dependencies
+            assert "Missing required dependencies" in str(exc_info.value)
 
     def test_get_org_and_init_calendar_service_success(self):
         """Happy path: _get_org_and_init_calendar_service returns service and org."""
-        from public_api.mutations import _get_org_and_init_calendar_service
-
         # Create a test organization
         test_org = baker.make(Organization, name="Test Org")
 
@@ -1902,11 +1896,12 @@ class TestGetCalendarMutationDependencies:
         # Assert returns match expectations
         assert calendar_service is not None
         assert org == test_org
+        # Assert the service was initialized with the org and user
+        assert calendar_service.organization == test_org
+        assert calendar_service.user_or_token == mock_system_user
 
     def test_get_org_and_init_calendar_service_missing_org_raises_error(self):
         """Missing organization in request context raises GraphQLError."""
-        from public_api.mutations import _get_org_and_init_calendar_service
-
         # Create a mock strawberry.Info with NO public_api_organization
         mock_request = Mock()
         mock_request.public_api_organization = None

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
 
 import pytest
+from graphql import GraphQLError
 from model_bakery import baker
 from rest_framework.test import APIClient
 
@@ -1835,3 +1836,87 @@ class TestUpdateBranding:
         assert OrganizationBranding.objects.filter(organization=reseller_a).count() == 1
         # Verify there is exactly one branding row for B
         assert OrganizationBranding.objects.filter(organization=reseller_b).count() == 1
+
+
+@pytest.mark.django_db
+class TestGetCalendarMutationDependencies:
+    """Unit tests for get_calendar_mutation_dependencies and helpers."""
+
+    def test_get_calendar_mutation_dependencies_success(self):
+        """Happy path: get_calendar_mutation_dependencies returns both services."""
+        from public_api.mutations import get_calendar_mutation_dependencies
+
+        deps = get_calendar_mutation_dependencies()
+        assert deps is not None
+        assert deps.calendar_service is not None
+        assert deps.calendar_group_service is not None
+
+    def test_get_calendar_mutation_dependencies_missing_calendar_service(self):
+        """Missing calendar_service raises GraphQLError."""
+        from di_core.containers import container
+        from public_api.mutations import get_calendar_mutation_dependencies
+
+        # Override with None to simulate missing dependency
+        with container.calendar_service.override(None):
+            with pytest.raises(Exception) as exc_info:
+                get_calendar_mutation_dependencies()
+            # The error should mention the missing dependency
+            assert "Missing required dependency" in str(exc_info.value) or "None" in str(
+                exc_info.value
+            )
+
+    def test_get_calendar_mutation_dependencies_missing_calendar_group_service(self):
+        """Missing calendar_group_service raises GraphQLError."""
+        from di_core.containers import container
+        from public_api.mutations import get_calendar_mutation_dependencies
+
+        # Override with None to simulate missing dependency
+        with container.calendar_group_service.override(None):
+            with pytest.raises(Exception) as exc_info:
+                get_calendar_mutation_dependencies()
+            # The error should mention the missing dependency
+            assert "Missing required dependency" in str(exc_info.value) or "None" in str(
+                exc_info.value
+            )
+
+    def test_get_org_and_init_calendar_service_success(self):
+        """Happy path: _get_org_and_init_calendar_service returns service and org."""
+        from public_api.mutations import _get_org_and_init_calendar_service
+
+        # Create a test organization
+        test_org = baker.make(Organization, name="Test Org")
+
+        # Create a mock strawberry.Info with public_api_organization and public_api_system_user
+        mock_request = Mock()
+        mock_request.public_api_organization = test_org
+        mock_system_user = baker.make("public_api.SystemUser", organization=test_org, id=999)
+        mock_request.public_api_system_user = mock_system_user
+
+        mock_info = Mock()
+        mock_info.context = Mock()
+        mock_info.context.request = mock_request
+
+        # Call the function
+        calendar_service, org = _get_org_and_init_calendar_service(mock_info)
+
+        # Assert returns match expectations
+        assert calendar_service is not None
+        assert org == test_org
+
+    def test_get_org_and_init_calendar_service_missing_org_raises_error(self):
+        """Missing organization in request context raises GraphQLError."""
+        from public_api.mutations import _get_org_and_init_calendar_service
+
+        # Create a mock strawberry.Info with NO public_api_organization
+        mock_request = Mock()
+        mock_request.public_api_organization = None
+
+        mock_info = Mock()
+        mock_info.context = Mock()
+        mock_info.context.request = mock_request
+
+        # Call the function and expect GraphQLError
+        with pytest.raises(GraphQLError) as exc_info:
+            _get_org_and_init_calendar_service(mock_info)
+
+        assert "Organization not found in request context" in str(exc_info.value)


### PR DESCRIPTION
## Summary
Foundation phase for the **Public GraphQL Service Wrappers** plan. Adds the reusable dependency-injection getter and org/init helper that every later wrapper phase (events, resource calendars, availability/blocked times, bundles, group reschedule) consumes. **No GraphQL fields, constants, or permission mappings are registered yet** — the schema builds unchanged.

What's added in `public_api/mutations.py`:
- `CalendarMutationDependencies` dataclass + `get_calendar_mutation_dependencies()` — `@inject` DI getter for `calendar_service` + `calendar_group_service`, raising `GraphQLError` when a provider is missing. Mirrors `get_calendar_group_mutation_dependencies` in `calendar_integration/mutations.py`.
- `_get_org_and_init_calendar_service(info)` — resolves the org from `info.context.request.public_api_organization` (raises `GraphQLError` when absent) and initializes the calendar service via `initialize_without_provider(user_or_token=request.public_api_system_user, organization=org)`. Mirrors `_prepare_service_and_calendar` in `public_api/queries.py`.

## Plan reference
Plan: `ai-plans/2026-06-17-PUBLIC_GRAPHQL_SERVICE_WRAPPERS_IMPLEMENTATION_PLAN.md` → Phase 0. No feature flag (purely additive surface; per-token `PublicAPIResources` grants gate exposure).

## Test plan
Run inside docker compose (host Postgres unused):
```
COMPOSE_PROJECT_NAME=vinta-schedule docker compose run --rm api uv run ruff check ./
COMPOSE_PROJECT_NAME=vinta-schedule docker compose run --rm api uv run python manage.py check --deploy
COMPOSE_PROJECT_NAME=vinta-schedule docker compose run --rm api uv run pytest -n auto
```
Outer gate verified green: ruff ✅, format ✅, check --deploy ✅, pytest **2004 passed**. New unit tests in `public_api/tests/test_mutations.py` cover the DI getter (missing-dep → `GraphQLError`) and the helper (missing-org → `GraphQLError`; happy path asserts the service is initialized with the right org/user).