### PR TITLE
feat(calendar): reschedule a calendar-group event with a code (Phase 6b)

### DIFF
--- a/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
+++ b/ai-plans/TRACKING_2026-06-17-SINGLE_USE_SCHEDULING_CODES.md
@@ -98,11 +98,20 @@
 - **Notable**: found + fixed a genuine pre-existing bug — `update_event` assigned to `start_time`/`end_time` which are read-only GeneratedFields (db-derived), so reschedules never persisted; fix writes `*_tz_unaware`+`timezone` (kept in shared update_event, matches create_event). A reviewer-flagged availability check that was added to shared update_event (would regress REST/bundle updates) was MOVED into the mutation.
 - **PR**: pending (filled after push).
 
+### Phase 6b — Reschedule calendar-group event with code ✅
+- **Status**: complete, reviewed (Layers 1–3 + fix loop). Layer 3 caught a tz BLOCKER — fixed.
+- **Model/tier**: implementer / Sonnet (Tier 3).
+- **Branch**: plan/single-use-scheduling-codes/phase-6b (base: phase-6a).
+- **Commits**: 0434b01 (reschedule-group-with-code + reschedule_grouped_event) + 52c7d06 (align blocked-time tz storage on create+reschedule).
+- **Outer gate**: `pytest -n auto` 2161 passed; check --deploy clean; makemigrations clean; ruff clean.
+- **Summary**: unauthenticated `rescheduleCalendarGroupEventWithCode`. New `CalendarGroupService.reschedule_grouped_event(event_id, times)` updates the primary event (details-preserved → only RESCHEDULE required) + the linked non-primary BlockedTimes (`external_id` LIKE `group-event-{id}-cal-`), preserving the event id (Building Blocks linkage). Mutation: resolve_code → require RESCHEDULE + event + GROUP scope (calendar-only codes → 6a) → availability pre-check (code path) → atomic update→consume (wires group_service.calendar_service to the code-bearing instance). Time-only v1; slot re-selection deferred (Open Question 3).
+- **BLOCKER caught + fixed**: tz storage divergence — `_create_non_primary_blocked_times` wrote blocked-time `*_tz_unaware` RAW (UTC wall-clock) while the primary event + reschedule write CONVERTED (local wall-clock), so non-primary blocked times drifted off the primary event for non-UTC zones (pre-existing create bug). Fixed create to convert; added a non-UTC (America/Recife) regression test asserting primary event + blocked times stay aligned.
+- **PR**: pending (filled after push).
+
 ## Current phase
-Phase 6b — Reschedule calendar-group event with code (next).
+Phase 6c — Cancel event with code (next, final implementable phase).
 
 ## Remaining phases
-- Phase 6b — Reschedule calendar-group event with code
 - Phase 6c — Cancel event with code
 
 ## Deferred phases

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -589,6 +589,21 @@ class RescheduleWithCodeInput:
     timezone: str
 
 
+@strawberry.input
+class RescheduleGroupWithCodeInput:
+    """Input for the unauthenticated rescheduleCalendarGroupEventWithCode mutation.
+
+    Slot selections are NOT included: v1 keeps existing group/calendar selections
+    and changes ONLY the event times.  Full slot re-selection is deferred to a
+    future version (see Open Question 3 in the implementation plan).
+    """
+
+    code: str
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+
+
 @strawberry.type
 class CalendarGroupMutations:
     """GraphQL mutations for CalendarGroup CRUD and grouped event booking."""
@@ -1562,6 +1577,188 @@ class CalendarGroupMutations:
                     user_or_token=input.code, organization=org
                 )
                 event = deps.calendar_service.update_event(calendar_id, event_id, event_data)
+                deps.calendar_permission_service.consume_code(token, source_ip)
+        except (TokenAlreadyUsedError, TokenExpiredError, TokenRevokedError) as e:
+            # Concurrent consumer won the race, or state changed between resolve and consume.
+            error_code = BookingCodeErrorCode.ALREADY_USED
+            error_message = "This booking code has already been used."
+            if isinstance(e, TokenExpiredError):
+                error_code = BookingCodeErrorCode.EXPIRED
+                error_message = "This booking code has expired."
+            elif isinstance(e, TokenRevokedError):
+                error_code = BookingCodeErrorCode.REVOKED
+                error_message = "This booking code has been revoked."
+            return CodeEventResult(
+                success=False,
+                error_code=error_code,
+                error_message=error_message,
+            )
+        except PermissionDenied:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit rescheduling this event.",
+            )
+        except (EventManagementError, CalendarGroupError):
+            # Slot outside availability / invalid times — code NOT consumed (txn rolled
+            # back), patient may retry with a different slot.
+            # Note: NoAvailableTimeWindowsError is a subclass of EventManagementError and
+            # is therefore already covered.
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
+                error_message="The requested time slot is not available.",
+            )
+
+        return CodeEventResult(success=True, event=event)  # type: ignore[arg-type]
+
+    @strawberry.mutation
+    def reschedule_calendar_group_event_with_code(
+        self,
+        info: strawberry.Info,
+        input: RescheduleGroupWithCodeInput,  # noqa: A002
+    ) -> CodeEventResult:
+        """Reschedule a grouped event bound to a single-use GROUP RESCHEDULE code.
+
+        This is an unauthenticated mutation: no org token is required.  The org
+        context, calendar-group scope, and the specific grouped event to reschedule
+        are all derived from the booking code.  On success the code is atomically
+        consumed so it cannot be replayed.  On a failed reschedule (slot outside
+        availability, etc.) the code is NOT consumed and the patient may retry.
+
+        Only the start/end/timezone fields change — title, description, attendees,
+        resource allocations, and the group's calendar selections are preserved
+        exactly from the existing event (time-only v1; full slot re-selection is
+        deferred per Open Question 3).  The event id is preserved so that external
+        integrations (e.g. Building Blocks) continue to reference the same event.
+        """
+        deps = get_group_booking_code_mutation_dependencies()
+
+        # --- Step 1: resolve and validate the code ---
+        try:
+            token = deps.calendar_permission_service.resolve_code(input.code)
+        except InvalidTokenError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+        except TokenExpiredError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.EXPIRED,
+                error_message="This booking code has expired.",
+            )
+        except TokenAlreadyUsedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.ALREADY_USED,
+                error_message="This booking code has already been used.",
+            )
+        except TokenRevokedError:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.REVOKED,
+                error_message="This booking code has been revoked.",
+            )
+
+        # --- Step 2: check permission — must hold RESCHEDULE ---
+        token_permissions = {p.permission for p in token.permissions.all()}
+        if EventManagementPermissions.RESCHEDULE not in token_permissions:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code does not permit rescheduling.",
+            )
+
+        # --- Step 3: scope check — must be event-scoped AND group-scoped ---
+        if token.event is None:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message="This code is not bound to a specific event.",
+            )
+
+        # A single-calendar reschedule code has no calendar_group; route to Phase 6a.
+        if token.calendar_group is None:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.NOT_PERMITTED,
+                error_message=(
+                    "This code is not scoped to a calendar group. "
+                    "Use rescheduleCalendarEventWithCode for single-calendar codes."
+                ),
+            )
+
+        # --- Step 4: resolve org ---
+        try:
+            org = Organization.objects.get(id=token.organization_id)
+        except Organization.DoesNotExist:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+
+        # --- Step 5: extract client IP for audit ---
+        source_ip = _client_ip_from_request(info.context.request)
+
+        # --- Step 6: event_id from token (not client input) ---
+        # calendar_id and event_id come strictly from the token so the code can
+        # only ever affect the exact grouped event it was minted for.
+        event_id: int = token.event_fk_id  # type: ignore[assignment]
+
+        # --- Step 7: availability pre-check (code-path only) ---
+        # For the primary calendar of the bound grouped event: if it manages
+        # availability windows, verify the new times fall within a declared window
+        # BEFORE entering the atomic block.  This keeps the code alive on failure.
+        try:
+            bound_event = (
+                CalendarEvent.objects.filter_by_organization(org.id)
+                .select_related("calendar")
+                .get(id=event_id)
+            )
+        except CalendarEvent.DoesNotExist:
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.INVALID_CODE,
+                error_message="Invalid or unknown booking code.",
+            )
+
+        primary_calendar = bound_event.calendar
+        if primary_calendar is not None and primary_calendar.manage_available_windows:
+            deps.calendar_service.initialize_without_provider(organization=org)
+            available_windows = deps.calendar_service.get_availability_windows_in_range(
+                primary_calendar,
+                input.start_time,
+                input.end_time,
+            )
+            if not available_windows:
+                return CodeEventResult(
+                    success=False,
+                    error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
+                    error_message="The requested time slot is not available.",
+                )
+
+        # --- Step 8: atomic update + consume ---
+        # Update FIRST, then consume — so on a race the loser's consume_code raises under
+        # the row lock and the whole transaction (including the just-updated event) rolls
+        # back, leaving exactly one update and the code consumed once.
+        # ``deps.calendar_service`` is explicitly wired into ``deps.calendar_group_service``
+        # so that the update runs on the same code-initialized CalendarService instance.
+        try:
+            with transaction.atomic():
+                deps.calendar_service.initialize_without_provider(
+                    user_or_token=input.code, organization=org
+                )
+                deps.calendar_group_service.calendar_service = deps.calendar_service
+                deps.calendar_group_service.initialize(organization=org)
+                event = deps.calendar_group_service.reschedule_grouped_event(
+                    event_id=event_id,
+                    start_time=input.start_time,
+                    end_time=input.end_time,
+                    tz=input.timezone,
+                )
                 deps.calendar_permission_service.consume_code(token, source_ip)
         except (TokenAlreadyUsedError, TokenExpiredError, TokenRevokedError) as e:
             # Concurrent consumer won the race, or state changed between resolve and consume.

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -27,6 +27,9 @@ from calendar_integration.models import (
 )
 from calendar_integration.querysets import CalendarEventQuerySet
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.calendar_service_utils import (
+    convert_naive_utc_datetime_to_timezone as _convert_naive_utc_datetime_to_timezone,
+)
 from calendar_integration.services.dataclasses import (
     BookableSlotProposal,
     CalendarEventInputData,
@@ -479,6 +482,135 @@ class CalendarGroupService:
         )
 
         return event
+
+    def reschedule_grouped_event(
+        self,
+        event_id: int,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        tz: str,
+    ) -> CalendarEvent:
+        """Reschedule a grouped event's times while preserving all other details.
+
+        Changes only the start/end/timezone of the primary event (via
+        ``CalendarService.update_event``, preserving title/description/attendances
+        /external_attendances/resource_allocations so that only {RESCHEDULE}
+        permission is required) and updates the linked non-primary BlockedTimes
+        that were created by ``_create_non_primary_blocked_times``.
+
+        Preconditions:
+          - ``self.calendar_service`` is set and initialized/authenticated for the
+            same organization (mirrors the requirement on ``create_grouped_event``).
+          - The event identified by ``event_id`` must be a grouped event
+            (``calendar_group_fk`` set) belonging to this service's organization.
+
+        The event id is preserved — this is intentional: external systems (e.g.
+        the Building Blocks integration) store it and rely on it remaining stable
+        across reschedules.
+        """
+        from calendar_integration.services.dataclasses import (
+            EventExternalAttendanceInputData,
+            ExternalAttendeeInputData,
+            ResourceAllocationInputData,
+        )
+
+        self._assert_initialized()
+        if self.calendar_service is None:
+            raise CalendarGroupValidationError(
+                "CalendarGroupService.calendar_service must be provided to reschedule grouped events."
+            )
+        if self.calendar_service.organization is None:
+            raise CalendarGroupValidationError(
+                "The injected CalendarService is not initialized with an organization."
+            )
+        if self.calendar_service.organization.id != self.organization.id:
+            raise CalendarGroupValidationError(
+                "The injected CalendarService is initialized with a different organization."
+            )
+
+        # Load the grouped event.
+        try:
+            event = (
+                CalendarEvent.objects.filter_by_organization(self.organization.id)
+                .select_related("calendar")
+                .prefetch_related(
+                    "attendances",
+                    "resource_allocations",
+                )
+                .get(id=event_id)
+            )
+        except CalendarEvent.DoesNotExist:
+            raise CalendarGroupValidationError(
+                f"Event {event_id} not found in this organization."
+            ) from None
+
+        if event.calendar_group_fk_id is None:
+            raise CalendarGroupValidationError(
+                f"Event {event_id} is not a grouped event (calendar_group_fk is not set)."
+            )
+
+        # Build the update input preserving all non-time details so that only
+        # RESCHEDULE permission is required (same approach as Phase 6a).
+        preserved_attendances = [
+            EventAttendanceInputData(user_id=attendance.user_id)
+            for attendance in event.attendances.all()
+        ]
+
+        preserved_external_attendances = [
+            EventExternalAttendanceInputData(
+                external_attendee=ExternalAttendeeInputData(
+                    email=ea.external_attendee_fk.email,  # type: ignore[union-attr]
+                    name=ea.external_attendee_fk.name or "",  # type: ignore[union-attr]
+                    id=ea.external_attendee_fk_id,  # type: ignore[union-attr]
+                )
+            )
+            for ea in event.external_attendances.select_related("external_attendee")
+        ]
+
+        preserved_resource_allocations = [
+            ResourceAllocationInputData(resource_id=ra.calendar_fk_id)  # type: ignore[arg-type]
+            for ra in event.resource_allocations.all()
+            if ra.calendar_fk_id
+        ]
+
+        event_data = CalendarEventInputData(
+            title=event.title,
+            description=event.description or "",
+            start_time=start_time,
+            end_time=end_time,
+            timezone=tz,
+            attendances=preserved_attendances,
+            external_attendances=preserved_external_attendances,
+            resource_allocations=preserved_resource_allocations,
+        )
+
+        primary_calendar_id: int = event.calendar_fk_id  # type: ignore[assignment]
+        updated_event = self.calendar_service.update_event(
+            primary_calendar_id, event_id, event_data
+        )
+
+        # Update the non-primary BlockedTimes linked to this grouped event.
+        # They are identified by the external_id convention set in
+        # _create_non_primary_blocked_times: ``group-event-{event.id}-cal-{cid}``.
+        new_start_tz_unaware = _convert_naive_utc_datetime_to_timezone(start_time, tz)
+        new_end_tz_unaware = _convert_naive_utc_datetime_to_timezone(end_time, tz)
+
+        blocked_times_qs = BlockedTime.objects.filter_by_organization(self.organization.id).filter(
+            external_id__startswith=f"group-event-{event_id}-cal-"
+        )
+
+        blocked_times = list(blocked_times_qs)
+        for bt in blocked_times:
+            bt.start_time_tz_unaware = new_start_tz_unaware
+            bt.end_time_tz_unaware = new_end_tz_unaware
+            bt.timezone = tz
+
+        if blocked_times:
+            BlockedTime.objects.bulk_update(
+                blocked_times, ["start_time_tz_unaware", "end_time_tz_unaware", "timezone"]
+            )
+
+        return updated_event
 
     def _validate_selections(
         self,

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -39,6 +39,9 @@ from calendar_integration.services.dataclasses import (
     CalendarGroupSlotAvailability,
     CalendarGroupSlotInputData,
     EventAttendanceInputData,
+    EventExternalAttendanceInputData,
+    ExternalAttendeeInputData,
+    ResourceAllocationInputData,
 )
 from organizations.models import Organization
 from users.models import User
@@ -507,13 +510,12 @@ class CalendarGroupService:
         The event id is preserved — this is intentional: external systems (e.g.
         the Building Blocks integration) store it and rely on it remaining stable
         across reschedules.
-        """
-        from calendar_integration.services.dataclasses import (
-            EventExternalAttendanceInputData,
-            ExternalAttendeeInputData,
-            ResourceAllocationInputData,
-        )
 
+        v1 limitation: non-primary calendar availability is NOT re-checked on
+        reschedule. Only the primary calendar is gated (in the mutation's
+        availability check). Non-primary double-booking is therefore possible and
+        intentionally unenforced for this time-only reschedule path.
+        """
         self._assert_initialized()
         if self.calendar_service is None:
             raise CalendarGroupValidationError(
@@ -777,8 +779,8 @@ class CalendarGroupService:
             BlockedTime.objects.create(
                 organization=self.organization,
                 calendar=calendar,
-                start_time_tz_unaware=start_time,
-                end_time_tz_unaware=end_time,
+                start_time_tz_unaware=_convert_naive_utc_datetime_to_timezone(start_time, tz),
+                end_time_tz_unaware=_convert_naive_utc_datetime_to_timezone(end_time, tz),
                 timezone=tz,
                 reason=f"Group booking: {event.title}",
                 external_id=f"group-event-{event.id}-cal-{cid}",

--- a/public_api/tests/test_reschedule_group_with_code.py
+++ b/public_api/tests/test_reschedule_group_with_code.py
@@ -38,7 +38,13 @@ from calendar_integration.models import (
     CalendarManagementToken,
     EventManagementPermissions,
 )
+from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import (
+    CalendarGroupEventInputData,
+    CalendarGroupSlotSelectionInputData,
+)
 from organizations.models import Organization
 
 
@@ -836,3 +842,169 @@ class TestRescheduleGroupWithCodeLifecycleRejections:
         result = data["data"]["rescheduleCalendarGroupEventWithCode"]
         assert result["success"] is False
         assert result["errorCode"] == "ALREADY_USED"
+
+
+# ---------------------------------------------------------------------------
+# Non-UTC regression: BLOCKER fix — create and reschedule agree on timezone
+# ---------------------------------------------------------------------------
+
+# America/Recife is UTC-3 (no DST).
+# Original slot: 12:00-13:00 UTC on 2030-06-01 → wall-clock 09:00-10:00 Recife.
+# New slot:      15:00-16:00 UTC on 2030-06-01 → wall-clock 12:00-13:00 Recife.
+RECIFE_ORIG_UTC_START = datetime.datetime(2030, 6, 1, 12, 0, tzinfo=datetime.UTC)
+RECIFE_ORIG_UTC_END = datetime.datetime(2030, 6, 1, 13, 0, tzinfo=datetime.UTC)
+RECIFE_NEW_UTC_START = datetime.datetime(2030, 6, 1, 15, 0, tzinfo=datetime.UTC)
+RECIFE_NEW_UTC_END = datetime.datetime(2030, 6, 1, 16, 0, tzinfo=datetime.UTC)
+RECIFE_TZ = "America/Recife"
+
+# The full window that covers both slots (in Recife wall-clock / stored as naive local).
+RECIFE_WINDOW_START = datetime.datetime(2030, 6, 1, 8, 0)
+RECIFE_WINDOW_END = datetime.datetime(2030, 6, 1, 18, 0)
+
+
+@pytest.mark.django_db
+class TestRescheduleGroupWithCodeNonUTCTimezone:
+    """Non-UTC regression: primary event and linked BlockedTimes derive the same
+    UTC instant after a reschedule in a non-UTC zone.
+
+    The test builds the grouped event via the real CalendarGroupService
+    (``create_grouped_event``) so that the BlockedTime rows are written by the
+    same fixed ``_create_non_primary_blocked_times`` path.  If the BLOCKER fix
+    is reverted, the BlockedTime's ``start_time``/``end_time`` GeneratedField
+    instants will disagree with the primary event's instants by 3 hours (the
+    America/Recife offset).
+    """
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_non_utc_reschedule_aligns_primary_and_blocked_times(
+        self,
+        mock_rate_limiter,
+        anon_client,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+
+        # --- Build org + calendars ------------------------------------------------
+        org = baker.make(Organization, name="Recife Org")
+
+        # Primary calendar must have accepts_public_scheduling=True so that
+        # CalendarService.create_event doesn't reject it without a user token.
+        primary_cal = Calendar.objects.create(
+            organization=org,
+            name="Recife Primary",
+            external_id="recife-primary",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+            accepts_public_scheduling=True,
+        )
+        secondary_cal = Calendar.objects.create(
+            organization=org,
+            name="Recife Room",
+            external_id="recife-room",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.RESOURCE,
+            manage_available_windows=True,
+            accepts_public_scheduling=False,
+        )
+
+        # --- Build group + availability -------------------------------------------
+        grp = baker.make(CalendarGroup, organization=org, name="Recife Group")
+        slot_a = CalendarGroupSlot.objects.create(
+            organization=org, group=grp, name="Physicians", order=0, required_count=1
+        )
+        slot_b = CalendarGroupSlot.objects.create(
+            organization=org, group=grp, name="Rooms", order=1, required_count=1
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=org, slot=slot_a, calendar=primary_cal
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=org, slot=slot_b, calendar=secondary_cal
+        )
+
+        # Availability windows in Recife wall-clock covering both slots.
+        for cal in (primary_cal, secondary_cal):
+            AvailableTime.objects.create(
+                organization=org,
+                calendar=cal,
+                start_time_tz_unaware=RECIFE_WINDOW_START,
+                end_time_tz_unaware=RECIFE_WINDOW_END,
+                timezone=RECIFE_TZ,
+            )
+
+        # --- Create the grouped event via the real service -------------------------
+        cs = CalendarService()
+        cs.initialize_without_provider(organization=org)
+        group_svc = CalendarGroupService(calendar_service=cs)
+        group_svc.initialize(organization=org)
+
+        event = group_svc.create_grouped_event(
+            CalendarGroupEventInputData(
+                title="Recife Appointment",
+                description="",
+                start_time=RECIFE_ORIG_UTC_START,
+                end_time=RECIFE_ORIG_UTC_END,
+                timezone=RECIFE_TZ,
+                group_id=grp.id,
+                slot_selections=[
+                    CalendarGroupSlotSelectionInputData(
+                        slot_id=slot_a.id, calendar_ids=[primary_cal.id]
+                    ),
+                    CalendarGroupSlotSelectionInputData(
+                        slot_id=slot_b.id, calendar_ids=[secondary_cal.id]
+                    ),
+                ],
+            )
+        )
+
+        # --- Create RESCHEDULE code -----------------------------------------------
+        perm_svc = CalendarPermissionService()
+        token, code = perm_svc.create_booking_token(
+            organization_id=org.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            calendar_group_id=grp.id,
+            event_id=event.id,
+        )
+
+        # --- Reschedule via GraphQL mutation --------------------------------------
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {
+                "input": {
+                    "code": code,
+                    "startTime": RECIFE_NEW_UTC_START.isoformat(),
+                    "endTime": RECIFE_NEW_UTC_END.isoformat(),
+                    "timezone": RECIFE_TZ,
+                }
+            },
+        )
+
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+
+        # --- Assert instants agree ------------------------------------------------
+        # Reload from DB to get the GeneratedField values.
+        event.refresh_from_db()
+        bt = BlockedTime.objects.filter_by_organization(org.id).get(
+            external_id=f"group-event-{event.id}-cal-{secondary_cal.id}"
+        )
+        bt.refresh_from_db()
+
+        # The GeneratedField ``start_time`` / ``end_time`` must be the same UTC
+        # instant for both the primary CalendarEvent and the linked BlockedTime.
+        assert event.start_time == bt.start_time, (
+            f"Primary start_time {event.start_time} != BlockedTime start_time {bt.start_time}"
+        )
+        assert event.end_time == bt.end_time, (
+            f"Primary end_time {event.end_time} != BlockedTime end_time {bt.end_time}"
+        )
+
+        # And those instants must equal the requested new UTC times.
+        assert event.start_time == RECIFE_NEW_UTC_START
+        assert event.end_time == RECIFE_NEW_UTC_END
+
+        # Code must be consumed.
+        token.refresh_from_db()
+        assert token.used_at is not None

--- a/public_api/tests/test_reschedule_group_with_code.py
+++ b/public_api/tests/test_reschedule_group_with_code.py
@@ -1,0 +1,838 @@
+"""Integration tests for rescheduleCalendarGroupEventWithCode (Phase 6b).
+
+All requests are unauthenticated (no Authorization header).  The group
+reschedule code provides the org scope, the calendar-group scope, the
+specific event scope, and the RESCHEDULE permission.
+
+Scenario coverage:
+1. Happy path — valid group-reschedule code + in-window new slot → success on a
+   RESTRICTED primary calendar (proves the code authorizes), event times updated
+   on the primary CalendarEvent AND on the linked non-primary BlockedTimes, event
+   id UNCHANGED, details preserved, code consumed.
+2. Replay → ALREADY_USED, no further change.
+3. Out-of-window new slot → SLOT_UNAVAILABLE, code NOT consumed, retryable.
+4. Calendar-scoped reschedule code (token.calendar_group is None) → NOT_PERMITTED
+   (routes to rescheduleCalendarEventWithCode).
+5. Missing RESCHEDULE permission (CREATE/CANCEL code) → NOT_PERMITTED.
+6. Expired / revoked / invalid codes → respective error codes.
+7. The rescheduled event is exactly `token.event` and still has `calendar_group_fk`
+   set (still a grouped event after reschedule).
+"""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarManagementToken,
+    EventManagementPermissions,
+)
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# GraphQL mutation string
+# ---------------------------------------------------------------------------
+
+RESCHEDULE_GROUP_WITH_CODE = """
+mutation RescheduleCalendarGroupEventWithCode($input: RescheduleGroupWithCodeInput!) {
+    rescheduleCalendarGroupEventWithCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        event {
+            id
+            title
+            startTime
+            endTime
+            externalAttendances {
+                externalAttendee {
+                    email
+                    name
+                }
+            }
+        }
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization():
+    return baker.make(Organization, name="Reschedule-Group-With-Code Test Org")
+
+
+@pytest.fixture
+def primary_calendar(organization):
+    """The primary calendar for the group.  RESTRICTED: accepts_public_scheduling=False.
+
+    Using a restricted calendar ensures the reschedule code alone authorizes the
+    operation — public scheduling is disabled, the code must be the gate.
+    """
+    return baker.make(
+        Calendar,
+        organization=organization,
+        name="Primary Calendar",
+        external_id="primary-cal-reschedulegrp-test",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=False,
+    )
+
+
+@pytest.fixture
+def secondary_calendar(organization):
+    """A second calendar belonging to a non-primary slot."""
+    return baker.make(
+        Calendar,
+        organization=organization,
+        name="Room Calendar",
+        external_id="room-cal-reschedulegrp-test",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.RESOURCE,
+        manage_available_windows=True,
+        accepts_public_scheduling=False,
+    )
+
+
+@pytest.fixture
+def group(organization, primary_calendar, secondary_calendar):
+    """A CalendarGroup with two slots: slot_a (primary_calendar) and slot_b (secondary_calendar)."""
+    grp = baker.make(CalendarGroup, organization=organization, name="Test Group")
+    slot_a = CalendarGroupSlot.objects.create(
+        organization=organization,
+        group=grp,
+        name="Physicians",
+        order=0,
+        required_count=1,
+    )
+    slot_b = CalendarGroupSlot.objects.create(
+        organization=organization,
+        group=grp,
+        name="Rooms",
+        order=1,
+        required_count=1,
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization,
+        slot=slot_a,
+        calendar=primary_calendar,
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization,
+        slot=slot_b,
+        calendar=secondary_calendar,
+    )
+    return grp
+
+
+@pytest.fixture
+def availability_windows(organization, primary_calendar, secondary_calendar):
+    """Availability windows for both calendars covering both the original and the new slots.
+
+    Original slot: 10:00-11:00 UTC
+    New slot:      14:00-15:00 UTC
+    Both fall inside 09:00-17:00 UTC.
+    """
+    windows = []
+    for cal in (primary_calendar, secondary_calendar):
+        windows.append(
+            AvailableTime.objects.create(
+                organization=organization,
+                calendar=cal,
+                start_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0),
+                end_time_tz_unaware=datetime.datetime(2030, 6, 1, 17, 0),
+                timezone="UTC",
+            )
+        )
+    return windows
+
+
+@pytest.fixture
+def grouped_event(organization, group, primary_calendar, secondary_calendar):
+    """A grouped primary CalendarEvent with a linked non-primary BlockedTime.
+
+    Constructed directly with baker/model calls (bypassing the group service
+    create_event path) so that the test is independent of the RESTRICTED-calendar
+    guard in can_perform_scheduling.  This mirrors how Phase 6a builds its test
+    event — the reschedule mutation is what we are testing, not event creation.
+
+    Structure created:
+    - Primary CalendarEvent on primary_calendar, calendar_group_fk = group.
+    - BlockedTime on secondary_calendar with the canonical external_id pattern.
+    - One EventExternalAttendance (patient@example.com) on the primary event.
+    """
+    from calendar_integration.models import EventExternalAttendance, ExternalAttendee
+
+    event = baker.make(
+        CalendarEvent,
+        organization=organization,
+        calendar=primary_calendar,
+        calendar_group=group,
+        title="Original Group Title",
+        description="Original description.",
+        timezone="UTC",
+        start_time_tz_unaware=datetime.datetime(2030, 6, 1, 10, 0),
+        end_time_tz_unaware=datetime.datetime(2030, 6, 1, 11, 0),
+        external_id="",
+    )
+
+    # Non-primary BlockedTime with the canonical external_id pattern.
+    BlockedTime.objects.create(
+        organization=organization,
+        calendar=secondary_calendar,
+        start_time_tz_unaware=datetime.datetime(2030, 6, 1, 10, 0),
+        end_time_tz_unaware=datetime.datetime(2030, 6, 1, 11, 0),
+        timezone="UTC",
+        reason=f"Group booking: {event.title}",
+        external_id=f"group-event-{event.id}-cal-{secondary_calendar.id}",
+    )
+
+    external_attendee = baker.make(
+        ExternalAttendee,
+        organization=organization,
+        email="patient@example.com",
+        name="Pat Patient",
+    )
+    baker.make(
+        EventExternalAttendance,
+        organization=organization,
+        event=event,
+        external_attendee=external_attendee,
+    )
+
+    return event
+
+
+@pytest.fixture
+def permission_service():
+    return CalendarPermissionService()
+
+
+@pytest.fixture
+def group_reschedule_code(permission_service, organization, group, grouped_event):
+    """A valid single-use GROUP RESCHEDULE code bound to ``grouped_event``."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_group_id=group.id,
+        event_id=grouped_event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def calendar_scoped_reschedule_code(
+    permission_service, organization, primary_calendar, grouped_event
+):
+    """A RESCHEDULE code scoped to a single calendar only (no calendar_group)."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.RESCHEDULE],
+        calendar_id=primary_calendar.id,
+        event_id=grouped_event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def create_only_code(permission_service, organization, group):
+    """A CREATE-only code — wrong permission for rescheduling."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=group.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def cancel_only_code(permission_service, organization, group, grouped_event):
+    """A CANCEL-only code bound to the grouped event — wrong permission for rescheduling."""
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CANCEL],
+        calendar_group_id=group.id,
+        event_id=grouped_event.id,
+    )
+    return token, code
+
+
+@pytest.fixture
+def anon_client():
+    """APIClient with no Authorization header."""
+    return APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Original slot set by the ``grouped_event`` fixture (10:00-11:00 UTC on 2030-06-01).
+ORIGINAL_START = datetime.datetime(2030, 6, 1, 10, 0, tzinfo=datetime.UTC)
+ORIGINAL_END = datetime.datetime(2030, 6, 1, 11, 0, tzinfo=datetime.UTC)
+
+# New slot for happy-path reschedule: 14:00-15:00 UTC (inside 09:00-17:00 window).
+NEW_START = datetime.datetime(2030, 6, 1, 14, 0, tzinfo=datetime.UTC)
+NEW_END = datetime.datetime(2030, 6, 1, 15, 0, tzinfo=datetime.UTC)
+
+# Out-of-window slot: 22:00-23:00 UTC (outside the 09:00-17:00 window).
+OOW_START = datetime.datetime(2030, 6, 1, 22, 0, tzinfo=datetime.UTC)
+OOW_END = datetime.datetime(2030, 6, 1, 23, 0, tzinfo=datetime.UTC)
+
+
+def _reschedule_group_input(code: str, **overrides) -> dict:
+    """Build a default happy-path mutation input dict."""
+    base = {
+        "code": code,
+        "startTime": NEW_START.isoformat(),
+        "endTime": NEW_END.isoformat(),
+        "timezone": "UTC",
+    }
+    base.update(overrides)
+    return base
+
+
+def post_graphql(client: APIClient, query: str, variables: dict) -> dict:
+    response = client.post(
+        "/graphql/",
+        data={"query": query, "variables": variables},
+        format="json",
+    )
+    assert response.status_code == 200, response.content.decode()
+    return response.json()
+
+
+def _get_blocked_time(organization: Organization, event_id: int, calendar_id: int) -> BlockedTime:
+    """Load the BlockedTime row linked to a grouped event for a specific calendar."""
+    return BlockedTime.objects.filter_by_organization(organization.id).get(
+        external_id=f"group-event-{event_id}-cal-{calendar_id}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRescheduleGroupWithCodeHappyPath:
+    """Scenario 1: Valid group-reschedule code + in-window slot → success.
+
+    Verifies:
+    - Primary CalendarEvent times are updated.
+    - Non-primary BlockedTime times are updated.
+    - Event id is preserved (same pk as the original grouped_event).
+    - Title, description, external attendee are preserved.
+    - Code is consumed.
+    - Works on a RESTRICTED primary calendar.
+    - The returned event still has calendar_group_fk set.
+    """
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_happy_path_updates_primary_event_and_blocked_times(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        group,
+        primary_calendar,
+        secondary_calendar,
+        grouped_event,
+        availability_windows,  # noqa: ARG002 — seeds DB rows
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+        assert result["errorCode"] is None
+        assert result["event"] is not None
+
+        # Event id is preserved (same pk, not a new event).
+        returned_event_id = int(result["event"]["id"])
+        assert returned_event_id == grouped_event.id
+
+        # Code must be consumed.
+        token.refresh_from_db()
+        assert token.used_at is not None
+        assert token.consumed_source_ip is not None
+
+        # Primary event times must be updated.
+        grouped_event.refresh_from_db()
+        assert grouped_event.start_time_tz_unaware.replace(tzinfo=None) == NEW_START.replace(
+            tzinfo=None
+        )
+        assert grouped_event.end_time_tz_unaware.replace(tzinfo=None) == NEW_END.replace(
+            tzinfo=None
+        )
+
+        # Non-primary BlockedTime must also be updated.
+        bt = _get_blocked_time(organization, grouped_event.id, secondary_calendar.id)
+        assert bt.start_time_tz_unaware.replace(tzinfo=None) == NEW_START.replace(tzinfo=None)
+        assert bt.end_time_tz_unaware.replace(tzinfo=None) == NEW_END.replace(tzinfo=None)
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_event_is_still_grouped_after_reschedule(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        group,
+        grouped_event,
+        availability_windows,  # noqa: ARG002
+    ):
+        """The rescheduled event still has calendar_group_fk set."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+
+        grouped_event.refresh_from_db()
+        assert grouped_event.calendar_group_fk_id == group.id
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_title_description_and_attendees_preserved(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        group,
+        grouped_event,
+        availability_windows,  # noqa: ARG002
+    ):
+        """Title, description, and external attendee are preserved after reschedule."""
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+
+        # Title preserved in GraphQL response.
+        assert result["event"]["title"] == "Original Group Title"
+
+        # External attendee preserved in GraphQL response.
+        external_attendances = result["event"]["externalAttendances"]
+        assert len(external_attendances) == 1
+        assert external_attendances[0]["externalAttendee"]["email"] == "patient@example.com"
+        assert external_attendances[0]["externalAttendee"]["name"] == "Pat Patient"
+
+        # DB: title and description unchanged.
+        grouped_event.refresh_from_db()
+        assert grouped_event.title == "Original Group Title"
+        assert grouped_event.description == "Original description."
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_returned_event_is_the_bound_event(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        group,
+        grouped_event,
+        availability_windows,  # noqa: ARG002
+    ):
+        """The rescheduled event is exactly the event the code was bound to."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+
+        returned_event_id = int(result["event"]["id"])
+        assert returned_event_id == grouped_event.id
+        assert returned_event_id == token.event_fk_id
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRescheduleGroupWithCodeReplay:
+    """Scenario 2: Replay with same code → ALREADY_USED, event not changed again."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_replay_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        group,
+        grouped_event,
+        availability_windows,  # noqa: ARG002
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = group_reschedule_code
+        input_data = _reschedule_group_input(code)
+
+        # First call — must succeed.
+        first = post_graphql(anon_client, RESCHEDULE_GROUP_WITH_CODE, {"input": input_data})
+        assert first["data"]["rescheduleCalendarGroupEventWithCode"]["success"] is True
+
+        # Second call — same code must return ALREADY_USED.
+        second = post_graphql(anon_client, RESCHEDULE_GROUP_WITH_CODE, {"input": input_data})
+        result = second["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"
+
+        # Event times must remain as set by the first reschedule.
+        grouped_event.refresh_from_db()
+        assert grouped_event.start_time_tz_unaware.replace(tzinfo=None) == NEW_START.replace(
+            tzinfo=None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Out-of-window slot → SLOT_UNAVAILABLE, code NOT consumed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRescheduleGroupWithCodeSlotUnavailable:
+    """Scenario 3: New slot outside availability → SLOT_UNAVAILABLE, code NOT consumed."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_out_of_window_slot_does_not_consume_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        group,
+        grouped_event,
+        availability_windows,  # noqa: ARG002 — window is 09:00-17:00 UTC
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {
+                "input": _reschedule_group_input(
+                    code,
+                    startTime=OOW_START.isoformat(),
+                    endTime=OOW_END.isoformat(),
+                )
+            },
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+        assert result["errorMessage"] == "The requested time slot is not available."
+
+        # Code must still be active.
+        token.refresh_from_db()
+        assert token.used_at is None
+
+        # Event times must be unchanged.
+        grouped_event.refresh_from_db()
+        assert grouped_event.start_time_tz_unaware.replace(tzinfo=None) == ORIGINAL_START.replace(
+            tzinfo=None
+        )
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_after_failed_reschedule_code_can_succeed(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        group_reschedule_code,
+        organization,
+        group,
+        grouped_event,
+        availability_windows,  # noqa: ARG002
+    ):
+        """After a SLOT_UNAVAILABLE failure the same code can succeed on a valid slot."""
+        mock_rate_limiter.return_value = iter([None])
+        token, code = group_reschedule_code
+
+        # First: out-of-window → failure.
+        fail = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {
+                "input": _reschedule_group_input(
+                    code,
+                    startTime=OOW_START.isoformat(),
+                    endTime=OOW_END.isoformat(),
+                )
+            },
+        )
+        assert (
+            fail["data"]["rescheduleCalendarGroupEventWithCode"]["errorCode"] == "SLOT_UNAVAILABLE"
+        )
+        token.refresh_from_db()
+        assert token.used_at is None
+
+        # Second: in-window → success.
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is True, result
+        token.refresh_from_db()
+        assert token.used_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Calendar-scoped code → NOT_PERMITTED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRescheduleGroupWithCodeCalendarScopedCode:
+    """Scenario 4: Calendar-scoped reschedule code (no calendar_group) → NOT_PERMITTED."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_calendar_only_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        calendar_scoped_reschedule_code,
+        organization,
+        grouped_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = calendar_scoped_reschedule_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+        # Event times must be unchanged.
+        grouped_event.refresh_from_db()
+        assert grouped_event.start_time_tz_unaware.replace(tzinfo=None) == ORIGINAL_START.replace(
+            tzinfo=None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Missing RESCHEDULE permission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRescheduleGroupWithCodeWrongPermission:
+    """Scenario 5: Code without RESCHEDULE permission → NOT_PERMITTED."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_create_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        create_only_code,
+        organization,
+        grouped_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = create_only_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_cancel_code_returns_not_permitted(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        cancel_only_code,
+        organization,
+        grouped_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        _token, code = cancel_only_code
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "NOT_PERMITTED"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6: Lifecycle rejections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRescheduleGroupWithCodeLifecycleRejections:
+    """Scenario 6: Expired / revoked / invalid codes → respective error codes."""
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_expired_code_returns_expired(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        group,
+        grouped_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        past = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+        _token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            calendar_group_id=group.id,
+            event_id=grouped_event.id,
+            expires_at=past,
+        )
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "EXPIRED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_revoked_code_returns_revoked(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        group,
+        grouped_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            calendar_group_id=group.id,
+            event_id=grouped_event.id,
+        )
+        permission_service.revoke_token(organization_id=organization.id, token_id=token.id)
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "REVOKED"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_invalid_code_returns_invalid_code(
+        self,
+        mock_rate_limiter,
+        anon_client,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input("aW52YWxpZGdyb3VwcmVzY2hlZHVsZQ==")},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "INVALID_CODE"
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_already_used_code_returns_already_used(
+        self,
+        mock_rate_limiter,
+        anon_client,
+        permission_service,
+        organization,
+        group,
+        grouped_event,
+    ):
+        mock_rate_limiter.return_value = iter([None])
+        token, code = permission_service.create_booking_token(
+            organization_id=organization.id,
+            permissions=[EventManagementPermissions.RESCHEDULE],
+            calendar_group_id=group.id,
+            event_id=grouped_event.id,
+        )
+        CalendarManagementToken.objects.filter(id=token.id).update(
+            used_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        )
+
+        data = post_graphql(
+            anon_client,
+            RESCHEDULE_GROUP_WITH_CODE,
+            {"input": _reschedule_group_input(code)},
+        )
+
+        result = data["data"]["rescheduleCalendarGroupEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "ALREADY_USED"


### PR DESCRIPTION

## Summary

Unauthenticated `rescheduleCalendarGroupEventWithCode` (no `permission_classes`). A group event-bound
RESCHEDULE code moves its grouped event to a new time, **time-only** (slot re-selection deferred —
Open Question 3), preserving the event id (the Building Blocks integration stores it).

New `CalendarGroupService.reschedule_grouped_event(event_id, start, end, tz)`:
- Updates the PRIMARY event's time via `update_event`, rebuilding `CalendarEventInputData` with all
  existing details preserved (title/description/attendances/external_attendances-by-email/resources),
  overriding only times → `can_perform_update` requires exactly `{RESCHEDULE}` (same technique as 6a).
- Updates the linked non-primary `BlockedTime`s (found by `external_id` LIKE `group-event-{id}-cal-`,
  org-scoped) to the new times.
- In-place: event id + `calendar_group_fk` preserved.

Mutation: `resolve_code` → require RESCHEDULE + event scope + GROUP scope (calendar-only codes →
NOT_PERMITTED, route to 6a) → availability pre-check on the primary calendar (scoped to the code path)
→ `transaction.atomic { calendar_service.initialize_without_provider(user_or_token=code) →
group_service.calendar_service = that instance → group_service.initialize → reschedule_grouped_event →
consume_code }`. event_id strictly from the token. First-write-wins; out-of-window → SLOT_UNAVAILABLE
(not consumed, retryable); replay → ALREADY_USED.

## Timezone-storage BLOCKER fixed (create + reschedule now agree)

The model stores `*_tz_unaware` as the naive LOCAL wall-clock paired with `timezone`; the primary event
is stored converted. But `_create_non_primary_blocked_times` was writing blocked-time `*_tz_unaware`
RAW (UTC wall-clock), so for non-UTC timezones the non-primary busy markers drifted off the primary
event (a pre-existing create bug, invisible to UTC-only tests). Fixed create to convert via
`convert_naive_utc_datetime_to_timezone`, matching the primary event and the reschedule path. Added a
non-UTC (`America/Recife`) regression test asserting the primary event and its blocked times resolve to
the same instants after reschedule (fails before the fix by the UTC offset).

## Plan reference

- Plan: `ai-plans/2026-06-17-SINGLE_USE_SCHEDULING_CODES_IMPLEMENTATION_PLAN.md` — Phase 6b; Open Question 3.
- Spec: Decisions → Use-cases, Use-case 4 (patient reschedules — group variant).

## Test plan

In-container (docker postgres): `public_api/tests/test_reschedule_group_with_code.py` — happy path on a
RESTRICTED primary calendar (times updated, linked blocked times moved, event id unchanged, details
preserved, code consumed), the non-UTC alignment test, replay → ALREADY_USED, out-of-window →
SLOT_UNAVAILABLE + not consumed, calendar-only code → NOT_PERMITTED, missing RESCHEDULE → NOT_PERMITTED,
expired/revoked/invalid. `ruff` clean · `makemigrations --check` no changes · `check --deploy` clean ·
`pytest -n auto` **2161 passed**.

Stacked on `plan/single-use-scheduling-codes/phase-6a`.