### PR TITLE
feat(calendar): mint single-use booking codes (Phase 1)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -31,11 +31,19 @@
 - **Summary**: Added `expires_at` / `minted_by_system_user` (FK→SystemUser, SET_NULL) / `consumed_source_ip` / `calendar_group` (OrganizationForeignKey) to `CalendarManagementToken`; `CalendarManagementTokenManager` with `active()`, atomic `consume()` (transaction.atomic + select_for_update + re-check, raises domain errors), `get_token_error_code()`. `CalendarPermissionService.create_booking_token` / `validate_code` / `consume_code`. New exceptions TokenExpired/AlreadyUsed/Revoked. `PublicAPIResources.CALENDAR_BOOKING_CODE` + 7 mint/revoke field mappings. Strawberry `BookingCodeErrorCode` + `BookingCodeResult` + `CodeEventResult` (defined, not yet wired). Migrations calendar_integration/0020 + public_api/0007. Real two-thread concurrency test proves first-write-wins.
 - **Key decisions**: `calendar_group` FK added (group booking codes need group binding; mirrors existing calendar/event composite-FK pattern). consume() wraps in reentrant `transaction.atomic()` so non-request callers (Celery/commands) are safe regardless of ATOMIC_REQUESTS.
 
+### Phase 1 — Mint booking codes ✅
+- **Status**: complete, reviewed (Layers 1–3 + fix loop), outer gate green.
+- **Model/tier**: implementer / Sonnet (Tier 3 — Haiku first attempt failed: misread base, duplicated Phase 0 defs, wrote stray edits into the MAIN checkout which were recovered + restored; reset clean and re-ran on Sonnet).
+- **Branch**: plan/single-use-scheduling-codes/phase-1 (base: phase-0).
+- **Commits**: b8c6434 (mint mutations) + 2af8a3d (org-scope validation fix).
+- **Outer gate**: `pytest -n auto` 2043 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: `createCalendarBookingCode` + `createCalendarGroupBookingCode` on `CalendarGroupMutations` (org-token-gated via CALENDAR_BOOKING_CODE), delegate to `create_booking_token(permissions=[CREATE])`, org from authenticated request, `minted_by` = request system user, bundle calendars transparent. Returns `BookingCodeResult{code, id}`. Not-found + organizationId-mismatch → INVALID_CODE (no cross-org leak). 11 tests.
+- **PR**: pending (filled below after push).
+
 ## Current phase
-Phase 1 — Mint booking codes (next).
+Phase 2 — Mint reschedule & cancel codes (next).
 
 ## Remaining phases
-- Phase 1 — Mint booking codes
 - Phase 2 — Mint reschedule & cancel codes
 - Phase 3 — Revoke codes
 - Phase 4 — Code-gated availability reads

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -405,7 +405,7 @@ def get_booking_code_mutation_dependencies(
 ) -> BookingCodeMutationDependencies:
     """Get booking-code mutation dependencies from DI container."""
     if calendar_permission_service is None:
-        raise GraphQLError("Missing required dependency: calendar_permission_service")
+        raise GraphQLError("Internal server error.")
     return BookingCodeMutationDependencies(
         calendar_permission_service=cast("CalendarPermissionService", calendar_permission_service),
     )
@@ -562,6 +562,13 @@ class CalendarGroupMutations:
                 error_message="Organization not found.",
             )
 
+        if input.organization_id != org.id:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
         # Verify the calendar belongs to the authenticated org.
         try:
             Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
@@ -597,6 +604,13 @@ class CalendarGroupMutations:
         """
         org = info.context.request.public_api_organization
         if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        if input.organization_id != org.id:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -10,11 +10,13 @@ from graphql import GraphQLError
 
 from calendar_integration.exceptions import CalendarGroupError
 from calendar_integration.graphql import (
+    BookingCodeErrorCode,
+    BookingCodeResult,
     CalendarEventGraphQLType,
     CalendarGroupGraphQLType,
     CalendarWebhookSubscriptionGraphQLType,
 )
-from calendar_integration.models import CalendarGroup
+from calendar_integration.models import Calendar, CalendarGroup, EventManagementPermissions
 from calendar_integration.services.dataclasses import (
     CalendarGroupEventInputData,
     CalendarGroupInputData,
@@ -26,10 +28,12 @@ from calendar_integration.services.dataclasses import (
 )
 from calendar_integration.services.webhook_analytics_service import WebhookAnalyticsService
 from organizations.models import Organization
+from public_api.permissions import IsAuthenticated, OrganizationResourceAccess
 
 
 if TYPE_CHECKING:
     from calendar_integration.services.calendar_group_service import CalendarGroupService
+    from calendar_integration.services.calendar_permission_service import CalendarPermissionService
     from calendar_integration.services.calendar_service import CalendarService
 
 
@@ -381,6 +385,50 @@ def _load_organization(organization_id: int) -> Organization | None:
         return None
 
 
+# ---------------------------------------------------------------------------
+# Booking-code mint mutations (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BookingCodeMutationDependencies:
+    """Dependencies for booking-code mint mutations."""
+
+    calendar_permission_service: "CalendarPermissionService"
+
+
+@inject
+def get_booking_code_mutation_dependencies(
+    calendar_permission_service: Annotated[
+        "CalendarPermissionService | None", Provide["calendar_permission_service"]
+    ] = None,
+) -> BookingCodeMutationDependencies:
+    """Get booking-code mutation dependencies from DI container."""
+    if calendar_permission_service is None:
+        raise GraphQLError("Missing required dependency: calendar_permission_service")
+    return BookingCodeMutationDependencies(
+        calendar_permission_service=cast("CalendarPermissionService", calendar_permission_service),
+    )
+
+
+@strawberry.input
+class CreateBookingCodeInput:
+    """Input for minting a single-use calendar booking code."""
+
+    organization_id: int
+    calendar_id: int
+    expires_at: datetime.datetime | None = None
+
+
+@strawberry.input
+class CreateGroupBookingCodeInput:
+    """Input for minting a single-use calendar-group booking code."""
+
+    organization_id: int
+    calendar_group_id: int
+    expires_at: datetime.datetime | None = None
+
+
 @strawberry.type
 class CalendarGroupMutations:
     """GraphQL mutations for CalendarGroup CRUD and grouped event booking."""
@@ -493,3 +541,85 @@ class CalendarGroupMutations:
         except CalendarGroupError as e:
             return CalendarGroupEventResult(success=False, error_message=str(e))
         return CalendarGroupEventResult(success=True, event=event)  # type: ignore[arg-type]
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_calendar_booking_code(
+        self,
+        info: strawberry.Info,
+        input: CreateBookingCodeInput,  # noqa: A002
+    ) -> BookingCodeResult:
+        """Mint a single-use booking code scoped to a calendar.
+
+        The token grants CREATE permission, allowing the code-bearer to book
+        an event on the bound calendar (or bundle calendar).  The code is
+        returned once in plaintext — only its hash is persisted.
+        """
+        org = info.context.request.public_api_organization
+        if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        # Verify the calendar belongs to the authenticated org.
+        try:
+            Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
+        except Calendar.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar not found.",
+            )
+
+        minted_by = getattr(info.context.request, "public_api_system_user", None)
+        deps = get_booking_code_mutation_dependencies()
+        token, plaintext_code = deps.calendar_permission_service.create_booking_token(
+            organization_id=org.id,
+            permissions=[EventManagementPermissions.CREATE],
+            expires_at=input.expires_at,
+            minted_by=minted_by,
+            calendar_id=input.calendar_id,
+        )
+        return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_calendar_group_booking_code(
+        self,
+        info: strawberry.Info,
+        input: CreateGroupBookingCodeInput,  # noqa: A002
+    ) -> BookingCodeResult:
+        """Mint a single-use booking code scoped to a calendar group.
+
+        The token grants CREATE permission, allowing the code-bearer to book
+        an event against the bound calendar group.  The code is returned once
+        in plaintext — only its hash is persisted.
+        """
+        org = info.context.request.public_api_organization
+        if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        # Verify the calendar group belongs to the authenticated org.
+        try:
+            CalendarGroup.objects.filter_by_organization(org.id).get(id=input.calendar_group_id)
+        except CalendarGroup.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar group not found.",
+            )
+
+        minted_by = getattr(info.context.request, "public_api_system_user", None)
+        deps = get_booking_code_mutation_dependencies()
+        token, plaintext_code = deps.calendar_permission_service.create_booking_token(
+            organization_id=org.id,
+            permissions=[EventManagementPermissions.CREATE],
+            expires_at=input.expires_at,
+            minted_by=minted_by,
+            calendar_group_id=input.calendar_group_id,
+        )
+        return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)

--- a/public_api/tests/test_booking_code_mutations.py
+++ b/public_api/tests/test_booking_code_mutations.py
@@ -1,0 +1,496 @@
+"""Integration tests for single-use booking-code mint mutations.
+
+Covers Phase 1: createCalendarBookingCode + createCalendarGroupBookingCode.
+"""
+
+import datetime
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarType
+from calendar_integration.models import (
+    Calendar,
+    CalendarGroup,
+    CalendarManagementToken,
+    CalendarManagementTokenPermission,
+    EventManagementPermissions,
+)
+from organizations.models import Organization
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+CREATE_CALENDAR_BOOKING_CODE_MUTATION = """
+mutation CreateCalendarBookingCode($input: CreateBookingCodeInput!) {
+    createCalendarBookingCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        code
+        id
+    }
+}
+"""
+
+CREATE_CALENDAR_GROUP_BOOKING_CODE_MUTATION = """
+mutation CreateCalendarGroupBookingCode($input: CreateGroupBookingCodeInput!) {
+    createCalendarGroupBookingCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        code
+        id
+    }
+}
+"""
+
+
+@pytest.fixture
+def organization():
+    """Create a test organization."""
+    return baker.make(Organization, name="Test Organization")
+
+
+@pytest.fixture
+def system_user_with_booking_code_resource(organization):
+    """Create a SystemUser + token with CALENDAR_BOOKING_CODE resource access."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="booking_code_integration", organization=organization
+    )
+    baker.make(
+        ResourceAccess,
+        system_user=system_user,
+        resource_name=PublicAPIResources.CALENDAR_BOOKING_CODE,
+    )
+    return system_user, token, auth_service
+
+
+@pytest.fixture
+def system_user_without_booking_code_resource(organization):
+    """Create a SystemUser + token WITHOUT CALENDAR_BOOKING_CODE resource access."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="no_booking_code_integration", organization=organization
+    )
+    # Deliberately grant a different resource but not CALENDAR_BOOKING_CODE
+    baker.make(
+        ResourceAccess,
+        system_user=system_user,
+        resource_name=PublicAPIResources.CALENDAR,
+    )
+    return system_user, token, auth_service
+
+
+@pytest.fixture
+def calendar(organization):
+    """Create a personal calendar in the test organization."""
+    return baker.make(Calendar, organization=organization, name="Test Calendar")
+
+
+@pytest.fixture
+def bundle_calendar(organization):
+    """Create a bundle calendar in the test organization."""
+    return baker.make(
+        Calendar,
+        organization=organization,
+        name="Bundle Calendar",
+        calendar_type=CalendarType.BUNDLE,
+    )
+
+
+@pytest.fixture
+def calendar_group(organization):
+    """Create a calendar group in the test organization."""
+    return baker.make(CalendarGroup, organization=organization, name="Test Group")
+
+
+@pytest.mark.django_db
+class TestCreateCalendarBookingCode:
+    """Tests for createCalendarBookingCode mutation."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _post_mutation(self, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_CALENDAR_BOOKING_CODE_MUTATION,
+                    "variables": variables,
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def test_mints_calendar_booking_code_with_resource(
+        self,
+        organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """Org token WITH CALENDAR_BOOKING_CODE mints a calendar code.
+
+        Asserts:
+        - Response has a non-empty ``code`` and non-null ``id``.
+        - A CalendarManagementToken row is scoped to the calendar.
+        - It has a CREATE permission row.
+        - minted_by_system_user is set.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "calendarId": calendar.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarBookingCode"]
+        assert result["success"] is True
+        assert result["code"] is not None and len(result["code"]) > 0
+        assert result["id"] is not None
+        assert result["errorCode"] is None
+        assert result["errorMessage"] is None
+
+        # Verify the token row in the database (must scope query by org — multi-tenancy contract)
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.organization_id == organization.id
+        assert db_token.calendar_fk_id == calendar.id
+        assert db_token.calendar_group_fk_id is None
+        assert db_token.minted_by_system_user_id == system_user.id
+
+        # Verify the CREATE permission row
+        permissions = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert permissions == [EventManagementPermissions.CREATE]
+
+    def test_mints_bundle_calendar_booking_code(
+        self,
+        organization,
+        bundle_calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """Bundle calendars are transparently handled by the calendar mint mutation."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "calendarId": bundle_calendar.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarBookingCode"]
+        assert result["success"] is True
+        assert result["code"] is not None and len(result["code"]) > 0
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.calendar_fk_id == bundle_calendar.id
+
+    def test_rejected_without_booking_code_resource(
+        self,
+        organization,
+        calendar,
+        system_user_without_booking_code_resource,
+    ):
+        """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected; no token row created."""
+        system_user, token, auth_service = system_user_without_booking_code_resource
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "calendarId": calendar.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+        # No new token row should have been created
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
+    def test_expires_at_persisted_on_token(
+        self,
+        organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """expiresAt input is persisted on the CalendarManagementToken row."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        expires_at = datetime.datetime(2030, 12, 31, 23, 59, 59, tzinfo=datetime.UTC)
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "expiresAt": expires_at.isoformat(),
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarBookingCode"]
+        assert result["success"] is True
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        # Django stores datetimes as timezone-aware UTC
+        assert db_token.expires_at is not None
+        assert db_token.expires_at.year == 2030
+        assert db_token.expires_at.month == 12
+        assert db_token.expires_at.day == 31
+
+    def test_cross_org_calendar_returns_invalid_code(
+        self,
+        organization,
+        system_user_with_booking_code_resource,
+    ):
+        """Calendar from another organization returns success=False with INVALID_CODE.
+
+        This prevents cross-org minting without revealing whether the calendar exists.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org")
+        other_calendar = baker.make(Calendar, organization=other_org)
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "calendarId": other_calendar.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        # No token row must have been created for the cross-org calendar
+        assert not CalendarManagementToken.objects.filter(calendar_fk_id=other_calendar.id).exists()
+
+
+@pytest.mark.django_db
+class TestCreateCalendarGroupBookingCode:
+    """Tests for createCalendarGroupBookingCode mutation."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _post_mutation(self, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_CALENDAR_GROUP_BOOKING_CODE_MUTATION,
+                    "variables": variables,
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def test_mints_group_booking_code_with_resource(
+        self,
+        organization,
+        calendar_group,
+        system_user_with_booking_code_resource,
+    ):
+        """Org token WITH CALENDAR_BOOKING_CODE mints a group booking code.
+
+        Asserts:
+        - Response has a non-empty ``code`` and non-null ``id``.
+        - A CalendarManagementToken row is scoped to the calendar_group.
+        - It has a CREATE permission row.
+        - minted_by_system_user is set.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarGroupBookingCode"]
+        assert result["success"] is True
+        assert result["code"] is not None and len(result["code"]) > 0
+        assert result["id"] is not None
+        assert result["errorCode"] is None
+        assert result["errorMessage"] is None
+
+        # Verify the token row in the database (must scope query by org — multi-tenancy contract)
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.organization_id == organization.id
+        assert db_token.calendar_group_fk_id == calendar_group.id
+        assert db_token.calendar_fk_id is None
+        assert db_token.minted_by_system_user_id == system_user.id
+
+        # Verify the CREATE permission row
+        permissions = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert permissions == [EventManagementPermissions.CREATE]
+
+    def test_rejected_without_booking_code_resource(
+        self,
+        organization,
+        calendar_group,
+        system_user_without_booking_code_resource,
+    ):
+        """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected; no token row created."""
+        system_user, token, auth_service = system_user_without_booking_code_resource
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
+    def test_expires_at_persisted_on_group_token(
+        self,
+        organization,
+        calendar_group,
+        system_user_with_booking_code_resource,
+    ):
+        """expiresAt input is persisted on the group CalendarManagementToken row."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        expires_at = datetime.datetime(2031, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                    "expiresAt": expires_at.isoformat(),
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarGroupBookingCode"]
+        assert result["success"] is True
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.expires_at is not None
+        assert db_token.expires_at.year == 2031
+        assert db_token.expires_at.month == 6
+
+    def test_cross_org_calendar_group_returns_invalid_code(
+        self,
+        organization,
+        system_user_with_booking_code_resource,
+    ):
+        """Calendar group from another organization returns success=False with INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org")
+        other_group = baker.make(CalendarGroup, organization=other_org)
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": other_group.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarGroupBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        # No token row must have been created for the cross-org group
+        assert not CalendarManagementToken.objects.filter(
+            calendar_group_fk_id=other_group.id
+        ).exists()

--- a/public_api/tests/test_booking_code_mutations.py
+++ b/public_api/tests/test_booking_code_mutations.py
@@ -273,11 +273,8 @@ class TestCreateCalendarBookingCode:
         db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
             id=result["id"]
         )
-        # Django stores datetimes as timezone-aware UTC
-        assert db_token.expires_at is not None
-        assert db_token.expires_at.year == 2030
-        assert db_token.expires_at.month == 12
-        assert db_token.expires_at.day == 31
+        # Django stores datetimes as timezone-aware UTC; compare full timestamp.
+        assert db_token.expires_at == expires_at
 
     def test_cross_org_calendar_returns_invalid_code(
         self,
@@ -309,6 +306,43 @@ class TestCreateCalendarBookingCode:
 
         # No token row must have been created for the cross-org calendar
         assert not CalendarManagementToken.objects.filter(calendar_fk_id=other_calendar.id).exists()
+
+    def test_organization_id_mismatch_returns_invalid_code(
+        self,
+        organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """Authenticated org token but organizationId in input set to a different org's id.
+
+        The mutation must reject the request without leaking cross-org existence.
+        No CalendarManagementToken row must be created.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org For Mismatch")
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": other_org.id, "calendarId": calendar.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
 
 
 @pytest.mark.django_db
@@ -456,9 +490,8 @@ class TestCreateCalendarGroupBookingCode:
         db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
             id=result["id"]
         )
-        assert db_token.expires_at is not None
-        assert db_token.expires_at.year == 2031
-        assert db_token.expires_at.month == 6
+        # Django stores datetimes as timezone-aware UTC; compare full timestamp.
+        assert db_token.expires_at == expires_at
 
     def test_cross_org_calendar_group_returns_invalid_code(
         self,
@@ -494,3 +527,45 @@ class TestCreateCalendarGroupBookingCode:
         assert not CalendarManagementToken.objects.filter(
             calendar_group_fk_id=other_group.id
         ).exists()
+
+    def test_organization_id_mismatch_returns_invalid_code(
+        self,
+        organization,
+        calendar_group,
+        system_user_with_booking_code_resource,
+    ):
+        """Authenticated org token but organizationId in input set to a different org's id.
+
+        The mutation must reject the request without leaking cross-org existence.
+        No CalendarManagementToken row must be created.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org For Group Mismatch")
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": other_org.id,
+                    "calendarGroupId": calendar_group.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarGroupBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before


### PR DESCRIPTION

## Summary

Adds the two org-token-gated mint mutations on `CalendarGroupMutations` (reaching the public
schema via `public_api.mutations.Mutation`):

- `createCalendarBookingCode(input: { organizationId, calendarId, expiresAt })` → `BookingCodeResult`
- `createCalendarGroupBookingCode(input: { organizationId, calendarGroupId, expiresAt })` → `BookingCodeResult`

Both are gated by `IsAuthenticated + OrganizationResourceAccess` → the `CALENDAR_BOOKING_CODE`
resource (mapping shipped in Phase 0). They delegate to Phase 0's
`CalendarPermissionService.create_booking_token(permissions=[CREATE])`, set `minted_by` from the
request system user, and return the plaintext code + opaque id once. Bundle calendars
(`calendar_type=BUNDLE`) mint through the calendar variant transparently.

Security: the organization is taken from the authenticated request (`public_api_organization`),
never trusted from the input. A `organizationId` that mismatches the token's org, or a
calendar/group not in the org, both return `success=False, errorCode=INVALID_CODE` with an
identical message — no cross-org existence is revealed.

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 1.
- Spec: Decisions → Use-cases, Use-case 1 (provider mints a booking code).

## Test plan

In-container (docker postgres) via `docker compose run --rm api uv run …`:

- `public_api/tests/test_booking_code_mutations.py` — 11 tests: calendar + group mint (asserting
  token scope, `CREATE` permission row, `minted_by` set), without-resource rejection (no token
  created), bundle calendar, `expiresAt` persisted (full-timestamp equality), cross-org calendar/
  group → INVALID_CODE, and organizationId-mismatch → INVALID_CODE (no token).
- `ruff check` clean · `makemigrations --check` no changes · `check --deploy` clean ·
  `pytest -n auto` **2043 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-0`.