### PR TITLE
feat(calendar): revoke single-use booking codes (Phase 3)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -49,11 +49,20 @@
 - **Summary**: `createCalendarRescheduleBookingCode` / `createCalendarGroupRescheduleBookingCode` (RESCHEDULE) + `createCalendarCancellationBookingCode` / `createCalendarGroupCancellationBookingCode` (CANCEL), event-bound. Validates event∈org AND event.calendar_fk_id==calendarId (calendar variants additionally require calendar_group_fk_id IS NULL → no grouped events) / event.calendar_group_fk_id==groupId (group variants). Uniform "Not found." INVALID_CODE on all failures. Shared inputs CreateEventCodeInput / CreateGroupEventCodeInput. Permission-swap guard + grouped-event-rejection tests.
 - **PR**: pending (filled after push).
 
+### Phase 3 — Revoke codes ✅
+- **Status**: complete, reviewed (Layers 1–3; no BLOCKERs/SHOULD-FIX, only test-cosmetic NITs noted).
+- **Model/tier**: implementer / Haiku (Tier 1 — succeeded on this small phase).
+- **Branch**: plan/single-use-scheduling-codes/phase-3 (base: phase-2).
+- **Commits**: dbc0f12 (revoke mutation + service method).
+- **Outer gate**: `pytest -n auto` 2072 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: `CalendarPermissionService.revoke_token(org_id, token_id)` — org-scoped fetch, InvalidTokenError if absent, idempotent `revoked_at` set. `revokeBookingCode(input{organizationId,id})` mutation org-gated; unknown/cross-org/mismatch → uniform "Not found." INVALID_CODE; success returns BookingCodeResult(success=True) with NO code. Reviewer confirmed revoke sets the same `revoked_at` that consume/active/get_token_error_code check. 6 tests, DB-verified.
+- **Open NITs (deferred, cosmetic)**: idempotency test docstring wording; tighten timestamp assertion to equality; late imports in test.
+- **PR**: pending (filled after push).
+
 ## Current phase
-Phase 3 — Revoke codes (next).
+Phase 4 — Code-gated availability reads (next).
 
 ## Remaining phases
-- Phase 3 — Revoke codes
 - Phase 4 — Code-gated availability reads
 - Phase 5a — Book single-calendar event with code
 - Phase 5b — Book calendar-group event with code

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -8,7 +8,7 @@ import strawberry
 from dependency_injector.wiring import Provide, inject
 from graphql import GraphQLError
 
-from calendar_integration.exceptions import CalendarGroupError
+from calendar_integration.exceptions import CalendarGroupError, InvalidTokenError
 from calendar_integration.graphql import (
     BookingCodeErrorCode,
     BookingCodeResult,
@@ -452,6 +452,14 @@ class CreateGroupEventCodeInput:
     calendar_group_id: int
     event_id: int
     expires_at: datetime.datetime | None = None
+
+
+@strawberry.input
+class RevokeBookingCodeInput:
+    """Input for revoking a single-use booking code."""
+
+    organization_id: int
+    id: int  # noqa: A002
 
 
 @strawberry.type
@@ -908,3 +916,42 @@ class CalendarGroupMutations:
             event_id=input.event_id,
         )
         return BookingCodeResult(success=True, code=plaintext_code, id=token.pk)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def revoke_booking_code(
+        self,
+        info: strawberry.Info,
+        input: RevokeBookingCodeInput,  # noqa: A002
+    ) -> BookingCodeResult:
+        """Revoke a single-use booking code by its opaque id.
+
+        The code becomes invalid immediately and cannot be used for any
+        subsequent operations (reads or writes). Revoke is idempotent:
+        revoking an already-revoked code returns success without error.
+        """
+        org = info.context.request.public_api_organization
+        if org is None:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Not found.",
+            )
+
+        if input.organization_id != org.id:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Not found.",
+            )
+
+        deps = get_booking_code_mutation_dependencies()
+        try:
+            deps.calendar_permission_service.revoke_token(organization_id=org.id, token_id=input.id)
+        except InvalidTokenError:
+            return BookingCodeResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Not found.",
+            )
+
+        return BookingCodeResult(success=True)

--- a/calendar_integration/services/calendar_permission_service.py
+++ b/calendar_integration/services/calendar_permission_service.py
@@ -652,3 +652,34 @@ class CalendarPermissionService:
             TokenRevokedError: If the token was revoked between validation and consume.
         """
         CalendarManagementToken.objects.consume(token, source_ip)
+
+    def revoke_token(self, organization_id: int, token_id: int) -> bool:
+        """Revoke a booking code by its opaque id (idempotent).
+
+        Fetch the token scoped to the organization, set ``revoked_at`` to
+        the current time if not already set, and save. If the token is already
+        revoked, return True without changing the timestamp (idempotent).
+
+        Args:
+            organization_id: Tenant scope.
+            token_id: The id of the token to revoke.
+
+        Returns:
+            True on success (revoked or already-revoked).
+
+        Raises:
+            InvalidTokenError: If no token with the given id exists in the
+                organization.
+        """
+        try:
+            token = CalendarManagementToken.objects.filter_by_organization(organization_id).get(
+                id=token_id
+            )
+        except CalendarManagementToken.DoesNotExist as e:
+            raise InvalidTokenError("Token not found") from e
+
+        if token.revoked_at is None:
+            token.revoked_at = timezone.now()
+            token.save(update_fields=["revoked_at"])
+
+        return True

--- a/public_api/tests/test_revoke_booking_code.py
+++ b/public_api/tests/test_revoke_booking_code.py
@@ -1,0 +1,368 @@
+"""Integration tests for single-use booking-code revoke mutation.
+
+Covers Phase 3: revokeBookingCode.
+"""
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.models import (
+    Calendar,
+    CalendarManagementToken,
+    EventManagementPermissions,
+)
+from organizations.models import Organization
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+REVOKE_BOOKING_CODE_MUTATION = """
+mutation RevokeBookingCode($input: RevokeBookingCodeInput!) {
+    revokeBookingCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        code
+        id
+    }
+}
+"""
+
+
+@pytest.fixture
+def organization():
+    """Create a test organization."""
+    return baker.make(Organization, name="Test Organization")
+
+
+@pytest.fixture
+def another_organization():
+    """Create another test organization for cross-org tests."""
+    return baker.make(Organization, name="Another Organization")
+
+
+@pytest.fixture
+def system_user_with_booking_code_resource(organization):
+    """Create a SystemUser + token with CALENDAR_BOOKING_CODE resource access."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="revoke_booking_code_integration", organization=organization
+    )
+    baker.make(
+        ResourceAccess,
+        system_user=system_user,
+        resource_name=PublicAPIResources.CALENDAR_BOOKING_CODE,
+    )
+    return system_user, token, auth_service
+
+
+@pytest.fixture
+def system_user_without_booking_code_resource(organization):
+    """Create a SystemUser + token WITHOUT CALENDAR_BOOKING_CODE resource access."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="no_revoke_booking_code_integration", organization=organization
+    )
+    # Deliberately grant a different resource but not CALENDAR_BOOKING_CODE
+    baker.make(
+        ResourceAccess,
+        system_user=system_user,
+        resource_name=PublicAPIResources.CALENDAR_EVENT,
+    )
+    return system_user, token, auth_service
+
+
+@pytest.fixture
+def calendar(organization):
+    """Create a test calendar in the organization."""
+    return baker.make(Calendar, organization=organization, name="Test Calendar")
+
+
+@pytest.fixture
+def another_org_calendar(another_organization):
+    """Create a test calendar in another organization."""
+    return baker.make(Calendar, organization=another_organization, name="Other Org Calendar")
+
+
+@pytest.mark.django_db
+class TestRevokeBookingCode:
+    """Tests for revokeBookingCode mutation."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _post_mutation(self, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={
+                    "query": REVOKE_BOOKING_CODE_MUTATION,
+                    "variables": variables,
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def test_revoke_unrevoked_code(
+        self,
+        organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """Revoking an active code sets revoked_at and returns success.
+
+        Asserts:
+        - Response is success=True.
+        - The token row's revoked_at is now set.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        # Create a booking code token
+        token_obj = baker.make(
+            CalendarManagementToken,
+            organization=organization,
+            calendar=calendar,
+            token_hash="dummy_hash",
+            revoked_at=None,
+            used_at=None,
+        )
+        baker.make(
+            CalendarManagementToken.permissions.field.model,
+            token=token_obj,
+            permission=EventManagementPermissions.CREATE,
+        )
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "id": token_obj.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["revokeBookingCode"]
+        assert result["success"] is True
+        assert result["errorCode"] is None
+        assert result["errorMessage"] is None
+        # Revoke should NOT return code or id
+        assert result["code"] is None
+        assert result["id"] is None
+
+        # Verify the token was revoked in the database
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=token_obj.id
+        )
+        assert db_token.revoked_at is not None
+
+    def test_revoke_is_idempotent(
+        self,
+        organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """Revoking an already-revoked code returns success; revoked_at unchanged.
+
+        Asserts:
+        - First revoke sets revoked_at.
+        - Second revoke returns success.
+        - revoked_at timestamp did not change.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        # Create a booking code token
+        from django.utils import timezone
+
+        original_revoked_at = timezone.now()
+        token_obj = baker.make(
+            CalendarManagementToken,
+            organization=organization,
+            calendar=calendar,
+            token_hash="dummy_hash",
+            revoked_at=original_revoked_at,
+            used_at=None,
+        )
+
+        # Revoke it again (it's already revoked)
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "id": token_obj.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["revokeBookingCode"]
+        assert result["success"] is True
+
+        # Verify the revoked_at timestamp did not change
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=token_obj.id
+        )
+        assert db_token.revoked_at is not None
+        # Allow up to 1 second of drift (NTP, system clock, etc.)
+        time_diff = abs((db_token.revoked_at - original_revoked_at).total_seconds())
+        assert time_diff < 1, "revoked_at timestamp should not have changed"
+
+    def test_revoke_cross_org_token_fails(
+        self,
+        organization,
+        another_organization,
+        another_org_calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """Revoking a token from another org returns INVALID_CODE.
+
+        Asserts:
+        - Response is success=False, errorCode=INVALID_CODE.
+        - The other org's token is NOT revoked.
+        """
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        # Create a booking code token in a different organization
+        other_token = baker.make(
+            CalendarManagementToken,
+            organization=another_organization,
+            calendar=another_org_calendar,
+            token_hash="other_hash",
+            revoked_at=None,
+            used_at=None,
+        )
+
+        # Try to revoke it from our organization's token
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "id": other_token.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["revokeBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+        assert result["errorMessage"] == "Not found."
+
+        # Verify the other org's token was NOT revoked
+        db_token = CalendarManagementToken.objects.filter_by_organization(
+            another_organization.id
+        ).get(id=other_token.id)
+        assert db_token.revoked_at is None
+
+    def test_revoke_unknown_code_fails(
+        self,
+        organization,
+        system_user_with_booking_code_resource,
+    ):
+        """Revoking an unknown code id returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        # Use a non-existent token id
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "id": 999999}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["revokeBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+        assert result["errorMessage"] == "Not found."
+
+    def test_revoke_without_resource_rejected(
+        self,
+        organization,
+        calendar,
+        system_user_without_booking_code_resource,
+    ):
+        """Org token WITHOUT CALENDAR_BOOKING_CODE is rejected."""
+        system_user, token, auth_service = system_user_without_booking_code_resource
+
+        # Create a booking code token
+        token_obj = baker.make(
+            CalendarManagementToken,
+            organization=organization,
+            calendar=calendar,
+            token_hash="dummy_hash",
+            revoked_at=None,
+            used_at=None,
+        )
+
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": organization.id, "id": token_obj.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+        # Verify the token was NOT revoked
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=token_obj.id
+        )
+        assert db_token.revoked_at is None
+
+    def test_revoke_organization_id_mismatch(
+        self,
+        organization,
+        another_organization,
+        calendar,
+        system_user_with_booking_code_resource,
+    ):
+        """organizationId mismatch in input returns INVALID_CODE."""
+        system_user, token, auth_service = system_user_with_booking_code_resource
+
+        # Create a booking code token in the correct organization
+        token_obj = baker.make(
+            CalendarManagementToken,
+            organization=organization,
+            calendar=calendar,
+            token_hash="dummy_hash",
+            revoked_at=None,
+            used_at=None,
+        )
+
+        # Try to revoke with a different organization id
+        response = self._post_mutation(
+            system_user,
+            token,
+            auth_service,
+            {"input": {"organizationId": another_organization.id, "id": token_obj.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        result = data["data"]["revokeBookingCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+        assert result["errorMessage"] == "Not found."
+
+        # Verify the token was NOT revoked
+        db_token = CalendarManagementToken.objects.filter_by_organization(organization.id).get(
+            id=token_obj.id
+        )
+        assert db_token.revoked_at is None


### PR DESCRIPTION

## Summary

Adds the org-token-gated `revokeBookingCode(input: { organizationId, id })` mutation plus a
`CalendarPermissionService.revoke_token(organization_id, token_id)` method. A provider/admin
invalidates an unused (or any) code by its opaque id; the code then fails all downstream use
(reads + writes) as `REVOKED`.

- Org-scoped fetch (`filter_by_organization`) — cannot revoke another org's token.
- Idempotent: revoking an already-revoked code returns success and does NOT move `revoked_at`.
- Unknown id / cross-org id / `organizationId` mismatch all return `success=False`,
  `errorCode=INVALID_CODE` with an identical generic `"Not found."` (no existence leak).
- Success returns `BookingCodeResult(success=True)` with NO `code` echoed back.

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 3.
- Spec: Decisions → Use-cases, Use-case 5 (provider revokes an unused code).

## Test plan

In-container (docker postgres): `public_api/tests/test_revoke_booking_code.py` — revoke sets
`revoked_at`; idempotent (timestamp unchanged); cross-org token untouched + INVALID_CODE; unknown
id INVALID_CODE; without-resource rejected (row untouched); organizationId mismatch INVALID_CODE.
All DB-verified. `ruff` clean · `makemigrations --check` no changes (Phase 0 added `revoked_at`) ·
`check --deploy` clean · `pytest -n auto` **2072 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-2`.