### PR TITLE
feat(webhooks): emit organization_member_created on invitation-accept membership (Phase 2)

### DIFF
--- a/ai-plans/TRACKING_ORGANIZATION_MEMBER_CREATED_WEBHOOK.md
+++ b/ai-plans/TRACKING_ORGANIZATION_MEMBER_CREATED_WEBHOOK.md
@@ -27,11 +27,20 @@
 - Review: no BLOCKER/SHOULD-FIX; 3 NITs (sentence-case label is spec-verbatim; `data: dict` matches plan; unneeded django_db marker) — left as-is.
 - PR-context: `.vinta-ai-workflows/prs-context/organization-member-created-webhook/phase-0.md` (status: pending).
 
+### Phase 1 — Enveloped delivery for all event types (breaking) ✅
+- Status: implemented, fixed (SHOULD-FIX), verified, reviewed, pushed. PR pending (gh unavailable).
+- Model: Tier 3 (sonnet).
+- Branch: `plan/organization-member-created-webhook/phase-1` → base `phase-0`.
+- Commits: `c1658ce` (feat envelope) + `195bdf1` (refactor: type as WebhookEnvelope + e2e retry test).
+- Key correctness: envelope `id = str(event.main_event_fk_id or event.id)` (composite ForeignObject → FK accessor is `main_event_fk_id`, not `main_event_id`); retry-chain-stable.
+- Verify: ruff clean; mypy no new errors; webhooks suite 58 passed; check --deploy only dev warnings.
+- Review: no BLOCKER; 1 SHOULD-FIX (use WebhookEnvelope TypedDict) fixed; NITs addressed (e2e retry test, `data: dict[str, Any]`).
+- PR-context: `.vinta-ai-workflows/prs-context/organization-member-created-webhook/phase-1.md` (pending).
+
 ## Current phase
-- Phase 1 — Enveloped delivery for all event types (breaking). Tier 3 (sonnet).
+- Phase 2 — Membership side-effects service + invitation-accept emission. Tier 3 (sonnet).
 
 ## Remaining phases
-- Phase 1 — Enveloped delivery for all event types (breaking)
 - Phase 2 — Membership side-effects service + invitation-accept emission
 - Phase 3 — Org-creator (admin) emission
 - Phase 4 — Provision-path coverage + multi-org refire

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -32,7 +32,11 @@ from vintasend_django_sms_template_renderer.services.notification_template_rende
 from vintasend_twilio.services.notification_adapters.twilio import (
     TwilioSMSNotificationAdapter,
 )
-from webhooks.services import WebhookCalendarEventSideEffectsService, WebhookService
+from webhooks.services import (
+    WebhookCalendarEventSideEffectsService,
+    WebhookMembershipSideEffectsService,
+    WebhookService,
+)
 
 
 class AppContainer(containers.DeclarativeContainer):
@@ -91,6 +95,11 @@ class AppContainer(containers.DeclarativeContainer):
         webhook_service=webhook_service,
     )
 
+    webhook_membership_side_effects_service = providers.Factory(
+        WebhookMembershipSideEffectsService,
+        webhook_service=webhook_service,
+    )
+
     calendar_side_effects_service = providers.Factory(
         CalendarSideEffectsService,
         side_effects_pipeline=(webhook_calendar_side_effects_service,),
@@ -115,6 +124,7 @@ class AppContainer(containers.DeclarativeContainer):
     organization_service = providers.Factory(
         OrganizationService,
         calendar_service=calendar_service,
+        webhook_membership_side_effects_service=webhook_membership_side_effects_service,
     )
 
     public_api_auth_service = providers.Factory(

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -39,6 +39,7 @@ from organizations.models import (
     OrganizationRole,
 )
 from users.models import User
+from webhooks.services.webhook_membership_side_effects import WebhookMembershipSideEffectsService
 
 
 logger = logging.getLogger(__name__)
@@ -50,9 +51,14 @@ class OrganizationService:
         self,
         calendar_service: Annotated[CalendarService, Provide["calendar_service"]],
         notification_service: Annotated[NotificationService, Provide["notification_service"]],
+        webhook_membership_side_effects_service: Annotated[
+            WebhookMembershipSideEffectsService,
+            Provide["webhook_membership_side_effects_service"],
+        ],
     ):
         self.calendar_service = calendar_service
         self.notification_service = notification_service
+        self.webhook_membership_side_effects_service = webhook_membership_side_effects_service
 
     def create_organization(
         self, creator: User, name: str, should_sync_rooms: bool = False
@@ -340,6 +346,7 @@ class OrganizationService:
                 invitation.accepted_at = now
                 invitation.membership = membership
                 invitation.save()
+                self.webhook_membership_side_effects_service.on_member_created(membership)
                 return membership
 
         raise InvalidInvitationTokenError()

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -1182,6 +1182,208 @@ class TestOrganizationService:
 
         assert OrganizationMembership.objects.filter(user=user).count() == 1
 
+    # -----------------------------------------------------------------------
+    # Phase 2 — organization_member_created webhook emission on accept_invitation
+    # -----------------------------------------------------------------------
+
+    @pytest.fixture
+    def mock_webhook_membership_side_effects_service(self):
+        """Return a MagicMock that stands in for WebhookMembershipSideEffectsService."""
+        from unittest.mock import MagicMock
+
+        mock = MagicMock()
+        mock.on_member_created.return_value = None
+        return mock
+
+    @pytest.fixture
+    def organization_service_with_webhook_mock(
+        self, mock_calendar_service, mock_webhook_membership_side_effects_service
+    ):
+        """OrganizationService with both calendar and webhook side-effects mocked."""
+        from di_core.containers import container
+
+        with (
+            container.calendar_service.override(mock_calendar_service),
+            container.webhook_membership_side_effects_service.override(
+                mock_webhook_membership_side_effects_service
+            ),
+        ):
+            yield OrganizationService()
+
+    def test_accept_invitation_calls_on_member_created_for_active_membership(
+        self,
+        organization_service_with_webhook_mock,
+        mock_webhook_membership_side_effects_service,
+        organization,
+    ):
+        """Integration: accepting a valid invitation calls on_member_created with the created membership."""
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        invitee = baker.make(User, email="webhook_invitee@example.com")
+        token = generate_long_lived_token()
+        token_hash = hash_long_lived_token(token)
+        baker.make(
+            OrganizationInvitation,
+            email=invitee.email,
+            organization=organization,
+            token_hash=token_hash,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership=None,
+            role=OrganizationRole.MEMBER,
+        )
+
+        membership = organization_service_with_webhook_mock.accept_invitation(
+            token=token, user=invitee
+        )
+
+        mock_webhook_membership_side_effects_service.on_member_created.assert_called_once_with(
+            membership
+        )
+        # The created membership must be active (default).
+        assert membership.is_active is True
+
+    def test_accept_invitation_webhook_payload_carries_correct_role(
+        self,
+        organization_service_with_webhook_mock,
+        mock_webhook_membership_side_effects_service,
+        organization,
+    ):
+        """Integration: the membership passed to on_member_created has the invitation's role."""
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        admin_invitee = baker.make(User, email="webhook_admin_invitee@example.com")
+        token = generate_long_lived_token()
+        token_hash = hash_long_lived_token(token)
+        baker.make(
+            OrganizationInvitation,
+            email=admin_invitee.email,
+            organization=organization,
+            token_hash=token_hash,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership=None,
+            role=OrganizationRole.ADMIN,
+        )
+
+        membership = organization_service_with_webhook_mock.accept_invitation(
+            token=token, user=admin_invitee
+        )
+
+        call_args = mock_webhook_membership_side_effects_service.on_member_created.call_args
+        passed_membership = call_args[0][0]
+        assert passed_membership == membership
+        assert passed_membership.role == OrganizationRole.ADMIN
+
+    def test_accept_invitation_no_webhook_emission_when_no_subscribed_config(
+        self,
+        organization,
+    ):
+        """Integration: no WebhookEvent rows when no WebhookConfiguration subscribes to the event type.
+
+        This test exercises the full stack down to WebhookService.send_event — no mock —
+        and asserts that accepting an invitation with no matching configuration produces
+        zero WebhookEvent rows.
+        """
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+        from di_core.containers import container
+        from webhooks.models import WebhookEvent
+
+        invitee = baker.make(User, email="no_config_invitee@example.com")
+        token = generate_long_lived_token()
+        token_hash = hash_long_lived_token(token)
+        baker.make(
+            OrganizationInvitation,
+            email=invitee.email,
+            organization=organization,
+            token_hash=token_hash,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership=None,
+        )
+
+        with container.calendar_service.override(Mock()):
+            service = OrganizationService()
+
+        from unittest.mock import patch
+
+        with patch("webhooks.services.webhook_service.process_webhook_event.delay"):
+            service.accept_invitation(token=token, user=invitee)
+
+        assert WebhookEvent.objects.filter(organization=organization).count() == 0
+
+    def test_accept_invitation_webhook_emission_with_subscribed_config(
+        self,
+        organization,
+    ):
+        """Integration: exactly one WebhookEvent row per subscribed config on invitation-accept.
+
+        Creates a WebhookConfiguration for ORGANIZATION_MEMBER_CREATED, accepts an
+        invitation that creates an active membership, and asserts that exactly one
+        WebhookEvent row exists with the correct payload and organization scope.
+        """
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+        from di_core.containers import container
+        from webhooks.constants import WebhookEventType
+        from webhooks.models import WebhookConfiguration, WebhookEvent
+
+        invitee = baker.make(User, email="with_config_invitee@example.com")
+        token = generate_long_lived_token()
+        token_hash = hash_long_lived_token(token)
+        baker.make(
+            OrganizationInvitation,
+            email=invitee.email,
+            organization=organization,
+            token_hash=token_hash,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership=None,
+            role=OrganizationRole.MEMBER,
+        )
+        baker.make(
+            WebhookConfiguration,
+            organization=organization,
+            event_type=WebhookEventType.ORGANIZATION_MEMBER_CREATED,
+            url="https://example.com/webhook",
+            headers={},
+            deleted_at=None,
+        )
+
+        with container.calendar_service.override(Mock()):
+            service = OrganizationService()
+
+        from unittest.mock import patch
+
+        with patch("webhooks.services.webhook_service.process_webhook_event.delay"):
+            membership = service.accept_invitation(token=token, user=invitee)
+
+        events = WebhookEvent.objects.filter(
+            organization=organization,
+            event_type=WebhookEventType.ORGANIZATION_MEMBER_CREATED,
+        )
+        assert events.count() == 1
+
+        event = events.first()
+        assert event is not None
+        assert event.payload["user_id"] == invitee.id
+        assert event.payload["email"] == invitee.email
+        assert event.payload["organization_id"] == organization.id
+        assert event.payload["organization_name"] == organization.name
+        assert event.payload["membership_role"] == OrganizationRole.MEMBER
+        assert event.payload["membership_id"] == membership.id
+
 
 @pytest.mark.django_db
 class TestRequestAllCalendarsSync:

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -1284,6 +1284,7 @@ class TestOrganizationService:
     def test_accept_invitation_no_webhook_emission_when_no_subscribed_config(
         self,
         organization,
+        django_capture_on_commit_callbacks,
     ):
         """Integration: no WebhookEvent rows when no WebhookConfiguration subscribes to the event type.
 
@@ -1317,13 +1318,15 @@ class TestOrganizationService:
         from unittest.mock import patch
 
         with patch("webhooks.services.webhook_service.process_webhook_event.delay"):
-            service.accept_invitation(token=token, user=invitee)
+            with django_capture_on_commit_callbacks(execute=True):
+                service.accept_invitation(token=token, user=invitee)
 
         assert WebhookEvent.objects.filter(organization=organization).count() == 0
 
     def test_accept_invitation_webhook_emission_with_subscribed_config(
         self,
         organization,
+        django_capture_on_commit_callbacks,
     ):
         """Integration: exactly one WebhookEvent row per subscribed config on invitation-accept.
 
@@ -1367,7 +1370,8 @@ class TestOrganizationService:
         from unittest.mock import patch
 
         with patch("webhooks.services.webhook_service.process_webhook_event.delay"):
-            membership = service.accept_invitation(token=token, user=invitee)
+            with django_capture_on_commit_callbacks(execute=True):
+                membership = service.accept_invitation(token=token, user=invitee)
 
         events = WebhookEvent.objects.filter(
             organization=organization,

--- a/webhooks/services/__init__.py
+++ b/webhooks/services/__init__.py
@@ -1,8 +1,10 @@
 from .webhook_calendar_side_effects import WebhookCalendarEventSideEffectsService
+from .webhook_membership_side_effects import WebhookMembershipSideEffectsService
 from .webhook_service import WebhookService
 
 
 __all__ = [
     "WebhookCalendarEventSideEffectsService",
+    "WebhookMembershipSideEffectsService",
     "WebhookService",
 ]

--- a/webhooks/services/webhook_membership_side_effects.py
+++ b/webhooks/services/webhook_membership_side_effects.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING, Annotated
+
+from dependency_injector.wiring import Provide, inject
+
+from organizations.models import OrganizationMembership
+from webhooks.constants import WebhookEventType
+from webhooks.services.payloads import OrganizationMemberCreatedWebhookPayload
+
+
+if TYPE_CHECKING:
+    from webhooks.services import WebhookService
+
+
+class WebhookMembershipSideEffectsService:
+    """Emits webhook side-effects for OrganizationMembership lifecycle events."""
+
+    @inject
+    def __init__(self, webhook_service: Annotated["WebhookService", Provide["webhook_service"]]):
+        self.webhook_service = webhook_service
+
+    def _serialize_membership(
+        self, membership: OrganizationMembership
+    ) -> OrganizationMemberCreatedWebhookPayload:
+        return {
+            "user_id": membership.user_id,
+            "email": membership.user.email,
+            "organization_id": membership.organization_id,
+            "organization_name": membership.organization.name,
+            "membership_role": membership.role,
+            "membership_id": membership.id,
+        }
+
+    def on_member_created(self, membership: OrganizationMembership) -> None:
+        """Emit the organization_member_created event for an active membership.
+
+        Returns early without emitting anything when the membership is not active,
+        following the plan's active-gate decision.
+
+        Args:
+            membership: The newly created OrganizationMembership. Must have
+                ``user``, ``organization``, ``role``, and ``id`` accessible
+                (i.e. already saved to the DB and related objects pre-loaded or
+                accessible via FK lookup).
+        """
+        if not membership.is_active:
+            return
+
+        self.webhook_service.send_event(
+            organization=membership.organization,
+            event_type=WebhookEventType.ORGANIZATION_MEMBER_CREATED,
+            payload=dict(self._serialize_membership(membership)),
+        )

--- a/webhooks/services/webhook_membership_side_effects.py
+++ b/webhooks/services/webhook_membership_side_effects.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Annotated
 
+from django.db import transaction
+
 from dependency_injector.wiring import Provide, inject
 
 from organizations.models import OrganizationMembership
@@ -45,8 +47,11 @@ class WebhookMembershipSideEffectsService:
         if not membership.is_active:
             return
 
-        self.webhook_service.send_event(
-            organization=membership.organization,
-            event_type=WebhookEventType.ORGANIZATION_MEMBER_CREATED,
-            payload=dict(self._serialize_membership(membership)),
+        payload = dict(self._serialize_membership(membership))
+        transaction.on_commit(
+            lambda: self.webhook_service.send_event(
+                organization=membership.organization,
+                event_type=WebhookEventType.ORGANIZATION_MEMBER_CREATED,
+                payload=payload,
+            )
         )

--- a/webhooks/tests/test_membership_side_effects.py
+++ b/webhooks/tests/test_membership_side_effects.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from model_bakery import baker
@@ -30,13 +30,10 @@ class TestWebhookMembershipSideEffectsService:
     @pytest.fixture
     def service(self, mock_webhook_service):
         """Create WebhookMembershipSideEffectsService with the webhook_service mocked."""
-        with patch("di_core.containers.AppContainer.webhook_service") as _:
-            svc = WebhookMembershipSideEffectsService.__new__(WebhookMembershipSideEffectsService)
-            svc.webhook_service = mock_webhook_service
-            return svc
+        return WebhookMembershipSideEffectsService(webhook_service=mock_webhook_service)
 
     def test_on_member_created_active_membership_emits_event(
-        self, service, mock_webhook_service, organization, user
+        self, service, mock_webhook_service, organization, user, django_capture_on_commit_callbacks
     ):
         """on_member_created emits ORGANIZATION_MEMBER_CREATED for an active membership."""
         membership = baker.make(
@@ -47,7 +44,8 @@ class TestWebhookMembershipSideEffectsService:
             is_active=True,
         )
 
-        service.on_member_created(membership)
+        with django_capture_on_commit_callbacks(execute=True):
+            service.on_member_created(membership)
 
         mock_webhook_service.send_event.assert_called_once_with(
             organization=organization,
@@ -63,7 +61,7 @@ class TestWebhookMembershipSideEffectsService:
         )
 
     def test_on_member_created_active_admin_membership_emits_event(
-        self, service, mock_webhook_service, organization, user
+        self, service, mock_webhook_service, organization, user, django_capture_on_commit_callbacks
     ):
         """on_member_created emits with correct admin role for admin memberships."""
         membership = baker.make(
@@ -74,7 +72,8 @@ class TestWebhookMembershipSideEffectsService:
             is_active=True,
         )
 
-        service.on_member_created(membership)
+        with django_capture_on_commit_callbacks(execute=True):
+            service.on_member_created(membership)
 
         mock_webhook_service.send_event.assert_called_once()
         call_kwargs = mock_webhook_service.send_event.call_args[1]
@@ -82,7 +81,7 @@ class TestWebhookMembershipSideEffectsService:
         assert call_kwargs["event_type"] == WebhookEventType.ORGANIZATION_MEMBER_CREATED
 
     def test_on_member_created_inactive_membership_does_not_emit(
-        self, service, mock_webhook_service, organization, user
+        self, service, mock_webhook_service, organization, user, django_capture_on_commit_callbacks
     ):
         """on_member_created must NOT emit for inactive memberships (is_active=False)."""
         membership = baker.make(
@@ -93,12 +92,13 @@ class TestWebhookMembershipSideEffectsService:
             is_active=False,
         )
 
-        service.on_member_created(membership)
+        with django_capture_on_commit_callbacks(execute=True):
+            service.on_member_created(membership)
 
         mock_webhook_service.send_event.assert_not_called()
 
     def test_on_member_created_payload_fields_match_contract(
-        self, service, mock_webhook_service, organization
+        self, service, mock_webhook_service, organization, django_capture_on_commit_callbacks
     ):
         """Payload contains exactly the fields mandated by OrganizationMemberCreatedWebhookPayload."""
         user = baker.make(User, email="payload@example.com")
@@ -110,7 +110,8 @@ class TestWebhookMembershipSideEffectsService:
             is_active=True,
         )
 
-        service.on_member_created(membership)
+        with django_capture_on_commit_callbacks(execute=True):
+            service.on_member_created(membership)
 
         call_kwargs = mock_webhook_service.send_event.call_args[1]
         payload = call_kwargs["payload"]
@@ -132,7 +133,7 @@ class TestWebhookMembershipSideEffectsService:
         }
 
     def test_on_member_created_organization_scoped_to_membership_org(
-        self, service, mock_webhook_service, user
+        self, service, mock_webhook_service, user, django_capture_on_commit_callbacks
     ):
         """send_event is called with the membership's organization, not any other org."""
         org_a = baker.make(Organization, name="Org A")
@@ -147,7 +148,38 @@ class TestWebhookMembershipSideEffectsService:
         # org_b is a distractor — must not appear in the send_event call
         _ = org_b
 
-        service.on_member_created(membership)
+        with django_capture_on_commit_callbacks(execute=True):
+            service.on_member_created(membership)
 
         call_kwargs = mock_webhook_service.send_event.call_args[1]
         assert call_kwargs["organization"] == org_a
+
+    def test_on_member_created_emission_is_deferred_to_post_commit(
+        self, service, mock_webhook_service, organization, user, django_capture_on_commit_callbacks
+    ):
+        """on_member_created registers the emission as an on_commit callback, not synchronously.
+
+        Capturing callbacks without executing them (execute=False) must show exactly one
+        pending callback and NO send_event call.  Only after the callbacks run does the
+        emission happen.
+        """
+        membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        with django_capture_on_commit_callbacks(execute=False) as callbacks:
+            service.on_member_created(membership)
+
+        # Emission must NOT have happened yet — still inside the test transaction.
+        mock_webhook_service.send_event.assert_not_called()
+        # Exactly one callback was registered.
+        assert len(callbacks) == 1
+
+        # Executing the captured callbacks now fires the emission.
+        for cb in callbacks:
+            cb()
+        mock_webhook_service.send_event.assert_called_once()

--- a/webhooks/tests/test_membership_side_effects.py
+++ b/webhooks/tests/test_membership_side_effects.py
@@ -1,0 +1,153 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from model_bakery import baker
+
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.models import User
+from webhooks.constants import WebhookEventType
+from webhooks.services.webhook_membership_side_effects import WebhookMembershipSideEffectsService
+
+
+@pytest.mark.django_db
+class TestWebhookMembershipSideEffectsService:
+    """Unit tests for WebhookMembershipSideEffectsService.on_member_created."""
+
+    @pytest.fixture
+    def organization(self):
+        return baker.make(Organization, name="Test Org")
+
+    @pytest.fixture
+    def user(self):
+        return baker.make(User, email="member@example.com")
+
+    @pytest.fixture
+    def mock_webhook_service(self):
+        mock = MagicMock()
+        mock.send_event.return_value = []
+        return mock
+
+    @pytest.fixture
+    def service(self, mock_webhook_service):
+        """Create WebhookMembershipSideEffectsService with the webhook_service mocked."""
+        with patch("di_core.containers.AppContainer.webhook_service") as _:
+            svc = WebhookMembershipSideEffectsService.__new__(WebhookMembershipSideEffectsService)
+            svc.webhook_service = mock_webhook_service
+            return svc
+
+    def test_on_member_created_active_membership_emits_event(
+        self, service, mock_webhook_service, organization, user
+    ):
+        """on_member_created emits ORGANIZATION_MEMBER_CREATED for an active membership."""
+        membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        service.on_member_created(membership)
+
+        mock_webhook_service.send_event.assert_called_once_with(
+            organization=organization,
+            event_type=WebhookEventType.ORGANIZATION_MEMBER_CREATED,
+            payload={
+                "user_id": user.id,
+                "email": user.email,
+                "organization_id": organization.id,
+                "organization_name": organization.name,
+                "membership_role": OrganizationRole.MEMBER,
+                "membership_id": membership.id,
+            },
+        )
+
+    def test_on_member_created_active_admin_membership_emits_event(
+        self, service, mock_webhook_service, organization, user
+    ):
+        """on_member_created emits with correct admin role for admin memberships."""
+        membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        service.on_member_created(membership)
+
+        mock_webhook_service.send_event.assert_called_once()
+        call_kwargs = mock_webhook_service.send_event.call_args[1]
+        assert call_kwargs["payload"]["membership_role"] == OrganizationRole.ADMIN
+        assert call_kwargs["event_type"] == WebhookEventType.ORGANIZATION_MEMBER_CREATED
+
+    def test_on_member_created_inactive_membership_does_not_emit(
+        self, service, mock_webhook_service, organization, user
+    ):
+        """on_member_created must NOT emit for inactive memberships (is_active=False)."""
+        membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+
+        service.on_member_created(membership)
+
+        mock_webhook_service.send_event.assert_not_called()
+
+    def test_on_member_created_payload_fields_match_contract(
+        self, service, mock_webhook_service, organization
+    ):
+        """Payload contains exactly the fields mandated by OrganizationMemberCreatedWebhookPayload."""
+        user = baker.make(User, email="payload@example.com")
+        membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+
+        service.on_member_created(membership)
+
+        call_kwargs = mock_webhook_service.send_event.call_args[1]
+        payload = call_kwargs["payload"]
+
+        assert payload["user_id"] == user.id
+        assert payload["email"] == user.email
+        assert payload["organization_id"] == organization.id
+        assert payload["organization_name"] == organization.name
+        assert payload["membership_role"] == OrganizationRole.MEMBER
+        assert payload["membership_id"] == membership.id
+        # Ensure no extra fields sneak in
+        assert set(payload.keys()) == {
+            "user_id",
+            "email",
+            "organization_id",
+            "organization_name",
+            "membership_role",
+            "membership_id",
+        }
+
+    def test_on_member_created_organization_scoped_to_membership_org(
+        self, service, mock_webhook_service, user
+    ):
+        """send_event is called with the membership's organization, not any other org."""
+        org_a = baker.make(Organization, name="Org A")
+        org_b = baker.make(Organization, name="Org B")
+        membership = baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org_a,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        # org_b is a distractor — must not appear in the send_event call
+        _ = org_b
+
+        service.on_member_created(membership)
+
+        call_kwargs = mock_webhook_service.send_event.call_args[1]
+        assert call_kwargs["organization"] == org_a


### PR DESCRIPTION

## Summary

First Medplum-facing value: when a user accepts an organization invitation and an **active** membership is created, one `organization_member_created` webhook is emitted per subscribed configuration in that org.

- New `WebhookMembershipSideEffectsService.on_member_created(membership)` — mirrors the calendar side-effects service. Emits only when `membership.is_active`; builds the `OrganizationMemberCreatedWebhookPayload` (user id, email, org id + name, membership role + id; no profile name).
- Registered in the DI container; injected into `OrganizationService`.
- Called from `accept_invitation` after the membership is committed.
- The emission is deferred via `transaction.on_commit(...)` so the Celery delivery task never races ahead of the request transaction (prod runs `ATOMIC_REQUESTS=True`).
- Additive — no feature flag, no migration. Only `accept_invitation` is wired (org-creation = Phase 3; provision path = Phase 4).

## Plan reference

Plan Phase 2 (spec use-case: "A user accepts an invitation and the Medplum bot links a Provider"). Stacked on Phase 1.

## Test plan

```
./dr python -m pytest webhooks/tests/test_membership_side_effects.py organizations/tests/test_services.py -vs --reuse-db
./dr python -m pytest -n auto --reuse-db   # 2022 passed
./dr python manage.py makemigrations --check   # no migration
```

Unit tests: active emits / inactive silent / exact payload, plus a deferral test (`django_capture_on_commit_callbacks(execute=False)` proves the emission is post-commit, not synchronous). Integration: invitation-accept emits one delivery per subscribed config scoped to the org, none when no config subscribes — wrapped in `django_capture_on_commit_callbacks(execute=True)`.

## Reviewer note

The emission is deferred with `transaction.on_commit` **inside** `on_member_created` (not at the call site) so Phase 3 (org-creation) and Phase 4 (provision path) callers are automatically protected from the before-commit race.