### PR TITLE
feat(calendar): book a single-calendar event with a code (Phase 5a)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -69,11 +69,20 @@
 - **NOTE**: main checkout has UNRELATED in-progress work (validateReturnUrl OAuth feature) on public_api/{queries,types,tests}; left untouched — worktree isolation kept my work separate.
 - **PR**: pending (filled after push).
 
+### Phase 5a — Book single-calendar event with code ✅
+- **Status**: complete, reviewed (Layers 1–3 + fix loop). Layer 3 caught a BLOCKER — fixed.
+- **Model/tier**: implementer / Sonnet (Tier 3).
+- **Branch**: plan/single-use-scheduling-codes/phase-5a (base: phase-4).
+- **Commits**: e0288b7 (book-with-code mutation) + c9d6d72 (BLOCKER fix: authorize on restricted calendars).
+- **Outer gate**: `pytest -n auto` 2114 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: unauthenticated `createCalendarEventWithCode` (no permission_classes). resolve_code → require CREATE perm + calendar scope → atomic { initialize_without_provider(user_or_token=code) → create_event → consume_code }. First-write-wins (consume after create, under lock, rolls back on race). SLOT_UNAVAILABLE ← NoAvailableTimeWindowsError/EventManagementError (code NOT consumed, retryable); PermissionDenied → NOT_PERMITTED; resolve_code errors → INVALID_CODE/EXPIRED/ALREADY_USED/REVOKED. IP audit from X-Forwarded-For/REMOTE_ADDR.
+- **BLOCKER caught + fixed**: original impl passed `user_or_token=None`, so `can_perform_scheduling` rejected bookings on RESTRICTED calendars (the core use case) — masked by tests using accepts_public_scheduling=True. Fix: thread the code as `user_or_token` so the event service's permission instance gets the token → CREATE-permission branch authorizes on restricted calendars. Tests rewritten to use a restricted calendar with seeded availability + a real (non-mocked) slot-unavailable test.
+- **PR**: pending (filled after push).
+
 ## Current phase
-Phase 5a — Book single-calendar event with code (next).
+Phase 5b — Book calendar-group event with code (next).
 
 ## Remaining phases
-- Phase 5a — Book single-calendar event with code
 - Phase 5b — Book calendar-group event with code
 - Phase 6a — Reschedule single-calendar event with code
 - Phase 6b — Reschedule calendar-group event with code

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -4,6 +4,7 @@ import datetime
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, cast
 
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 
 import strawberry
@@ -1100,7 +1101,7 @@ class CalendarGroupMutations:
         try:
             with transaction.atomic():
                 deps.calendar_service.initialize_without_provider(
-                    user_or_token=None, organization=org
+                    user_or_token=input.code, organization=org
                 )
                 event = deps.calendar_service.create_event(token.calendar.id, event_data)
                 deps.calendar_permission_service.consume_code(token, source_ip)
@@ -1119,12 +1120,18 @@ class CalendarGroupMutations:
                 error_code=error_code,
                 error_message=error_message,
             )
-        except (NoAvailableTimeWindowsError, EventManagementError) as e:
+        except PermissionDenied:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit booking on this calendar.",
+            )
+        except (NoAvailableTimeWindowsError, EventManagementError):
             # Slot taken / invalid times — code NOT consumed (txn rolled back), patient may retry.
             return CodeEventResult(
                 success=False,
                 error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
-                error_message=str(e) or "The requested time slot is not available.",
+                error_message="The requested time slot is not available.",
             )
 
         return CodeEventResult(success=True, event=event)  # type: ignore[arg-type]

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -4,17 +4,28 @@ import datetime
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, cast
 
+from django.db import transaction
+
 import strawberry
 from dependency_injector.wiring import Provide, inject
 from graphql import GraphQLError
 
-from calendar_integration.exceptions import CalendarGroupError, InvalidTokenError
+from calendar_integration.exceptions import (
+    CalendarGroupError,
+    EventManagementError,
+    InvalidTokenError,
+    NoAvailableTimeWindowsError,
+    TokenAlreadyUsedError,
+    TokenExpiredError,
+    TokenRevokedError,
+)
 from calendar_integration.graphql import (
     BookingCodeErrorCode,
     BookingCodeResult,
     CalendarEventGraphQLType,
     CalendarGroupGraphQLType,
     CalendarWebhookSubscriptionGraphQLType,
+    CodeEventResult,
 )
 from calendar_integration.models import (
     Calendar,
@@ -23,6 +34,7 @@ from calendar_integration.models import (
     EventManagementPermissions,
 )
 from calendar_integration.services.dataclasses import (
+    CalendarEventInputData,
     CalendarGroupEventInputData,
     CalendarGroupInputData,
     CalendarGroupSlotInputData,
@@ -397,9 +409,10 @@ def _load_organization(organization_id: int) -> Organization | None:
 
 @dataclass
 class BookingCodeMutationDependencies:
-    """Dependencies for booking-code mint mutations."""
+    """Dependencies for booking-code mint and with-code mutations."""
 
     calendar_permission_service: "CalendarPermissionService"
+    calendar_service: "CalendarService"
 
 
 @inject
@@ -407,12 +420,14 @@ def get_booking_code_mutation_dependencies(
     calendar_permission_service: Annotated[
         "CalendarPermissionService | None", Provide["calendar_permission_service"]
     ] = None,
+    calendar_service: Annotated["CalendarService | None", Provide["calendar_service"]] = None,
 ) -> BookingCodeMutationDependencies:
     """Get booking-code mutation dependencies from DI container."""
-    if calendar_permission_service is None:
+    if calendar_permission_service is None or calendar_service is None:
         raise GraphQLError("Internal server error.")
     return BookingCodeMutationDependencies(
         calendar_permission_service=cast("CalendarPermissionService", calendar_permission_service),
+        calendar_service=cast("CalendarService", calendar_service),
     )
 
 
@@ -460,6 +475,32 @@ class RevokeBookingCodeInput:
 
     organization_id: int
     id: int  # noqa: A002
+
+
+# ---------------------------------------------------------------------------
+# With-code booking inputs (Phase 5a)
+# ---------------------------------------------------------------------------
+
+
+@strawberry.input
+class ExternalAttendeeCodeInput:
+    """External attendee input for unauthenticated code-bearing booking mutations."""
+
+    email: str
+    name: str = ""
+
+
+@strawberry.input
+class CreateEventWithCodeInput:
+    """Input for the unauthenticated createCalendarEventWithCode mutation."""
+
+    code: str
+    title: str
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+    external_attendee: ExternalAttendeeCodeInput
+    description: str = ""
 
 
 @strawberry.type
@@ -955,3 +996,135 @@ class CalendarGroupMutations:
             )
 
         return BookingCodeResult(success=True)
+
+    @strawberry.mutation
+    def create_calendar_event_with_code(
+        self,
+        info: strawberry.Info,
+        input: CreateEventWithCodeInput,  # noqa: A002
+    ) -> CodeEventResult:
+        """Book a single-calendar event using a single-use booking code.
+
+        This is an unauthenticated mutation: no org token is required.  The org
+        context, permissions, and calendar scope are all derived from the booking
+        code.  On success the code is atomically consumed so it cannot be replayed.
+        On a failed create (slot unavailable, invalid time range, etc.) the code is
+        NOT consumed and the patient may retry with a different slot.
+        """
+        deps = get_booking_code_mutation_dependencies()
+
+        # --- Step 1: resolve and validate the code ---
+        try:
+            token = deps.calendar_permission_service.resolve_code(input.code)
+        except InvalidTokenError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+        except TokenExpiredError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.EXPIRED,
+                error_message="This booking code has expired.",
+            )
+        except TokenAlreadyUsedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.ALREADY_USED,
+                error_message="This booking code has already been used.",
+            )
+        except TokenRevokedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.REVOKED,
+                error_message="This booking code has been revoked.",
+            )
+
+        # --- Step 2: check permission ---
+        token_permissions = {p.permission for p in token.permissions.all()}
+        if EventManagementPermissions.CREATE not in token_permissions:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit booking.",
+            )
+
+        # --- Step 3: scope check — must be single-calendar (not group) ---
+        if token.calendar is None:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code is not scoped to a single calendar.",
+            )
+
+        # --- Step 4: resolve org ---
+        try:
+            org = Organization.objects.get(id=token.organization_id)
+        except Organization.DoesNotExist:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+
+        # --- Step 5: extract client IP for audit ---
+        request = info.context.request
+        forwarded_for = getattr(request, "META", {}).get("HTTP_X_FORWARDED_FOR", "")
+        if forwarded_for:
+            source_ip = forwarded_for.split(",")[0].strip()
+        else:
+            source_ip = getattr(request, "META", {}).get("REMOTE_ADDR", "")
+
+        # --- Step 6: build event data ---
+        event_data = CalendarEventInputData(
+            title=input.title,
+            description=input.description or "",
+            start_time=input.start_time,
+            end_time=input.end_time,
+            timezone=input.timezone,
+            external_attendances=[
+                EventExternalAttendanceInputData(
+                    external_attendee=ExternalAttendeeInputData(
+                        email=input.external_attendee.email,
+                        name=input.external_attendee.name or "",
+                    )
+                )
+            ],
+        )
+
+        # --- Step 7: atomic create + consume ---
+        # Create FIRST, then consume — so on a race the loser's consume_code raises under
+        # the row lock and the whole transaction (including the just-created event) rolls
+        # back, leaving exactly one event and the code consumed once.
+        try:
+            with transaction.atomic():
+                deps.calendar_service.initialize_without_provider(
+                    user_or_token=None, organization=org
+                )
+                event = deps.calendar_service.create_event(token.calendar.id, event_data)
+                deps.calendar_permission_service.consume_code(token, source_ip)
+        except (TokenAlreadyUsedError, TokenExpiredError, TokenRevokedError) as e:
+            # Concurrent consumer won the race, or state changed between resolve and consume.
+            error_code = BookingCodeErrorCode.ALREADY_USED
+            error_message = "This booking code has already been used."
+            if isinstance(e, TokenExpiredError):
+                error_code = BookingCodeErrorCode.EXPIRED
+                error_message = "This booking code has expired."
+            elif isinstance(e, TokenRevokedError):
+                error_code = BookingCodeErrorCode.REVOKED
+                error_message = "This booking code has been revoked."
+            return CodeEventResult(
+                success=False,
+                error_code=error_code,
+                error_message=error_message,
+            )
+        except (NoAvailableTimeWindowsError, EventManagementError) as e:
+            # Slot taken / invalid times — code NOT consumed (txn rolled back), patient may retry.
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
+                error_message=str(e) or "The requested time slot is not available.",
+            )
+
+        return CodeEventResult(success=True, event=event)  # type: ignore[arg-type]

--- a/public_api/tests/test_book_with_code.py
+++ b/public_api/tests/test_book_with_code.py
@@ -1,0 +1,585 @@
+"""Integration tests for createCalendarEventWithCode (Phase 5a).
+
+All requests are unauthenticated (no Authorization header).  The booking
+code provides the org scope, calendar scope, and CREATE permission.
+
+Scenario coverage:
+1. Happy path — valid code + available slot → event created, code consumed.
+2. Replay — same code again → ALREADY_USED, no second event.
+3. Failed write does not consume — SLOT_UNAVAILABLE, code remains active.
+4. Wrong permission — code without CREATE → NOT_PERMITTED, no event.
+5. Wrong scope — group code used on single-calendar mutation → NOT_PERMITTED.
+6. Lifecycle rejections — expired / revoked / invalid → EXPIRED / REVOKED / INVALID_CODE.
+7. Cross-org: event is created in the code's org.
+"""
+
+import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.exceptions import NoAvailableTimeWindowsError
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    CalendarManagementToken,
+    EventManagementPermissions,
+)
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# GraphQL mutation string
+# ---------------------------------------------------------------------------
+
+CREATE_EVENT_WITH_CODE = """
+mutation CreateCalendarEventWithCode($input: CreateEventWithCodeInput!) {
+    createCalendarEventWithCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        event {
+            id
+            title
+            externalAttendances {
+                externalAttendee {
+                    email
+                    name
+                }
+            }
+        }
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization():
+    return baker.make(Organization, name="Book-With-Code Test Org")
+
+
+@pytest.fixture
+def other_organization():
+    return baker.make(Organization, name="Other Org")
+
+
+@pytest.fixture
+def calendar(organization):
+    """A calendar that accepts public scheduling and manages its own availability windows."""
+    return baker.make(
+        Calendar,
+        organization=organization,
+        name="Test Calendar",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=True,
+    )
+
+
+@pytest.fixture
+def calendar_group(organization):
+    return baker.make(CalendarGroup, organization=organization, name="Test Group")
+
+
+@pytest.fixture
+def available_window(organization, calendar):
+    """A future availability window that covers the test booking slot."""
+    return baker.make(
+        AvailableTime,
+        organization=organization,
+        calendar=calendar,
+        # Start at 09:00 UTC, end at 17:00 UTC -- covers the test slot (10:00-11:00).
+        start_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0),
+        end_time_tz_unaware=datetime.datetime(2030, 6, 1, 17, 0),
+        timezone="UTC",
+    )
+
+
+@pytest.fixture
+def permission_service():
+    return CalendarPermissionService()
+
+
+@pytest.fixture
+def booking_code(permission_service, organization, calendar):
+    """A valid single-use CREATE code scoped to `calendar`."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_id=calendar.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def reschedule_code(permission_service, organization, calendar):
+    """A RESCHEDULE-only code (no CREATE) — wrong permission for booking."""
+    event = baker.make(
+        CalendarEvent,
+        organization=organization,
+        calendar=calendar,
+        title="Existing Event",
+        timezone="UTC",
+        start_time_tz_unaware=datetime.datetime(2030, 6, 1, 10, 0),
+        end_time_tz_unaware=datetime.datetime(2030, 6, 1, 11, 0),
+        external_id="existing-event-external-id",
+    )
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_id=calendar.id,
+        event_id=event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def group_booking_code(permission_service, organization, calendar_group):
+    """A CREATE code scoped to a calendar GROUP (wrong scope for single-calendar mutation)."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=calendar_group.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def anon_client():
+    """APIClient with no Authorization header."""
+    return APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BOOKING_START = datetime.datetime(2030, 6, 1, 10, 0, tzinfo=datetime.UTC)
+BOOKING_END = datetime.datetime(2030, 6, 1, 11, 0, tzinfo=datetime.UTC)
+
+
+def _booking_input(code: str, **overrides) -> dict:
+    """Build the default happy-path mutation input dict."""
+    base = {
+        "code": code,
+        "title": "My Appointment",
+        "description": "A test booking",
+        "startTime": BOOKING_START.isoformat(),
+        "endTime": BOOKING_END.isoformat(),
+        "timezone": "UTC",
+        "externalAttendee": {
+            "email": "patient@example.com",
+            "name": "Pat Patient",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def post_graphql(client: APIClient, query: str, variables: dict) -> dict:
+    response = client.post(
+        "/graphql/",
+        data={"query": query, "variables": variables},
+        format="json",
+    )
+    assert response.status_code == 200, response.content.decode()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodeHappyPath:
+    """Scenario 1: Valid booking code + available slot → event created, code consumed."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_happy_path_creates_event_and_consumes_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        booking_code,
+        organization,
+        calendar,
+        available_window,  # noqa: ARG002 — seeds DB rows consumed by create_event
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = booking_code
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True
+        assert result["errorCode"] is None
+        assert result["event"] is not None
+        assert result["event"]["title"] == "My Appointment"
+
+        # Code must be consumed.
+        token.refresh_from_db()
+        assert token.used_at is not None
+        assert token.consumed_source_ip is not None
+
+        # The event must exist in the DB, on the right calendar/org.
+        event_id = int(result["event"]["id"])
+        event = CalendarEvent.objects.filter_by_organization(organization.id).get(id=event_id)
+        assert event.calendar_fk_id == calendar.id
+        assert event.organization_id == organization.id
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_event_has_external_attendee(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        booking_code,
+        organization,
+        calendar,
+        available_window,  # noqa: ARG002
+    ):
+        """The created event carries the external attendee supplied in the input."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = booking_code
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True
+        event_id = int(result["event"]["id"])
+        event = CalendarEvent.objects.filter_by_organization(organization.id).get(id=event_id)
+        external_attendances = list(event.external_attendances.select_related("external_attendee"))
+        assert len(external_attendances) == 1
+        assert external_attendances[0].external_attendee.email == "patient@example.com"
+        assert external_attendances[0].external_attendee.name == "Pat Patient"
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodeReplay:
+    """Scenario 2: Replay with same code → ALREADY_USED, no second event."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_replay_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        booking_code,
+        organization,
+        available_window,  # noqa: ARG002
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = booking_code
+        input_data = _booking_input(code)
+
+        # First call — must succeed.
+        first = post_graphql(anon_client, CREATE_EVENT_WITH_CODE, {"input": input_data})
+        assert first["data"]["createCalendarEventWithCode"]["success"] is True
+
+        # Second call — same code must return ALREADY_USED.
+        second = post_graphql(anon_client, CREATE_EVENT_WITH_CODE, {"input": input_data})
+        result = second["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"
+
+        # Only one event should have been created.
+        event_count = CalendarEvent.objects.filter_by_organization(organization.id).count()
+        assert event_count == 1
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodeFailedWriteDoesNotConsume:
+    """Scenario 3: Failed write (SLOT_UNAVAILABLE) leaves the code active for retry."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_slot_unavailable_does_not_consume_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        booking_code,
+        organization,
+        available_window,  # noqa: ARG002
+    ):
+        """When create_event raises NoAvailableTimeWindowsError the code is NOT consumed."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        token, code = booking_code
+
+        mock_calendar_service = Mock()
+        mock_calendar_service.initialize_without_provider.return_value = None
+        mock_calendar_service.create_event.side_effect = NoAvailableTimeWindowsError()
+
+        with container.calendar_service.override(mock_calendar_service):
+            data = post_graphql(
+                anon_client,
+                CREATE_EVENT_WITH_CODE,
+                {"input": _booking_input(code)},
+            )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+
+        # The code must still be unused so a subsequent call can succeed.
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_after_failed_write_code_can_still_be_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        booking_code,
+        organization,
+        available_window,  # noqa: ARG002
+    ):
+        """After a SLOT_UNAVAILABLE failure, the same code succeeds on a valid slot."""
+        from di_core.containers import container
+
+        mock_rate_limiter.return_value = iter([None])
+        token, code = booking_code
+
+        # First call — simulated failure.
+        mock_fail_service = Mock()
+        mock_fail_service.initialize_without_provider.return_value = None
+        mock_fail_service.create_event.side_effect = NoAvailableTimeWindowsError()
+
+        with container.calendar_service.override(mock_fail_service):
+            fail_result = post_graphql(
+                anon_client,
+                CREATE_EVENT_WITH_CODE,
+                {"input": _booking_input(code)},
+            )
+
+        assert fail_result["data"]["createCalendarEventWithCode"]["success"] is False
+
+        token.refresh_from_db()
+        assert token.used_at is None, "Code must remain active after failed write"
+
+        # Second call — real service with availability seeded; must succeed.
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True
+        token.refresh_from_db()
+        assert token.used_at is not None
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodeWrongPermission:
+    """Scenario 4: Code without CREATE permission → NOT_PERMITTED."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_reschedule_only_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_code,
+        organization,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+        # No event should have been created.
+        assert CalendarEvent.objects.filter_by_organization(organization.id).count() == 1
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodeWrongScope:
+    """Scenario 5: Group-scoped code on single-calendar mutation → NOT_PERMITTED."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_group_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+        organization,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+        # No event should have been created.
+        assert not CalendarEvent.objects.filter_by_organization(organization.id).exists()
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodeLifecycleRejections:
+    """Scenario 6: Expired / revoked / invalid codes are rejected with the correct error codes."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_expired_code_returns_expired(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+        _token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+            expires_at=past,
+        )
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "EXPIRED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_revoked_code_returns_revoked(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+        )
+        permission_service.revoke_token(organization_id=organization.id, token_id=token.id)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "REVOKED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_invalid_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input("aW52YWxpZGJvb2tpbmdjb2Rl")},  # "invalidbookingcode" base64
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_used_code_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar,
+    ):
+        """A code that was already marked as used before this call → ALREADY_USED."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_id=calendar.id,
+        )
+        CalendarManagementToken.objects.filter(id=token.id).update(
+            used_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        )
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodeCrossOrg:
+    """Scenario 7: Event is created in the code's org."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_event_created_in_code_org(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        booking_code,
+        organization,
+        available_window,  # noqa: ARG002
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = booking_code
+
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": _booking_input(code)},
+        )
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True
+
+        event_id = int(result["event"]["id"])
+        event = CalendarEvent.objects.filter_by_organization(organization.id).get(id=event_id)
+        assert event.organization_id == token.organization_id

--- a/public_api/tests/test_book_with_code.py
+++ b/public_api/tests/test_book_with_code.py
@@ -14,14 +14,13 @@ Scenario coverage:
 """
 
 import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from model_bakery import baker
 from rest_framework.test import APIClient
 
 from calendar_integration.constants import CalendarProvider, CalendarType
-from calendar_integration.exceptions import NoAvailableTimeWindowsError
 from calendar_integration.models import (
     AvailableTime,
     Calendar,
@@ -76,7 +75,11 @@ def other_organization():
 
 @pytest.fixture
 def calendar(organization):
-    """A calendar that accepts public scheduling and manages its own availability windows."""
+    """A RESTRICTED calendar (accepts_public_scheduling=False) with managed availability windows.
+
+    Tests must seed AvailableTime rows to make a slot bookable; the code-as-token provides
+    the CREATE permission so that can_perform_scheduling returns True via the token path.
+    """
     return baker.make(
         Calendar,
         organization=organization,
@@ -84,7 +87,7 @@ def calendar(organization):
         provider=CalendarProvider.INTERNAL,
         calendar_type=CalendarType.PERSONAL,
         manage_available_windows=True,
-        accepts_public_scheduling=True,
+        accepts_public_scheduling=False,
     )
 
 
@@ -308,7 +311,12 @@ class TestCreateCalendarEventWithCodeReplay:
 
 @pytest.mark.django_db
 class TestCreateCalendarEventWithCodeFailedWriteDoesNotConsume:
-    """Scenario 3: Failed write (SLOT_UNAVAILABLE) leaves the code active for retry."""
+    """Scenario 3: Failed write (SLOT_UNAVAILABLE) leaves the code active for retry.
+
+    Uses the REAL calendar service against a RESTRICTED calendar with an AvailableTime
+    window.  The out-of-window request triggers a genuine NoAvailableTimeWindowsError
+    without any mocking, then a follow-up in-window request succeeds.
+    """
 
     @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
     def test_slot_unavailable_does_not_consume_code(
@@ -317,32 +325,37 @@ class TestCreateCalendarEventWithCodeFailedWriteDoesNotConsume:
         anon_client,
         booking_code,
         organization,
-        available_window,  # noqa: ARG002
+        available_window,  # noqa: ARG002 - seeds DB rows; window is 09:00-17:00 UTC
+        calendar,
     ):
-        """When create_event raises NoAvailableTimeWindowsError the code is NOT consumed."""
-        from di_core.containers import container
-
+        """Booking a slot OUTSIDE the availability window returns SLOT_UNAVAILABLE; code stays active."""
         mock_rate_limiter.return_value = iter([None])
         token, code = booking_code
 
-        mock_calendar_service = Mock()
-        mock_calendar_service.initialize_without_provider.return_value = None
-        mock_calendar_service.create_event.side_effect = NoAvailableTimeWindowsError()
+        # Request a slot at 22:00-23:00 UTC - outside the 09:00-17:00 window.
+        out_of_window_input = _booking_input(
+            code,
+            startTime=datetime.datetime(2030, 6, 1, 22, 0, tzinfo=datetime.UTC).isoformat(),
+            endTime=datetime.datetime(2030, 6, 1, 23, 0, tzinfo=datetime.UTC).isoformat(),
+        )
 
-        with container.calendar_service.override(mock_calendar_service):
-            data = post_graphql(
-                anon_client,
-                CREATE_EVENT_WITH_CODE,
-                {"input": _booking_input(code)},
-            )
+        data = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": out_of_window_input},
+        )
 
         result = data["data"]["createCalendarEventWithCode"]
         assert result["success"] is False
         assert result["errorCode"] == "SLOT_UNAVAILABLE"
+        assert result["errorMessage"] == "The requested time slot is not available."
 
         # The code must still be unused so a subsequent call can succeed.
         token.refresh_from_db()
         assert token.used_at is None
+
+        # No event must have been created.
+        assert not CalendarEvent.objects.filter_by_organization(organization.id).exists()
 
     @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
     def test_after_failed_write_code_can_still_be_used(
@@ -351,32 +364,31 @@ class TestCreateCalendarEventWithCodeFailedWriteDoesNotConsume:
         anon_client,
         booking_code,
         organization,
-        available_window,  # noqa: ARG002
+        available_window,  # noqa: ARG002 - window is 09:00-17:00 UTC
+        calendar,
     ):
-        """After a SLOT_UNAVAILABLE failure, the same code succeeds on a valid slot."""
-        from di_core.containers import container
-
+        """After a SLOT_UNAVAILABLE failure on restricted calendar, the same code succeeds on a valid slot."""
         mock_rate_limiter.return_value = iter([None])
         token, code = booking_code
 
-        # First call — simulated failure.
-        mock_fail_service = Mock()
-        mock_fail_service.initialize_without_provider.return_value = None
-        mock_fail_service.create_event.side_effect = NoAvailableTimeWindowsError()
-
-        with container.calendar_service.override(mock_fail_service):
-            fail_result = post_graphql(
-                anon_client,
-                CREATE_EVENT_WITH_CODE,
-                {"input": _booking_input(code)},
-            )
-
+        # First call - slot outside the availability window: SLOT_UNAVAILABLE.
+        out_of_window_input = _booking_input(
+            code,
+            startTime=datetime.datetime(2030, 6, 1, 22, 0, tzinfo=datetime.UTC).isoformat(),
+            endTime=datetime.datetime(2030, 6, 1, 23, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+        fail_result = post_graphql(
+            anon_client,
+            CREATE_EVENT_WITH_CODE,
+            {"input": out_of_window_input},
+        )
         assert fail_result["data"]["createCalendarEventWithCode"]["success"] is False
+        assert fail_result["data"]["createCalendarEventWithCode"]["errorCode"] == "SLOT_UNAVAILABLE"
 
         token.refresh_from_db()
         assert token.used_at is None, "Code must remain active after failed write"
 
-        # Second call — real service with availability seeded; must succeed.
+        # Second call - in-window slot (10:00-11:00 UTC); must succeed.
         data = post_graphql(
             anon_client,
             CREATE_EVENT_WITH_CODE,
@@ -384,9 +396,10 @@ class TestCreateCalendarEventWithCodeFailedWriteDoesNotConsume:
         )
 
         result = data["data"]["createCalendarEventWithCode"]
-        assert result["success"] is True
+        assert result["success"] is True, result
         token.refresh_from_db()
         assert token.used_at is not None
+        assert CalendarEvent.objects.filter_by_organization(organization.id).count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION

## Summary

First unauthenticated **write**: `createCalendarEventWithCode` (no `permission_classes`; authorized
solely by the code). Flow: `resolve_code(code)` (org-from-code + lifecycle) → require `CREATE`
permission + calendar scope → `transaction.atomic { initialize_without_provider(user_or_token=code)
→ create_event(token.calendar.id, …) → consume_code }`.

- **Single-use, first-write-wins**: consume runs AFTER create, inside the same transaction, under a
  `SELECT FOR UPDATE` re-check — a losing concurrent request raises and the whole txn (including the
  just-created event) rolls back. Exactly one event, consumed once.
- **Failed write does not consume**: a slot outside availability → `SLOT_UNAVAILABLE`, txn rolls back,
  `used_at` stays NULL, the patient can retry with the same code.
- **Error mapping**: resolve_code → INVALID_CODE / EXPIRED / ALREADY_USED / REVOKED; missing CREATE or
  group-scoped code → NOT_PERMITTED; `PermissionDenied` → NOT_PERMITTED; slot/validation →
  SLOT_UNAVAILABLE (static message, no internal detail leaked).
- Audit: `consumed_source_ip` from `X-Forwarded-For`/`REMOTE_ADDR`.

## Restricted-calendar fix (review BLOCKER, resolved)

The first implementation passed `user_or_token=None`, so the event service's internal
`can_perform_scheduling` rejected bookings on **restricted** (`accepts_public_scheduling=False`)
calendars — the entire point of the feature — and the tests hid it by making the calendar publicly
schedulable. Fixed by threading the code as `user_or_token`, so `initialize_without_provider` calls
`initialize_with_token(code)` on the event service's own permission instance; `can_perform_scheduling`
then authorizes via the `calendar_fk_id == calendar_id` + CREATE branch on a restricted calendar.
Tests rewritten to use a restricted calendar with seeded availability + a real (non-mocked)
slot-unavailable test.

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 5a.
- Spec: Decisions → Use-cases, Use-case 2 (patient books — single-calendar). Acceptance: replay → ALREADY_USED; failed write not consumed.

## Test plan

In-container (docker postgres): `public_api/tests/test_book_with_code.py` (12 tests) on a RESTRICTED
calendar — happy path (event created + code consumed via the code's authorization, not public
scheduling), replay → ALREADY_USED (no 2nd event), real slot-unavailable → SLOT_UNAVAILABLE + code
survives + retry succeeds, missing-CREATE → NOT_PERMITTED, group-scoped code → NOT_PERMITTED,
expired/revoked/invalid, cross-org (event in code's org). `ruff` clean · `makemigrations --check` no
changes · `check --deploy` clean · `pytest -n auto` **2114 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-4`.