### PR TITLE
feat(webhooks): emit organization_member_created on organization creation (admin) (Phase 3)

### DIFF
--- a/ai-plans/TRACKING_ORGANIZATION_MEMBER_CREATED_WEBHOOK.md
+++ b/ai-plans/TRACKING_ORGANIZATION_MEMBER_CREATED_WEBHOOK.md
@@ -37,11 +37,19 @@
 - Review: no BLOCKER; 1 SHOULD-FIX (use WebhookEnvelope TypedDict) fixed; NITs addressed (e2e retry test, `data: dict[str, Any]`).
 - PR-context: `.vinta-ai-workflows/prs-context/organization-member-created-webhook/phase-1.md` (pending).
 
+### Phase 2 — Membership side-effects service + invitation-accept emission ✅
+- Status: implemented, fixed (1 BLOCKER + 2 SHOULD-FIX), verified, reviewed, pushed. PR pending (gh unavailable).
+- Model: Tier 3 (sonnet).
+- Branch: `plan/organization-member-created-webhook/phase-2` → base `phase-1`.
+- Commits: `e8a8807` (feat) + `0b0c748` (fix: defer to transaction.on_commit).
+- BLOCKER fixed: prod ATOMIC_REQUESTS=True meant the synchronous `send_event` raced the Celery worker before commit (lost delivery). Now `transaction.on_commit` inside `on_member_created` (protects Phase 3/4 callers too). Regression test added (capture execute=False).
+- Verify: ruff/mypy clean (0 new); makemigrations clean; full suite 2022 passed; check --deploy only dev warnings.
+- PR-context: `.vinta-ai-workflows/prs-context/organization-member-created-webhook/phase-2.md` (pending).
+
 ## Current phase
-- Phase 2 — Membership side-effects service + invitation-accept emission. Tier 3 (sonnet).
+- Phase 3 — Org-creator (admin) emission. Tier 2 (sonnet/haiku).
 
 ## Remaining phases
-- Phase 2 — Membership side-effects service + invitation-accept emission
 - Phase 3 — Org-creator (admin) emission
 - Phase 4 — Provision-path coverage + multi-org refire
 - Phase 5 — GraphQL foundation: resource + WebhookConfiguration type

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -75,11 +75,12 @@ class OrganizationService:
         )
         # The creator of the organization is its first admin — every org must
         # have at least one admin, and no one else exists yet to promote them.
-        OrganizationMembership.objects.create(
+        admin_membership = OrganizationMembership.objects.create(
             user=creator,
             organization=self.organization,
             role=OrganizationRole.ADMIN,
         )
+        self.webhook_membership_side_effects_service.on_member_created(admin_membership)
 
         if should_sync_rooms:
             # A newly created organization cannot have a service account yet, so

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -1388,6 +1388,97 @@ class TestOrganizationService:
         assert event.payload["membership_role"] == OrganizationRole.MEMBER
         assert event.payload["membership_id"] == membership.id
 
+    # -----------------------------------------------------------------------
+    # Phase 3 — organization_member_created webhook emission on create_organization
+    # -----------------------------------------------------------------------
+
+    def test_create_organization_calls_on_member_created_for_admin_membership(
+        self,
+        organization_service_with_webhook_mock,
+        mock_webhook_membership_side_effects_service,
+    ):
+        """Integration: creating an organization calls on_member_created with the admin membership."""
+        creator = baker.make(User, email="org_creator_webhook@example.com")
+
+        organization_service_with_webhook_mock.create_organization(
+            creator=creator, name="Webhook Test Org"
+        )
+
+        mock_webhook_membership_side_effects_service.on_member_created.assert_called_once()
+        passed_membership = (
+            mock_webhook_membership_side_effects_service.on_member_created.call_args[0][0]
+        )
+        assert passed_membership.user == creator
+        assert passed_membership.role == OrganizationRole.ADMIN
+        assert passed_membership.is_active is True
+
+    def test_create_organization_no_webhook_emission_when_no_subscribed_config(
+        self,
+        django_capture_on_commit_callbacks,
+    ):
+        """Integration: no WebhookEvent rows when no WebhookConfiguration subscribes to the event type.
+
+        Exercises the full stack (no mocks on the webhook path) to confirm that creating an
+        organization with no matching config produces zero WebhookEvent rows.
+        """
+        from unittest.mock import patch
+
+        from di_core.containers import container
+        from webhooks.models import WebhookEvent
+
+        creator = baker.make(User, email="no_config_creator@example.com")
+
+        with container.calendar_service.override(Mock()):
+            service = OrganizationService()
+
+        with patch("webhooks.services.webhook_service.process_webhook_event.delay"):
+            with django_capture_on_commit_callbacks(execute=True):
+                org = service.create_organization(creator=creator, name="No Config Org")
+
+        assert WebhookEvent.objects.filter(organization=org).count() == 0
+
+    def test_create_organization_webhook_emission_payload_and_role(
+        self,
+        django_capture_on_commit_callbacks,
+    ):
+        """Integration: on_commit fires send_event with membership_role='admin' and correct payload.
+
+        Since the org does not exist until create_organization runs, we cannot pre-create a
+        WebhookConfiguration for it. Instead we intercept WebhookService.send_event to capture
+        the call and assert the payload without needing a config row. The no-config gate is
+        already covered by test_create_organization_no_webhook_emission_when_no_subscribed_config.
+        """
+        from unittest.mock import patch
+
+        from di_core.containers import container
+        from webhooks.constants import WebhookEventType
+
+        creator = baker.make(User, email="with_config_creator@example.com")
+
+        with container.calendar_service.override(Mock()):
+            service = OrganizationService()
+
+        captured_calls: list[dict] = []
+
+        def fake_send_event(self_svc, organization, event_type, payload):
+            captured_calls.append(
+                {"organization": organization, "event_type": event_type, "payload": payload}
+            )
+
+        with patch("webhooks.services.webhook_service.WebhookService.send_event", fake_send_event):
+            with django_capture_on_commit_callbacks(execute=True):
+                org = service.create_organization(creator=creator, name="With Config Org")
+
+        assert len(captured_calls) == 1
+        call = captured_calls[0]
+        assert call["organization"] == org
+        assert call["event_type"] == WebhookEventType.ORGANIZATION_MEMBER_CREATED
+        assert call["payload"]["user_id"] == creator.id
+        assert call["payload"]["email"] == creator.email
+        assert call["payload"]["organization_id"] == org.id
+        assert call["payload"]["organization_name"] == org.name
+        assert call["payload"]["membership_role"] == OrganizationRole.ADMIN
+
 
 @pytest.mark.django_db
 class TestRequestAllCalendarsSync:


### PR DESCRIPTION

## Summary

When a user creates a new organization and becomes its active admin, a `organization_member_created` webhook is emitted with `membership_role = "admin"`.

- `create_organization` now captures the admin membership and calls `on_member_created(admin_membership)`.
- No new deferral logic — `on_member_created` (Phase 2) already gates on `is_active` and defers via `transaction.on_commit`.
- No DI changes (`webhook_membership_side_effects_service` already injected in Phase 2). Additive — no flag, no migration.

## Plan reference

Plan Phase 3 (spec use-case: "A user creates a brand-new organization"). Stacked on Phase 2.

## Test plan

```
./dr python -m pytest organizations/tests/test_services.py -vs --reuse-db
./dr python -m pytest -n auto --reuse-db   # 2025 passed
./dr python manage.py makemigrations --check   # no migration
```

Tests: org-creation emits one delivery with `membership_role == "admin"` scoped to the new org (driven through `django_capture_on_commit_callbacks`; `send_event` patched because the org PK doesn't exist before creation to pre-subscribe a config), and no delivery when no config subscribes (real `WebhookEvent` row count).