### PR TITLE
feat(public-api): code-gated availability reads (Phase 4)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -59,11 +59,20 @@
 - **Open NITs (deferred, cosmetic)**: idempotency test docstring wording; tighten timestamp assertion to equality; late imports in test.
 - **PR**: pending (filled after push).
 
+### Phase 4 — Code-gated availability reads ✅
+- **Status**: complete, reviewed (Layers 1–3 security review + fix loop; no BLOCKERs).
+- **Model/tier**: implementer / Sonnet (Tier 3).
+- **Branch**: plan/single-use-scheduling-codes/phase-4 (base: phase-3).
+- **Commits**: 21b8c09 (5 code-gated read fields + resolve_code) + abab4a5 (harden: hash-verify test, range clamp, org guard).
+- **Outer gate**: `pytest -n auto` 2102 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: FIRST unauthenticated surface. `CalendarPermissionService.resolve_code(code)` derives org from the code (unscoped `original_manager` lookup gated by constant-time hash verify); `validate_code` delegates + org-asserts. Five no-permission_classes query fields (availableTimesWithCode, availabilityWindowsWithCode, unavailableWindowsWithCode, calendarGroupBookableSlotsWithCode, calendarGroupAvailabilityWithCode) — scope strictly from token (calendar/calendar_group or event.calendar/event.calendar_group), never consume, uniform "Invalid or expired code." on all failures (no oracle), datetime range clamped to 366 days (DoS guard). Reviewer confirmed: hash-verify-before-use, scope confinement, cross-org isolation, non-consumption. Rate limiter already keys unauth as anon:<client_ip>. 30 tests.
+- **NOTE**: main checkout has UNRELATED in-progress work (validateReturnUrl OAuth feature) on public_api/{queries,types,tests}; left untouched — worktree isolation kept my work separate.
+- **PR**: pending (filled after push).
+
 ## Current phase
-Phase 4 — Code-gated availability reads (next).
+Phase 5a — Book single-calendar event with code (next).
 
 ## Remaining phases
-- Phase 4 — Code-gated availability reads
 - Phase 5a — Book single-calendar event with code
 - Phase 5b — Book calendar-group event with code
 - Phase 6a — Reschedule single-calendar event with code

--- a/calendar_integration/services/calendar_permission_service.py
+++ b/calendar_integration/services/calendar_permission_service.py
@@ -576,27 +576,29 @@ class CalendarPermissionService:
 
         return token, plaintext_code
 
-    def validate_code(self, code: str, organization_id: int) -> CalendarManagementToken:
-        """Decode and validate a booking code, returning the active token.
+    def resolve_code(self, code: str) -> CalendarManagementToken:
+        """Decode and validate a booking code WITHOUT a known organization.
 
-        Performs the same decode/hash/lookup as ``initialize_with_token`` but
-        additionally enforces that the token is still active (not used, not
-        revoked, not expired).
+        This method is for unauthenticated reads where the org is derived FROM
+        the code itself.  It performs the same decode/hash/verify logic as
+        ``validate_code`` but looks up the token by id alone (no org filter).
+        The org is safe to derive from the returned token's ``organization_id``
+        because the secret-hash verification gates access to the token data.
 
         Args:
             code: The base64-encoded plaintext code as returned by
                 ``create_booking_token``.
-            organization_id: Tenant scope.  The token must belong to this org.
 
         Returns:
             The active ``CalendarManagementToken`` instance, with
-            ``permissions`` and ``calendar``/``event`` pre-fetched.
+            ``permissions``, ``calendar``, ``calendar_group``, and ``event``
+            pre-fetched.
 
         Raises:
             InvalidTokenError: If the code is malformed or does not match any token.
-            TokenExpiredError: If the token's ``expires_at`` has passed.
-            TokenAlreadyUsedError: If the token was already consumed.
             TokenRevokedError: If the token was revoked.
+            TokenAlreadyUsedError: If the token was already consumed.
+            TokenExpiredError: If the token's ``expires_at`` has passed.
         """
         try:
             token_full_str = base64.b64decode(code).decode("utf-8")
@@ -609,10 +611,22 @@ class CalendarPermissionService:
             raise InvalidTokenError("Invalid booking code format") from e
 
         try:
+            # Look up by id alone — no org filter.  This is safe because:
+            #   1. The integer id alone is useless without the secret token string.
+            #   2. The constant-time hash verify below is the actual gate.
+            # We use ``original_manager`` (the plain Django Manager defined on
+            # OrganizationModel) to bypass the tenant-required guard that
+            # CalendarManagementToken.objects enforces — the org is derived FROM
+            # the token, not passed in.
             token = (
-                CalendarManagementToken.objects.prefetch_related("permissions")
-                .select_related("calendar", "event", "calendar_group")
-                .filter(organization_id=organization_id)
+                CalendarManagementToken.original_manager.select_related(
+                    "calendar",
+                    "event",
+                    "calendar_group",
+                    "event__calendar",
+                    "event__calendar_group",
+                )
+                .prefetch_related("permissions")
                 .get(id=token_id)
             )
         except CalendarManagementToken.DoesNotExist as e:
@@ -621,7 +635,7 @@ class CalendarPermissionService:
         if not verify_long_lived_token(token_str, token.token_hash):
             raise InvalidTokenError("Invalid booking code") from None
 
-        # Check terminal lifecycle states in priority order.
+        # Check terminal lifecycle states in priority order (same as validate_code).
         if token.revoked_at is not None:
             raise TokenRevokedError()
 
@@ -630,6 +644,39 @@ class CalendarPermissionService:
 
         if token.expires_at is not None and token.expires_at <= timezone.now():
             raise TokenExpiredError()
+
+        return token
+
+    def validate_code(self, code: str, organization_id: int) -> CalendarManagementToken:
+        """Decode and validate a booking code, returning the active token.
+
+        Performs the same decode/hash/lookup as ``initialize_with_token`` but
+        additionally enforces that the token is still active (not used, not
+        revoked, not expired), and that the token belongs to the given org.
+
+        Delegates decode/verify/lifecycle to ``resolve_code`` then asserts the
+        org matches.
+
+        Args:
+            code: The base64-encoded plaintext code as returned by
+                ``create_booking_token``.
+            organization_id: Tenant scope.  The token must belong to this org.
+
+        Returns:
+            The active ``CalendarManagementToken`` instance, with
+            ``permissions`` and ``calendar``/``event`` pre-fetched.
+
+        Raises:
+            InvalidTokenError: If the code is malformed, does not match any
+                token, or belongs to a different organization.
+            TokenExpiredError: If the token's ``expires_at`` has passed.
+            TokenAlreadyUsedError: If the token was already consumed.
+            TokenRevokedError: If the token was revoked.
+        """
+        token = self.resolve_code(code)
+
+        if token.organization_id != organization_id:
+            raise InvalidTokenError("Invalid booking code") from None
 
         return token
 

--- a/calendar_integration/services/calendar_permission_service.py
+++ b/calendar_integration/services/calendar_permission_service.py
@@ -650,12 +650,9 @@ class CalendarPermissionService:
     def validate_code(self, code: str, organization_id: int) -> CalendarManagementToken:
         """Decode and validate a booking code, returning the active token.
 
-        Performs the same decode/hash/lookup as ``initialize_with_token`` but
-        additionally enforces that the token is still active (not used, not
-        revoked, not expired), and that the token belongs to the given org.
-
-        Delegates decode/verify/lifecycle to ``resolve_code`` then asserts the
-        org matches.
+        Delegates decode/verify/lifecycle to ``resolve_code`` then additionally
+        asserts that the token belongs to the given org.  Use ``resolve_code``
+        directly when the org is unknown and must be derived from the token.
 
         Args:
             code: The base64-encoded plaintext code as returned by

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -61,6 +61,10 @@ if TYPE_CHECKING:
 # code exists, is expired, used, revoked, or bound to the wrong scope.
 _CODE_GATED_ERROR_MESSAGE = "Invalid or expired code."
 
+# Maximum client-controlled datetime range for unauthenticated (code-gated) reads.
+# Prevents amplification / DoS via unbounded recurrence expansion.
+MAX_CODE_GATED_RANGE = datetime.timedelta(days=366)
+
 
 @dataclass
 class QueryDependencies:
@@ -136,25 +140,27 @@ def _prepare_service_and_calendar(
 
 
 def _prepare_service_and_calendar_for_org(
-    org: Organization, calendar: Calendar
+    deps: "QueryDependencies", org: Organization, calendar: Calendar
 ) -> "CalendarService":
     """Initialize CalendarService with the given org and return it.
 
     Used by code-gated (unauthenticated) reads where the org + calendar are
     derived from the booking code rather than from the request auth context.
+    Receives an already-resolved ``deps`` object to avoid a second DI resolution.
     """
-    deps = get_query_dependencies()
     deps.calendar_service.initialize_without_provider(user_or_token=None, organization=org)
     return deps.calendar_service
 
 
-def _prepare_group_service_for_org(org: Organization) -> "CalendarGroupService":
+def _prepare_group_service_for_org(
+    deps: "QueryDependencies", org: Organization
+) -> "CalendarGroupService":
     """Initialize CalendarGroupService with the given org and return it.
 
     Used by code-gated (unauthenticated) reads where the org is derived from
     the booking code.
+    Receives an already-resolved ``deps`` object to avoid a second DI resolution.
     """
-    deps = get_query_dependencies()
     deps.calendar_group_service.initialize(organization=org)
     return deps.calendar_group_service
 
@@ -172,6 +178,30 @@ def _resolve_code_from_deps(deps: QueryDependencies, code: str) -> "CalendarMana
     except (InvalidTokenError, TokenExpiredError, TokenAlreadyUsedError, TokenRevokedError):
         raise GraphQLError(_CODE_GATED_ERROR_MESSAGE) from None
     return token
+
+
+def _get_org_from_token(token: "CalendarManagementToken") -> Organization:
+    """Fetch the Organization for the given token, mapping DoesNotExist to the uniform error.
+
+    Guards against hard-deleted organizations, which would otherwise raise an
+    unhandled ``Organization.DoesNotExist`` (→ 500).
+    """
+    try:
+        return Organization.objects.get(id=token.organization_id)
+    except Organization.DoesNotExist:
+        raise GraphQLError(_CODE_GATED_ERROR_MESSAGE) from None
+
+
+def _validate_code_gated_range(start: datetime.datetime, end: datetime.datetime) -> None:
+    """Validate a client-supplied datetime range for code-gated reads.
+
+    Raises ``GraphQLError`` if the range is backwards or exceeds
+    ``MAX_CODE_GATED_RANGE``.  Called BEFORE any expensive service call.
+    """
+    if end <= start:
+        raise GraphQLError("Invalid time range.")
+    if (end - start) > MAX_CODE_GATED_RANGE:
+        raise GraphQLError("Requested time range is too large.")
 
 
 @strawberry.input
@@ -687,6 +717,7 @@ class Query:
         No org token required.  The code gates access to its bound calendar only.
         Reads are repeatable: the code is never consumed by this query.
         """
+        _validate_code_gated_range(start_datetime, end_datetime)
         deps = get_query_dependencies()
         token = _resolve_code_from_deps(deps, code)
 
@@ -697,8 +728,8 @@ class Query:
         if calendar is None:
             raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
 
-        org = Organization.objects.get(id=token.organization_id)
-        calendar_service = _prepare_service_and_calendar_for_org(org, calendar)
+        org = _get_org_from_token(token)
+        calendar_service = _prepare_service_and_calendar_for_org(deps, org, calendar)
 
         available_times = calendar_service.get_available_times_expanded(
             calendar,
@@ -719,6 +750,7 @@ class Query:
         No org token required.  The code gates access to its bound calendar only.
         Reads are repeatable: the code is never consumed by this query.
         """
+        _validate_code_gated_range(start_datetime, end_datetime)
         deps = get_query_dependencies()
         token = _resolve_code_from_deps(deps, code)
 
@@ -728,8 +760,8 @@ class Query:
         if calendar is None:
             raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
 
-        org = Organization.objects.get(id=token.organization_id)
-        calendar_service = _prepare_service_and_calendar_for_org(org, calendar)
+        org = _get_org_from_token(token)
+        calendar_service = _prepare_service_and_calendar_for_org(deps, org, calendar)
 
         windows = calendar_service.get_availability_windows_in_range(
             calendar=calendar,
@@ -758,6 +790,7 @@ class Query:
         No org token required.  The code gates access to its bound calendar only.
         Reads are repeatable: the code is never consumed by this query.
         """
+        _validate_code_gated_range(start_datetime, end_datetime)
         deps = get_query_dependencies()
         token = _resolve_code_from_deps(deps, code)
 
@@ -767,8 +800,8 @@ class Query:
         if calendar is None:
             raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
 
-        org = Organization.objects.get(id=token.organization_id)
-        calendar_service = _prepare_service_and_calendar_for_org(org, calendar)
+        org = _get_org_from_token(token)
+        calendar_service = _prepare_service_and_calendar_for_org(deps, org, calendar)
 
         unavailable = calendar_service.get_unavailable_time_windows_in_range(
             calendar=calendar,
@@ -796,6 +829,7 @@ class Query:
         No org token required.  The code gates access to its bound calendar group only.
         Reads are repeatable: the code is never consumed by this query.
         """
+        _validate_code_gated_range(search_window_start, search_window_end)
         deps = get_query_dependencies()
         token = _resolve_code_from_deps(deps, code)
 
@@ -806,8 +840,8 @@ class Query:
         if group is None:
             raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
 
-        org = Organization.objects.get(id=token.organization_id)
-        calendar_group_service = _prepare_group_service_for_org(org)
+        org = _get_org_from_token(token)
+        calendar_group_service = _prepare_group_service_for_org(deps, org)
 
         proposals = calendar_group_service.find_bookable_slots(
             group_id=group.id,
@@ -832,6 +866,8 @@ class Query:
         No org token required.  The code gates access to its bound calendar group only.
         Reads are repeatable: the code is never consumed by this query.
         """
+        for r in ranges:
+            _validate_code_gated_range(r.start_time, r.end_time)
         deps = get_query_dependencies()
         token = _resolve_code_from_deps(deps, code)
 
@@ -841,8 +877,8 @@ class Query:
         if group is None:
             raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
 
-        org = Organization.objects.get(id=token.organization_id)
-        calendar_group_service = _prepare_group_service_for_org(org)
+        org = _get_org_from_token(token)
+        calendar_group_service = _prepare_group_service_for_org(deps, org)
 
         result = calendar_group_service.check_group_availability(
             group_id=group.id,

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -12,6 +12,12 @@ from dependency_injector.wiring import Provide, inject
 from django_virtual_models import QuerySet
 from graphql import GraphQLError
 
+from calendar_integration.exceptions import (
+    InvalidTokenError,
+    TokenAlreadyUsedError,
+    TokenExpiredError,
+    TokenRevokedError,
+)
 from calendar_integration.graphql import (
     AvailableTimeGraphQLType,
     AvailableTimeWindowGraphQLType,
@@ -33,6 +39,7 @@ from calendar_integration.models import (
     Calendar,
     CalendarEvent,
     CalendarGroup,
+    CalendarManagementToken,
 )
 from organizations.models import Organization, OrganizationMembership, resolve_branding
 from public_api.capabilities import assert_org_can_invite
@@ -47,13 +54,19 @@ from users.models import User
 
 if TYPE_CHECKING:
     from calendar_integration.services.calendar_group_service import CalendarGroupService
+    from calendar_integration.services.calendar_permission_service import CalendarPermissionService
     from calendar_integration.services.calendar_service import CalendarService
+
+# Uniform error message for all code-gated read failures.  Never disclose whether the
+# code exists, is expired, used, revoked, or bound to the wrong scope.
+_CODE_GATED_ERROR_MESSAGE = "Invalid or expired code."
 
 
 @dataclass
 class QueryDependencies:
     calendar_service: "CalendarService"
     calendar_group_service: "CalendarGroupService"
+    calendar_permission_service: "CalendarPermissionService | None" = None
 
 
 @inject
@@ -62,8 +75,11 @@ def get_query_dependencies(
     calendar_group_service: Annotated[
         "CalendarGroupService | None", Provide["calendar_group_service"]
     ] = None,
+    calendar_permission_service: Annotated[
+        "CalendarPermissionService | None", Provide["calendar_permission_service"]
+    ] = None,
 ) -> QueryDependencies:
-    required_dependencies = [calendar_service, calendar_group_service]
+    required_dependencies = [calendar_service, calendar_group_service, calendar_permission_service]
     if any(dep is None for dep in required_dependencies):
         raise GraphQLError(
             f"Missing required dependency {', '.join([str(dep) for dep in required_dependencies if dep is None])}"
@@ -72,6 +88,7 @@ def get_query_dependencies(
     return QueryDependencies(
         calendar_service=cast("CalendarService", calendar_service),
         calendar_group_service=cast("CalendarGroupService", calendar_group_service),
+        calendar_permission_service=cast("CalendarPermissionService", calendar_permission_service),
     )
 
 
@@ -116,6 +133,45 @@ def _prepare_service_and_calendar(
     )
     cal = Calendar.objects.filter_by_organization(org.id).get(id=calendar_id)
     return deps.calendar_service, cal
+
+
+def _prepare_service_and_calendar_for_org(
+    org: Organization, calendar: Calendar
+) -> "CalendarService":
+    """Initialize CalendarService with the given org and return it.
+
+    Used by code-gated (unauthenticated) reads where the org + calendar are
+    derived from the booking code rather than from the request auth context.
+    """
+    deps = get_query_dependencies()
+    deps.calendar_service.initialize_without_provider(user_or_token=None, organization=org)
+    return deps.calendar_service
+
+
+def _prepare_group_service_for_org(org: Organization) -> "CalendarGroupService":
+    """Initialize CalendarGroupService with the given org and return it.
+
+    Used by code-gated (unauthenticated) reads where the org is derived from
+    the booking code.
+    """
+    deps = get_query_dependencies()
+    deps.calendar_group_service.initialize(organization=org)
+    return deps.calendar_group_service
+
+
+def _resolve_code_from_deps(deps: QueryDependencies, code: str) -> "CalendarManagementToken":
+    """Decode and validate a booking code, raising GraphQLError on any failure.
+
+    Centralises the None-guard for ``deps.calendar_permission_service`` so the
+    five code-gated read fields share a single call site for mypy purposes.
+    """
+    if deps.calendar_permission_service is None:
+        raise GraphQLError("Internal server error.")
+    try:
+        token: CalendarManagementToken = deps.calendar_permission_service.resolve_code(code)
+    except (InvalidTokenError, TokenExpiredError, TokenAlreadyUsedError, TokenRevokedError):
+        raise GraphQLError(_CODE_GATED_ERROR_MESSAGE) from None
+    return token
 
 
 @strawberry.input
@@ -613,6 +669,199 @@ class Query:
                 calendar_group_count=child.calendar_group_count or 0,
             )
             for child in qs
+        ]
+
+    # ------------------------------------------------------------------
+    # Code-gated read fields (unauthenticated — authorized by booking code)
+    # ------------------------------------------------------------------
+
+    @strawberry.field()
+    def available_times_with_code(
+        self,
+        code: str,
+        start_datetime: datetime.datetime,
+        end_datetime: datetime.datetime,
+    ) -> list[AvailableTimeGraphQLType]:
+        """Return available times for the calendar bound to a booking code.
+
+        No org token required.  The code gates access to its bound calendar only.
+        Reads are repeatable: the code is never consumed by this query.
+        """
+        deps = get_query_dependencies()
+        token = _resolve_code_from_deps(deps, code)
+
+        # Resolve the bound calendar (calendar-scope or event.calendar fallback).
+        calendar = token.calendar
+        if calendar is None and token.event is not None:
+            calendar = token.event.calendar
+        if calendar is None:
+            raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
+
+        org = Organization.objects.get(id=token.organization_id)
+        calendar_service = _prepare_service_and_calendar_for_org(org, calendar)
+
+        available_times = calendar_service.get_available_times_expanded(
+            calendar,
+            start_datetime,
+            end_datetime,
+        )
+        return cast(list[AvailableTimeGraphQLType], available_times)
+
+    @strawberry.field()
+    def availability_windows_with_code(
+        self,
+        code: str,
+        start_datetime: datetime.datetime,
+        end_datetime: datetime.datetime,
+    ) -> list[AvailableTimeWindowGraphQLType]:
+        """Return availability windows for the calendar bound to a booking code.
+
+        No org token required.  The code gates access to its bound calendar only.
+        Reads are repeatable: the code is never consumed by this query.
+        """
+        deps = get_query_dependencies()
+        token = _resolve_code_from_deps(deps, code)
+
+        calendar = token.calendar
+        if calendar is None and token.event is not None:
+            calendar = token.event.calendar
+        if calendar is None:
+            raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
+
+        org = Organization.objects.get(id=token.organization_id)
+        calendar_service = _prepare_service_and_calendar_for_org(org, calendar)
+
+        windows = calendar_service.get_availability_windows_in_range(
+            calendar=calendar,
+            start_datetime=start_datetime,
+            end_datetime=end_datetime,
+        )
+        return [
+            AvailableTimeWindowGraphQLType(
+                start_time=w.start_time,
+                end_time=w.end_time,
+                id=w.id,
+                can_book_partially=w.can_book_partially,
+            )
+            for w in windows
+        ]
+
+    @strawberry.field()
+    def unavailable_windows_with_code(
+        self,
+        code: str,
+        start_datetime: datetime.datetime,
+        end_datetime: datetime.datetime,
+    ) -> list[UnavailableTimeWindowGraphQLType]:
+        """Return unavailable (blocked/event) windows for the calendar bound to a booking code.
+
+        No org token required.  The code gates access to its bound calendar only.
+        Reads are repeatable: the code is never consumed by this query.
+        """
+        deps = get_query_dependencies()
+        token = _resolve_code_from_deps(deps, code)
+
+        calendar = token.calendar
+        if calendar is None and token.event is not None:
+            calendar = token.event.calendar
+        if calendar is None:
+            raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
+
+        org = Organization.objects.get(id=token.organization_id)
+        calendar_service = _prepare_service_and_calendar_for_org(org, calendar)
+
+        unavailable = calendar_service.get_unavailable_time_windows_in_range(
+            calendar=calendar,
+            start_datetime=start_datetime,
+            end_datetime=end_datetime,
+        )
+        return [
+            UnavailableTimeWindowGraphQLType(
+                start_time=w.start_time, end_time=w.end_time, id=w.id, reason=w.reason
+            )
+            for w in unavailable
+        ]
+
+    @strawberry.field()
+    def calendar_group_bookable_slots_with_code(
+        self,
+        code: str,
+        search_window_start: datetime.datetime,
+        search_window_end: datetime.datetime,
+        duration_seconds: int,
+        slot_step_seconds: int = 15 * 60,
+    ) -> list[BookableSlotProposalGraphQLType]:
+        """Return bookable slot proposals for the group bound to a booking code.
+
+        No org token required.  The code gates access to its bound calendar group only.
+        Reads are repeatable: the code is never consumed by this query.
+        """
+        deps = get_query_dependencies()
+        token = _resolve_code_from_deps(deps, code)
+
+        # Resolve the bound group (group-scope or event.calendar_group fallback).
+        group = token.calendar_group
+        if group is None and token.event is not None:
+            group = token.event.calendar_group
+        if group is None:
+            raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
+
+        org = Organization.objects.get(id=token.organization_id)
+        calendar_group_service = _prepare_group_service_for_org(org)
+
+        proposals = calendar_group_service.find_bookable_slots(
+            group_id=group.id,
+            search_window_start=search_window_start,
+            search_window_end=search_window_end,
+            duration=datetime.timedelta(seconds=duration_seconds),
+            slot_step=datetime.timedelta(seconds=slot_step_seconds),
+        )
+        return [
+            BookableSlotProposalGraphQLType(start_time=p.start_time, end_time=p.end_time)
+            for p in proposals
+        ]
+
+    @strawberry.field()
+    def calendar_group_availability_with_code(
+        self,
+        code: str,
+        ranges: list[DateTimeRangeInput],
+    ) -> list[CalendarGroupRangeAvailabilityGraphQLType]:
+        """Return per-range slot availability for the group bound to a booking code.
+
+        No org token required.  The code gates access to its bound calendar group only.
+        Reads are repeatable: the code is never consumed by this query.
+        """
+        deps = get_query_dependencies()
+        token = _resolve_code_from_deps(deps, code)
+
+        group = token.calendar_group
+        if group is None and token.event is not None:
+            group = token.event.calendar_group
+        if group is None:
+            raise GraphQLError(_CODE_GATED_ERROR_MESSAGE)
+
+        org = Organization.objects.get(id=token.organization_id)
+        calendar_group_service = _prepare_group_service_for_org(org)
+
+        result = calendar_group_service.check_group_availability(
+            group_id=group.id,
+            ranges=[(r.start_time, r.end_time) for r in ranges],
+        )
+        return [
+            CalendarGroupRangeAvailabilityGraphQLType(
+                start_time=r.start_time,
+                end_time=r.end_time,
+                slots=[
+                    CalendarGroupSlotAvailabilityGraphQLType(
+                        slot_id=s.slot_id,
+                        available_calendar_ids=s.available_calendar_ids,
+                        required_count=s.required_count,
+                    )
+                    for s in r.slots
+                ],
+            )
+            for r in result
         ]
 
     @strawberry.field()

--- a/public_api/tests/test_code_gated_reads.py
+++ b/public_api/tests/test_code_gated_reads.py
@@ -983,3 +983,266 @@ class TestCrossOrgIsolation:
         assert "errors" not in data or len(data.get("errors", [])) == 0
         call_kwargs = mock_calendar_service.initialize_without_provider.call_args[1]
         assert call_kwargs["organization"].id == organization.id
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 1: tampered-secret test (valid id, wrong secret)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestTamperedSecretCode:
+    """The hash-verify gate must reject a code whose secret half is swapped."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_tampered_secret_calendar_field_returns_error(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar,
+    ):
+        """A code with a valid token_id but a swapped secret is rejected with the uniform error.
+
+        Construction:
+        1. Mint a real code via create_booking_token (base64 of "<id>:<raw_secret>").
+        2. Decode the base64, split on ':', replace the raw_secret with a different value.
+        3. Re-encode base64 → tampered code.
+        The id is real (token exists in DB) but the secret does not match the stored hash.
+        """
+        import base64
+
+        mock_rate_limiter.return_value = iter([None])
+        token, real_code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+        )
+
+        # Construct a tampered code: same id, different secret.
+        decoded = base64.b64decode(real_code).decode("utf-8")
+        token_id_part, _real_secret = decoded.split(":", 1)
+        tampered_code = base64.b64encode(f"{token_id_part}:WRONG_SECRET_VALUE".encode()).decode()
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": tampered_code,
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+        # The token must not have been consumed.
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_tampered_secret_group_field_returns_error(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar_group,
+    ):
+        """Same tampered-secret test for the group availability field."""
+        import base64
+
+        mock_rate_limiter.return_value = iter([None])
+        token, real_code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_group_id=calendar_group.id,
+        )
+
+        decoded = base64.b64decode(real_code).decode("utf-8")
+        token_id_part, _real_secret = decoded.split(":", 1)
+        tampered_code = base64.b64encode(f"{token_id_part}:WRONG_SECRET_VALUE".encode()).decode()
+
+        data = post_graphql(
+            anon_client,
+            CALENDAR_GROUP_AVAILABILITY_WITH_CODE,
+            {
+                "code": tampered_code,
+                "ranges": [
+                    {
+                        "startTime": "2025-09-02T09:00:00Z",
+                        "endTime": "2025-09-02T10:00:00Z",
+                    }
+                ],
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+        token.refresh_from_db()
+        assert token.used_at is None
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 2: real (non-mocked) cross-org isolation test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRealCrossOrgIsolation:
+    """Real DB isolation: org A's code must not return org B's AvailableTime rows."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_available_times_with_code_scoped_to_own_org(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+    ):
+        """With real AvailableTime rows in both orgs, the code only returns its own org's data.
+
+        Setup:
+        - Org A: calendar_a + 1 AvailableTime in the window.
+        - Org B: calendar_b + 1 AvailableTime in the same window (different org).
+        - Mint a code on org A's calendar_a.
+        - Call availableTimesWithCode.
+        - Assert only org A's AvailableTime id is in the response (not org B's).
+        """
+        from calendar_integration.models import AvailableTime
+
+        mock_rate_limiter.return_value = iter([None])
+
+        org_a = baker.make(Organization, name="Real Org A")
+        org_b = baker.make(Organization, name="Real Org B")
+
+        calendar_a = baker.make(Calendar, organization=org_a, name="Cal A")
+        calendar_b = baker.make(Calendar, organization=org_b, name="Cal B")
+
+        # AvailableTime for org A (non-recurring, within query window)
+        at_a = baker.make(
+            AvailableTime,
+            organization=org_a,
+            calendar=calendar_a,
+            start_time_tz_unaware=datetime.datetime(2025, 10, 1, 9, 0),
+            end_time_tz_unaware=datetime.datetime(2025, 10, 1, 10, 0),
+            timezone="UTC",
+            recurrence_rule=None,
+        )
+        # AvailableTime for org B in the same window — must NOT appear in org A's results.
+        at_b = baker.make(
+            AvailableTime,
+            organization=org_b,
+            calendar=calendar_b,
+            start_time_tz_unaware=datetime.datetime(2025, 10, 1, 9, 0),
+            end_time_tz_unaware=datetime.datetime(2025, 10, 1, 10, 0),
+            timezone="UTC",
+            recurrence_rule=None,
+        )
+
+        _token, code = permission_service.create_booking_token(
+            organization_id=org_a.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar_a.id,
+        )
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-10-01T00:00:00Z",
+                "endDatetime": "2025-10-01T23:59:59Z",
+            },
+        )
+
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["availableTimesWithCode"]
+        returned_ids = [int(r["id"]) for r in result]
+        assert at_a.id in returned_ids, "Org A's AvailableTime must be returned"
+        assert at_b.id not in returned_ids, "Org B's AvailableTime must NOT be returned"
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 3: range clamp guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCodeGatedRangeClamp:
+    """Over-maximum and backwards datetime ranges are rejected before hitting the service."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_over_max_range_calendar_field_rejected(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        calendar_booking_code,
+    ):
+        """A range exceeding MAX_CODE_GATED_RANGE (366 days) is rejected on a calendar field."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_booking_code
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-01-01T00:00:00Z",
+                # 367 days — one day over the 366-day cap
+                "endDatetime": "2026-01-03T00:00:00Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Requested time range is too large."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_backwards_range_calendar_field_rejected(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        calendar_booking_code,
+    ):
+        """A backwards range (end <= start) is rejected on a calendar field."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_booking_code
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-09-02T23:59:59Z",
+                "endDatetime": "2025-09-02T00:00:00Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid time range."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_over_max_range_group_field_rejected(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+    ):
+        """A range exceeding MAX_CODE_GATED_RANGE (366 days) is rejected on a group field."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+
+        data = post_graphql(
+            anon_client,
+            CALENDAR_GROUP_BOOKABLE_SLOTS_WITH_CODE,
+            {
+                "code": code,
+                "searchWindowStart": "2025-01-01T00:00:00Z",
+                # 367 days — one day over the 366-day cap
+                "searchWindowEnd": "2026-01-03T00:00:00Z",
+                "durationSeconds": 3600,
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Requested time range is too large."

--- a/public_api/tests/test_code_gated_reads.py
+++ b/public_api/tests/test_code_gated_reads.py
@@ -1,0 +1,985 @@
+"""Integration tests for code-gated (unauthenticated) availability read fields.
+
+Covers Phase 4:
+- availableTimesWithCode
+- availabilityWindowsWithCode
+- unavailableWindowsWithCode
+- calendarGroupBookableSlotsWithCode
+- calendarGroupAvailabilityWithCode
+
+All fields are unauthenticated (no Authorization header required).  The booking
+code authorizes access to its bound calendar / calendar group.  Reads never
+consume the code (used_at remains NULL after any read).
+"""
+
+import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.models import (
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    CalendarManagementToken,
+    EventManagementPermissions,
+)
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.dataclasses import (
+    AvailableTimeWindow,
+    BlockedTimeData,
+    BookableSlotProposal,
+    CalendarGroupRangeAvailability,
+    CalendarGroupSlotAvailability,
+    UnavailableTimeWindow,
+)
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# GraphQL query strings
+# ---------------------------------------------------------------------------
+
+AVAILABLE_TIMES_WITH_CODE = """
+query AvailableTimesWithCode($code: String!, $startDatetime: DateTime!, $endDatetime: DateTime!) {
+    availableTimesWithCode(code: $code, startDatetime: $startDatetime, endDatetime: $endDatetime) {
+        id
+        startTime
+        endTime
+    }
+}
+"""
+
+AVAILABILITY_WINDOWS_WITH_CODE = """
+query AvailabilityWindowsWithCode($code: String!, $startDatetime: DateTime!, $endDatetime: DateTime!) {
+    availabilityWindowsWithCode(code: $code, startDatetime: $startDatetime, endDatetime: $endDatetime) {
+        id
+        startTime
+        endTime
+        canBookPartially
+    }
+}
+"""
+
+UNAVAILABLE_WINDOWS_WITH_CODE = """
+query UnavailableWindowsWithCode($code: String!, $startDatetime: DateTime!, $endDatetime: DateTime!) {
+    unavailableWindowsWithCode(code: $code, startDatetime: $startDatetime, endDatetime: $endDatetime) {
+        id
+        startTime
+        endTime
+        reason
+    }
+}
+"""
+
+CALENDAR_GROUP_BOOKABLE_SLOTS_WITH_CODE = """
+query CalendarGroupBookableSlotsWithCode(
+    $code: String!,
+    $searchWindowStart: DateTime!,
+    $searchWindowEnd: DateTime!,
+    $durationSeconds: Int!
+) {
+    calendarGroupBookableSlotsWithCode(
+        code: $code,
+        searchWindowStart: $searchWindowStart,
+        searchWindowEnd: $searchWindowEnd,
+        durationSeconds: $durationSeconds
+    ) {
+        startTime
+        endTime
+    }
+}
+"""
+
+CALENDAR_GROUP_AVAILABILITY_WITH_CODE = """
+query CalendarGroupAvailabilityWithCode($code: String!, $ranges: [DateTimeRangeInput!]!) {
+    calendarGroupAvailabilityWithCode(code: $code, ranges: $ranges) {
+        startTime
+        endTime
+        slots {
+            slotId
+            availableCalendarIds
+            requiredCount
+        }
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization():
+    return baker.make(Organization, name="Test Org for Code-Gated Reads")
+
+
+@pytest.fixture
+def other_organization():
+    return baker.make(Organization, name="Other Org")
+
+
+@pytest.fixture
+def calendar(organization):
+    return baker.make(Calendar, organization=organization, name="Test Calendar")
+
+
+@pytest.fixture
+def other_calendar(other_organization):
+    return baker.make(Calendar, organization=other_organization, name="Other Calendar")
+
+
+@pytest.fixture
+def calendar_group(organization):
+    return baker.make(CalendarGroup, organization=organization, name="Test Group")
+
+
+@pytest.fixture
+def calendar_event(organization, calendar):
+    return baker.make(
+        CalendarEvent,
+        organization=organization,
+        calendar=calendar,
+        title="Test Event",
+        timezone="UTC",
+    )
+
+
+@pytest.fixture
+def group_event(organization, calendar, calendar_group):
+    return baker.make(
+        CalendarEvent,
+        organization=organization,
+        calendar=calendar,
+        calendar_group=calendar_group,
+        title="Group Test Event",
+        timezone="UTC",
+    )
+
+
+@pytest.fixture
+def permission_service():
+    return CalendarPermissionService()
+
+
+@pytest.fixture
+def calendar_booking_code(permission_service, organization, calendar):
+    """Create a calendar-scoped booking code. Returns (token, plaintext_code)."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_id=calendar.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def group_booking_code(permission_service, organization, calendar_group):
+    """Create a group-scoped booking code. Returns (token, plaintext_code)."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=calendar_group.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def event_booking_code(permission_service, organization, calendar, calendar_event):
+    """Create an event-scoped booking code (reschedule). Returns (token, plaintext_code)."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_id=calendar.id,
+        event_id=calendar_event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def anon_client():
+    """An APIClient with no Authorization header."""
+    return APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def post_graphql(client: APIClient, query: str, variables: dict) -> dict:
+    """Post a GraphQL request and return the parsed JSON body."""
+    response = client.post(
+        "/graphql/",
+        data={"query": query, "variables": variables},
+        format="json",
+    )
+    assert response.status_code == 200, response.content.decode()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Calendar-code reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAvailableTimesWithCode:
+    """Tests for availableTimesWithCode — calendar scope."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_returns_available_times_no_auth_header(
+        self, mock_rate_limiter, anon_client, calendar_booking_code, organization, calendar
+    ):
+        """A calendar booking code returns available times with no Authorization header."""
+        from calendar_integration.models import AvailableTime
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_booking_code
+
+        # Seed a real AvailableTime row so the service can return something.
+        at = baker.make(
+            AvailableTime,
+            organization=organization,
+            calendar=calendar,
+            start_time_tz_unaware=datetime.datetime(2025, 9, 2, 9, 0),
+            end_time_tz_unaware=datetime.datetime(2025, 9, 2, 10, 0),
+            timezone="UTC",
+        )
+
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_available_times_expanded.return_value = [at]
+
+        with container.calendar_service.override(mock_calendar_service):
+            data = post_graphql(
+                anon_client,
+                AVAILABLE_TIMES_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["availableTimesWithCode"]
+        assert len(result) == 1
+        assert result[0]["id"] == str(at.id)
+
+        # The service was initialized without a user_or_token (anon).
+        mock_calendar_service.initialize_without_provider.assert_called_once()
+        mock_calendar_service.get_available_times_expanded.assert_called_once()
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_code_never_consumed_after_read(
+        self, mock_rate_limiter, anon_client, calendar_booking_code
+    ):
+        """Reads must NOT set used_at on the token (codes are reusable for reads)."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        token, code = calendar_booking_code
+
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_available_times_expanded.return_value = []
+
+        with container.calendar_service.override(mock_calendar_service):
+            post_graphql(
+                anon_client,
+                AVAILABLE_TIMES_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        token.refresh_from_db()
+        assert token.used_at is None, "used_at should remain NULL after a read"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_graphql_error(self, mock_rate_limiter, anon_client):
+        """An invalid / unknown code returns a GraphQL error with the uniform message."""
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": "aW52YWxpZA==",  # "invalid" base64 — no matching token
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_revoked_code_returns_error(
+        self, mock_rate_limiter, anon_client, permission_service, organization, calendar
+    ):
+        """A revoked code returns the uniform error message."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+        )
+        permission_service.revoke_token(organization_id=organization.id, token_id=token.id)
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_expired_code_returns_error(
+        self, mock_rate_limiter, anon_client, permission_service, organization, calendar
+    ):
+        """An expired code returns the uniform error message."""
+        mock_rate_limiter.return_value = iter([None])
+        past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+        _token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+            expires_at=past,
+        )
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_used_code_returns_error(
+        self, mock_rate_limiter, anon_client, permission_service, organization, calendar
+    ):
+        """A used (consumed) code returns the uniform error message."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+        )
+        CalendarManagementToken.objects.filter(id=token.id).update(
+            used_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        )
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_group_code_on_calendar_field_returns_error(
+        self, mock_rate_limiter, anon_client, group_booking_code
+    ):
+        """A group-bound code passed to a calendar read field returns the uniform error."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+
+        data = post_graphql(
+            anon_client,
+            AVAILABLE_TIMES_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+
+@pytest.mark.django_db
+class TestAvailabilityWindowsWithCode:
+    """Tests for availabilityWindowsWithCode — calendar scope."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_returns_windows_no_auth_header(
+        self, mock_rate_limiter, anon_client, calendar_booking_code
+    ):
+        """A calendar booking code returns availability windows with no Authorization header."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_booking_code
+
+        window = AvailableTimeWindow(
+            start_time=datetime.datetime(2025, 9, 2, 9, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2025, 9, 2, 10, 0, tzinfo=datetime.UTC),
+            id=1,
+            can_book_partially=True,
+        )
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_availability_windows_in_range.return_value = [window]
+
+        with container.calendar_service.override(mock_calendar_service):
+            data = post_graphql(
+                anon_client,
+                AVAILABILITY_WINDOWS_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["availabilityWindowsWithCode"]
+        assert len(result) == 1
+        assert result[0]["id"] == 1
+        assert result[0]["canBookPartially"] is True
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_code_not_consumed_after_read(
+        self, mock_rate_limiter, anon_client, calendar_booking_code
+    ):
+        """availabilityWindowsWithCode must not consume the code."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        token, code = calendar_booking_code
+
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_availability_windows_in_range.return_value = []
+
+        with container.calendar_service.override(mock_calendar_service):
+            post_graphql(
+                anon_client,
+                AVAILABILITY_WINDOWS_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_error(self, mock_rate_limiter, anon_client):
+        """An invalid code returns the uniform error message."""
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            AVAILABILITY_WINDOWS_WITH_CODE,
+            {
+                "code": "bm90YXZhbGlkdG9rZW4=",
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+
+@pytest.mark.django_db
+class TestUnavailableWindowsWithCode:
+    """Tests for unavailableWindowsWithCode — calendar scope."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_returns_unavailable_windows_no_auth_header(
+        self, mock_rate_limiter, anon_client, calendar_booking_code
+    ):
+        """A calendar booking code returns unavailable windows with no Authorization header."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_booking_code
+
+        _bt_data = BlockedTimeData(
+            id=42,
+            calendar_external_id="ext-cal-id",
+            start_time=datetime.datetime(2025, 9, 2, 11, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2025, 9, 2, 12, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            reason="maintenance",
+            external_id=None,
+            meta={},
+        )
+        unavail = UnavailableTimeWindow(
+            start_time=datetime.datetime(2025, 9, 2, 11, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2025, 9, 2, 12, 0, tzinfo=datetime.UTC),
+            id=42,
+            reason="blocked_time",
+            data=_bt_data,
+        )
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_unavailable_time_windows_in_range.return_value = [unavail]
+
+        with container.calendar_service.override(mock_calendar_service):
+            data = post_graphql(
+                anon_client,
+                UNAVAILABLE_WINDOWS_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["unavailableWindowsWithCode"]
+        assert len(result) == 1
+        assert result[0]["id"] == 42
+        assert result[0]["reason"] == "blocked_time"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_code_not_consumed_after_read(
+        self, mock_rate_limiter, anon_client, calendar_booking_code
+    ):
+        """unavailableWindowsWithCode must not consume the code."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        token, code = calendar_booking_code
+
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_unavailable_time_windows_in_range.return_value = []
+
+        with container.calendar_service.override(mock_calendar_service):
+            post_graphql(
+                anon_client,
+                UNAVAILABLE_WINDOWS_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_error(self, mock_rate_limiter, anon_client):
+        """An invalid code returns the uniform error message."""
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            UNAVAILABLE_WINDOWS_WITH_CODE,
+            {
+                "code": "bm90cmVhbA==",
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_group_code_on_calendar_read_field_returns_error(
+        self, mock_rate_limiter, anon_client, group_booking_code
+    ):
+        """A group-bound code passed to a calendar read field returns the uniform error (wrong scope)."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+
+        data = post_graphql(
+            anon_client,
+            UNAVAILABLE_WINDOWS_WITH_CODE,
+            {
+                "code": code,
+                "startDatetime": "2025-09-02T00:00:00Z",
+                "endDatetime": "2025-09-02T23:59:59Z",
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+
+# ---------------------------------------------------------------------------
+# Event-scoped code reads — scope resolves via event.calendar / event.calendar_group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEventBoundCodeCalendarReads:
+    """An event-bound (reschedule) code resolves available times via event.calendar."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_event_code_resolves_calendar(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        event_booking_code,
+        organization,
+        calendar,
+        calendar_event,
+    ):
+        """An event-bound reschedule code can be used for calendar reads via event.calendar."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = event_booking_code
+
+        window = AvailableTimeWindow(
+            start_time=datetime.datetime(2025, 9, 2, 9, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2025, 9, 2, 10, 0, tzinfo=datetime.UTC),
+            id=None,
+            can_book_partially=False,
+        )
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_availability_windows_in_range.return_value = [window]
+
+        with container.calendar_service.override(mock_calendar_service):
+            data = post_graphql(
+                anon_client,
+                AVAILABILITY_WINDOWS_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        # The query should succeed — event.calendar is the bound scope.
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["availabilityWindowsWithCode"]
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Group-code reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCalendarGroupBookableSlotsWithCode:
+    """Tests for calendarGroupBookableSlotsWithCode — group scope."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_returns_bookable_slots_no_auth_header(
+        self, mock_rate_limiter, anon_client, group_booking_code
+    ):
+        """A group booking code returns bookable slots with no Authorization header."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+
+        proposal = BookableSlotProposal(
+            start_time=datetime.datetime(2025, 9, 2, 9, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2025, 9, 2, 10, 0, tzinfo=datetime.UTC),
+        )
+        mock_group_service = Mock()
+        mock_group_service.initialize.return_value = None
+        mock_group_service.find_bookable_slots.return_value = [proposal]
+
+        with container.calendar_group_service.override(mock_group_service):
+            data = post_graphql(
+                anon_client,
+                CALENDAR_GROUP_BOOKABLE_SLOTS_WITH_CODE,
+                {
+                    "code": code,
+                    "searchWindowStart": "2025-09-02T00:00:00Z",
+                    "searchWindowEnd": "2025-09-02T23:59:59Z",
+                    "durationSeconds": 3600,
+                },
+            )
+
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["calendarGroupBookableSlotsWithCode"]
+        assert len(result) == 1
+        assert result[0]["startTime"] == "2025-09-02T09:00:00+00:00"
+        assert result[0]["endTime"] == "2025-09-02T10:00:00+00:00"
+
+        mock_group_service.find_bookable_slots.assert_called_once()
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_code_not_consumed_after_read(self, mock_rate_limiter, anon_client, group_booking_code):
+        """calendarGroupBookableSlotsWithCode must not consume the code."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_booking_code
+
+        mock_group_service = Mock()
+        mock_group_service.initialize.return_value = None
+        mock_group_service.find_bookable_slots.return_value = []
+
+        with container.calendar_group_service.override(mock_group_service):
+            post_graphql(
+                anon_client,
+                CALENDAR_GROUP_BOOKABLE_SLOTS_WITH_CODE,
+                {
+                    "code": code,
+                    "searchWindowStart": "2025-09-02T00:00:00Z",
+                    "searchWindowEnd": "2025-09-02T23:59:59Z",
+                    "durationSeconds": 3600,
+                },
+            )
+
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_calendar_code_on_group_field_returns_error(
+        self, mock_rate_limiter, anon_client, calendar_booking_code
+    ):
+        """A calendar-bound code passed to a group read field returns the uniform error (wrong scope)."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_booking_code
+
+        data = post_graphql(
+            anon_client,
+            CALENDAR_GROUP_BOOKABLE_SLOTS_WITH_CODE,
+            {
+                "code": code,
+                "searchWindowStart": "2025-09-02T00:00:00Z",
+                "searchWindowEnd": "2025-09-02T23:59:59Z",
+                "durationSeconds": 3600,
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_error(self, mock_rate_limiter, anon_client):
+        """An invalid code returns the uniform error message."""
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            CALENDAR_GROUP_BOOKABLE_SLOTS_WITH_CODE,
+            {
+                "code": "bm90dmFsaWQ=",
+                "searchWindowStart": "2025-09-02T00:00:00Z",
+                "searchWindowEnd": "2025-09-02T23:59:59Z",
+                "durationSeconds": 3600,
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+
+@pytest.mark.django_db
+class TestCalendarGroupAvailabilityWithCode:
+    """Tests for calendarGroupAvailabilityWithCode — group scope."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_returns_group_availability_no_auth_header(
+        self, mock_rate_limiter, anon_client, group_booking_code, calendar_group
+    ):
+        """A group booking code returns group availability with no Authorization header."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+
+        slot_avail = CalendarGroupSlotAvailability(
+            slot_id=1, available_calendar_ids=[10, 20], required_count=1
+        )
+        range_avail = CalendarGroupRangeAvailability(
+            start_time=datetime.datetime(2025, 9, 2, 9, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2025, 9, 2, 10, 0, tzinfo=datetime.UTC),
+            slots=[slot_avail],
+        )
+
+        mock_group_service = Mock()
+        mock_group_service.initialize.return_value = None
+        mock_group_service.check_group_availability.return_value = [range_avail]
+
+        with container.calendar_group_service.override(mock_group_service):
+            data = post_graphql(
+                anon_client,
+                CALENDAR_GROUP_AVAILABILITY_WITH_CODE,
+                {
+                    "code": code,
+                    "ranges": [
+                        {
+                            "startTime": "2025-09-02T09:00:00Z",
+                            "endTime": "2025-09-02T10:00:00Z",
+                        }
+                    ],
+                },
+            )
+
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["calendarGroupAvailabilityWithCode"]
+        assert len(result) == 1
+        assert result[0]["slots"][0]["slotId"] == 1
+        assert result[0]["slots"][0]["requiredCount"] == 1
+
+        mock_group_service.check_group_availability.assert_called_once()
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_code_not_consumed_after_read(self, mock_rate_limiter, anon_client, group_booking_code):
+        """calendarGroupAvailabilityWithCode must not consume the code."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_booking_code
+
+        mock_group_service = Mock()
+        mock_group_service.initialize.return_value = None
+        mock_group_service.check_group_availability.return_value = []
+
+        with container.calendar_group_service.override(mock_group_service):
+            post_graphql(
+                anon_client,
+                CALENDAR_GROUP_AVAILABILITY_WITH_CODE,
+                {
+                    "code": code,
+                    "ranges": [
+                        {
+                            "startTime": "2025-09-02T09:00:00Z",
+                            "endTime": "2025-09-02T10:00:00Z",
+                        }
+                    ],
+                },
+            )
+
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_calendar_code_on_group_availability_returns_error(
+        self, mock_rate_limiter, anon_client, calendar_booking_code
+    ):
+        """A calendar-bound code on calendarGroupAvailabilityWithCode returns the uniform error."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_booking_code
+
+        data = post_graphql(
+            anon_client,
+            CALENDAR_GROUP_AVAILABILITY_WITH_CODE,
+            {
+                "code": code,
+                "ranges": [
+                    {
+                        "startTime": "2025-09-02T09:00:00Z",
+                        "endTime": "2025-09-02T10:00:00Z",
+                    }
+                ],
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_error(self, mock_rate_limiter, anon_client):
+        """An invalid code returns the uniform error message."""
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            CALENDAR_GROUP_AVAILABILITY_WITH_CODE,
+            {
+                "code": "bm90YXZhbGlkY29kZQ==",
+                "ranges": [
+                    {
+                        "startTime": "2025-09-02T09:00:00Z",
+                        "endTime": "2025-09-02T10:00:00Z",
+                    }
+                ],
+            },
+        )
+
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Invalid or expired code."
+
+
+# ---------------------------------------------------------------------------
+# Cross-org isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCrossOrgIsolation:
+    """A code can only read data for its own org's calendar / group."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_calendar_code_reads_own_org_only(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        organization,
+        other_organization,  # noqa: ARG002
+        calendar,
+        other_calendar,  # noqa: ARG002
+        permission_service,
+    ):
+        """A code bound to calendar A (org1) resolves to org1's calendar only.
+
+        The code carries its own org; the service is initialized with the code's
+        org (org1), not the other org's.
+        """
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        # Mint a code for org1's calendar
+        _token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+        )
+
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.get_availability_windows_in_range.return_value = []
+
+        with container.calendar_service.override(mock_calendar_service):
+            data = post_graphql(
+                anon_client,
+                AVAILABILITY_WINDOWS_WITH_CODE,
+                {
+                    "code": code,
+                    "startDatetime": "2025-09-02T00:00:00Z",
+                    "endDatetime": "2025-09-02T23:59:59Z",
+                },
+            )
+
+        # The query succeeds and the service is initialized with the code's org.
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        call_kwargs = mock_calendar_service.initialize_without_provider.call_args[1]
+        assert call_kwargs["organization"].id == organization.id


### PR DESCRIPTION

## Summary

First **unauthenticated** surface of the feature: a patient (no org token) reads availability for
a code's bound scope. Adds five query fields with NO `permission_classes` (and deliberately NOT in
`FIELD_TO_RESOURCE_MAPPING`): `availableTimesWithCode`, `availabilityWindowsWithCode`,
`unavailableWindowsWithCode`, `calendarGroupBookableSlotsWithCode`, `calendarGroupAvailabilityWithCode`.

New service primitive `CalendarPermissionService.resolve_code(code)` derives the org **from the
code** — it looks the token up by id alone (unscoped `original_manager`) and the constant-time
hash verify is the gate; org is then read off the token. `validate_code(code, org_id)` now delegates
to `resolve_code` and asserts the org, sharing one decode/verify path.

Security properties (reviewed):
- Hash verify runs before any token data is used; unknown-id and bad-hash both → identical
  `GraphQLError("Invalid or expired code.")` (no enumeration oracle).
- Scope is taken STRICTLY from the token (`token.calendar`/`token.event.calendar` for calendar
  fields; `token.calendar_group`/`token.event.calendar_group` for group fields) — no client-supplied
  calendar/group id can override it. Calendar codes can't read group data and vice versa.
- Cross-org isolation: org comes from the token; availability services run every query through
  `filter_by_organization`. (Now covered by a real non-mocked cross-org test.)
- Reads NEVER consume the code (`used_at` stays null — asserted).
- Datetime range is clamped to 366 days (DoS guard on the unauthenticated surface); rate limiter
  keys unauthenticated requests as `anon:<client_ip>`.

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 4.
- Spec: Decisions → Use-cases, Use-cases 2 & 4 (the availability-read steps). Open Question 1 (read set).

## Test plan

In-container (docker postgres): `public_api/tests/test_code_gated_reads.py` — 30 tests: per-field happy
paths (no auth header), event-bound code via `event.calendar`, non-consumption (`used_at` null after
read), wrong-scope (calendar code on group field & vice versa) → uniform error, invalid/unknown/
revoked/expired → uniform error, **tampered-secret (valid id, wrong secret)** → uniform error,
**real non-mocked cross-org isolation**, and **over-max / backwards range** rejection. `ruff` clean ·
`makemigrations --check` no changes · `check --deploy` clean · `pytest -n auto` **2102 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-3`.