### PR TITLE
feat(calendar): book a calendar-group event with a code (Phase 5b)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -79,11 +79,19 @@
 - **BLOCKER caught + fixed**: original impl passed `user_or_token=None`, so `can_perform_scheduling` rejected bookings on RESTRICTED calendars (the core use case) — masked by tests using accepts_public_scheduling=True. Fix: thread the code as `user_or_token` so the event service's permission instance gets the token → CREATE-permission branch authorizes on restricted calendars. Tests rewritten to use a restricted calendar with seeded availability + a real (non-mocked) slot-unavailable test.
 - **PR**: pending (filled after push).
 
+### Phase 5b — Book calendar-group event with code ✅
+- **Status**: complete, reviewed (Layers 1–3 + fix loop; no BLOCKERs).
+- **Model/tier**: implementer / Sonnet (Tier 3).
+- **Branch**: plan/single-use-scheduling-codes/phase-5b (base: phase-5a).
+- **Commits**: 5a910c4 (book-group-with-code + can_perform_scheduling group branch) + 3224907 (cross-org coverage + IP helper).
+- **Outer gate**: `pytest -n auto` 2133 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: unauthenticated `createCalendarGroupEventWithCode`. Required extending `can_perform_scheduling` with a GROUP-scoped branch (token group-scoped + CREATE + calendar is a member of the group's slots, org-scoped via CalendarGroupSlotMembership) — because `create_grouped_event` books on the primary calendar and a group code has calendar_fk_id=None. Mutation: resolve_code → require CREATE + group scope → atomic { calendar_service.initialize_without_provider(user_or_token=code) → wire group_service.calendar_service=calendar_service → group_service.initialize → create_grouped_event → consume_code }. Real restricted-primary-calendar tests + real cross-org isolation (org-A code can't book org-B calendar → SLOT_UNAVAILABLE, not consumed). Shared `_client_ip_from_request` helper. 17+ tests.
+- **PR**: pending (filled after push).
+
 ## Current phase
-Phase 5b — Book calendar-group event with code (next).
+Phase 6a — Reschedule single-calendar event with code (next).
 
 ## Remaining phases
-- Phase 5b — Book calendar-group event with code
 - Phase 6a — Reschedule single-calendar event with code
 - Phase 6b — Reschedule calendar-group event with code
 - Phase 6c — Cancel event with code

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -403,6 +403,19 @@ def _load_organization(organization_id: int) -> Organization | None:
         return None
 
 
+def _client_ip_from_request(request: object) -> str:
+    """Extract the client IP address from a Django request for audit logging.
+
+    Prefers the first entry of ``X-Forwarded-For`` (set by load balancers /
+    proxies); falls back to ``REMOTE_ADDR``.  Robust to a missing ``META``
+    attribute (returns ``""`` rather than raising).
+    """
+    forwarded_for = getattr(request, "META", {}).get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return getattr(request, "META", {}).get("REMOTE_ADDR", "")
+
+
 # ---------------------------------------------------------------------------
 # Booking-code mint mutations (Phase 1)
 # ---------------------------------------------------------------------------
@@ -1131,12 +1144,7 @@ class CalendarGroupMutations:
             )
 
         # --- Step 5: extract client IP for audit ---
-        request = info.context.request
-        forwarded_for = getattr(request, "META", {}).get("HTTP_X_FORWARDED_FOR", "")
-        if forwarded_for:
-            source_ip = forwarded_for.split(",")[0].strip()
-        else:
-            source_ip = getattr(request, "META", {}).get("REMOTE_ADDR", "")
+        source_ip = _client_ip_from_request(info.context.request)
 
         # --- Step 6: build event data ---
         event_data = CalendarEventInputData(
@@ -1275,12 +1283,7 @@ class CalendarGroupMutations:
             )
 
         # --- Step 5: extract client IP for audit ---
-        request = info.context.request
-        forwarded_for = getattr(request, "META", {}).get("HTTP_X_FORWARDED_FOR", "")
-        if forwarded_for:
-            source_ip = forwarded_for.split(",")[0].strip()
-        else:
-            source_ip = getattr(request, "META", {}).get("REMOTE_ADDR", "")
+        source_ip = _client_ip_from_request(info.context.request)
 
         # --- Step 6: build group event data ---
         # group_id comes from the token — not from client input — to enforce scope.
@@ -1347,9 +1350,11 @@ class CalendarGroupMutations:
                 error_code=BookingCodeErrorCode.NOT_PERMITTED,
                 error_message="This code does not permit booking on this calendar.",
             )
-        except (NoAvailableTimeWindowsError, EventManagementError, CalendarGroupError):
+        except (EventManagementError, CalendarGroupError):
             # Slot taken / invalid selection / invalid times — code NOT consumed (txn rolled
             # back), patient may retry with a different slot.
+            # Note: NoAvailableTimeWindowsError is a subclass of EventManagementError and
+            # is therefore already covered by the EventManagementError branch.
             return CodeEventResult(
                 success=False,
                 error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -432,6 +432,45 @@ def get_booking_code_mutation_dependencies(
     )
 
 
+@dataclass
+class GroupBookingCodeMutationDependencies:
+    """Dependencies for the unauthenticated group-booking-code mutations."""
+
+    calendar_permission_service: "CalendarPermissionService"
+    calendar_service: "CalendarService"
+    calendar_group_service: "CalendarGroupService"
+
+
+@inject
+def get_group_booking_code_mutation_dependencies(
+    calendar_permission_service: Annotated[
+        "CalendarPermissionService | None", Provide["calendar_permission_service"]
+    ] = None,
+    calendar_service: Annotated["CalendarService | None", Provide["calendar_service"]] = None,
+    calendar_group_service: Annotated[
+        "CalendarGroupService | None", Provide["calendar_group_service"]
+    ] = None,
+) -> GroupBookingCodeMutationDependencies:
+    """Get group-booking-code mutation dependencies from DI container.
+
+    The DI container wires ``calendar_group_service.calendar_service`` to the
+    same ``CalendarService`` factory instance that is returned as
+    ``calendar_service`` here, so initialising ``calendar_service`` with a
+    booking code automatically propagates to ``calendar_group_service``.
+    """
+    if (
+        calendar_permission_service is None
+        or calendar_service is None
+        or calendar_group_service is None
+    ):
+        raise GraphQLError("Internal server error.")
+    return GroupBookingCodeMutationDependencies(
+        calendar_permission_service=cast("CalendarPermissionService", calendar_permission_service),
+        calendar_service=cast("CalendarService", calendar_service),
+        calendar_group_service=cast("CalendarGroupService", calendar_group_service),
+    )
+
+
 @strawberry.input
 class CreateBookingCodeInput:
     """Input for minting a single-use calendar booking code."""
@@ -492,6 +531,14 @@ class ExternalAttendeeCodeInput:
 
 
 @strawberry.input
+class CodeSlotSelectionInput:
+    """Per-slot calendar selection for the unauthenticated group-booking mutation."""
+
+    slot_id: int
+    calendar_ids: list[int]
+
+
+@strawberry.input
 class CreateEventWithCodeInput:
     """Input for the unauthenticated createCalendarEventWithCode mutation."""
 
@@ -500,6 +547,20 @@ class CreateEventWithCodeInput:
     start_time: datetime.datetime
     end_time: datetime.datetime
     timezone: str
+    external_attendee: ExternalAttendeeCodeInput
+    description: str = ""
+
+
+@strawberry.input
+class CreateGroupEventWithCodeInput:
+    """Input for the unauthenticated createCalendarGroupEventWithCode mutation."""
+
+    code: str
+    title: str
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+    slot_selections: list[CodeSlotSelectionInput]
     external_attendee: ExternalAttendeeCodeInput
     description: str = ""
 
@@ -1128,6 +1189,167 @@ class CalendarGroupMutations:
             )
         except (NoAvailableTimeWindowsError, EventManagementError):
             # Slot taken / invalid times — code NOT consumed (txn rolled back), patient may retry.
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
+                error_message="The requested time slot is not available.",
+            )
+
+        return CodeEventResult(success=True, event=event)  # type: ignore[arg-type]
+
+    @strawberry.mutation
+    def create_calendar_group_event_with_code(
+        self,
+        info: strawberry.Info,
+        input: CreateGroupEventWithCodeInput,  # noqa: A002
+    ) -> CodeEventResult:
+        """Book a grouped calendar event using a single-use group booking code.
+
+        This is an unauthenticated mutation: no org token is required.  The org
+        context, permissions, and group scope are all derived from the booking
+        code.  On success the code is atomically consumed so it cannot be
+        replayed.  On a failed create (slot unavailable, invalid selection, etc.)
+        the code is NOT consumed and the patient may retry.
+
+        The group_id is taken STRICTLY from the token — the client cannot
+        override it via the input.
+        """
+        deps = get_group_booking_code_mutation_dependencies()
+
+        # --- Step 1: resolve and validate the code ---
+        try:
+            token = deps.calendar_permission_service.resolve_code(input.code)
+        except InvalidTokenError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+        except TokenExpiredError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.EXPIRED,
+                error_message="This booking code has expired.",
+            )
+        except TokenAlreadyUsedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.ALREADY_USED,
+                error_message="This booking code has already been used.",
+            )
+        except TokenRevokedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.REVOKED,
+                error_message="This booking code has been revoked.",
+            )
+
+        # --- Step 2: check permission ---
+        token_permissions = {p.permission for p in token.permissions.all()}
+        if EventManagementPermissions.CREATE not in token_permissions:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit booking.",
+            )
+
+        # --- Step 3: scope check — must be group-scoped (not single-calendar) ---
+        if token.calendar_group is None:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message=(
+                    "This code is not scoped to a calendar group. "
+                    "Use createCalendarEventWithCode for single-calendar codes."
+                ),
+            )
+
+        # --- Step 4: resolve org ---
+        try:
+            org = Organization.objects.get(id=token.organization_id)
+        except Organization.DoesNotExist:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+
+        # --- Step 5: extract client IP for audit ---
+        request = info.context.request
+        forwarded_for = getattr(request, "META", {}).get("HTTP_X_FORWARDED_FOR", "")
+        if forwarded_for:
+            source_ip = forwarded_for.split(",")[0].strip()
+        else:
+            source_ip = getattr(request, "META", {}).get("REMOTE_ADDR", "")
+
+        # --- Step 6: build group event data ---
+        # group_id comes from the token — not from client input — to enforce scope.
+        group_event_data = CalendarGroupEventInputData(
+            group_id=token.calendar_group.id,
+            title=input.title,
+            description=input.description or "",
+            start_time=input.start_time,
+            end_time=input.end_time,
+            timezone=input.timezone,
+            slot_selections=[
+                CalendarGroupSlotSelectionInputData(
+                    slot_id=s.slot_id,
+                    calendar_ids=list(s.calendar_ids),
+                )
+                for s in input.slot_selections
+            ],
+            external_attendances=[
+                EventExternalAttendanceInputData(
+                    external_attendee=ExternalAttendeeInputData(
+                        email=input.external_attendee.email,
+                        name=input.external_attendee.name or "",
+                    )
+                )
+            ],
+        )
+
+        # --- Step 7: atomic create + consume ---
+        # ``deps.calendar_service`` is the authoritative, code-initialized instance.
+        # Explicitly wire it into ``deps.calendar_group_service`` so that the event
+        # is created on the same CalendarService instance that carries the booking
+        # code's token — this is necessary because the DI container's Factory
+        # provider gives CalendarGroupService its OWN CalendarService instance via its
+        # @inject __init__.  Without this explicit wiring the primary-calendar create
+        # would use an uninitialized instance and the permission / availability checks
+        # would fail.
+        try:
+            with transaction.atomic():
+                deps.calendar_service.initialize_without_provider(
+                    user_or_token=input.code, organization=org
+                )
+                deps.calendar_group_service.calendar_service = deps.calendar_service
+                deps.calendar_group_service.initialize(organization=org)
+                event = deps.calendar_group_service.create_grouped_event(group_event_data)
+                deps.calendar_permission_service.consume_code(token, source_ip)
+        except (TokenAlreadyUsedError, TokenExpiredError, TokenRevokedError) as e:
+            # Concurrent consumer won the race, or state changed between resolve and consume.
+            error_code = BookingCodeErrorCode.ALREADY_USED
+            error_message = "This booking code has already been used."
+            if isinstance(e, TokenExpiredError):
+                error_code = BookingCodeErrorCode.EXPIRED
+                error_message = "This booking code has expired."
+            elif isinstance(e, TokenRevokedError):
+                error_code = BookingCodeErrorCode.REVOKED
+                error_message = "This booking code has been revoked."
+            return CodeEventResult(
+                success=False,
+                error_code=error_code,
+                error_message=error_message,
+            )
+        except PermissionDenied:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit booking on this calendar.",
+            )
+        except (NoAvailableTimeWindowsError, EventManagementError, CalendarGroupError):
+            # Slot taken / invalid selection / invalid times — code NOT consumed (txn rolled
+            # back), patient may retry with a different slot.
             return CodeEventResult(
                 success=False,
                 error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,

--- a/calendar_integration/services/calendar_permission_service.py
+++ b/calendar_integration/services/calendar_permission_service.py
@@ -17,6 +17,7 @@ from calendar_integration.exceptions import (
 )
 from calendar_integration.models import (
     CalendarGroup,
+    CalendarGroupSlotMembership,
     CalendarManagementToken,
     CalendarOwnership,
     EventManagementPermissions,
@@ -338,8 +339,17 @@ class CalendarPermissionService:
         calendar_settings: CalendarSettingsData,
         event: CalendarEventInputData,
     ) -> bool:
-        """
-        Check if the token has all the required permissions to perform the scheduling.
+        """Check if the token has all the required permissions to perform the scheduling.
+
+        Authorization is granted when any of the following holds:
+
+        1. The calendar accepts public scheduling (``accepts_public_scheduling=True``).
+        2. The token is calendar-scoped (``calendar_fk_id == calendar_id``) and has
+           the CREATE permission.
+        3. The token is group-scoped (``calendar_group_fk_id`` is set), has the CREATE
+           permission, **and** ``calendar_id`` is a member of one of that group's slots.
+           This case covers group-booking codes: the code is minted with a group scope,
+           and the create call targets the primary calendar of the group.
         """
         if calendar_settings.accepts_public_scheduling:
             return True
@@ -349,6 +359,21 @@ class CalendarPermissionService:
 
         if self.token.calendar_fk_id == calendar_id:  # type: ignore
             return self.has_permission(EventManagementPermissions.CREATE)
+
+        # Group-scoped token: authorize if calendar_id belongs to any slot of the bound group.
+        if self.token.calendar_group_fk_id is not None and self.has_permission(
+            EventManagementPermissions.CREATE
+        ):
+            return (
+                CalendarGroupSlotMembership.objects.filter_by_organization(
+                    self.token.organization_id
+                )
+                .filter(
+                    slot__group_fk_id=self.token.calendar_group_fk_id,
+                    calendar_fk_id=calendar_id,
+                )
+                .exists()
+            )
 
         return False
 

--- a/calendar_integration/tests/test_calendar_permission_service_codes.py
+++ b/calendar_integration/tests/test_calendar_permission_service_codes.py
@@ -27,10 +27,13 @@ from calendar_integration.models import (
     Calendar,
     CalendarEvent,
     CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
     CalendarManagementToken,
     CalendarManagementTokenPermission,
 )
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.dataclasses import CalendarEventInputData, CalendarSettingsData
 from organizations.models import Organization
 from public_api.models import SystemUser
 
@@ -321,3 +324,157 @@ def test_validate_code_future_expiry_is_valid(service, org, calendar):
 
     result = service.validate_code(code, org.id)
     assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# can_perform_scheduling() — group-scoped token branch (Phase 5b)
+# ---------------------------------------------------------------------------
+
+
+def _restricted_settings() -> CalendarSettingsData:
+    """A calendar settings fixture where public scheduling is disabled."""
+    return CalendarSettingsData(manage_available_windows=True, accepts_public_scheduling=False)
+
+
+def _public_settings() -> CalendarSettingsData:
+    """A calendar settings fixture where public scheduling is enabled."""
+    return CalendarSettingsData(manage_available_windows=False, accepts_public_scheduling=True)
+
+
+def _dummy_event_data(org: Organization, cal: Calendar) -> CalendarEventInputData:
+    """Minimal CalendarEventInputData for use in can_perform_scheduling calls."""
+    now = timezone.now()
+    return CalendarEventInputData(
+        title="Test",
+        description="",
+        start_time=now,
+        end_time=now + datetime.timedelta(hours=1),
+        timezone="UTC",
+    )
+
+
+@pytest.fixture
+def group_with_member_calendar(org, calendar):
+    """A CalendarGroup with one slot containing `calendar`."""
+    grp = CalendarGroup.objects.create(organization=org, name="Test Group")
+    slot = CalendarGroupSlot.objects.create(
+        organization=org,
+        group=grp,
+        name="Physicians",
+        order=0,
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=org,
+        slot=slot,
+        calendar=calendar,
+    )
+    return grp
+
+
+@pytest.fixture
+def non_member_calendar(org):
+    """A calendar that does NOT belong to any group slot."""
+    return Calendar.objects.create(
+        name="Non-Member Calendar",
+        organization=org,
+        external_id="non-member-cal",
+    )
+
+
+@pytest.mark.django_db
+def test_can_perform_scheduling_group_token_member_calendar_with_create_returns_true(
+    service, org, calendar, group_with_member_calendar
+):
+    """Group-scoped token + CREATE + member calendar → True.
+
+    This is the fix verified by Phase 5b's happy-path test.  Before the fix,
+    this would have returned False for a restricted calendar.
+    """
+    token, _ = service.create_booking_token(
+        organization_id=org.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=group_with_member_calendar.id,
+    )
+    # Simulate what initialize_with_token does: set the token on the service.
+    service.token = token
+
+    result = service.can_perform_scheduling(
+        calendar_id=calendar.id,
+        calendar_settings=_restricted_settings(),
+        event=_dummy_event_data(org, calendar),
+    )
+    assert result is True
+
+
+@pytest.mark.django_db
+def test_can_perform_scheduling_group_token_non_member_calendar_returns_false(
+    service, org, non_member_calendar, group_with_member_calendar
+):
+    """Group-scoped token + CREATE + calendar NOT in the group → False."""
+    token, _ = service.create_booking_token(
+        organization_id=org.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=group_with_member_calendar.id,
+    )
+    service.token = token
+
+    result = service.can_perform_scheduling(
+        calendar_id=non_member_calendar.id,
+        calendar_settings=_restricted_settings(),
+        event=_dummy_event_data(org, non_member_calendar),
+    )
+    assert result is False
+
+
+@pytest.mark.django_db
+def test_can_perform_scheduling_group_token_without_create_returns_false(
+    service, org, calendar, group_with_member_calendar
+):
+    """Group-scoped token without CREATE permission → False even for a member calendar."""
+    token, _ = service.create_booking_token(
+        organization_id=org.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_group_id=group_with_member_calendar.id,
+    )
+    service.token = token
+
+    result = service.can_perform_scheduling(
+        calendar_id=calendar.id,
+        calendar_settings=_restricted_settings(),
+        event=_dummy_event_data(org, calendar),
+    )
+    assert result is False
+
+
+@pytest.mark.django_db
+def test_can_perform_scheduling_public_calendar_always_returns_true(
+    service, org, calendar, group_with_member_calendar
+):
+    """accepts_public_scheduling=True bypasses token check (existing behaviour)."""
+    # No token set.
+    result = service.can_perform_scheduling(
+        calendar_id=calendar.id,
+        calendar_settings=_public_settings(),
+        event=_dummy_event_data(org, calendar),
+    )
+    assert result is True
+
+
+@pytest.mark.django_db
+def test_can_perform_scheduling_calendar_scoped_token_own_calendar_returns_true(
+    service, org, calendar
+):
+    """Calendar-scoped token for the exact calendar + CREATE → True (existing behaviour)."""
+    token, _ = service.create_booking_token(
+        organization_id=org.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_id=calendar.id,
+    )
+    service.token = token
+
+    result = service.can_perform_scheduling(
+        calendar_id=calendar.id,
+        calendar_settings=_restricted_settings(),
+        event=_dummy_event_data(org, calendar),
+    )
+    assert result is True

--- a/calendar_integration/tests/test_calendar_permission_service_codes.py
+++ b/calendar_integration/tests/test_calendar_permission_service_codes.py
@@ -1,10 +1,12 @@
-"""Unit tests for CalendarPermissionService booking-code methods (Phase 0).
+"""Unit tests for CalendarPermissionService booking-code methods (Phase 0 and Phase 5b).
 
 Covers:
 - create_booking_token() persists scope, permissions, expiry, and minter.
 - validate_code() returns the token on a valid active code.
 - validate_code() raises the right exception for each terminal state
   (expired / used / revoked / unknown).
+- can_perform_scheduling() group-scoped token branch, including the cross-org
+  isolation case introduced in Phase 5b.
 """
 
 import base64
@@ -341,7 +343,7 @@ def _public_settings() -> CalendarSettingsData:
     return CalendarSettingsData(manage_available_windows=False, accepts_public_scheduling=True)
 
 
-def _dummy_event_data(org: Organization, cal: Calendar) -> CalendarEventInputData:
+def _dummy_event_data() -> CalendarEventInputData:
     """Minimal CalendarEventInputData for use in can_perform_scheduling calls."""
     now = timezone.now()
     return CalendarEventInputData(
@@ -401,7 +403,7 @@ def test_can_perform_scheduling_group_token_member_calendar_with_create_returns_
     result = service.can_perform_scheduling(
         calendar_id=calendar.id,
         calendar_settings=_restricted_settings(),
-        event=_dummy_event_data(org, calendar),
+        event=_dummy_event_data(),
     )
     assert result is True
 
@@ -421,7 +423,7 @@ def test_can_perform_scheduling_group_token_non_member_calendar_returns_false(
     result = service.can_perform_scheduling(
         calendar_id=non_member_calendar.id,
         calendar_settings=_restricted_settings(),
-        event=_dummy_event_data(org, non_member_calendar),
+        event=_dummy_event_data(),
     )
     assert result is False
 
@@ -441,7 +443,7 @@ def test_can_perform_scheduling_group_token_without_create_returns_false(
     result = service.can_perform_scheduling(
         calendar_id=calendar.id,
         calendar_settings=_restricted_settings(),
-        event=_dummy_event_data(org, calendar),
+        event=_dummy_event_data(),
     )
     assert result is False
 
@@ -455,7 +457,7 @@ def test_can_perform_scheduling_public_calendar_always_returns_true(
     result = service.can_perform_scheduling(
         calendar_id=calendar.id,
         calendar_settings=_public_settings(),
-        event=_dummy_event_data(org, calendar),
+        event=_dummy_event_data(),
     )
     assert result is True
 
@@ -475,6 +477,55 @@ def test_can_perform_scheduling_calendar_scoped_token_own_calendar_returns_true(
     result = service.can_perform_scheduling(
         calendar_id=calendar.id,
         calendar_settings=_restricted_settings(),
-        event=_dummy_event_data(org, calendar),
+        event=_dummy_event_data(),
     )
     assert result is True
+
+
+@pytest.mark.django_db
+def test_can_perform_scheduling_group_token_member_calendar_in_other_org_returns_false(
+    service, org
+):
+    """Group-scoped token in org A must NOT authorize a calendar that belongs to org B.
+
+    This test proves that the ``filter_by_organization(self.token.organization_id)``
+    guard inside ``can_perform_scheduling`` prevents cross-org access even when org B's
+    calendar happens to be a member of a structurally similar group.
+
+    Setup:
+    - org A has a group (grp_a) with one slot containing cal_a.
+    - org B has its own group (grp_b) with one slot containing cal_b.
+    - A CREATE token is minted in org A scoped to grp_a.
+    - can_perform_scheduling is called with org B's calendar id → must return False.
+    """
+    other_org = baker.make("organizations.Organization")
+
+    # Org A side
+    grp_a = CalendarGroup.objects.create(organization=org, name="Org-A Group")
+    slot_a = CalendarGroupSlot.objects.create(organization=org, group=grp_a, name="Slot A", order=0)
+    cal_a = Calendar.objects.create(name="Org-A Calendar", organization=org)
+    CalendarGroupSlotMembership.objects.create(organization=org, slot=slot_a, calendar=cal_a)
+
+    # Org B side — mirrors org A's structure with distinct DB rows
+    grp_b = CalendarGroup.objects.create(organization=other_org, name="Org-B Group")
+    slot_b = CalendarGroupSlot.objects.create(
+        organization=other_org, group=grp_b, name="Slot B", order=0
+    )
+    cal_b = Calendar.objects.create(name="Org-B Calendar", organization=other_org)
+    CalendarGroupSlotMembership.objects.create(organization=other_org, slot=slot_b, calendar=cal_b)
+
+    # Token minted in org A scoped to grp_a
+    token, _ = service.create_booking_token(
+        organization_id=org.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=grp_a.id,
+    )
+    service.token = token
+
+    # Attempt to authorize org B's calendar with org A's token → must be False
+    result = service.can_perform_scheduling(
+        calendar_id=cal_b.id,
+        calendar_settings=_restricted_settings(),
+        event=_dummy_event_data(),
+    )
+    assert result is False

--- a/public_api/tests/test_book_group_with_code.py
+++ b/public_api/tests/test_book_group_with_code.py
@@ -1,0 +1,715 @@
+"""Integration tests for createCalendarGroupEventWithCode (Phase 5b).
+
+All requests are unauthenticated (no Authorization header).  The booking
+code provides the org scope, group scope, and CREATE permission.
+
+Scenario coverage:
+1. Happy path on a RESTRICTED primary calendar (accepts_public_scheduling=False)
+   → event created, code consumed.  This verifies the can_perform_scheduling fix
+   that authorizes group-scoped tokens against member calendars.
+2. Replay — same code again → ALREADY_USED, no second event.
+3. Failed write (slot outside availability) → SLOT_UNAVAILABLE, code NOT consumed.
+4. Calendar-scoped code (no group) → NOT_PERMITTED.
+5. Missing CREATE permission → NOT_PERMITTED.
+6. Lifecycle rejections — expired / revoked / invalid → respective error codes.
+7. Cross-org: event is created in the code's org; other org's group is unreachable.
+"""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarManagementToken,
+    EventManagementPermissions,
+)
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# GraphQL mutation string
+# ---------------------------------------------------------------------------
+
+CREATE_GROUP_EVENT_WITH_CODE = """
+mutation CreateCalendarGroupEventWithCode($input: CreateGroupEventWithCodeInput!) {
+    createCalendarGroupEventWithCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        event {
+            id
+            title
+            externalAttendances {
+                externalAttendee {
+                    email
+                    name
+                }
+            }
+        }
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization():
+    return baker.make(Organization, name="Group-Book-With-Code Test Org")
+
+
+@pytest.fixture
+def other_organization():
+    return baker.make(Organization, name="Other Org")
+
+
+@pytest.fixture
+def primary_calendar(organization):
+    """The primary (first-slot) calendar.  RESTRICTED: accepts_public_scheduling=False.
+
+    Using a restricted calendar ensures the test exercises the new group-scoped
+    branch of can_perform_scheduling.  A public calendar would mask the fix.
+    """
+    return baker.make(
+        Calendar,
+        organization=organization,
+        name="Primary Calendar (Dr. A)",
+        external_id="primary-cal-group-code-test",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=False,  # RESTRICTED — must fail without the fix
+    )
+
+
+@pytest.fixture
+def secondary_calendar(organization):
+    """A second calendar belonging to slot 2."""
+    return baker.make(
+        Calendar,
+        organization=organization,
+        name="Room Calendar",
+        external_id="room-cal-group-code-test",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.RESOURCE,
+        manage_available_windows=True,
+        accepts_public_scheduling=False,
+    )
+
+
+@pytest.fixture
+def group(organization, primary_calendar, secondary_calendar):
+    """A CalendarGroup with two slots: slot_a (primary_calendar) and slot_b (secondary_calendar)."""
+    grp = baker.make(CalendarGroup, organization=organization, name="Test Group")
+    slot_a = CalendarGroupSlot.objects.create(
+        organization=organization,
+        group=grp,
+        name="Physicians",
+        order=0,
+        required_count=1,
+    )
+    slot_b = CalendarGroupSlot.objects.create(
+        organization=organization,
+        group=grp,
+        name="Rooms",
+        order=1,
+        required_count=1,
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization,
+        slot=slot_a,
+        calendar=primary_calendar,
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization,
+        slot=slot_b,
+        calendar=secondary_calendar,
+    )
+    return grp
+
+
+@pytest.fixture
+def availability_windows(organization, primary_calendar, secondary_calendar):
+    """Availability windows for both calendars: 09:00-17:00 UTC on 2030-06-01."""
+    windows = []
+    for cal in (primary_calendar, secondary_calendar):
+        windows.append(
+            AvailableTime.objects.create(
+                organization=organization,
+                calendar=cal,
+                start_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0),
+                end_time_tz_unaware=datetime.datetime(2030, 6, 1, 17, 0),
+                timezone="UTC",
+            )
+        )
+    return windows
+
+
+@pytest.fixture
+def permission_service():
+    return CalendarPermissionService()
+
+
+@pytest.fixture
+def group_booking_code(permission_service, organization, group):
+    """A valid single-use CREATE code scoped to the group."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=group.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def calendar_scoped_code(permission_service, organization, primary_calendar):
+    """A CREATE code scoped to a single calendar — wrong scope for group mutation."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_id=primary_calendar.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def reschedule_group_code(permission_service, organization, group):
+    """A RESCHEDULE-only group code — wrong permission for booking."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_group_id=group.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def anon_client():
+    """APIClient with no Authorization header."""
+    return APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BOOKING_START = datetime.datetime(2030, 6, 1, 10, 0, tzinfo=datetime.UTC)
+BOOKING_END = datetime.datetime(2030, 6, 1, 11, 0, tzinfo=datetime.UTC)
+
+
+def _group_booking_input(
+    code: str,
+    slot_selections: list[dict],
+    **overrides,
+) -> dict:
+    """Build the default happy-path group mutation input dict."""
+    base = {
+        "code": code,
+        "title": "Group Appointment",
+        "description": "A group booking",
+        "startTime": BOOKING_START.isoformat(),
+        "endTime": BOOKING_END.isoformat(),
+        "timezone": "UTC",
+        "slotSelections": slot_selections,
+        "externalAttendee": {
+            "email": "patient@example.com",
+            "name": "Pat Patient",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def post_graphql(client: APIClient, query: str, variables: dict) -> dict:
+    response = client.post(
+        "/graphql/",
+        data={"query": query, "variables": variables},
+        format="json",
+    )
+    assert response.status_code == 200, response.content.decode()
+    return response.json()
+
+
+def _slot_selections(
+    group: CalendarGroup, primary_calendar: Calendar, secondary_calendar: Calendar
+):
+    """Build slot selections that pick one calendar per slot."""
+    slot_a = group.slots.get(name="Physicians")
+    slot_b = group.slots.get(name="Rooms")
+    return [
+        {"slotId": slot_a.id, "calendarIds": [primary_calendar.id]},
+        {"slotId": slot_b.id, "calendarIds": [secondary_calendar.id]},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Happy path on RESTRICTED primary calendar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateGroupEventWithCodeHappyPath:
+    """Scenario 1: Valid group code + restricted primary calendar + available slot → success.
+
+    This is the critical test that validates the can_perform_scheduling fix.  With a
+    RESTRICTED primary calendar (accepts_public_scheduling=False) and a group-scoped
+    token, the fix must authorize via the group-membership branch.  Before the fix
+    this test fails with NOT_PERMITTED / PermissionDenied.
+    """
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_happy_path_creates_grouped_event_and_consumes_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+        availability_windows,  # noqa: ARG002 — seeds DB rows
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_booking_code
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+        assert result["errorCode"] is None
+        assert result["event"] is not None
+        assert result["event"]["title"] == "Group Appointment"
+
+        # Code must be consumed.
+        token.refresh_from_db()
+        assert token.used_at is not None
+        assert token.consumed_source_ip is not None
+
+        # The event must exist in the DB, on the primary calendar, linked to the group.
+        event_id = int(result["event"]["id"])
+        event = CalendarEvent.objects.filter_by_organization(organization.id).get(id=event_id)
+        assert event.calendar_fk_id == primary_calendar.id
+        assert event.calendar_group_fk_id == group.id
+        assert event.organization_id == organization.id
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_event_has_external_attendee(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+        availability_windows,  # noqa: ARG002
+    ):
+        """The created event carries the external attendee supplied in the input."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+        event_id = int(result["event"]["id"])
+        event = CalendarEvent.objects.filter_by_organization(organization.id).get(id=event_id)
+        external_attendances = list(event.external_attendances.select_related("external_attendee"))
+        assert len(external_attendances) == 1
+        assert external_attendances[0].external_attendee.email == "patient@example.com"
+        assert external_attendances[0].external_attendee.name == "Pat Patient"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateGroupEventWithCodeReplay:
+    """Scenario 2: Replay with same code → ALREADY_USED, no second event."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_replay_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+        availability_windows,  # noqa: ARG002
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_booking_code
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+        input_data = _group_booking_input(code, selections)
+
+        # First call — must succeed.
+        first = post_graphql(anon_client, CREATE_GROUP_EVENT_WITH_CODE, {"input": input_data})
+        assert first["data"]["createCalendarGroupEventWithCode"]["success"] is True
+
+        # Second call — same code must return ALREADY_USED.
+        second = post_graphql(anon_client, CREATE_GROUP_EVENT_WITH_CODE, {"input": input_data})
+        result = second["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"
+
+        # Only one event should have been created.
+        event_count = CalendarEvent.objects.filter_by_organization(organization.id).count()
+        assert event_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Failed write does not consume
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateGroupEventWithCodeFailedWriteDoesNotConsume:
+    """Scenario 3: Failed write (SLOT_UNAVAILABLE) leaves the code active for retry."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_slot_outside_availability_does_not_consume_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+        availability_windows,  # noqa: ARG002 — window is 09:00-17:00 UTC
+    ):
+        """Booking outside availability window → SLOT_UNAVAILABLE, code stays active."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_booking_code
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        # 22:00-23:00 UTC is outside the 09:00-17:00 window.
+        out_of_window_input = _group_booking_input(
+            code,
+            selections,
+            startTime=datetime.datetime(2030, 6, 1, 22, 0, tzinfo=datetime.UTC).isoformat(),
+            endTime=datetime.datetime(2030, 6, 1, 23, 0, tzinfo=datetime.UTC).isoformat(),
+        )
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": out_of_window_input},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+        assert result["errorMessage"] == "The requested time slot is not available."
+
+        # Code must still be unused.
+        token.refresh_from_db()
+        assert token.used_at is None
+
+        # No event must have been created.
+        assert not CalendarEvent.objects.filter_by_organization(organization.id).exists()
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_slot_selection_does_not_consume_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+        availability_windows,  # noqa: ARG002
+    ):
+        """An invalid slot selection (non-existent slot_id) returns SLOT_UNAVAILABLE
+        and leaves the code active."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_booking_code
+
+        # Use a bogus slot_id.
+        bad_selections = [
+            {"slotId": 999999, "calendarIds": [primary_calendar.id]},
+        ]
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, bad_selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+
+        # Code must still be unused.
+        token.refresh_from_db()
+        assert token.used_at is None
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Calendar-scoped code → NOT_PERMITTED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateGroupEventWithCodeCalendarScopedCode:
+    """Scenario 4: Calendar-scoped code (token.calendar set, no group) → NOT_PERMITTED."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_calendar_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        calendar_scoped_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_scoped_code
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+        # No event should have been created.
+        assert not CalendarEvent.objects.filter_by_organization(organization.id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Missing CREATE permission → NOT_PERMITTED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateGroupEventWithCodeMissingPermission:
+    """Scenario 5: Code without CREATE permission → NOT_PERMITTED."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_reschedule_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_group_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = reschedule_group_code
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+        # No event should have been created.
+        assert not CalendarEvent.objects.filter_by_organization(organization.id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6: Lifecycle rejections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateGroupEventWithCodeLifecycleRejections:
+    """Scenario 6: Expired / revoked / invalid codes are rejected correctly."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_expired_code_returns_expired(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+        _token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_group_id=group.id,
+            expires_at=past,
+        )
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "EXPIRED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_revoked_code_returns_revoked(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_group_id=group.id,
+        )
+        permission_service.revoke_token(organization_id=organization.id, token_id=token.id)
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "REVOKED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_invalid_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group,
+        primary_calendar,
+        secondary_calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input("aW52YWxpZGJvb2tpbmdjb2Rl", selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_used_code_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_group_id=group.id,
+        )
+        CalendarManagementToken.objects.filter(id=token.id).update(
+            used_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        )
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7: Cross-org
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateGroupEventWithCodeCrossOrg:
+    """Scenario 7: Event is created in the code's org; other-org group is unreachable."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_event_created_in_code_org(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_booking_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+        availability_windows,  # noqa: ARG002
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_booking_code
+        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+
+        event_id = int(result["event"]["id"])
+        event = CalendarEvent.objects.filter_by_organization(organization.id).get(id=event_id)
+        assert event.organization_id == token.organization_id

--- a/public_api/tests/test_book_group_with_code.py
+++ b/public_api/tests/test_book_group_with_code.py
@@ -12,7 +12,10 @@ Scenario coverage:
 4. Calendar-scoped code (no group) → NOT_PERMITTED.
 5. Missing CREATE permission → NOT_PERMITTED.
 6. Lifecycle rejections — expired / revoked / invalid → respective error codes.
-7. Cross-org: event is created in the code's org; other org's group is unreachable.
+7. Cross-org:
+   a. Org-A code with org-A slot selections books ONLY org-A resources (event.organization_id == org A).
+   b. Org-A code with an org-B calendar id in slot_selections → rejected (SLOT_UNAVAILABLE),
+      no event created, code NOT consumed.
 """
 
 import datetime
@@ -683,24 +686,112 @@ class TestCreateGroupEventWithCodeLifecycleRejections:
 
 @pytest.mark.django_db
 class TestCreateGroupEventWithCodeCrossOrg:
-    """Scenario 7: Event is created in the code's org; other-org group is unreachable."""
+    """Scenario 7: Org isolation exercised, not just code-read.
+
+    7a — Org-A code + org-A slot selections → success, event.organization_id == org A.
+         org-B group/calendars exist in the DB but are untouched.
+
+    7b — Org-A code + org-B calendar id injected into slot_selections → rejected
+         (SLOT_UNAVAILABLE), no event created, code NOT consumed.
+    """
 
     @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
-    def test_event_created_in_code_org(
+    def test_org_a_code_books_only_org_a_resources(
         self,
         mock_rate_limiter,
         anon_client,
-        group_booking_code,
+        permission_service,
         organization,
-        group,
-        primary_calendar,
-        secondary_calendar,
-        availability_windows,  # noqa: ARG002
+        availability_windows,  # noqa: ARG002 — seeds org-A calendar windows
     ):
-        mock_rate_limiter.return_value = iter([None])
-        token, code = group_booking_code
-        selections = _slot_selections(group, primary_calendar, secondary_calendar)
+        """7a: Org-A code with org-A slot selections books in org A.
 
+        Org B's group, slots, calendars, and availability windows are created in the DB
+        to confirm they don't interfere.  After booking we verify event.organization_id
+        equals org A and no event rows exist in org B.
+        """
+        mock_rate_limiter.return_value = iter([None])
+
+        # --- build org A (uses shared fixtures already created) ---
+        org_a = organization
+        grp_a = baker.make(CalendarGroup, organization=org_a, name="Org-A Group")
+        cal_a1 = baker.make(
+            Calendar,
+            organization=org_a,
+            external_id="cross-org-test-a1",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+            accepts_public_scheduling=False,
+        )
+        cal_a2 = baker.make(
+            Calendar,
+            organization=org_a,
+            external_id="cross-org-test-a2",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.RESOURCE,
+            manage_available_windows=True,
+            accepts_public_scheduling=False,
+        )
+        slot_a1 = CalendarGroupSlot.objects.create(
+            organization=org_a, group=grp_a, name="A-Physicians", order=0, required_count=1
+        )
+        slot_a2 = CalendarGroupSlot.objects.create(
+            organization=org_a, group=grp_a, name="A-Rooms", order=1, required_count=1
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=org_a, slot=slot_a1, calendar=cal_a1
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=org_a, slot=slot_a2, calendar=cal_a2
+        )
+        for cal in (cal_a1, cal_a2):
+            AvailableTime.objects.create(
+                organization=org_a,
+                calendar=cal,
+                start_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0),
+                end_time_tz_unaware=datetime.datetime(2030, 6, 1, 17, 0),
+                timezone="UTC",
+            )
+
+        # --- build org B (distinct DB rows; group has same structural shape) ---
+        org_b = baker.make(Organization, name="Org-B (cross-org target)")
+        grp_b = baker.make(CalendarGroup, organization=org_b, name="Org-B Group")
+        cal_b1 = baker.make(
+            Calendar,
+            organization=org_b,
+            external_id="cross-org-test-b1",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+            accepts_public_scheduling=False,
+        )
+        slot_b1 = CalendarGroupSlot.objects.create(
+            organization=org_b, group=grp_b, name="B-Physicians", order=0, required_count=1
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=org_b, slot=slot_b1, calendar=cal_b1
+        )
+        AvailableTime.objects.create(
+            organization=org_b,
+            calendar=cal_b1,
+            start_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0),
+            end_time_tz_unaware=datetime.datetime(2030, 6, 1, 17, 0),
+            timezone="UTC",
+        )
+
+        # --- mint an org-A group code ---
+        _token, code = permission_service.create_booking_token(
+            organization_id=org_a.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_group_id=grp_a.id,
+        )
+
+        # --- call mutation with org-A slot selections ---
+        selections = [
+            {"slotId": slot_a1.id, "calendarIds": [cal_a1.id]},
+            {"slotId": slot_a2.id, "calendarIds": [cal_a2.id]},
+        ]
         data = post_graphql(
             anon_client,
             CREATE_GROUP_EVENT_WITH_CODE,
@@ -710,6 +801,94 @@ class TestCreateGroupEventWithCodeCrossOrg:
         result = data["data"]["createCalendarGroupEventWithCode"]
         assert result["success"] is True, result
 
+        # Event must live in org A
         event_id = int(result["event"]["id"])
-        event = CalendarEvent.objects.filter_by_organization(organization.id).get(id=event_id)
-        assert event.organization_id == token.organization_id
+        event = CalendarEvent.objects.filter_by_organization(org_a.id).get(id=event_id)
+        assert event.organization_id == org_a.id
+        assert event.calendar_group_fk_id == grp_a.id
+
+        # No events exist in org B
+        assert not CalendarEvent.objects.filter_by_organization(org_b.id).exists()
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_org_a_code_cannot_book_org_b_calendar(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        availability_windows,  # noqa: ARG002
+    ):
+        """7b: Org-A code + org-B calendar id in slot_selections → rejected, code NOT consumed.
+
+        This proves the org isolation guard: the slot_selection passes an org-B calendar id
+        to an org-A group booking code.  The server must reject it (SLOT_UNAVAILABLE, since
+        the foreign calendar is not a member of the org-A group's slots) and must NOT consume
+        the code — so the patient could theoretically retry.
+        """
+        mock_rate_limiter.return_value = iter([None])
+
+        # --- build org A ---
+        org_a = organization
+        grp_a = baker.make(CalendarGroup, organization=org_a, name="Org-A Group")
+        cal_a = baker.make(
+            Calendar,
+            organization=org_a,
+            external_id="cross-org-b-test-a",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+            accepts_public_scheduling=False,
+        )
+        slot_a = CalendarGroupSlot.objects.create(
+            organization=org_a, group=grp_a, name="A-Physicians", order=0, required_count=1
+        )
+        CalendarGroupSlotMembership.objects.create(organization=org_a, slot=slot_a, calendar=cal_a)
+        AvailableTime.objects.create(
+            organization=org_a,
+            calendar=cal_a,
+            start_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0),
+            end_time_tz_unaware=datetime.datetime(2030, 6, 1, 17, 0),
+            timezone="UTC",
+        )
+
+        # --- build org B with its own calendar ---
+        org_b = baker.make(Organization, name="Org-B (cross-org attacker)")
+        cal_b = baker.make(
+            Calendar,
+            organization=org_b,
+            external_id="cross-org-b-test-b",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+            accepts_public_scheduling=False,
+        )
+
+        # --- mint an org-A group code ---
+        token, code = permission_service.create_booking_token(
+            organization_id=org_a.id,
+            permissions=[EventManagementPermissions.CREATE],
+            calendar_group_id=grp_a.id,
+        )
+
+        # --- inject org-B's calendar id into the slot selection for org-A's slot ---
+        bad_selections = [
+            {"slotId": slot_a.id, "calendarIds": [cal_b.id]},
+        ]
+        data = post_graphql(
+            anon_client,
+            CREATE_GROUP_EVENT_WITH_CODE,
+            {"input": _group_booking_input(code, bad_selections)},
+        )
+
+        result = data["data"]["createCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+
+        # Code must NOT have been consumed
+        token.refresh_from_db()
+        assert token.used_at is None
+
+        # No event must exist in either org
+        assert not CalendarEvent.objects.filter_by_organization(org_a.id).exists()
+        assert not CalendarEvent.objects.filter_by_organization(org_b.id).exists()


### PR DESCRIPTION

## Summary

Unauthenticated GROUP booking: `createCalendarGroupEventWithCode` (no `permission_classes`). Mirrors
Phase 5a but for a group-scoped code, with one extra authorization piece.

`create_grouped_event` books the event on the group's PRIMARY calendar via
`calendar_service.create_event`, which calls `can_perform_scheduling`. A group code has
`calendar_fk_id=None`, so this phase **extends `can_perform_scheduling`** with a third branch:
authorize when the token is group-scoped, has CREATE, and the target calendar is a member of that
group's slots (`CalendarGroupSlotMembership`, org-scoped). The existing calendar-scoped and
public-scheduling branches are unchanged.

Flow: `resolve_code` → require CREATE + group scope (`token.calendar_group`) → `transaction.atomic
{ calendar_service.initialize_without_provider(user_or_token=code) → group_service.calendar_service
= that instance → group_service.initialize → create_grouped_event → consume_code }`. Group id comes
STRICTLY from the token; client slot-selections are validated against the group's slot pools
(`_validate_selections`), so a code can't book a calendar outside its group. First-write-wins
(consume after create, under lock, full rollback on race). Error mapping as Phase 5a
(SLOT_UNAVAILABLE / NOT_PERMITTED / EXPIRED / ALREADY_USED / REVOKED / INVALID_CODE).

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 5b.
- Spec: Decisions → Use-cases, Use-case 2 (patient books — group variant).

## Test plan

In-container (docker postgres): `public_api/tests/test_book_group_with_code.py` — happy path on a
RESTRICTED primary calendar (proves the code authorizes, not public scheduling), replay →
ALREADY_USED, failed write not consumed, calendar-scoped code → NOT_PERMITTED, missing CREATE →
NOT_PERMITTED, expired/revoked/invalid, and **real cross-org**: org-A code books only org-A
resources; injecting an org-B calendar id → SLOT_UNAVAILABLE + not consumed. Plus
`test_calendar_permission_service_codes.py` group-branch unit tests incl. cross-org member→False.
`ruff` clean · `makemigrations --check` no changes · `check --deploy` clean · `pytest -n auto`
**2133 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-5a`.