### PR TITLE
feat(calendar): reschedule a single-calendar event with a code (Phase 6a)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -88,11 +88,20 @@
 - **Summary**: unauthenticated `createCalendarGroupEventWithCode`. Required extending `can_perform_scheduling` with a GROUP-scoped branch (token group-scoped + CREATE + calendar is a member of the group's slots, org-scoped via CalendarGroupSlotMembership) — because `create_grouped_event` books on the primary calendar and a group code has calendar_fk_id=None. Mutation: resolve_code → require CREATE + group scope → atomic { calendar_service.initialize_without_provider(user_or_token=code) → wire group_service.calendar_service=calendar_service → group_service.initialize → create_grouped_event → consume_code }. Real restricted-primary-calendar tests + real cross-org isolation (org-A code can't book org-B calendar → SLOT_UNAVAILABLE, not consumed). Shared `_client_ip_from_request` helper. 17+ tests.
 - **PR**: pending (filled after push).
 
+### Phase 6a — Reschedule single-calendar event with code ✅
+- **Status**: complete, reviewed (Layers 1–3 + fix loop; no BLOCKERs).
+- **Model/tier**: implementer / Sonnet (Tier 3).
+- **Branch**: plan/single-use-scheduling-codes/phase-6a (base: phase-5b).
+- **Commits**: a787454 (reschedule-with-code mutation + GeneratedField fix) + ef29b50 (scope availability check to code path).
+- **Outer gate**: `pytest -n auto` 2146 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: unauthenticated `rescheduleCalendarEventWithCode`. resolve_code → require RESCHEDULE + event scope + single-calendar (token.calendar_group is None → group codes route to 6b). calendar_id/event_id strictly from token. Rebuilds CalendarEventInputData PRESERVING title/description/attendances/external_attendances (so can_perform_update requires only {RESCHEDULE}, not UPDATE_DETAILS/ATTENDEES), overriding only times. Atomic update→consume. Availability pre-check in the mutation (scoped to code path).
+- **Notable**: found + fixed a genuine pre-existing bug — `update_event` assigned to `start_time`/`end_time` which are read-only GeneratedFields (db-derived), so reschedules never persisted; fix writes `*_tz_unaware`+`timezone` (kept in shared update_event, matches create_event). A reviewer-flagged availability check that was added to shared update_event (would regress REST/bundle updates) was MOVED into the mutation.
+- **PR**: pending (filled after push).
+
 ## Current phase
-Phase 6a — Reschedule single-calendar event with code (next).
+Phase 6b — Reschedule calendar-group event with code (next).
 
 ## Remaining phases
-- Phase 6a — Reschedule single-calendar event with code
 - Phase 6b — Reschedule calendar-group event with code
 - Phase 6c — Cancel event with code
 

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -43,6 +43,7 @@ from calendar_integration.services.dataclasses import (
     EventAttendanceInputData,
     EventExternalAttendanceInputData,
     ExternalAttendeeInputData,
+    ResourceAllocationInputData,
 )
 from calendar_integration.services.webhook_analytics_service import WebhookAnalyticsService
 from organizations.models import Organization
@@ -576,6 +577,16 @@ class CreateGroupEventWithCodeInput:
     slot_selections: list[CodeSlotSelectionInput]
     external_attendee: ExternalAttendeeCodeInput
     description: str = ""
+
+
+@strawberry.input
+class RescheduleWithCodeInput:
+    """Input for the unauthenticated rescheduleCalendarEventWithCode mutation."""
+
+    code: str
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
 
 
 @strawberry.type
@@ -1355,6 +1366,208 @@ class CalendarGroupMutations:
             # back), patient may retry with a different slot.
             # Note: NoAvailableTimeWindowsError is a subclass of EventManagementError and
             # is therefore already covered by the EventManagementError branch.
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
+                error_message="The requested time slot is not available.",
+            )
+
+        return CodeEventResult(success=True, event=event)  # type: ignore[arg-type]
+
+    @strawberry.mutation
+    def reschedule_calendar_event_with_code(
+        self,
+        info: strawberry.Info,
+        input: RescheduleWithCodeInput,  # noqa: A002
+    ) -> CodeEventResult:
+        """Reschedule an event bound to a single-use RESCHEDULE booking code.
+
+        This is an unauthenticated mutation: no org token is required.  The org
+        context, calendar scope, and the specific event to reschedule are all
+        derived from the booking code.  On success the code is atomically consumed
+        so it cannot be replayed.  On a failed reschedule (slot outside availability,
+        etc.) the code is NOT consumed and the patient may retry with a different slot.
+
+        Only the start/end/timezone fields change — title, description, attendees,
+        and resource allocations are preserved exactly from the existing event so
+        that the permission check requires exactly {RESCHEDULE} and no other
+        permission.
+        """
+        deps = get_booking_code_mutation_dependencies()
+
+        # --- Step 1: resolve and validate the code ---
+        try:
+            token = deps.calendar_permission_service.resolve_code(input.code)
+        except InvalidTokenError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+        except TokenExpiredError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.EXPIRED,
+                error_message="This booking code has expired.",
+            )
+        except TokenAlreadyUsedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.ALREADY_USED,
+                error_message="This booking code has already been used.",
+            )
+        except TokenRevokedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.REVOKED,
+                error_message="This booking code has been revoked.",
+            )
+
+        # --- Step 2: check permission — must hold RESCHEDULE ---
+        token_permissions = {p.permission for p in token.permissions.all()}
+        if EventManagementPermissions.RESCHEDULE not in token_permissions:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit rescheduling.",
+            )
+
+        # --- Step 3: scope check — must be event-scoped and single-calendar (not group) ---
+        if token.event is None:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code is not bound to a specific event.",
+            )
+
+        # A group-reschedule code has calendar_group set; route to Phase 6b instead.
+        if token.calendar_group is not None:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message=(
+                    "This code is scoped to a calendar group. "
+                    "Use rescheduleCalendarGroupEventWithCode for group-scoped codes."
+                ),
+            )
+
+        # --- Step 4: resolve org ---
+        try:
+            org = Organization.objects.get(id=token.organization_id)
+        except Organization.DoesNotExist:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+
+        # --- Step 5: extract client IP for audit ---
+        source_ip = _client_ip_from_request(info.context.request)
+
+        # --- Step 6: resolve the bound event and its calendar from the token ---
+        # calendar_id and event_id come strictly from the token — not from client input —
+        # so the code can only ever affect the exact event it was minted for.
+        event_id: int = token.event_fk_id  # type: ignore[assignment]
+        calendar_id: int = token.event.calendar_fk_id  # type: ignore[assignment]
+
+        # Load the existing event to snapshot its current details (title, description,
+        # attendances, external_attendances, resource_allocations).  We build the
+        # CalendarEventInputData by COPYING all preserved fields and overriding only
+        # the time fields so that _determine_required_update_permissions yields exactly
+        # {RESCHEDULE}.
+        try:
+            existing_event = (
+                CalendarEvent.objects.filter_by_organization(org.id)
+                .prefetch_related(
+                    "attendances",
+                    "external_attendances__external_attendee",
+                    "resource_allocations",
+                )
+                .get(id=event_id, calendar_fk_id=calendar_id)
+            )
+        except CalendarEvent.DoesNotExist:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+
+        # --- Step 7: build the preserved-details event data ---
+        # Preserve internal attendances.
+        preserved_attendances = [
+            EventAttendanceInputData(user_id=attendance.user_id)
+            for attendance in existing_event.attendances.all()
+        ]
+
+        # Preserve external attendances — include the ExternalAttendee id so that
+        # serialize_event_data_input can correlate the status correctly and produce
+        # a CalendarEventData matching the old event's external_attendees by email,
+        # ensuring _check_attendances_update_necessary_permissions sees no change.
+        preserved_external_attendances = [
+            EventExternalAttendanceInputData(
+                external_attendee=ExternalAttendeeInputData(
+                    email=ea.external_attendee_fk.email,  # type: ignore[union-attr]
+                    name=ea.external_attendee_fk.name or "",  # type: ignore[union-attr]
+                    id=ea.external_attendee_fk_id,  # type: ignore[union-attr]
+                )
+            )
+            for ea in existing_event.external_attendances.select_related("external_attendee")
+        ]
+
+        # Preserve resource allocations.
+        preserved_resource_allocations = [
+            ResourceAllocationInputData(resource_id=ra.calendar_fk_id)  # type: ignore[arg-type]
+            for ra in existing_event.resource_allocations.all()
+        ]
+
+        event_data = CalendarEventInputData(
+            title=existing_event.title,
+            description=existing_event.description or "",
+            start_time=input.start_time,
+            end_time=input.end_time,
+            timezone=input.timezone,
+            attendances=preserved_attendances,
+            external_attendances=preserved_external_attendances,
+            resource_allocations=preserved_resource_allocations,
+        )
+
+        # --- Step 8: atomic update + consume ---
+        # Update FIRST, then consume — so on a race the loser's consume_code raises under
+        # the row lock and the whole transaction (including the just-updated event) rolls
+        # back, leaving exactly one update and the code consumed once.
+        try:
+            with transaction.atomic():
+                deps.calendar_service.initialize_without_provider(
+                    user_or_token=input.code, organization=org
+                )
+                event = deps.calendar_service.update_event(calendar_id, event_id, event_data)
+                deps.calendar_permission_service.consume_code(token, source_ip)
+        except (TokenAlreadyUsedError, TokenExpiredError, TokenRevokedError) as e:
+            # Concurrent consumer won the race, or state changed between resolve and consume.
+            error_code = BookingCodeErrorCode.ALREADY_USED
+            error_message = "This booking code has already been used."
+            if isinstance(e, TokenExpiredError):
+                error_code = BookingCodeErrorCode.EXPIRED
+                error_message = "This booking code has expired."
+            elif isinstance(e, TokenRevokedError):
+                error_code = BookingCodeErrorCode.REVOKED
+                error_message = "This booking code has been revoked."
+            return CodeEventResult(
+                success=False,
+                error_code=error_code,
+                error_message=error_message,
+            )
+        except PermissionDenied:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit rescheduling this event.",
+            )
+        except (EventManagementError, CalendarGroupError):
+            # Slot outside availability / invalid times — code NOT consumed (txn rolled
+            # back), patient may retry with a different slot.
+            # Note: NoAvailableTimeWindowsError is a subclass of EventManagementError and
+            # is therefore already covered.
             return CodeEventResult(
                 success=False,
                 error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -1478,9 +1478,9 @@ class CalendarGroupMutations:
         try:
             existing_event = (
                 CalendarEvent.objects.filter_by_organization(org.id)
+                .select_related("calendar")
                 .prefetch_related(
                     "attendances",
-                    "external_attendances__external_attendee",
                     "resource_allocations",
                 )
                 .get(id=event_id, calendar_fk_id=calendar_id)
@@ -1514,10 +1514,12 @@ class CalendarGroupMutations:
             for ea in existing_event.external_attendances.select_related("external_attendee")
         ]
 
-        # Preserve resource allocations.
+        # Preserve resource allocations (skip any with a null calendar_fk_id, mirroring
+        # the recurring-event transfer guard in calendar_event_service.py).
         preserved_resource_allocations = [
             ResourceAllocationInputData(resource_id=ra.calendar_fk_id)  # type: ignore[arg-type]
             for ra in existing_event.resource_allocations.all()
+            if ra.calendar_fk_id
         ]
 
         event_data = CalendarEventInputData(
@@ -1530,6 +1532,25 @@ class CalendarGroupMutations:
             external_attendances=preserved_external_attendances,
             resource_allocations=preserved_resource_allocations,
         )
+
+        # --- Step 7b: availability pre-check (code-path only) ---
+        # For calendars that manage availability windows, verify the requested slot falls
+        # inside a declared window BEFORE entering the atomic block.  This keeps the check
+        # scoped to the reschedule-with-code path (REST/bundle updates are unaffected) and
+        # ensures the code is never consumed on an out-of-window attempt.
+        if existing_event.calendar.manage_available_windows:
+            deps.calendar_service.initialize_without_provider(organization=org)
+            available_windows = deps.calendar_service.get_availability_windows_in_range(
+                existing_event.calendar,
+                input.start_time,
+                input.end_time,
+            )
+            if not available_windows:
+                return CodeEventResult(
+                    success=False,
+                    error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
+                    error_message="The requested time slot is not available.",
+                )
 
         # --- Step 8: atomic update + consume ---
         # Update FIRST, then consume — so on a race the loser's consume_code raises under

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -468,19 +468,6 @@ class CalendarEventService:
                 "calendar event"
             )
 
-        # Enforce availability windows when the calendar manages them.  A reschedule
-        # that moves the event outside all declared windows must fail the same way as
-        # a booking attempt on an unavailable slot.  This mirrors the check in
-        # ``create_event`` so that managed-window calendars remain consistent.
-        if event.calendar.manage_available_windows:
-            available_windows = self._host.get_availability_windows_in_range(
-                event.calendar,
-                event_data.start_time,
-                event_data.end_time,
-            )
-            if not available_windows:
-                raise NoAvailableTimeWindowsError()
-
         original_payload: dict[str, Any] = {}
         if event.calendar.calendar_type in [
             CalendarType.PERSONAL,

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -468,6 +468,19 @@ class CalendarEventService:
                 "calendar event"
             )
 
+        # Enforce availability windows when the calendar manages them.  A reschedule
+        # that moves the event outside all declared windows must fail the same way as
+        # a booking attempt on an unavailable slot.  This mirrors the check in
+        # ``create_event`` so that managed-window calendars remain consistent.
+        if event.calendar.manage_available_windows:
+            available_windows = self._host.get_availability_windows_in_range(
+                event.calendar,
+                event_data.start_time,
+                event_data.end_time,
+            )
+            if not available_windows:
+                raise NoAvailableTimeWindowsError()
+
         original_payload: dict[str, Any] = {}
         if event.calendar.calendar_type in [
             CalendarType.PERSONAL,
@@ -534,8 +547,18 @@ class CalendarEventService:
 
         event.title = event_data.title
         event.description = event_data.description
-        event.start_time = event_data.start_time
-        event.end_time = event_data.end_time
+        # ``start_time`` / ``end_time`` are DB-generated fields (``GeneratedField``
+        # with ``db_persist=True``) that derive from ``start_time_tz_unaware`` and
+        # the IANA ``timezone``.  Assigning to the generated fields is silently
+        # ignored by Django's UPDATE statement, so we must update the underlying
+        # writable fields instead.
+        event.start_time_tz_unaware = self.convert_naive_utc_datetime_to_timezone(
+            event_data.start_time, event_data.timezone
+        )
+        event.end_time_tz_unaware = self.convert_naive_utc_datetime_to_timezone(
+            event_data.end_time, event_data.timezone
+        )
+        event.timezone = event_data.timezone
         if context.calendar_adapter:
             event.meta["latest_original_payload"] = original_payload
 

--- a/public_api/tests/test_reschedule_with_code.py
+++ b/public_api/tests/test_reschedule_with_code.py
@@ -1,0 +1,713 @@
+"""Integration tests for rescheduleCalendarEventWithCode (Phase 6a).
+
+All requests are unauthenticated (no Authorization header).  The reschedule
+code provides the org scope, the specific event scope, and the RESCHEDULE
+permission.
+
+Scenario coverage:
+1. Happy path — valid code + in-window new slot → event times updated, title/description/
+   attendees PRESERVED, code consumed.  Works on a RESTRICTED calendar (proves the
+   code authorizes via RESCHEDULE; also proves details-preservation so only RESCHEDULE
+   is required — if details were accidentally altered the test would fail with
+   PermissionDenied).
+2. Replay — same code again → ALREADY_USED, event not changed again.
+3. Failed reschedule (new slot outside availability) → SLOT_UNAVAILABLE, code NOT
+   consumed (``used_at`` remains NULL), retryable.
+4. Wrong permission — a CREATE/CANCEL-only code → NOT_PERMITTED.
+5. Wrong scope — a group reschedule code (token.calendar_group set) → NOT_PERMITTED.
+6. Code is event-bound: calendar_id and event_id come from the token, so the code
+   always targets exactly ``token.event``.
+7. Expired / revoked / invalid → respective error.
+"""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    CalendarManagementToken,
+    EventManagementPermissions,
+)
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# GraphQL mutation string
+# ---------------------------------------------------------------------------
+
+RESCHEDULE_WITH_CODE = """
+mutation RescheduleCalendarEventWithCode($input: RescheduleWithCodeInput!) {
+    rescheduleCalendarEventWithCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        event {
+            id
+            title
+            startTime
+            endTime
+            externalAttendances {
+                externalAttendee {
+                    email
+                    name
+                }
+            }
+        }
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization():
+    return baker.make(Organization, name="Reschedule-With-Code Test Org")
+
+
+@pytest.fixture
+def other_organization():
+    return baker.make(Organization, name="Other Org")
+
+
+@pytest.fixture
+def calendar(organization):
+    """A RESTRICTED calendar (accepts_public_scheduling=False) with managed availability.
+
+    The reschedule code grants RESCHEDULE permission so that can_perform_update
+    returns True even though public scheduling is disabled.
+    """
+    return baker.make(
+        Calendar,
+        organization=organization,
+        name="Test Calendar",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=False,
+    )
+
+
+@pytest.fixture
+def calendar_group(organization):
+    return baker.make(CalendarGroup, organization=organization, name="Test Group")
+
+
+@pytest.fixture
+def available_window(organization, calendar):
+    """Availability window covering both the original and the new slots.
+
+    Original slot: 10:00-11:00 UTC
+    New slot:      14:00-15:00 UTC
+    Both fall inside 09:00-17:00 UTC.
+    """
+    return baker.make(
+        AvailableTime,
+        organization=organization,
+        calendar=calendar,
+        start_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0),
+        end_time_tz_unaware=datetime.datetime(2030, 6, 1, 17, 0),
+        timezone="UTC",
+    )
+
+
+@pytest.fixture
+def existing_event(organization, calendar):
+    """An existing event with a title, description, and one external attendee."""
+    from calendar_integration.models import EventExternalAttendance, ExternalAttendee
+
+    event = baker.make(
+        CalendarEvent,
+        organization=organization,
+        calendar=calendar,
+        title="Original Title",
+        description="Original description.",
+        timezone="UTC",
+        start_time_tz_unaware=datetime.datetime(2030, 6, 1, 10, 0),
+        end_time_tz_unaware=datetime.datetime(2030, 6, 1, 11, 0),
+        external_id="",
+    )
+    external_attendee = baker.make(
+        ExternalAttendee,
+        organization=organization,
+        email="patient@example.com",
+        name="Pat Patient",
+    )
+    baker.make(
+        EventExternalAttendance,
+        organization=organization,
+        event=event,
+        external_attendee=external_attendee,
+    )
+    return event
+
+
+@pytest.fixture
+def permission_service():
+    return CalendarPermissionService()
+
+
+@pytest.fixture
+def reschedule_code(permission_service, organization, calendar, existing_event):
+    """A valid single-use RESCHEDULE code bound to ``existing_event``."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_id=calendar.id,
+        event_id=existing_event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def cancel_code(permission_service, organization, calendar, existing_event):
+    """A CANCEL-only code — wrong permission for rescheduling."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CANCEL],
+        calendar_id=calendar.id,
+        event_id=existing_event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def create_code(permission_service, organization, calendar):
+    """A CREATE-only code — wrong permission for rescheduling."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_id=calendar.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def group_reschedule_code(permission_service, organization, calendar_group, existing_event):
+    """A group-scoped RESCHEDULE code — wrong scope for the single-calendar mutation."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_group_id=calendar_group.id,
+        event_id=existing_event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def anon_client():
+    """APIClient with no Authorization header."""
+    return APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Original slot: 10:00-11:00 UTC (set on existing_event fixture)
+ORIGINAL_START = datetime.datetime(2030, 6, 1, 10, 0, tzinfo=datetime.UTC)
+ORIGINAL_END = datetime.datetime(2030, 6, 1, 11, 0, tzinfo=datetime.UTC)
+
+# New slot for the happy-path reschedule: 14:00-15:00 UTC (inside the availability window)
+NEW_START = datetime.datetime(2030, 6, 1, 14, 0, tzinfo=datetime.UTC)
+NEW_END = datetime.datetime(2030, 6, 1, 15, 0, tzinfo=datetime.UTC)
+
+# Out-of-window slot: 22:00-23:00 UTC (outside the 09:00-17:00 window)
+OOW_START = datetime.datetime(2030, 6, 1, 22, 0, tzinfo=datetime.UTC)
+OOW_END = datetime.datetime(2030, 6, 1, 23, 0, tzinfo=datetime.UTC)
+
+
+def _reschedule_input(code: str, **overrides) -> dict:
+    """Build a default happy-path mutation input dict."""
+    base = {
+        "code": code,
+        "startTime": NEW_START.isoformat(),
+        "endTime": NEW_END.isoformat(),
+        "timezone": "UTC",
+    }
+    base.update(overrides)
+    return base
+
+
+def post_graphql(client: APIClient, query: str, variables: dict) -> dict:
+    response = client.post(
+        "/graphql/",
+        data={"query": query, "variables": variables},
+        format="json",
+    )
+    assert response.status_code == 200, response.content.decode()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRescheduleCalendarEventWithCodeHappyPath:
+    """Scenario 1: Valid reschedule code + in-window new slot → success, code consumed.
+
+    Also verifies that title, description, and attendees are PRESERVED so that only
+    RESCHEDULE permission is required (not UPDATE_DETAILS / UPDATE_ATTENDEES).
+    Uses a RESTRICTED calendar (accepts_public_scheduling=False) to prove the code
+    alone authorizes the operation.
+    """
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_happy_path_reschedules_event_and_consumes_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_code,
+        organization,
+        calendar,
+        existing_event,
+        available_window,  # noqa: ARG002 — seeds DB rows
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is True, result
+        assert result["errorCode"] is None
+        assert result["event"] is not None
+
+        # The event returned is the bound event.
+        event_id = int(result["event"]["id"])
+        assert event_id == existing_event.id
+
+        # The code must be consumed.
+        token.refresh_from_db()
+        assert token.used_at is not None
+        assert token.consumed_source_ip is not None
+
+        # Times must have been updated.  ``start_time_tz_unaware`` is returned with
+        # UTC tzinfo when USE_TZ=True, so compare by stripping tzinfo from both sides.
+        existing_event.refresh_from_db()
+        assert existing_event.start_time_tz_unaware.replace(tzinfo=None) == NEW_START.replace(
+            tzinfo=None
+        )
+        assert existing_event.end_time_tz_unaware.replace(tzinfo=None) == NEW_END.replace(
+            tzinfo=None
+        )
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_title_description_and_attendees_preserved(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_code,
+        organization,
+        calendar,
+        existing_event,
+        available_window,  # noqa: ARG002
+    ):
+        """Title, description, and external attendee are unchanged after reschedule."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is True, result
+
+        # Title preserved.
+        assert result["event"]["title"] == "Original Title"
+
+        # External attendee preserved (via GraphQL response).
+        external_attendances = result["event"]["externalAttendances"]
+        assert len(external_attendances) == 1
+        assert external_attendances[0]["externalAttendee"]["email"] == "patient@example.com"
+        assert external_attendances[0]["externalAttendee"]["name"] == "Pat Patient"
+
+        # DB: title and description unchanged.
+        existing_event.refresh_from_db()
+        assert existing_event.title == "Original Title"
+        assert existing_event.description == "Original description."
+
+        # DB: external attendee still exists.
+        from calendar_integration.models import EventExternalAttendance
+
+        ext_attendances = list(
+            EventExternalAttendance.objects.filter_by_organization(organization.id)
+            .select_related("external_attendee")
+            .filter(event=existing_event)
+        )
+        assert len(ext_attendances) == 1
+        assert ext_attendances[0].external_attendee.email == "patient@example.com"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_event_belongs_to_bound_event(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_code,
+        organization,
+        calendar,
+        existing_event,
+        available_window,  # noqa: ARG002
+    ):
+        """The rescheduled event is exactly the event the code was bound to."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is True, result
+
+        returned_event_id = int(result["event"]["id"])
+        assert returned_event_id == existing_event.id
+        assert returned_event_id == token.event_fk_id
+
+
+@pytest.mark.django_db
+class TestRescheduleCalendarEventWithCodeReplay:
+    """Scenario 2: Replay with same code → ALREADY_USED, event not changed again."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_replay_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_code,
+        organization,
+        existing_event,
+        available_window,  # noqa: ARG002
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = reschedule_code
+        input_data = _reschedule_input(code)
+
+        # First call — must succeed.
+        first = post_graphql(anon_client, RESCHEDULE_WITH_CODE, {"input": input_data})
+        assert first["data"]["rescheduleCalendarEventWithCode"]["success"] is True
+
+        # Second call — same code must return ALREADY_USED.
+        second = post_graphql(anon_client, RESCHEDULE_WITH_CODE, {"input": input_data})
+        result = second["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"
+
+        # Event times must remain as set by the first reschedule, not reset again.
+        existing_event.refresh_from_db()
+        assert existing_event.start_time_tz_unaware.replace(tzinfo=None) == NEW_START.replace(
+            tzinfo=None
+        )
+
+
+@pytest.mark.django_db
+class TestRescheduleCalendarEventWithCodeSlotUnavailable:
+    """Scenario 3: New slot outside availability → SLOT_UNAVAILABLE, code NOT consumed."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_slot_outside_window_does_not_consume(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_code,
+        organization,
+        existing_event,
+        available_window,  # noqa: ARG002 — window is 09:00-17:00 UTC
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = reschedule_code
+
+        # Request a slot at 22:00-23:00 UTC — outside the 09:00-17:00 window.
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {
+                "input": _reschedule_input(
+                    code,
+                    startTime=OOW_START.isoformat(),
+                    endTime=OOW_END.isoformat(),
+                )
+            },
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+        assert result["errorMessage"] == "The requested time slot is not available."
+
+        # Code must still be active (not consumed).
+        token.refresh_from_db()
+        assert token.used_at is None
+
+        # Event times must be unchanged.
+        existing_event.refresh_from_db()
+        assert existing_event.start_time_tz_unaware.replace(tzinfo=None) == ORIGINAL_START.replace(
+            tzinfo=None
+        )
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_after_failed_reschedule_code_can_still_be_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        reschedule_code,
+        organization,
+        existing_event,
+        available_window,  # noqa: ARG002
+    ):
+        """After a SLOT_UNAVAILABLE failure the same code can succeed on a valid slot."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = reschedule_code
+
+        # First: out-of-window → failure.
+        fail = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {
+                "input": _reschedule_input(
+                    code,
+                    startTime=OOW_START.isoformat(),
+                    endTime=OOW_END.isoformat(),
+                )
+            },
+        )
+        assert fail["data"]["rescheduleCalendarEventWithCode"]["errorCode"] == "SLOT_UNAVAILABLE"
+        token.refresh_from_db()
+        assert token.used_at is None
+
+        # Second: in-window → success.
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is True, result
+        token.refresh_from_db()
+        assert token.used_at is not None
+
+
+@pytest.mark.django_db
+class TestRescheduleCalendarEventWithCodeWrongPermission:
+    """Scenario 4: Code without RESCHEDULE permission → NOT_PERMITTED."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_cancel_only_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        cancel_code,
+        organization,
+        existing_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = cancel_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+        # Event times must be unchanged.
+        existing_event.refresh_from_db()
+        assert existing_event.start_time_tz_unaware.replace(tzinfo=None) == ORIGINAL_START.replace(
+            tzinfo=None
+        )
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_create_only_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        create_code,
+        organization,
+        existing_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = create_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+
+@pytest.mark.django_db
+class TestRescheduleCalendarEventWithCodeWrongScope:
+    """Scenario 5: Group-scoped reschedule code → NOT_PERMITTED (routes to Phase 6b)."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_group_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        existing_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+        # Event times must be unchanged.
+        existing_event.refresh_from_db()
+        assert existing_event.start_time_tz_unaware.replace(tzinfo=None) == ORIGINAL_START.replace(
+            tzinfo=None
+        )
+
+
+@pytest.mark.django_db
+class TestRescheduleCalendarEventWithCodeLifecycleRejections:
+    """Scenario 7: Expired / revoked / invalid codes are rejected with the correct error codes."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_expired_code_returns_expired(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar,
+        existing_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+        _token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            calendar_id=calendar.id,
+            event_id=existing_event.id,
+            expires_at=past,
+        )
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "EXPIRED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_revoked_code_returns_revoked(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar,
+        existing_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            calendar_id=calendar.id,
+            event_id=existing_event.id,
+        )
+        permission_service.revoke_token(organization_id=organization.id, token_id=token.id)
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "REVOKED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_invalid_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input("aW52YWxpZHJlc2NoZWR1bGVjb2Rl")},  # base64 junk
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_used_code_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        calendar,
+        existing_event,
+    ):
+        """A code already marked as used → ALREADY_USED."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            calendar_id=calendar.id,
+            event_id=existing_event.id,
+        )
+        CalendarManagementToken.objects.filter(id=token.id).update(
+            used_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        )
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_WITH_CODE,
+            {"input": _reschedule_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"


### PR DESCRIPTION

## Summary

Unauthenticated `rescheduleCalendarEventWithCode` (no `permission_classes`). An event-bound RESCHEDULE
code moves exactly its bound event to a new time. Flow: `resolve_code` → require RESCHEDULE + event
scope + single-calendar (`token.calendar_group is None`; group reschedule codes route to Phase 6b) →
availability pre-check → `transaction.atomic { initialize_without_provider(user_or_token=code) →
update_event → consume_code }`. `calendar_id`/`event_id` come STRICTLY from the token's bound event
(a code for event E can only reschedule E). First-write-wins; out-of-window → SLOT_UNAVAILABLE, code
not consumed, retryable; replay → ALREADY_USED.

## Two notable correctness points

1. **Details-preservation (so only RESCHEDULE is required).** `can_perform_update` derives the required
   permissions from the diff between old and new event — a title/description/attendee change would also
   require UPDATE_DETAILS/UPDATE_ATTENDEES, which a reschedule code lacks. So the mutation rebuilds
   `CalendarEventInputData` COPYING the existing event's title/description/attendances/external_attendances
   (by email)/resource allocations and overrides ONLY start/end/timezone → the diff is exactly `{RESCHEDULE}`.

2. **Pre-existing `update_event` bug fixed (shared, kept).** `start_time`/`end_time` on `CalendarEvent`
   are read-only `GeneratedField`s (db-derived from `start_time_tz_unaware` + `timezone`), so the old
   `event.start_time = …` was silently dropped — `update_event` never actually changed times for ANY
   caller. Fixed to write `*_tz_unaware` + `timezone` (mirrors `create_event`). A reviewer-flagged
   availability check that was initially added to shared `update_event` (would have regressed authenticated
   REST + bundle updates) was MOVED into this mutation, scoped to the code path.

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 6a.
- Spec: Decisions → Use-cases, Use-case 4 (patient reschedules — single-calendar).

## Test plan

In-container (docker postgres): `public_api/tests/test_reschedule_with_code.py` on a RESTRICTED calendar —
happy path (times updated, details preserved, code consumed), replay → ALREADY_USED, out-of-window →
SLOT_UNAVAILABLE + not consumed + retryable, missing RESCHEDULE → NOT_PERMITTED, group reschedule code →
NOT_PERMITTED, expired/revoked/invalid, and the rescheduled event is exactly `token.event`. `ruff` clean ·
`makemigrations --check` no changes · `check --deploy` clean · `pytest -n auto` **2146 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-5b`.