### PR TITLE
feat(public_api): owner-scope the blocked-time write mutations

### DIFF
--- a/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
+++ b/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
@@ -1,0 +1,40 @@
+# Tracking — Per-Owner-Scoped Public API Token Writes
+
+- **Plan**: [ai-plans/2026-06-18-PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES_IMPLEMENTATION_PLAN.md](2026-06-18-PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES_IMPLEMENTATION_PLAN.md)
+- **Spec**: [ai-plans/2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md](2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md)
+- **Started**: 2026-06-18
+- **Last updated**: 2026-06-18
+- **Feature flag**: none (owner-scope guard is a no-op for org-wide tokens)
+
+## run_options
+- `pause_between_phases`: false (auto-flow)
+- `generate_inline_comments`: true
+- `use_worktree`: true (reusing existing worktree)
+- `worktree_path`: `.claude/worktrees/plan-per-owner-scoped-public-api-tokens`
+- `worktree_branch`: `plan/per-owner-scoped-public-api-tokens/phase-3` (this plan stacks on the original plan's phase-3 / PR #107, not main)
+- `commit_strategy_resolved`: stacked-branches
+
+## Branch topology
+- Phase 1 base: `plan/per-owner-scoped-public-api-tokens/phase-3`
+- Branch pattern: `plan/per-owner-scoped-public-api-token-writes/phase-{id}`
+
+## Completed Phases
+
+### Phase 1 — Owner-guard blocked-time writes ✅
+- **Status**: complete, reviewed (Layers 1–3 clean; 1 SHOULD-FIX applied)
+- **Model**: claude-sonnet-4-6 (plan tier 3)
+- **Branch**: `plan/per-owner-scoped-public-api-token-writes/phase-1`
+- **Base**: `plan/per-owner-scoped-public-api-tokens/phase-3`
+- **Commits**: `7d345b7` (feat: guard), `61d5efb` (test: id-calendar mismatch regression)
+- **Summary**: Added shared write guard `assert_calendar_in_owner_scope(system_user, org, calendar_id)` to [public_api/scoping.py](../public_api/scoping.py) — no-op for `system_user=None` and org-wide tokens (`scoped_calendar_ids` → None), raises `Calendar.DoesNotExist("Calendar matching query does not exist.")` for a scoped token targeting an out-of-scope calendar. Wired it into `create_blocked_time`/`update_blocked_time`/`delete_blocked_time` INSIDE the existing `try/except Calendar.DoesNotExist`, so a cross-owner attempt is byte-identical to a genuinely-missing calendar (`"Calendar not found."`, success=False, no row touched). Added `CREATE/UPDATE/DELETE_BLOCKED_TIME` to `PROVIDER_SCOPED_RESOURCES`. Tests: 5 guard unit tests + 13 integration tests (success / cross-owner-indistinguishable+no-row / org-wide-unaffected / missing-grant per verb, plus a pinned id↔calendar-mismatch rejection test). Full suite 2392 passed.
+
+## Current Phase
+Phase 2 — Owner-guard availability writes.
+
+## Remaining Phases
+- Phase 2 — Owner-guard availability writes (Tier 3)
+- Phase 3 — scheduleEvent mutation + owner-scoped event allowance (Tier 4)
+- Phase 4 — Nested-field owner-scope sweep + security review (Tier 4)
+
+## Deferred Phases
+_(none — no cross-repo, no flag-removal)_

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -63,5 +63,8 @@ PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
         PublicAPIResources.AVAILABILITY_WINDOWS,
         PublicAPIResources.UNAVAILABLE_WINDOWS,
         PublicAPIResources.CALENDAR,
+        PublicAPIResources.CREATE_BLOCKED_TIME,
+        PublicAPIResources.UPDATE_BLOCKED_TIME,
+        PublicAPIResources.DELETE_BLOCKED_TIME,
     ]
 )

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -31,6 +31,7 @@ from public_api.capabilities import assert_org_can_invite, assert_target_in_subt
 from public_api.constants import PROVIDER_SCOPED_RESOURCES, PublicAPIResources
 from public_api.models import ResourceAccess, SystemUser
 from public_api.permissions import IsAuthenticated, OrganizationResourceAccess
+from public_api.scoping import assert_calendar_in_owner_scope
 from public_api.services import PublicAPIAuthService
 from public_api.types import (
     BrandingResult,
@@ -1452,15 +1453,21 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.create_blocked_time with the supplied parameters.
-        4. Returns the created BlockedTime on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.create_blocked_time with the supplied parameters.
+        5. Returns the created BlockedTime on success, or success=False + errorMessage on failure.
 
         The token's OrganizationResourceAccess must include the CREATE_BLOCKED_TIME resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return CreateBlockedTimeResult(success=False, error_message="Calendar not found.")
@@ -1492,17 +1499,23 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.update_blocked_time with the supplied parameters.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.update_blocked_time with the supplied parameters.
            Only fields present (non-None) in the input are applied; others are left unchanged.
-        4. Returns the updated BlockedTime on success, or success=False + errorMessage on failure.
+        5. Returns the updated BlockedTime on success, or success=False + errorMessage on failure.
            Note: a missing or cross-calendar blocked_time_id raises ValueError (success=False).
 
         The token's OrganizationResourceAccess must include the UPDATE_BLOCKED_TIME resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return UpdateBlockedTimeResult(success=False, error_message="Calendar not found.")
@@ -1535,9 +1548,10 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.delete_blocked_time with the supplied blocked_time_id.
-        4. Returns success=True on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.delete_blocked_time with the supplied blocked_time_id.
+        5. Returns success=True on success, or success=False + errorMessage on failure.
            Note: a missing or cross-calendar blocked_time_id raises ValueError (success=False).
 
         Note on recurrence: a recurring blocked time is stored as one row (rrule on
@@ -1549,8 +1563,13 @@ class Mutation(CalendarGroupMutations):
         The token's OrganizationResourceAccess must include the DELETE_BLOCKED_TIME resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return DeleteBlockedTimeResult(success=False, error_message="Calendar not found.")

--- a/public_api/scoping.py
+++ b/public_api/scoping.py
@@ -25,3 +25,34 @@ def scoped_calendar_ids(system_user: SystemUser, organization: Organization) -> 
         .distinct()
         .values_list("id", flat=True)
     )
+
+
+def assert_calendar_in_owner_scope(
+    system_user: SystemUser | None,
+    organization: Organization,
+    calendar_id: int,
+) -> None:
+    """Assert that the given calendar_id is accessible by the token's owner scope.
+
+    This is the shared write-side guard reused by all owner-guarded mutations.
+    It is a no-op when the system_user is None or when the token is org-wide
+    (scoped_calendar_ids returns None). When the token is scoped and calendar_id
+    is NOT in the allowed set, raises Calendar.DoesNotExist with the same message
+    that a genuinely-missing calendar produces — the caller must not reveal whether
+    the target exists.
+
+    Args:
+        system_user: The SystemUser (token) making the request, or None (no-op).
+        organization: The organization context.
+        calendar_id: The calendar ID targeted by the write operation.
+
+    Raises:
+        Calendar.DoesNotExist: When the token is scoped and calendar_id is outside
+            the owner's allowed calendar set. The message is intentionally identical
+            to a real not-found error to prevent existence leaks.
+    """
+    if system_user is None:
+        return
+    allowed_ids = scoped_calendar_ids(system_user, organization)
+    if allowed_ids is not None and calendar_id not in allowed_ids:
+        raise Calendar.DoesNotExist("Calendar matching query does not exist.")

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -7090,6 +7090,92 @@ class TestScopedTokenBlockedTimeWrites:
         assert BlockedTime.objects.filter(id=bt_b_id).exists()
 
     # ------------------------------------------------------------------
+    # blockedTimeId / calendarId mismatch — service-layer filter is load-bearing
+    # ------------------------------------------------------------------
+
+    def test_update_delete_blocked_time_in_scope_calendar_with_foreign_blocked_time_id_rejected(
+        self,
+    ):
+        """A scoped token passing its OWN calendar_id but a foreign blocked_time_id is rejected.
+
+        This pins the service-layer ``calendar_fk=calendar`` filter (the load-bearing
+        constraint for the new threat model). The new owner guard does NOT trip here
+        because ``calendarId`` is the token's in-scope calendar A; the only thing
+        rejecting the write is the service scoping the BlockedTime lookup to the
+        supplied calendar, so a foreign ``blocked_time_id`` on calendar B yields
+        ``success=False`` and leaves B's row untouched.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        # Provider A: scoped token, owns calendar A (in-scope for the token)
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        # Provider B: a different owner with a real BlockedTime row on calendar B
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME, PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        blocked_time_b = self._create_blocked_time_on_calendar(org, org_wide_su_b, calendar_b)
+        bt_b_id = blocked_time_b.id
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org,
+            membership_a,
+            [PublicAPIResources.UPDATE_BLOCKED_TIME, PublicAPIResources.DELETE_BLOCKED_TIME],
+        )
+
+        new_start = datetime.datetime(2026, 10, 9, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 9, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # updateBlockedTime: in-scope calendar A id, foreign blocked_time id on B
+        update_response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_a.id,
+                    "blockedTimeId": bt_b_id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert update_response.status_code == 200
+        update_data = update_response.json()
+        assert "errors" not in update_data or len(update_data.get("errors", [])) == 0
+        assert update_data["data"]["updateBlockedTime"]["success"] is False
+        # B's row must be unchanged by the rejected update
+        blocked_time_b.refresh_from_db()
+        assert blocked_time_b.reason == "Scoped test block"
+
+        # deleteBlockedTime: in-scope calendar A id, foreign blocked_time id on B
+        delete_response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_a.id,
+                    "blockedTimeId": bt_b_id,
+                }
+            },
+        )
+
+        assert delete_response.status_code == 200
+        delete_data = delete_response.json()
+        assert "errors" not in delete_data or len(delete_data.get("errors", [])) == 0
+        assert delete_data["data"]["deleteBlockedTime"]["success"] is False
+        # B's row must still exist — the foreign delete must NOT have succeeded
+        assert BlockedTime.objects.filter(id=bt_b_id).exists()
+
+    # ------------------------------------------------------------------
     # Org-wide token — no-regression assertions for all three verbs
     # ------------------------------------------------------------------
 

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -6578,3 +6578,732 @@ class TestCreateScopedSystemUserMutation:
 
         # No SystemUser or token row must have been created
         assert not SystemUser.objects.filter(integration_name="inactive_owner_provider").exists()
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Owner-guard blocked-time writes
+# ---------------------------------------------------------------------------
+#
+# GraphQL mutations reused from the existing blocked-time test sections.
+#
+_CREATE_BLOCKED_TIME_SCOPED = """
+mutation CreateBlockedTime($input: CreateBlockedTimeInput!) {
+    createBlockedTime(input: $input) {
+        success
+        errorMessage
+        blockedTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_UPDATE_BLOCKED_TIME_SCOPED = """
+mutation UpdateBlockedTime($input: UpdateBlockedTimeInput!) {
+    updateBlockedTime(input: $input) {
+        success
+        errorMessage
+        blockedTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_DELETE_BLOCKED_TIME_SCOPED = """
+mutation DeleteBlockedTime($input: DeleteBlockedTimeInput!) {
+    deleteBlockedTime(input: $input) {
+        success
+        errorMessage
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestScopedTokenBlockedTimeWrites:
+    """Integration tests for owner-scoped blocked-time mutations (Phase 1).
+
+    Coverage:
+    - Scoped token can create/update/delete on its owned calendar (happy path).
+    - Cross-owner write returns the same not-found message as a genuinely missing
+      calendar, revealing nothing about the target's existence.
+    - Org-wide token is structurally unchanged (no-regression assertion).
+    - A scoped token missing the required resource grant is denied by the permission
+      class before the guard even runs.
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _setup_org(self):
+        """Create a base organization for the test scenario."""
+        return baker.make(Organization, name="Test Org")
+
+    def _make_owner_with_calendar(self, org):
+        """Create a provider user, their membership, and a calendar they own.
+
+        Returns (user, membership, calendar).
+        """
+        import uuid
+
+        from calendar_integration.models import CalendarOwnership
+
+        user_model = get_user_model()
+        unique = uuid.uuid4().hex[:8]
+        owner = baker.make(user_model, email=f"owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = baker.make(
+            Calendar,
+            organization=org,
+            name="Provider Calendar",
+            external_id=f"provider-cal-{unique}",
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=owner, organization=org)
+        return owner, membership, calendar
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        """Mint a scoped SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        import uuid
+
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_org_wide_system_user(self, org, resources):
+        """Mint an org-wide (unscoped) SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        import uuid
+
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _create_blocked_time_on_calendar(self, org, system_user, calendar):
+        """Create a BlockedTime row directly via the service (not the API).
+
+        Used to set up rows for update/delete happy-path tests.
+        """
+        from di_core.containers import container
+
+        calendar_service: CalendarService = container.calendar_service()
+        calendar_service.initialize_without_provider(user_or_token=system_user, organization=org)
+        return calendar_service.create_blocked_time(
+            calendar=calendar,
+            start_time=datetime.datetime(2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2026, 10, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            reason="Scoped test block",
+        )
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    # ------------------------------------------------------------------
+    # createBlockedTime — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token creates a blocked time on its owner's calendar."""
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                    "reason": "Scoped block",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createBlockedTime"]
+        assert result["success"] is True
+        assert result["blockedTime"] is not None
+        bt_id = int(result["blockedTime"]["id"])
+
+        # Verify the DB row exists and belongs to the correct calendar
+        bt = BlockedTime.objects.filter_by_organization(org.id).get(id=bt_id)
+        assert bt.calendar_fk_id == calendar.id
+        assert bt.reason == "Scoped block"
+
+    # ------------------------------------------------------------------
+    # createBlockedTime — cross-owner not-found is identical to missing calendar
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner createBlockedTime returns identical not-found as a truly missing calendar.
+
+        A scoped token targeting another provider's calendar_id must get the same
+        success=False / errorMessage as a genuinely nonexistent calendar — revealing
+        nothing about the target's existence.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        # Two independent providers in the same org
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+
+        # Token scoped to provider A
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        # Attempt against provider B's calendar (cross-owner)
+        cross_owner_response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Attempt against a genuinely nonexistent calendar_id
+        nonexistent_id = 999998
+        missing_response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": nonexistent_id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Both must be success=False, no errors list, and IDENTICAL errorMessage
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["createBlockedTime"]
+            assert r["success"] is False
+            assert r["errorMessage"] is not None
+
+        cross_msg = cross_owner_response.json()["data"]["createBlockedTime"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["createBlockedTime"]["errorMessage"]
+        assert cross_msg == missing_msg, (
+            f"Cross-owner error '{cross_msg}' must equal missing-calendar error '{missing_msg}'"
+        )
+
+        # No BlockedTime rows must have been created in either case
+        assert not BlockedTime.objects.filter(calendar_fk_id=calendar_b.id).exists()
+
+    # ------------------------------------------------------------------
+    # updateBlockedTime — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_update_blocked_time_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token updates a blocked time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        # Create row via org-wide service call so the calendar service can initialize freely
+        org_wide_su, _org_wide_token, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+
+        new_start = datetime.datetime(2026, 10, 2, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 2, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateBlockedTime"]
+        assert result["success"] is True
+        assert result["blockedTime"] is not None
+
+    # ------------------------------------------------------------------
+    # updateBlockedTime — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_update_blocked_time_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner updateBlockedTime returns identical not-found as a truly missing calendar."""
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        # Create a blocked time on B's calendar using org-wide token
+        blocked_time_b = self._create_blocked_time_on_calendar(org, org_wide_su_b, calendar_b)
+
+        # Token scoped to provider A — must not update B's calendar
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+
+        new_start = datetime.datetime(2026, 10, 3, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 3, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id belongs to B, not A
+        cross_owner_response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "blockedTimeId": blocked_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Genuinely missing calendar_id attempt
+        missing_response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999997,
+                    "blockedTimeId": blocked_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["updateBlockedTime"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["updateBlockedTime"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["updateBlockedTime"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # The blocked time row must be unchanged
+        blocked_time_b.refresh_from_db()
+        assert blocked_time_b.reason == "Scoped test block"
+
+    # ------------------------------------------------------------------
+    # deleteBlockedTime — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_delete_blocked_time_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token deletes a blocked time on its owner's calendar."""
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        org_wide_su, _, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+        bt_id = blocked_time.id
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+
+        response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": bt_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteBlockedTime"]
+        assert result["success"] is True
+
+        # DB row must be gone
+        assert not BlockedTime.objects.filter(id=bt_id).exists()
+
+    # ------------------------------------------------------------------
+    # deleteBlockedTime — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_delete_blocked_time_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner deleteBlockedTime returns identical not-found as a truly missing calendar.
+
+        The blocked-time row must NOT be deleted when the token targets a cross-owner calendar.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        blocked_time_b = self._create_blocked_time_on_calendar(org, org_wide_su_b, calendar_b)
+        bt_b_id = blocked_time_b.id
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+
+        # Cross-owner attempt (calendar_b belongs to owner B)
+        cross_owner_response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "blockedTimeId": bt_b_id,
+                }
+            },
+        )
+
+        # Genuinely missing calendar attempt
+        missing_response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999996,
+                    "blockedTimeId": bt_b_id,
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["deleteBlockedTime"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["deleteBlockedTime"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["deleteBlockedTime"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # Row must still exist — the cross-owner delete must NOT have succeeded
+        assert BlockedTime.objects.filter(id=bt_b_id).exists()
+
+    # ------------------------------------------------------------------
+    # Org-wide token — no-regression assertions for all three verbs
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can create blocked times on any calendar (guard is no-op).
+
+        This is the no-regression assertion: the guard must be a structural no-op for
+        org-wide tokens, leaving their behavior byte-for-byte unchanged.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        # Calendar owned by a different provider — org-wide should not be blocked
+        _other_owner, _other_membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+
+        start = datetime.datetime(2026, 10, 6, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 6, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createBlockedTime"]
+        assert result["success"] is True
+        assert result["blockedTime"] is not None
+        bt_id = int(result["blockedTime"]["id"])
+        assert BlockedTime.objects.filter_by_organization(org.id).filter(id=bt_id).exists()
+
+    def test_update_blocked_time_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can update blocked times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, system_user, calendar)
+
+        new_start = datetime.datetime(2026, 10, 7, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 7, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateBlockedTime"]
+        assert result["success"] is True
+
+    def test_delete_blocked_time_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can delete blocked times on any calendar (guard is no-op)."""
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, system_user, calendar)
+        bt_id = blocked_time.id
+
+        response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": bt_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteBlockedTime"]
+        assert result["success"] is True
+        assert not BlockedTime.objects.filter(id=bt_id).exists()
+
+    # ------------------------------------------------------------------
+    # Missing resource grant — scoped token denied
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_scoped_token_missing_grant_denied(self):
+        """A scoped token without CREATE_BLOCKED_TIME grant is denied by the permission class."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        # Grant CALENDAR instead of CREATE_BLOCKED_TIME
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        start = datetime.datetime(2026, 10, 8, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 8, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_update_blocked_time_scoped_token_missing_grant_denied(self):
+        """A scoped token without UPDATE_BLOCKED_TIME grant is denied by the permission class."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        # Create row first using org-wide token
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+        # Scoped token with wrong resource
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_delete_blocked_time_scoped_token_missing_grant_denied(self):
+        """A scoped token without DELETE_BLOCKED_TIME grant is denied by the permission class."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()

--- a/public_api/tests/test_scoping.py
+++ b/public_api/tests/test_scoping.py
@@ -4,7 +4,7 @@ from model_bakery import baker
 from calendar_integration.models import Calendar, CalendarOwnership
 from organizations.models import Organization, OrganizationMembership
 from public_api.models import SystemUser
-from public_api.scoping import scoped_calendar_ids
+from public_api.scoping import assert_calendar_in_owner_scope, scoped_calendar_ids
 from public_api.services import PublicAPIAuthService
 from users.models import User
 
@@ -198,3 +198,116 @@ class TestScopedCalendarIds:
         assert system_user.organization_id == membership.organization_id
         # The scalar id is always accessible regardless of the FK join path.
         assert system_user.scoped_to_membership_fk_id == membership.id
+
+
+@pytest.mark.django_db
+class TestAssertCalendarInOwnerScope:
+    """Unit tests for the assert_calendar_in_owner_scope write-side guard."""
+
+    @pytest.fixture
+    def organization(self):
+        """Create a test organization."""
+        return baker.make(Organization, name="Test Organization")
+
+    @pytest.fixture
+    def user(self, organization):
+        """Create a test user."""
+        return baker.make(User, email="provider@example.com")
+
+    @pytest.fixture
+    def other_user(self, organization):
+        """Create another test user (different provider)."""
+        return baker.make(User, email="other_provider@example.com")
+
+    @pytest.fixture
+    def membership(self, organization, user):
+        """Create an active membership for the main user."""
+        return baker.make(
+            OrganizationMembership, user=user, organization=organization, is_active=True
+        )
+
+    @pytest.fixture
+    def other_membership(self, organization, other_user):
+        """Create an active membership for the other user."""
+        return baker.make(
+            OrganizationMembership, user=other_user, organization=organization, is_active=True
+        )
+
+    @pytest.fixture
+    def owned_calendar(self, organization, user):
+        """Create a calendar owned by the main user."""
+        calendar = baker.make(
+            Calendar, organization=organization, name="Owned Calendar", external_id="owned-cal"
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=user, organization=organization)
+        return calendar
+
+    @pytest.fixture
+    def other_calendar(self, organization, other_user):
+        """Create a calendar owned by the other user (cross-owner target)."""
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            name="Other Calendar",
+            external_id="other-cal",
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=other_user, organization=organization)
+        return calendar
+
+    @pytest.fixture
+    def org_wide_system_user(self, organization):
+        """Create an org-wide system user (no owner scope)."""
+        auth_service = PublicAPIAuthService()
+        system_user, _ = auth_service.create_system_user(
+            integration_name="org_wide_write_token", organization=organization
+        )
+        return system_user
+
+    @pytest.fixture
+    def scoped_system_user(self, organization, membership):
+        """Create a system user scoped to the main user's membership."""
+        return baker.make(
+            SystemUser,
+            organization=organization,
+            scoped_to_membership_fk=membership,
+            integration_name="scoped_write_token",
+        )
+
+    def test_no_raise_when_system_user_is_none(self, organization, owned_calendar):
+        """Guard is a no-op when system_user is None (no auth context)."""
+        # Must not raise regardless of calendar_id
+        assert_calendar_in_owner_scope(None, organization, owned_calendar.id)
+
+    def test_no_raise_for_org_wide_token(self, org_wide_system_user, organization, other_calendar):
+        """Guard is a no-op for org-wide tokens (scoped_calendar_ids returns None).
+
+        An org-wide token can target any calendar without the guard raising — this is
+        the no-regression assertion that ensures org-wide behavior is structurally unchanged.
+        """
+        assert_calendar_in_owner_scope(org_wide_system_user, organization, other_calendar.id)
+
+    def test_no_raise_for_in_scope_calendar(self, scoped_system_user, organization, owned_calendar):
+        """Guard does not raise when the calendar is within the token owner's scope."""
+        assert_calendar_in_owner_scope(scoped_system_user, organization, owned_calendar.id)
+
+    def test_raises_does_not_exist_for_out_of_scope_calendar(
+        self, scoped_system_user, organization, other_calendar
+    ):
+        """Guard raises Calendar.DoesNotExist for a cross-owner calendar_id when scoped.
+
+        The raised exception uses the same message as a genuinely missing calendar to
+        prevent existence leaks.
+        """
+        with pytest.raises(
+            Calendar.DoesNotExist, match=r"Calendar matching query does not exist\."
+        ):
+            assert_calendar_in_owner_scope(scoped_system_user, organization, other_calendar.id)
+
+    def test_raises_for_nonexistent_calendar_id_when_scoped(self, scoped_system_user, organization):
+        """Guard raises Calendar.DoesNotExist for a nonexistent calendar_id when scoped.
+
+        A nonexistent id is not in the allowed set, so the same exception is raised.
+        """
+        nonexistent_id = 999999
+        with pytest.raises(Calendar.DoesNotExist):
+            assert_calendar_in_owner_scope(scoped_system_user, organization, nonexistent_id)


### PR DESCRIPTION
## Summary
Phase 1 of the **Per-Owner-Scoped Public API Token Writes** plan — the continuation of the
Per-Owner-Scoped Public API Tokens feature that delivers the provider *write* capabilities against a
`main` that already ships org-wide write mutations. This phase makes the existing
`createBlockedTime` / `updateBlockedTime` / `deleteBlockedTime` mutations **owner-aware**: a
provider-scoped token may only write blocked times on its owner's calendars; org-wide tokens are
byte-for-byte unchanged.

Rather than add parallel mutations (which would collide on the GraphQL field name and double the
enforcement surface), the existing mutations get a single shared guard call.

## What changed
- **`public_api/scoping.py`**: new shared write guard `assert_calendar_in_owner_scope(system_user,
  organization, calendar_id)`. No-op when `system_user is None` and when the token is org-wide
  (`scoped_calendar_ids` returns `None`); otherwise raises `Calendar.DoesNotExist` with the same
  message a genuinely-missing calendar produces. Reused by phases 2 and 3.
- **`public_api/mutations.py`**: the guard is called in all three blocked-time mutations, *inside* the
  existing `try/except Calendar.DoesNotExist`, before the calendar fetch and the service call — so a
  cross-owner attempt is indistinguishable from a genuinely-missing calendar (`success=False`,
  `"Calendar not found."`, no row touched). Org-wide behavior is unchanged (guard short-circuits).
- **`public_api/constants.py`**: `CREATE_BLOCKED_TIME`, `UPDATE_BLOCKED_TIME`, `DELETE_BLOCKED_TIME`
  added to `PROVIDER_SCOPED_RESOURCES` so a scoped token can be granted them — one resource vocabulary
  for org-wide and scoped tokens; owner-scope stays an orthogonal layer.

## Plan reference
Plan `ai-plans/2026-06-18-PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES_IMPLEMENTATION_PLAN.md` — Phase 1.
Spec `ai-plans/2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md`: use-case 2 (provider manages its
owner's blocked times) + use-case 3 (cross-owner refused as not-found). Stacks on phase-3 of the
original plan (PR #107), which carries the read-scoping + mint + `scoped_calendar_ids` infra.

## Test plan
- `public_api/tests/test_scoping.py` — `assert_calendar_in_owner_scope`: no-raise for `None` user, for
  org-wide token, and for in-scope calendar; raises for out-of-scope and for a nonexistent id when scoped.
- `public_api/tests/test_mutations.py` (`TestScopedTokenBlockedTimeWrites`) — per verb (create/update/
  delete): scoped token succeeds on its owned calendar; cross-owner `calendarId` returns a not-found
  byte-identical to a genuinely-missing calendar AND writes no row; org-wide token unaffected; missing
  resource grant denied. Plus a pinned regression: a scoped token passing its OWN `calendarId` with a
  `blockedTimeId` from another calendar is rejected (`success=False`, the foreign row unchanged) by the
  service's `calendar_fk=calendar` filter.
- Outer gate (docker): `check --deploy` + `pytest -n auto` → **2392 passed**.