### PR TITLE
feat(calendar): mint single-use reschedule & cancel codes (Phase 2)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -40,11 +40,19 @@
 - **Summary**: `createCalendarBookingCode` + `createCalendarGroupBookingCode` on `CalendarGroupMutations` (org-token-gated via CALENDAR_BOOKING_CODE), delegate to `create_booking_token(permissions=[CREATE])`, org from authenticated request, `minted_by` = request system user, bundle calendars transparent. Returns `BookingCodeResult{code, id}`. Not-found + organizationId-mismatch → INVALID_CODE (no cross-org leak). 11 tests.
 - **PR**: pending (filled below after push).
 
+### Phase 2 — Mint reschedule & cancel codes ✅
+- **Status**: complete, reviewed (Layers 1–3 + fix loop), outer gate green.
+- **Model/tier**: implementer / Sonnet (Tier 3, used over Haiku for reliability after Phase 1).
+- **Branch**: plan/single-use-scheduling-codes/phase-2 (base: phase-1).
+- **Commits**: 57b6eb2 (4 mint mutations) + d5e8929 (restrict calendar codes to non-grouped events).
+- **Outer gate**: `pytest -n auto` 2066 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: `createCalendarRescheduleBookingCode` / `createCalendarGroupRescheduleBookingCode` (RESCHEDULE) + `createCalendarCancellationBookingCode` / `createCalendarGroupCancellationBookingCode` (CANCEL), event-bound. Validates event∈org AND event.calendar_fk_id==calendarId (calendar variants additionally require calendar_group_fk_id IS NULL → no grouped events) / event.calendar_group_fk_id==groupId (group variants). Uniform "Not found." INVALID_CODE on all failures. Shared inputs CreateEventCodeInput / CreateGroupEventCodeInput. Permission-swap guard + grouped-event-rejection tests.
+- **PR**: pending (filled after push).
+
 ## Current phase
-Phase 2 — Mint reschedule & cancel codes (next).
+Phase 3 — Revoke codes (next).
 
 ## Remaining phases
-- Phase 2 — Mint reschedule & cancel codes
 - Phase 3 — Revoke codes
 - Phase 4 — Code-gated availability reads
 - Phase 5a — Book single-calendar event with code

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -16,7 +16,12 @@ from calendar_integration.graphql import (
     CalendarGroupGraphQLType,
     CalendarWebhookSubscriptionGraphQLType,
 )
-from calendar_integration.models import Calendar, CalendarGroup, EventManagementPermissions
+from calendar_integration.models import (
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    EventManagementPermissions,
+)
 from calendar_integration.services.dataclasses import (
     CalendarGroupEventInputData,
     CalendarGroupInputData,
@@ -429,6 +434,26 @@ class CreateGroupBookingCodeInput:
     expires_at: datetime.datetime | None = None
 
 
+@strawberry.input
+class CreateEventCodeInput:
+    """Input for minting a single-use reschedule or cancel code scoped to a calendar + event."""
+
+    organization_id: int
+    calendar_id: int
+    event_id: int
+    expires_at: datetime.datetime | None = None
+
+
+@strawberry.input
+class CreateGroupEventCodeInput:
+    """Input for minting a single-use reschedule or cancel code scoped to a calendar group + event."""
+
+    organization_id: int
+    calendar_group_id: int
+    event_id: int
+    expires_at: datetime.datetime | None = None
+
+
 @strawberry.type
 class CalendarGroupMutations:
     """GraphQL mutations for CalendarGroup CRUD and grouped event booking."""
@@ -635,5 +660,249 @@ class CalendarGroupMutations:
             expires_at=input.expires_at,
             minted_by=minted_by,
             calendar_group_id=input.calendar_group_id,
+        )
+        return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_calendar_reschedule_booking_code(
+        self,
+        info: strawberry.Info,
+        input: CreateEventCodeInput,  # noqa: A002
+    ) -> BookingCodeResult:
+        """Mint a single-use reschedule code bound to a specific event on a calendar.
+
+        The token grants RESCHEDULE permission for the bound event only.  The
+        code is returned once in plaintext — only its hash is persisted.
+        """
+        org = info.context.request.public_api_organization
+        if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        if input.organization_id != org.id:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        # Verify the calendar belongs to the authenticated org.
+        try:
+            Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
+        except Calendar.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar or event not found.",
+            )
+
+        # Verify the event belongs to this org AND to the named calendar.
+        try:
+            CalendarEvent.objects.filter_by_organization(org.id).get(
+                id=input.event_id,
+                calendar_fk_id=input.calendar_id,
+            )
+        except CalendarEvent.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar or event not found.",
+            )
+
+        minted_by = getattr(info.context.request, "public_api_system_user", None)
+        deps = get_booking_code_mutation_dependencies()
+        token, plaintext_code = deps.calendar_permission_service.create_booking_token(
+            organization_id=org.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            expires_at=input.expires_at,
+            minted_by=minted_by,
+            calendar_id=input.calendar_id,
+            event_id=input.event_id,
+        )
+        return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_calendar_group_reschedule_booking_code(
+        self,
+        info: strawberry.Info,
+        input: CreateGroupEventCodeInput,  # noqa: A002
+    ) -> BookingCodeResult:
+        """Mint a single-use reschedule code bound to a specific event on a calendar group.
+
+        The token grants RESCHEDULE permission for the bound event only.  The
+        code is returned once in plaintext — only its hash is persisted.
+        """
+        org = info.context.request.public_api_organization
+        if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        if input.organization_id != org.id:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        # Verify the calendar group belongs to the authenticated org.
+        try:
+            CalendarGroup.objects.filter_by_organization(org.id).get(id=input.calendar_group_id)
+        except CalendarGroup.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar group or event not found.",
+            )
+
+        # Verify the event belongs to this org AND to the named calendar group.
+        try:
+            CalendarEvent.objects.filter_by_organization(org.id).get(
+                id=input.event_id,
+                calendar_group_fk_id=input.calendar_group_id,
+            )
+        except CalendarEvent.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar group or event not found.",
+            )
+
+        minted_by = getattr(info.context.request, "public_api_system_user", None)
+        deps = get_booking_code_mutation_dependencies()
+        token, plaintext_code = deps.calendar_permission_service.create_booking_token(
+            organization_id=org.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            expires_at=input.expires_at,
+            minted_by=minted_by,
+            calendar_group_id=input.calendar_group_id,
+            event_id=input.event_id,
+        )
+        return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_calendar_cancellation_booking_code(
+        self,
+        info: strawberry.Info,
+        input: CreateEventCodeInput,  # noqa: A002
+    ) -> BookingCodeResult:
+        """Mint a single-use cancellation code bound to a specific event on a calendar.
+
+        The token grants CANCEL permission for the bound event only.  The code
+        is returned once in plaintext — only its hash is persisted.
+        """
+        org = info.context.request.public_api_organization
+        if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        if input.organization_id != org.id:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        # Verify the calendar belongs to the authenticated org.
+        try:
+            Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
+        except Calendar.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar or event not found.",
+            )
+
+        # Verify the event belongs to this org AND to the named calendar.
+        try:
+            CalendarEvent.objects.filter_by_organization(org.id).get(
+                id=input.event_id,
+                calendar_fk_id=input.calendar_id,
+            )
+        except CalendarEvent.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar or event not found.",
+            )
+
+        minted_by = getattr(info.context.request, "public_api_system_user", None)
+        deps = get_booking_code_mutation_dependencies()
+        token, plaintext_code = deps.calendar_permission_service.create_booking_token(
+            organization_id=org.id,
+            permissions=[EventManagementPermissions.CANCEL],
+            expires_at=input.expires_at,
+            minted_by=minted_by,
+            calendar_id=input.calendar_id,
+            event_id=input.event_id,
+        )
+        return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_calendar_group_cancellation_booking_code(
+        self,
+        info: strawberry.Info,
+        input: CreateGroupEventCodeInput,  # noqa: A002
+    ) -> BookingCodeResult:
+        """Mint a single-use cancellation code bound to a specific event on a calendar group.
+
+        The token grants CANCEL permission for the bound event only.  The code
+        is returned once in plaintext — only its hash is persisted.
+        """
+        org = info.context.request.public_api_organization
+        if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        if input.organization_id != org.id:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Organization not found.",
+            )
+
+        # Verify the calendar group belongs to the authenticated org.
+        try:
+            CalendarGroup.objects.filter_by_organization(org.id).get(id=input.calendar_group_id)
+        except CalendarGroup.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar group or event not found.",
+            )
+
+        # Verify the event belongs to this org AND to the named calendar group.
+        try:
+            CalendarEvent.objects.filter_by_organization(org.id).get(
+                id=input.event_id,
+                calendar_group_fk_id=input.calendar_group_id,
+            )
+        except CalendarEvent.DoesNotExist:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Calendar group or event not found.",
+            )
+
+        minted_by = getattr(info.context.request, "public_api_system_user", None)
+        deps = get_booking_code_mutation_dependencies()
+        token, plaintext_code = deps.calendar_permission_service.create_booking_token(
+            organization_id=org.id,
+            permissions=[EventManagementPermissions.CANCEL],
+            expires_at=input.expires_at,
+            minted_by=minted_by,
+            calendar_group_id=input.calendar_group_id,
+            event_id=input.event_id,
         )
         return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -679,14 +679,14 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         if input.organization_id != org.id:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         # Verify the calendar belongs to the authenticated org.
@@ -696,20 +696,21 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar or event not found.",
+                error_message="Not found.",
             )
 
-        # Verify the event belongs to this org AND to the named calendar.
+        # Verify the event belongs to this org AND to the named calendar, and is not a grouped event.
         try:
             CalendarEvent.objects.filter_by_organization(org.id).get(
                 id=input.event_id,
                 calendar_fk_id=input.calendar_id,
+                calendar_group_fk_id__isnull=True,
             )
         except CalendarEvent.DoesNotExist:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar or event not found.",
+                error_message="Not found.",
             )
 
         minted_by = getattr(info.context.request, "public_api_system_user", None)
@@ -740,14 +741,14 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         if input.organization_id != org.id:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         # Verify the calendar group belongs to the authenticated org.
@@ -757,7 +758,7 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar group or event not found.",
+                error_message="Not found.",
             )
 
         # Verify the event belongs to this org AND to the named calendar group.
@@ -770,7 +771,7 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar group or event not found.",
+                error_message="Not found.",
             )
 
         minted_by = getattr(info.context.request, "public_api_system_user", None)
@@ -801,14 +802,14 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         if input.organization_id != org.id:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         # Verify the calendar belongs to the authenticated org.
@@ -818,20 +819,21 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar or event not found.",
+                error_message="Not found.",
             )
 
-        # Verify the event belongs to this org AND to the named calendar.
+        # Verify the event belongs to this org AND to the named calendar, and is not a grouped event.
         try:
             CalendarEvent.objects.filter_by_organization(org.id).get(
                 id=input.event_id,
                 calendar_fk_id=input.calendar_id,
+                calendar_group_fk_id__isnull=True,
             )
         except CalendarEvent.DoesNotExist:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar or event not found.",
+                error_message="Not found.",
             )
 
         minted_by = getattr(info.context.request, "public_api_system_user", None)
@@ -862,14 +864,14 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         if input.organization_id != org.id:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Organization not found.",
+                error_message="Not found.",
             )
 
         # Verify the calendar group belongs to the authenticated org.
@@ -879,7 +881,7 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar group or event not found.",
+                error_message="Not found.",
             )
 
         # Verify the event belongs to this org AND to the named calendar group.
@@ -892,7 +894,7 @@ class CalendarGroupMutations:
             return BookingCodeResult(
                 success=False,
                 error_code=BookingCodeErrorCode.INVALID_CODE,
-                error_message="Calendar group or event not found.",
+                error_message="Not found.",
             )
 
         minted_by = getattr(info.context.request, "public_api_system_user", None)

--- a/public_api/tests/test_reschedule_cancel_code_mutations.py
+++ b/public_api/tests/test_reschedule_cancel_code_mutations.py
@@ -271,8 +271,8 @@ class TestCreateCalendarRescheduleBookingCode:
             end_time_tz_unaware=now + datetime.timedelta(hours=1),
             timezone="UTC",
         )
-        tokens_before = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_before = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
 
         response = self._post(
@@ -294,8 +294,8 @@ class TestCreateCalendarRescheduleBookingCode:
         assert result["success"] is False
         assert result["errorCode"] == "INVALID_CODE"
 
-        tokens_after = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_after = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
         assert tokens_after == tokens_before
 
@@ -348,8 +348,8 @@ class TestCreateCalendarRescheduleBookingCode:
     ):
         """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected; no token row created."""
         system_user, token, auth_service = system_user_without_booking_code_resource
-        tokens_before = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_before = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
 
         response = self._post(
@@ -370,8 +370,8 @@ class TestCreateCalendarRescheduleBookingCode:
         assert "errors" in data and len(data["errors"]) > 0
         assert "don't have access" in str(data["errors"]).lower()
 
-        tokens_after = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_after = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
         assert tokens_after == tokens_before
 
@@ -404,6 +404,48 @@ class TestCreateCalendarRescheduleBookingCode:
         result = data["data"]["createCalendarRescheduleBookingCode"]
         assert result["success"] is False
         assert result["errorCode"] == "INVALID_CODE"
+
+    def test_grouped_event_is_rejected(
+        self,
+        organization,
+        calendar,
+        calendar_group,
+        group_event,
+        system_user_with_booking_code_resource,
+    ):
+        """Calendar reschedule code for a grouped event returns INVALID_CODE; no token created.
+
+        A grouped event has calendar_group_fk set.  The calendar variant must not
+        bind to it even though the event's calendar_fk points to a valid calendar.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        tokens_before = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
+        ).count()
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": group_event.calendar_fk_id,
+                    "eventId": group_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarRescheduleBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
+        ).count()
+        assert tokens_after == tokens_before
 
 
 # ---------------------------------------------------------------------------
@@ -487,8 +529,8 @@ class TestCreateCalendarGroupRescheduleBookingCode:
         """An event not linked to the named group returns INVALID_CODE; no token created."""
         system_user, token, auth_service = system_user_with_booking_code_resource
         # `event` fixture has no calendar_group set
-        tokens_before = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_before = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
 
         response = self._post(
@@ -510,8 +552,8 @@ class TestCreateCalendarGroupRescheduleBookingCode:
         assert result["success"] is False
         assert result["errorCode"] == "INVALID_CODE"
 
-        tokens_after = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_after = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
         assert tokens_after == tokens_before
 
@@ -688,8 +730,8 @@ class TestCreateCalendarCancellationBookingCode:
             end_time_tz_unaware=now + datetime.timedelta(hours=1),
             timezone="UTC",
         )
-        tokens_before = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_before = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
 
         response = self._post(
@@ -711,8 +753,8 @@ class TestCreateCalendarCancellationBookingCode:
         assert result["success"] is False
         assert result["errorCode"] == "INVALID_CODE"
 
-        tokens_after = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_after = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
         assert tokens_after == tokens_before
 
@@ -812,6 +854,48 @@ class TestCreateCalendarCancellationBookingCode:
         assert result["success"] is False
         assert result["errorCode"] == "INVALID_CODE"
 
+    def test_grouped_event_is_rejected(
+        self,
+        organization,
+        calendar,
+        calendar_group,
+        group_event,
+        system_user_with_booking_code_resource,
+    ):
+        """Calendar cancellation code for a grouped event returns INVALID_CODE; no token created.
+
+        A grouped event has calendar_group_fk set.  The calendar variant must not
+        bind to it even though the event's calendar_fk points to a valid calendar.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        tokens_before = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
+        ).count()
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": group_event.calendar_fk_id,
+                    "eventId": group_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarCancellationBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
 
 # ---------------------------------------------------------------------------
 # createCalendarGroupCancellationBookingCode
@@ -894,8 +978,8 @@ class TestCreateCalendarGroupCancellationBookingCode:
     ):
         """An event not linked to the named group returns INVALID_CODE; no token created."""
         system_user, token, auth_service = system_user_with_booking_code_resource
-        tokens_before = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_before = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
 
         response = self._post(
@@ -917,8 +1001,8 @@ class TestCreateCalendarGroupCancellationBookingCode:
         assert result["success"] is False
         assert result["errorCode"] == "INVALID_CODE"
 
-        tokens_after = CalendarManagementToken.objects.filter(
-            organization_id=organization.id
+        tokens_after = CalendarManagementToken.objects.filter_by_organization(
+            organization.id
         ).count()
         assert tokens_after == tokens_before
 

--- a/public_api/tests/test_reschedule_cancel_code_mutations.py
+++ b/public_api/tests/test_reschedule_cancel_code_mutations.py
@@ -1,0 +1,1111 @@
+"""Integration tests for reschedule and cancel booking-code mint mutations.
+
+Covers Phase 2: createCalendarRescheduleBookingCode,
+createCalendarGroupRescheduleBookingCode, createCalendarCancellationBookingCode,
+createCalendarGroupCancellationBookingCode.
+"""
+
+import datetime
+
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.models import (
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    CalendarManagementToken,
+    CalendarManagementTokenPermission,
+    EventManagementPermissions,
+)
+from organizations.models import Organization
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+CREATE_CALENDAR_RESCHEDULE_CODE_MUTATION = """
+mutation CreateCalendarRescheduleBookingCode($input: CreateEventCodeInput!) {
+    createCalendarRescheduleBookingCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        code
+        id
+    }
+}
+"""
+
+CREATE_CALENDAR_GROUP_RESCHEDULE_CODE_MUTATION = """
+mutation CreateCalendarGroupRescheduleBookingCode($input: CreateGroupEventCodeInput!) {
+    createCalendarGroupRescheduleBookingCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        code
+        id
+    }
+}
+"""
+
+CREATE_CALENDAR_CANCELLATION_CODE_MUTATION = """
+mutation CreateCalendarCancellationBookingCode($input: CreateEventCodeInput!) {
+    createCalendarCancellationBookingCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        code
+        id
+    }
+}
+"""
+
+CREATE_CALENDAR_GROUP_CANCELLATION_CODE_MUTATION = """
+mutation CreateCalendarGroupCancellationBookingCode($input: CreateGroupEventCodeInput!) {
+    createCalendarGroupCancellationBookingCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        code
+        id
+    }
+}
+"""
+
+
+@pytest.fixture
+def organization():
+    """Create a test organization."""
+    return baker.make(Organization, name="Test Organization")
+
+
+@pytest.fixture
+def system_user_with_booking_code_resource(organization):
+    """Create a SystemUser + token with CALENDAR_BOOKING_CODE resource access."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="reschedule_cancel_integration", organization=organization
+    )
+    baker.make(
+        ResourceAccess,
+        system_user=system_user,
+        resource_name=PublicAPIResources.CALENDAR_BOOKING_CODE,
+    )
+    return system_user, token, auth_service
+
+
+@pytest.fixture
+def system_user_without_booking_code_resource(organization):
+    """Create a SystemUser + token WITHOUT CALENDAR_BOOKING_CODE resource access."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="no_booking_code_integration", organization=organization
+    )
+    baker.make(
+        ResourceAccess,
+        system_user=system_user,
+        resource_name=PublicAPIResources.CALENDAR,
+    )
+    return system_user, token, auth_service
+
+
+@pytest.fixture
+def calendar(organization):
+    """Create a calendar in the test organization."""
+    return baker.make(Calendar, organization=organization, name="Test Calendar")
+
+
+@pytest.fixture
+def calendar_group(organization):
+    """Create a calendar group in the test organization."""
+    return baker.make(CalendarGroup, organization=organization, name="Test Group")
+
+
+@pytest.fixture
+def event(organization, calendar):
+    """Create a CalendarEvent on the test calendar."""
+    now = timezone.now()
+    return CalendarEvent.objects.create(
+        organization=organization,
+        calendar_fk=calendar,
+        title="Test Event",
+        start_time_tz_unaware=now,
+        end_time_tz_unaware=now + datetime.timedelta(hours=1),
+        timezone="UTC",
+    )
+
+
+@pytest.fixture
+def group_event(organization, calendar, calendar_group):
+    """Create a CalendarEvent associated with the test calendar group."""
+    now = timezone.now()
+    return CalendarEvent.objects.create(
+        organization=organization,
+        calendar_fk=calendar,
+        calendar_group_fk=calendar_group,
+        title="Group Event",
+        start_time_tz_unaware=now,
+        end_time_tz_unaware=now + datetime.timedelta(hours=1),
+        timezone="UTC",
+    )
+
+
+def _post_graphql(client, system_user, token, auth_service, query, variables):
+    """Post a GraphQL mutation with bearer auth."""
+    from di_core.containers import container
+
+    with container.public_api_auth_service.override(auth_service):
+        return client.post(
+            "/graphql/",
+            data={"query": query, "variables": variables},
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# createCalendarRescheduleBookingCode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateCalendarRescheduleBookingCode:
+    """Tests for createCalendarRescheduleBookingCode mutation."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _post(self, system_user, token, auth_service, variables):
+        return _post_graphql(
+            self.client,
+            system_user,
+            token,
+            auth_service,
+            CREATE_CALENDAR_RESCHEDULE_CODE_MUTATION,
+            variables,
+        )
+
+    def test_happy_path_mints_reschedule_code(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """Org token with CALENDAR_BOOKING_CODE mints an event-scoped reschedule code.
+
+        Asserts:
+        - Response has non-empty code and non-null id.
+        - CalendarManagementToken row is scoped to calendar + event.
+        - It has exactly one RESCHEDULE permission row.
+        - minted_by_system_user is set.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarRescheduleBookingCode"]
+        assert result["success"] is True
+        assert result["code"] is not None and len(result["code"]) > 0
+        assert result["id"] is not None
+        assert result["errorCode"] is None
+        assert result["errorMessage"] is None
+
+        # Verify the token row (org-scoped — multi-tenancy contract)
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.organization_id == organization.id
+        assert db_token.calendar_fk_id == calendar.id
+        assert db_token.event_fk_id == event.id
+        assert db_token.calendar_group_fk_id is None
+        assert db_token.minted_by_system_user_id == system_user.id
+
+        # Must have exactly RESCHEDULE — not CREATE, not CANCEL
+        permissions = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert permissions == [EventManagementPermissions.RESCHEDULE]
+
+    def test_event_belonging_to_different_calendar_is_rejected(
+        self,
+        organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """An event from a different calendar returns INVALID_CODE; no token created."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        # Unique external_id avoids the (external_id, provider, org) unique-together constraint.
+        other_calendar = baker.make(
+            Calendar,
+            organization=organization,
+            name="Other Calendar",
+            external_id="other-cal-reschedule",
+        )
+        now = timezone.now()
+        other_event = CalendarEvent.objects.create(
+            organization=organization,
+            calendar_fk=other_calendar,
+            title="Other Event",
+            start_time_tz_unaware=now,
+            end_time_tz_unaware=now + datetime.timedelta(hours=1),
+            timezone="UTC",
+        )
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": other_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarRescheduleBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
+    def test_cross_org_calendar_and_event_returns_invalid_code(
+        self,
+        organization,
+        system_user_with_booking_code_resource,
+    ):
+        """Calendar/event from another org returns INVALID_CODE; no token created."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org")
+        other_calendar = baker.make(Calendar, organization=other_org)
+        now = timezone.now()
+        other_event = CalendarEvent.objects.create(
+            organization=other_org,
+            calendar_fk=other_calendar,
+            title="Cross-Org Event",
+            start_time_tz_unaware=now,
+            end_time_tz_unaware=now + datetime.timedelta(hours=1),
+            timezone="UTC",
+        )
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": other_calendar.id,
+                    "eventId": other_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarRescheduleBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        assert not CalendarManagementToken.objects.filter(event_fk_id=other_event.id).exists()
+
+    def test_rejected_without_booking_code_resource(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_without_booking_code_resource,
+    ):
+        """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected; no token row created."""
+        system_user, token, auth_service = system_user_without_booking_code_resource
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
+    def test_organization_id_mismatch_returns_invalid_code(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """input.organizationId != authenticated org id returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Mismatch Org")
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": other_org.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarRescheduleBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+
+# ---------------------------------------------------------------------------
+# createCalendarGroupRescheduleBookingCode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateCalendarGroupRescheduleBookingCode:
+    """Tests for createCalendarGroupRescheduleBookingCode mutation."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _post(self, system_user, token, auth_service, variables):
+        return _post_graphql(
+            self.client,
+            system_user,
+            token,
+            auth_service,
+            CREATE_CALENDAR_GROUP_RESCHEDULE_CODE_MUTATION,
+            variables,
+        )
+
+    def test_happy_path_mints_group_reschedule_code(
+        self,
+        organization,
+        calendar,
+        calendar_group,
+        group_event,
+        system_user_with_booking_code_resource,
+    ):
+        """Org token mints a group+event-scoped reschedule code with RESCHEDULE permission."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                    "eventId": group_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarGroupRescheduleBookingCode"]
+        assert result["success"] is True
+        assert result["code"] is not None and len(result["code"]) > 0
+        assert result["id"] is not None
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.calendar_group_fk_id == calendar_group.id
+        assert db_token.event_fk_id == group_event.id
+        assert db_token.calendar_fk_id is None
+        assert db_token.minted_by_system_user_id == system_user.id
+
+        permissions = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert permissions == [EventManagementPermissions.RESCHEDULE]
+
+    def test_event_not_in_group_is_rejected(
+        self,
+        organization,
+        calendar,
+        calendar_group,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """An event not linked to the named group returns INVALID_CODE; no token created."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        # `event` fixture has no calendar_group set
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarGroupRescheduleBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
+    def test_cross_org_group_and_event_returns_invalid_code(
+        self,
+        organization,
+        system_user_with_booking_code_resource,
+    ):
+        """Group/event from another org returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org Group")
+        other_calendar = baker.make(Calendar, organization=other_org)
+        other_group = baker.make(CalendarGroup, organization=other_org)
+        now = timezone.now()
+        other_event = CalendarEvent.objects.create(
+            organization=other_org,
+            calendar_fk=other_calendar,
+            calendar_group_fk=other_group,
+            title="Cross-Org Group Event",
+            start_time_tz_unaware=now,
+            end_time_tz_unaware=now + datetime.timedelta(hours=1),
+            timezone="UTC",
+        )
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": other_group.id,
+                    "eventId": other_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarGroupRescheduleBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+    def test_rejected_without_booking_code_resource(
+        self,
+        organization,
+        calendar_group,
+        group_event,
+        system_user_without_booking_code_resource,
+    ):
+        """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected."""
+        system_user, token, auth_service = system_user_without_booking_code_resource
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                    "eventId": group_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+
+# ---------------------------------------------------------------------------
+# createCalendarCancellationBookingCode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateCalendarCancellationBookingCode:
+    """Tests for createCalendarCancellationBookingCode mutation."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _post(self, system_user, token, auth_service, variables):
+        return _post_graphql(
+            self.client,
+            system_user,
+            token,
+            auth_service,
+            CREATE_CALENDAR_CANCELLATION_CODE_MUTATION,
+            variables,
+        )
+
+    def test_happy_path_mints_cancellation_code(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """Org token with CALENDAR_BOOKING_CODE mints an event-scoped cancellation code.
+
+        Asserts:
+        - Response has non-empty code and non-null id.
+        - CalendarManagementToken row is scoped to calendar + event.
+        - It has exactly one CANCEL permission row — NOT RESCHEDULE.
+        - minted_by_system_user is set.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarCancellationBookingCode"]
+        assert result["success"] is True
+        assert result["code"] is not None and len(result["code"]) > 0
+        assert result["id"] is not None
+        assert result["errorCode"] is None
+        assert result["errorMessage"] is None
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.organization_id == organization.id
+        assert db_token.calendar_fk_id == calendar.id
+        assert db_token.event_fk_id == event.id
+        assert db_token.calendar_group_fk_id is None
+        assert db_token.minted_by_system_user_id == system_user.id
+
+        # Must have exactly CANCEL — not RESCHEDULE
+        permissions = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert permissions == [EventManagementPermissions.CANCEL]
+
+    def test_event_belonging_to_different_calendar_is_rejected(
+        self,
+        organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """An event from a different calendar returns INVALID_CODE; no token created."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        # Unique external_id avoids the (external_id, provider, org) unique-together constraint.
+        other_calendar = baker.make(
+            Calendar,
+            organization=organization,
+            name="Other Calendar",
+            external_id="other-cal-cancel",
+        )
+        now = timezone.now()
+        other_event = CalendarEvent.objects.create(
+            organization=organization,
+            calendar_fk=other_calendar,
+            title="Other Event",
+            start_time_tz_unaware=now,
+            end_time_tz_unaware=now + datetime.timedelta(hours=1),
+            timezone="UTC",
+        )
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": other_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarCancellationBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
+    def test_cross_org_returns_invalid_code(
+        self,
+        organization,
+        system_user_with_booking_code_resource,
+    ):
+        """Calendar/event from another org returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org Cancel")
+        other_calendar = baker.make(Calendar, organization=other_org)
+        now = timezone.now()
+        other_event = CalendarEvent.objects.create(
+            organization=other_org,
+            calendar_fk=other_calendar,
+            title="Cross-Org Event",
+            start_time_tz_unaware=now,
+            end_time_tz_unaware=now + datetime.timedelta(hours=1),
+            timezone="UTC",
+        )
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": other_calendar.id,
+                    "eventId": other_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarCancellationBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+    def test_rejected_without_booking_code_resource(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_without_booking_code_resource,
+    ):
+        """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected."""
+        system_user, token, auth_service = system_user_without_booking_code_resource
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_organization_id_mismatch_returns_invalid_code(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """input.organizationId != authenticated org id returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Mismatch Org Cancel")
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": other_org.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarCancellationBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+
+# ---------------------------------------------------------------------------
+# createCalendarGroupCancellationBookingCode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateCalendarGroupCancellationBookingCode:
+    """Tests for createCalendarGroupCancellationBookingCode mutation."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _post(self, system_user, token, auth_service, variables):
+        return _post_graphql(
+            self.client,
+            system_user,
+            token,
+            auth_service,
+            CREATE_CALENDAR_GROUP_CANCELLATION_CODE_MUTATION,
+            variables,
+        )
+
+    def test_happy_path_mints_group_cancellation_code(
+        self,
+        organization,
+        calendar,
+        calendar_group,
+        group_event,
+        system_user_with_booking_code_resource,
+    ):
+        """Org token mints a group+event-scoped cancellation code with CANCEL permission."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                    "eventId": group_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["createCalendarGroupCancellationBookingCode"]
+        assert result["success"] is True
+        assert result["code"] is not None and len(result["code"]) > 0
+        assert result["id"] is not None
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        assert db_token.calendar_group_fk_id == calendar_group.id
+        assert db_token.event_fk_id == group_event.id
+        assert db_token.calendar_fk_id is None
+        assert db_token.minted_by_system_user_id == system_user.id
+
+        # Must have exactly CANCEL — not RESCHEDULE
+        permissions = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert permissions == [EventManagementPermissions.CANCEL]
+
+    def test_event_not_in_group_is_rejected(
+        self,
+        organization,
+        calendar,
+        calendar_group,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """An event not linked to the named group returns INVALID_CODE; no token created."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        tokens_before = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarGroupCancellationBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+        tokens_after = CalendarManagementToken.objects.filter(
+            organization_id=organization.id
+        ).count()
+        assert tokens_after == tokens_before
+
+    def test_cross_org_group_and_event_returns_invalid_code(
+        self,
+        organization,
+        system_user_with_booking_code_resource,
+    ):
+        """Group/event from another org returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Other Org Group Cancel")
+        other_calendar = baker.make(Calendar, organization=other_org)
+        other_group = baker.make(CalendarGroup, organization=other_org)
+        now = timezone.now()
+        other_event = CalendarEvent.objects.create(
+            organization=other_org,
+            calendar_fk=other_calendar,
+            calendar_group_fk=other_group,
+            title="Cross-Org Group Event Cancel",
+            start_time_tz_unaware=now,
+            end_time_tz_unaware=now + datetime.timedelta(hours=1),
+            timezone="UTC",
+        )
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": other_group.id,
+                    "eventId": other_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarGroupCancellationBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+    def test_rejected_without_booking_code_resource(
+        self,
+        organization,
+        calendar_group,
+        group_event,
+        system_user_without_booking_code_resource,
+    ):
+        """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected."""
+        system_user, token, auth_service = system_user_without_booking_code_resource
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarGroupId": calendar_group.id,
+                    "eventId": group_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_organization_id_mismatch_returns_invalid_code(
+        self,
+        organization,
+        calendar_group,
+        group_event,
+        system_user_with_booking_code_resource,
+    ):
+        """input.organizationId != authenticated org id returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        other_org = baker.make(Organization, name="Mismatch Org Group Cancel")
+
+        response = self._post(
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": other_org.id,
+                    "calendarGroupId": calendar_group.id,
+                    "eventId": group_event.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        result = data["data"]["createCalendarGroupCancellationBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+
+# ---------------------------------------------------------------------------
+# Permission-swap safety checks: reschedule != cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPermissionNotSwapped:
+    """Assert that reschedule mutations use RESCHEDULE and cancel mutations use CANCEL.
+
+    This prevents accidental permission swaps between the two families.
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def test_reschedule_code_has_reschedule_not_cancel(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """createCalendarRescheduleBookingCode must create RESCHEDULE, never CANCEL."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        response = _post_graphql(
+            self.client,
+            system_user,
+            token,
+            auth_service,
+            CREATE_CALENDAR_RESCHEDULE_CODE_MUTATION,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+        result = response.json()["data"]["createCalendarRescheduleBookingCode"]
+        assert result["success"] is True
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        perms = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert EventManagementPermissions.RESCHEDULE in perms
+        assert EventManagementPermissions.CANCEL not in perms
+
+    def test_cancellation_code_has_cancel_not_reschedule(
+        self,
+        organization,
+        calendar,
+        event,
+        system_user_with_booking_code_resource,
+    ):
+        """createCalendarCancellationBookingCode must create CANCEL, never RESCHEDULE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+        response = _post_graphql(
+            self.client,
+            system_user,
+            token,
+            auth_service,
+            CREATE_CALENDAR_CANCELLATION_CODE_MUTATION,
+            {
+                "input": {
+                    "organizationId": organization.id,
+                    "calendarId": calendar.id,
+                    "eventId": event.id,
+                }
+            },
+        )
+        result = response.json()["data"]["createCalendarCancellationBookingCode"]
+        assert result["success"] is True
+
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=result["id"]
+        )
+        perms = list(
+            CalendarManagementTokenPermission.objects.filter_by_organization(organization.id)
+            .filter(token_fk_id=db_token.id)
+            .values_list("permission", flat=True)
+        )
+        assert EventManagementPermissions.CANCEL in perms
+        assert EventManagementPermissions.RESCHEDULE not in perms


### PR DESCRIPTION

## Summary

Adds the four event-bound, org-token-gated mint mutations on `CalendarGroupMutations`:

- `createCalendarRescheduleBookingCode` / `createCalendarGroupRescheduleBookingCode` → permission `RESCHEDULE`
- `createCalendarCancellationBookingCode` / `createCalendarGroupCancellationBookingCode` → permission `CANCEL`

Each binds to one specific event (single-use, `event_id` set) and follows the Phase 1 pattern:
org from the authenticated request, `organizationId`-mismatch rejected, `minted_by` from the
request system user, returns `BookingCodeResult{code, id}`.

Scope validation at mint:
- The named calendar/group must belong to the org.
- The event must belong to the org AND to the named calendar (`calendar_fk_id`) or group
  (`calendar_group_fk_id`).
- **Calendar variants additionally require `calendar_group_fk_id IS NULL`** so a calendar-shaped
  reschedule/cancel code can never bind to a grouped event (which the group consume path in
  Phase 6 handles differently). Group variants require the event's `calendar_group_fk_id` to match.

All failure branches return an identical generic `"Not found."` with `INVALID_CODE`, so a prober
can't distinguish org / scope / event failures.

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 2.
- Spec: Decisions → Use-cases, Use-case 3 (provider mints a reschedule/cancel code).

## Test plan

In-container (docker postgres): `public_api/tests/test_reschedule_cancel_code_mutations.py` covers,
per mutation — happy path (token event-scoped + correct SINGLE permission + minted_by), event-in-
different-calendar/group → INVALID_CODE (no token), cross-org → INVALID_CODE, without-resource
rejection, organizationId-mismatch, a permission-swap guard (RESCHEDULE vs CANCEL not swapped), and
grouped-event-rejected for the calendar variants. `ruff` clean · `makemigrations --check` no changes ·
`check --deploy` clean · `pytest -n auto` **2066 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-1`.