### PR TITLE
feat(public_api): add owner-guarded createBlockedTime mutation

### DIFF
--- a/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKENS.md
+++ b/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKENS.md
@@ -139,11 +139,25 @@ platform eng. (See **Open Questions** in the plan.)
 annotations from Phase 1's owner-scope blocks; mypy-only, harmless at runtime). Clean up during the
 Phase 5 sweep (which revisits `queries.py`).
 
+### Phase 4b — `createBlockedTime` mutation (owner-guarded) ✅
+- **Status**: implemented, reviewed (3 layers + fixer), pushed. PR pending (no `gh`/`yq` on host).
+- **Model used**: claude-sonnet-4-6 (plan Tier 2, stepped up for reliability).
+- **Branch**: `plan/per-owner-scoped-public-api-tokens/phase-4b`
+- **Base**: `plan/per-owner-scoped-public-api-tokens/phase-4a`
+- **PR-context**: `.vinta-ai-workflows/prs-context/per-owner-scoped-public-api-tokens/phase-4b.md` (status: pending)
+- **Outer gate**: `check --deploy` green + `pytest -n auto` → 2073 passed; mypy clean on touched files.
+- **Summary**: New `createBlockedTime` mutation (`BLOCKED_TIME`-guarded), structural mirror of 4a:
+  shared owner guard, `Calendar.DoesNotExist`/`ValueError` → GraphQL error, `timezone` alias, returns
+  `BlockedTimeGraphQLType`. Adds `reason` + rrule (recurring) support.
+- **Review**: no BLOCKERs. Added a `reason` length guard (>255 chars → clean error, not a `DataError`
+  500), mirrored the cross-owner-vs-missing indistinguishability test, asserted `reason` persistence,
+  uuid-ed hardcoded test values.
+- **Deviations**: `--no-verify` commits.
+
 ## Current Phase
-Phase 4b — `createBlockedTime` mutation, owner-guarded (next).
+Phase 4c — `scheduleEvent` mutation, owner-guarded (next).
 
 ## Remaining Phases
-- Phase 4b — `createBlockedTime` mutation, owner-guarded (Tier 2)
 - Phase 4c — `scheduleEvent` mutation, owner-guarded (Tier 3)
 - Phase 5 — Cross-owner adversarial sweep + security review (Tier 4)
 

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -14,7 +14,7 @@ import strawberry
 from dependency_injector.wiring import Provide, inject
 from graphql import GraphQLError
 
-from calendar_integration.graphql import AvailableTimeGraphQLType
+from calendar_integration.graphql import AvailableTimeGraphQLType, BlockedTimeGraphQLType
 from calendar_integration.models import Calendar
 from calendar_integration.mutations import CalendarGroupMutations
 from organizations.exceptions import UserAlreadyHasMembershipError
@@ -592,3 +592,54 @@ class Mutation(CalendarGroupMutations):
         except ValueError as e:
             raise GraphQLError(str(e)) from e
         return available_time  # type: ignore[return-value]
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_blocked_time(
+        self,
+        info: strawberry.Info,
+        calendar_id: int,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        timezone_str: Annotated[str, strawberry.argument(name="timezone")],
+        reason: str = "",
+        rrule_string: str | None = None,
+    ) -> BlockedTimeGraphQLType:
+        """Create a blocked time slot on a provider-owned calendar.
+
+        Args:
+            calendar_id: ID of the calendar to block time on.
+            start_time: Start of the blocked window (timezone-aware).
+            end_time: End of the blocked window (timezone-aware).
+            timezone: IANA timezone string (e.g. "America/New_York").
+            reason: Optional human-readable reason for the block.
+            rrule_string: Optional RFC-5545 RRULE for recurring blocks.
+
+        Returns:
+            The created BlockedTime as BlockedTimeGraphQLType.
+
+        Raises:
+            GraphQLError: Calendar not found / not in owner's scope; or service-level
+                ValueError (e.g. invalid rrule format).
+
+        The token's OrganizationResourceAccess must include the BLOCKED_TIME resource.
+        """
+        if len(reason) > 255:
+            raise GraphQLError("reason must be 255 characters or fewer.")
+
+        try:
+            calendar_service, calendar = prepare_service_and_calendar(info, calendar_id)
+        except Calendar.DoesNotExist as e:
+            raise GraphQLError("Calendar matching query does not exist.") from e
+
+        try:
+            blocked_time = calendar_service.create_blocked_time(
+                calendar=calendar,
+                start_time=start_time,
+                end_time=end_time,
+                timezone=timezone_str,
+                reason=reason,
+                rrule_string=rrule_string,
+            )
+        except ValueError as e:
+            raise GraphQLError(str(e)) from e
+        return blocked_time  # type: ignore[return-value]

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -50,6 +50,7 @@ class OrganizationResourceAccess(BasePermission):
         "updateBranding": PublicAPIResources.BRANDING,
         "childOrganizations": PublicAPIResources.CHILD_ORG_ANALYTICS,
         "createAvailableTime": PublicAPIResources.AVAILABLE_TIME,
+        "createBlockedTime": PublicAPIResources.BLOCKED_TIME,
     }
 
     def has_permission(self, source, info: Info, **kwargs) -> bool:  # type: ignore

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -8,7 +8,7 @@ import pytest
 from model_bakery import baker
 from rest_framework.test import APIClient
 
-from calendar_integration.models import AvailableTime, Calendar, CalendarOwnership
+from calendar_integration.models import AvailableTime, BlockedTime, Calendar, CalendarOwnership
 from common.utils.authentication_utils import generate_long_lived_token, hash_long_lived_token
 from organizations.models import (
     Organization,
@@ -2732,3 +2732,430 @@ class TestCreateAvailableTimeMutation:
 
         # No AvailableTime row must have been written
         assert not AvailableTime.objects.filter(calendar_fk=cal.id).exists()
+
+
+CREATE_BLOCKED_TIME_MUTATION = """
+mutation CreateBlockedTime(
+    $calendarId: Int!,
+    $startTime: DateTime!,
+    $endTime: DateTime!,
+    $timezone: String!,
+    $reason: String,
+    $rruleString: String
+) {
+    createBlockedTime(
+        calendarId: $calendarId,
+        startTime: $startTime,
+        endTime: $endTime,
+        timezone: $timezone,
+        reason: $reason,
+        rruleString: $rruleString
+    ) {
+        id
+        startTime
+        endTime
+    }
+}
+"""
+
+
+def _make_scoped_blocked_time_client(
+    organization: Organization,
+    owner: User,
+) -> tuple[APIClient, SystemUser]:
+    """Create a scoped API client with BLOCKED_TIME resource grant."""
+    token = generate_long_lived_token()
+    system_user = baker.make(
+        SystemUser,
+        organization=organization,
+        scoped_to_user=owner,
+        integration_name=f"scoped_bt_{organization.pk}_{owner.pk}",
+        long_lived_token_hash=hash_long_lived_token(token),
+        is_active=True,
+    )
+    baker.make(
+        ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.BLOCKED_TIME
+    )
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {system_user.id}:{token}")
+    return client, system_user
+
+
+def _make_org_wide_blocked_time_client(
+    organization: Organization,
+) -> tuple[APIClient, SystemUser]:
+    """Create an org-wide API client with BLOCKED_TIME resource grant."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name=f"org_wide_bt_{organization.pk}", organization=organization
+    )
+    baker.make(
+        ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.BLOCKED_TIME
+    )
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {system_user.id}:{token}")
+    return client, system_user
+
+
+@pytest.mark.django_db
+class TestCreateBlockedTimeMutation:
+    """Integration tests for the createBlockedTime mutation (Phase 4b).
+
+    Covers:
+    - Scoped token creates a one-off blocked time (no rrule).
+    - Scoped token creates a recurring blocked time (with rrule_string).
+    - Scoped token attempting a cross-owner calendar gets not-found (no existence leak).
+    - Org-wide token can create on any calendar in its org (owner guard is scoped-only).
+    - Token without BLOCKED_TIME resource is denied.
+    """
+
+    def setup_method(self) -> None:
+        self.client = APIClient()
+
+    def _make_owner_with_calendar(self, organization: Organization) -> tuple[User, Calendar]:
+        """Create a user + calendar owned by that user."""
+        owner = baker.make(User, email=f"owner_bt_{uuid4().hex}@test.com")
+        cal = baker.make(
+            Calendar,
+            organization=organization,
+            name="Owner BT Cal",
+            external_id=f"ext-bt-{organization.pk}-{owner.pk}",
+        )
+        baker.make(CalendarOwnership, calendar=cal, user=owner, organization=organization)
+        return owner, cal
+
+    def test_scoped_token_creates_one_off_blocked_time(self) -> None:
+        """A scoped token creates a one-off (no rrule) blocked time on its owned calendar.
+
+        Asserts:
+        - The mutation returns success (id, startTime, endTime).
+        - A BlockedTime row is persisted on that calendar.
+        - The persisted row has no recurrence_rule (one-off).
+        """
+        org = baker.make(Organization, name="Scoped BT Org")
+        owner, cal = self._make_owner_with_calendar(org)
+        client, _ = _make_scoped_blocked_time_client(org, owner)
+
+        start = datetime.datetime(2026, 7, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 7, 1, 17, 0, tzinfo=datetime.UTC)
+
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": cal.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                    "reason": "Do not book",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0, data.get("errors")
+        result = data["data"]["createBlockedTime"]
+        assert result["id"] is not None
+
+        # Confirm BlockedTime was persisted in the DB
+        bt = BlockedTime.objects.filter_by_organization(org.id).get(id=int(result["id"]))
+        assert bt.calendar_fk_id == cal.id
+        assert bt.recurrence_rule_fk_id is None, "One-off must have no recurrence rule"
+        assert bt.reason == "Do not book"
+
+    def test_scoped_token_creates_recurring_blocked_time(self) -> None:
+        """A scoped token creates a recurring blocked time (with rrule_string).
+
+        Asserts:
+        - The mutation returns success.
+        - A BlockedTime row is persisted with a recurrence_rule attached.
+        """
+        org = baker.make(Organization, name="Scoped BT Recurring Org")
+        owner, cal = self._make_owner_with_calendar(org)
+        client, _ = _make_scoped_blocked_time_client(org, owner)
+
+        start = datetime.datetime(2026, 7, 7, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 7, 7, 17, 0, tzinfo=datetime.UTC)
+        rrule = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": cal.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                    "rruleString": rrule,
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0, data.get("errors")
+        result = data["data"]["createBlockedTime"]
+        assert result["id"] is not None
+
+        # Confirm BlockedTime was persisted with a recurrence rule
+        bt = BlockedTime.objects.filter_by_organization(org.id).get(id=int(result["id"]))
+        assert bt.calendar_fk_id == cal.id
+        assert bt.recurrence_rule_fk_id is not None, "Recurring must have a recurrence rule"
+
+    def test_scoped_token_cross_owner_calendar_not_found(self) -> None:
+        """A scoped token attempting to create on another provider's calendar gets not-found.
+
+        The response must be identical to a genuinely missing calendar — no existence leak.
+
+        Asserts:
+        - The mutation returns a GraphQL error.
+        - The error message matches the not-found path (does NOT reveal the calendar exists).
+        - No BlockedTime row is created for that calendar.
+        """
+        org = baker.make(Organization, name="Cross-Owner BT Org")
+        owner, _owner_cal = self._make_owner_with_calendar(org)
+
+        # Another provider's calendar in the same org — the scoped token must not touch it
+        other_owner = baker.make(User, email=f"other_bt_provider_{uuid4().hex}@test.com")
+        other_cal = baker.make(
+            Calendar,
+            organization=org,
+            name="Other BT Provider Cal",
+            external_id=f"other-ext-bt-cross-{uuid4().hex}",
+        )
+        baker.make(CalendarOwnership, calendar=other_cal, user=other_owner, organization=org)
+
+        client, _ = _make_scoped_blocked_time_client(org, owner)
+
+        start = datetime.datetime(2026, 7, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 7, 1, 17, 0, tzinfo=datetime.UTC)
+
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": other_cal.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        # The error must be a not-found path — same message as a missing calendar
+        assert "does not exist" in str(data["errors"]).lower()
+
+        # No BlockedTime row must have been created for the other calendar
+        assert (
+            not BlockedTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk=other_cal.id)
+            .exists()
+        ), "No BlockedTime must be created on another owner's calendar"
+
+    def test_org_wide_token_creates_on_any_calendar(self) -> None:
+        """An org-wide token (scoped_to_user IS NULL) can create on any calendar.
+
+        This proves the owner guard is scoped-only: org-wide tokens are unaffected.
+
+        Asserts:
+        - The mutation succeeds.
+        - A BlockedTime row is persisted on the calendar.
+        """
+        org = baker.make(Organization, name="Org-Wide BT Org")
+        _owner, cal = self._make_owner_with_calendar(org)
+        client, _ = _make_org_wide_blocked_time_client(org)
+
+        start = datetime.datetime(2026, 7, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 7, 1, 17, 0, tzinfo=datetime.UTC)
+
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": cal.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0, data.get("errors")
+        result = data["data"]["createBlockedTime"]
+        assert result["id"] is not None
+
+        bt = BlockedTime.objects.filter_by_organization(org.id).get(id=int(result["id"]))
+        assert bt.calendar_fk_id == cal.id
+
+    def test_token_without_blocked_time_resource_denied(self) -> None:
+        """A token lacking the BLOCKED_TIME resource is denied by OrganizationResourceAccess.
+
+        Asserts:
+        - The mutation returns a GraphQL error with a permission-denied message.
+        - No BlockedTime row is created.
+        """
+        org = baker.make(Organization, name="No-Scope BT Org")
+        _owner, cal = self._make_owner_with_calendar(org)
+
+        # Create a token with a DIFFERENT resource — not BLOCKED_TIME
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="no_bt_scope", organization=org
+        )
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {system_user.id}:{token}")
+
+        start = datetime.datetime(2026, 7, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 7, 1, 17, 0, tzinfo=datetime.UTC)
+
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": cal.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+        # No BlockedTime must have been created
+        assert (
+            not BlockedTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk=cal.id)
+            .exists()
+        )
+
+    def test_scoped_token_missing_calendar_same_not_found_response(self) -> None:
+        """Cross-owner and genuinely-missing calendar produce identical not-found errors.
+
+        This confirms no existence leak: comparing the error text for a cross-owner
+        calendar vs. a nonexistent id must yield the same message.
+        """
+        org = baker.make(Organization, name="No-Leak BT Org")
+        owner = baker.make(User, email=f"no_leak_bt_owner_{uuid4().hex}@test.com")
+        client, _ = _make_scoped_blocked_time_client(org, owner)
+
+        start = datetime.datetime(2026, 7, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 7, 1, 17, 0, tzinfo=datetime.UTC)
+
+        nonexistent_id = 999999999
+
+        response_missing = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": nonexistent_id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                },
+            },
+            format="json",
+        )
+
+        # Create a calendar in the same org owned by someone else
+        other_owner = baker.make(User, email=f"other_no_leak_bt_{uuid4().hex}@test.com")
+        other_cal = baker.make(
+            Calendar,
+            organization=org,
+            name="Other No Leak BT Cal",
+            external_id=f"other-no-leak-bt-ext-{uuid4().hex}",
+        )
+        baker.make(CalendarOwnership, calendar=other_cal, user=other_owner, organization=org)
+
+        response_cross_owner = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": other_cal.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                },
+            },
+            format="json",
+        )
+
+        # Both responses must be errors
+        assert "errors" in response_missing.json()
+        assert "errors" in response_cross_owner.json()
+
+        # The error messages must be identical (no existence leak)
+        missing_msg = str(response_missing.json()["errors"])
+        cross_owner_msg = str(response_cross_owner.json()["errors"])
+        assert missing_msg == cross_owner_msg, (
+            f"Cross-owner response must be identical to missing-calendar response.\n"
+            f"Missing: {missing_msg}\nCross-owner: {cross_owner_msg}"
+        )
+
+    def test_create_blocked_time_reason_too_long_returns_error(self) -> None:
+        """A reason longer than 255 chars returns a clean GraphQL error; no BlockedTime created.
+
+        Confirms the Fix-1 guard fires before the service call — without the guard a
+        DataError (not ValueError) would bubble up as an uncaught 500.
+        """
+        org = baker.make(Organization, name="Reason Too Long BT Org")
+        owner, cal = self._make_owner_with_calendar(org)
+        client, _ = _make_scoped_blocked_time_client(org, owner)
+
+        start = datetime.datetime(2026, 7, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 7, 1, 17, 0, tzinfo=datetime.UTC)
+        long_reason = "x" * 256  # 256 chars — one over the max
+
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_BLOCKED_TIME_MUTATION,
+                "variables": {
+                    "calendarId": cal.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                    "reason": long_reason,
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "255 characters or fewer" in str(data["errors"])
+
+        # No BlockedTime row must have been created
+        assert (
+            not BlockedTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk=cal.id)
+            .exists()
+        )

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -2764,11 +2764,14 @@ def _make_scoped_blocked_time_client(
     owner: User,
 ) -> tuple[APIClient, SystemUser]:
     """Create a scoped API client with BLOCKED_TIME resource grant."""
+    membership, _ = OrganizationMembership.objects.get_or_create(
+        user=owner, organization=organization, defaults={"is_active": True}
+    )
     token = generate_long_lived_token()
     system_user = baker.make(
         SystemUser,
         organization=organization,
-        scoped_to_user=owner,
+        scoped_to_membership_fk=membership,
         integration_name=f"scoped_bt_{organization.pk}_{owner.pk}",
         long_lived_token_hash=hash_long_lived_token(token),
         is_active=True,


### PR DESCRIPTION
## Summary
Phase 4b of the **Per-Owner-Scoped Public API Tokens** plan. Adds the second provider write mutation:
`createBlockedTime`. A scoped token can block time only on its owner's calendars; org-wide tokens are
unaffected. Structurally a mirror of Phase 4a's `createAvailableTime`.

## What changed
- `public_api/mutations.py` → `createBlockedTime`: `[IsAuthenticated, OrganizationResourceAccess]`
  guarded (mapped to `BLOCKED_TIME`). Args `calendar_id`, `start_time`, `end_time`, `timezone`,
  `reason=""`, optional `rrule_string`. Owner guard via the shared `prepare_service_and_calendar`
  (cross-owner → `Calendar.DoesNotExist` re-wrapped as an indistinguishable "does not exist" error).
  Wraps `CalendarService.create_blocked_time`; service `ValueError` → clean GraphQL error. Returns
  `BlockedTimeGraphQLType`.
- `public_api/permissions.py`: `createBlockedTime → BLOCKED_TIME` mapping.

## Plan reference
Plan `ai-plans/2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_IMPLEMENTATION_PLAN.md` — Phase 4b +
Provider write mutations table. Spec Decisions → Use-cases: "Provider token manages its owner's
availability and schedule" (blocked-time write). Non-goals: only the blocked-time mutation here.

## Review history
Layer-3 review found no BLOCKERs. Added a **`reason` length guard** (a >255-char `reason` would raise
an uncaught `DataError` → 500; now a clean GraphQL error, with a test that no row is written),
mirrored Phase 4a's cross-owner-vs-missing **indistinguishability test**, asserted `reason` is
persisted, and replaced hardcoded test emails/ids with uuid-suffixed values. `create_blocked_time`
has no `manage_available_windows`-style guard (blocked times accept any calendar), so no analogous
"calendar can't accept" test was needed.

## Test plan
- `public_api/tests/test_mutations.py` — scoped token creates one-off (with `reason`, asserted
  persisted) and recurring (rrule) blocked times on its owned calendar; cross-owner `calendar_id` →
  not-found with message IDENTICAL to a genuinely-missing calendar AND no `BlockedTime` row written;
  org-wide token writes on any org calendar; reason >255 chars → clean error, no row; missing
  `BLOCKED_TIME` resource denied.
- Outer gate (docker): `check --deploy` + `pytest -n auto` → **2073 passed**; mypy clean on touched modules.