### PR TITLE
feat(public_api): owner-scope the availability-window write mutations

### DIFF
--- a/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
+++ b/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
@@ -11,12 +11,18 @@
 - `generate_inline_comments`: true
 - `use_worktree`: true (reusing existing worktree)
 - `worktree_path`: `.claude/worktrees/plan-per-owner-scoped-public-api-tokens`
-- `worktree_branch`: `plan/per-owner-scoped-public-api-tokens/phase-3` (this plan stacks on the original plan's phase-3 / PR #107, not main)
+- `worktree_branch`: `main` (the original plan's phases 1–3 merged to main mid-run — PRs #105/#106/#107 — so this plan now bases on `main`, not phase-3)
 - `commit_strategy_resolved`: stacked-branches
 
 ## Branch topology
-- Phase 1 base: `plan/per-owner-scoped-public-api-tokens/phase-3`
+- Phase 1 base: `main` (rebased after PRs #105–107 merged)
 - Branch pattern: `plan/per-owner-scoped-public-api-token-writes/phase-{id}`
+
+## Main-health fix carried in Phase 1
+`main` had a broken migration graph: two `0007` leaves in `public_api`
+(`0007_systemuser_scoped_to_membership` + `0007_add_webhook_configuration_resource`, from separate
+merged plans). Phase 1 adds `0008_merge_20260619_0111` + `0009_alter_resourceaccess_resource_name`
+(commit `099e67e`) to repair it. Cherry-pickable as a standalone hotfix.
 
 ## Completed Phases
 
@@ -24,15 +30,23 @@
 - **Status**: complete, reviewed (Layers 1–3 clean; 1 SHOULD-FIX applied)
 - **Model**: claude-sonnet-4-6 (plan tier 3)
 - **Branch**: `plan/per-owner-scoped-public-api-token-writes/phase-1`
-- **Base**: `plan/per-owner-scoped-public-api-tokens/phase-3`
-- **Commits**: `7d345b7` (feat: guard), `61d5efb` (test: id-calendar mismatch regression)
+- **Base**: `main` (rebased; PR #138)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/138
+- **Commits**: `a1e3c7b` (feat: guard), `ff9c26e` (test: id-calendar mismatch regression), `099e67e` (fix: merge conflicting 0007 migrations) — SHAs after rebase onto main
+- **Final gate**: full suite 2438 passed; `makemigrations --check` clean
 - **Summary**: Added shared write guard `assert_calendar_in_owner_scope(system_user, org, calendar_id)` to [public_api/scoping.py](../public_api/scoping.py) — no-op for `system_user=None` and org-wide tokens (`scoped_calendar_ids` → None), raises `Calendar.DoesNotExist("Calendar matching query does not exist.")` for a scoped token targeting an out-of-scope calendar. Wired it into `create_blocked_time`/`update_blocked_time`/`delete_blocked_time` INSIDE the existing `try/except Calendar.DoesNotExist`, so a cross-owner attempt is byte-identical to a genuinely-missing calendar (`"Calendar not found."`, success=False, no row touched). Added `CREATE/UPDATE/DELETE_BLOCKED_TIME` to `PROVIDER_SCOPED_RESOURCES`. Tests: 5 guard unit tests + 13 integration tests (success / cross-owner-indistinguishable+no-row / org-wide-unaffected / missing-grant per verb, plus a pinned id↔calendar-mismatch rejection test). Full suite 2392 passed.
 
+### Phase 2 — Owner-guard availability writes ✅
+- **Status**: complete, reviewed (Layers 1–3 clean; 2 SHOULD-FIX test-hardening applied)
+- **Model**: claude-sonnet-4-6 (plan tier 3)
+- **Branch**: `plan/per-owner-scoped-public-api-token-writes/phase-2` (base phase-1)
+- **Commits**: `a0242e1` (feat: guard 4 availability mutations), `18d2a78` (test: harden cross-owner row-unchanged assertions)
+- **Summary**: Added `assert_calendar_in_owner_scope` (the Phase-1 guard) to `create_availability_window`/`update_availability_window`/`delete_availability_window`/`batch_update_availability_windows`, inside each existing `try/except Calendar.DoesNotExist` (cross-owner → byte-identical not-found, no row touched). Confirmed `batch_update_availability_windows` uses a single top-level `calendar_id` for the whole atomic batch → one guard up front rejects a cross-owner batch wholesale with no partial write. The update/delete `available_time_id` second-vector is constrained by the service (`filter(calendar_fk=calendar)`). Added the 4 availability write resources to `PROVIDER_SCOPED_RESOURCES`. 17 integration tests (success no-rrule/rrule, cross-owner-indistinguishable+no-row, org-wide-unaffected, missing-grant per verb; batch wholesale-rejection with seeded create/update/delete ops). Full suite 2455 passed.
+
 ## Current Phase
-Phase 2 — Owner-guard availability writes.
+Phase 3 — scheduleEvent mutation + owner-scoped event allowance.
 
 ## Remaining Phases
-- Phase 2 — Owner-guard availability writes (Tier 3)
 - Phase 3 — scheduleEvent mutation + owner-scoped event allowance (Tier 4)
 - Phase 4 — Nested-field owner-scope sweep + security review (Tier 4)
 

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -66,5 +66,9 @@ PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
         PublicAPIResources.CREATE_BLOCKED_TIME,
         PublicAPIResources.UPDATE_BLOCKED_TIME,
         PublicAPIResources.DELETE_BLOCKED_TIME,
+        PublicAPIResources.CREATE_AVAILABILITY_WINDOW,
+        PublicAPIResources.UPDATE_AVAILABILITY_WINDOW,
+        PublicAPIResources.DELETE_AVAILABILITY_WINDOW,
+        PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS,
     ]
 )

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1223,16 +1223,22 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.create_available_time with the supplied parameters.
-        4. Returns the created AvailableTime on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.create_available_time with the supplied parameters.
+        5. Returns the created AvailableTime on success, or success=False + errorMessage on failure.
            Note: the service raises ValueError if calendar.manage_available_windows is False.
 
         The token's OrganizationResourceAccess must include the CREATE_AVAILABILITY_WINDOW resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return CreateAvailabilityWindowResult(
@@ -1265,18 +1271,24 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Builds a single-op batch dict including only the fields provided in the input.
-        4. Delegates to CalendarService.batch_modify_available_times with the single op.
-        5. Finds the updated AvailableTime by id in the returned list and returns it.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Builds a single-op batch dict including only the fields provided in the input.
+        5. Delegates to CalendarService.batch_modify_available_times with the single op.
+        6. Finds the updated AvailableTime by id in the returned list and returns it.
            Note: a missing or cross-calendar available_time_id raises ValueError (success=False).
            Note: the service raises ValueError if calendar.manage_available_windows is False.
 
         The token's OrganizationResourceAccess must include the UPDATE_AVAILABILITY_WINDOW resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return UpdateAvailabilityWindowResult(
@@ -1328,9 +1340,10 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.batch_modify_available_times with a single delete op.
-        4. Returns success=True on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.batch_modify_available_times with a single delete op.
+        5. Returns success=True on success, or success=False + errorMessage on failure.
            Note: a missing or cross-calendar available_time_id raises ValueError (success=False).
            Note: the service raises ValueError if calendar.manage_available_windows is False.
            Note: the v2 doc proposed a deleteSeries argument, but batch_modify_available_times
@@ -1339,8 +1352,13 @@ class Mutation(CalendarGroupMutations):
         The token's OrganizationResourceAccess must include the DELETE_AVAILABILITY_WINDOW resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return DeleteAvailabilityWindowResult(
@@ -1366,12 +1384,16 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Validates every operation's action is one of {create, update, delete}.
-        4. Translates each BatchAvailabilityOperationInput into the service dict shape
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+           The single input.calendar_id governs the whole atomic batch; one guard call up front
+           rejects a cross-owner batch wholesale with no partial write (individual operations
+           share the same calendar_id — they carry no per-op calendar_id of their own).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Validates every operation's action is one of {create, update, delete}.
+        5. Translates each BatchAvailabilityOperationInput into the service dict shape
            (mapping available_time_id -> id; including only fields that are not None).
-        5. Delegates to CalendarService.batch_modify_available_times with the full ops list.
-        6. Returns the calendar's full AvailableTime list after the batch is applied.
+        6. Delegates to CalendarService.batch_modify_available_times with the full ops list.
+        7. Returns the calendar's full AvailableTime list after the batch is applied.
            The entire batch is rolled back if any operation fails (ATOMIC_REQUESTS = True
            means the request transaction wraps the whole mutation).
 
@@ -1381,8 +1403,15 @@ class Mutation(CalendarGroupMutations):
         _valid_actions = {"create", "update", "delete"}
 
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # One guard call covers the entire batch because all operations share this
+            # single calendar_id — individual BatchAvailabilityOperationInput entries carry
+            # no per-operation calendar_id. Raises Calendar.DoesNotExist (same as a genuinely
+            # missing calendar) so a cross-owner attempt reveals nothing about the target.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return BatchUpdateAvailabilityWindowsResult(

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -7775,6 +7775,12 @@ class TestScopedTokenAvailabilityWrites:
         _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
         available_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
 
+        # Capture B's row field values BEFORE the cross-owner attempt so the
+        # unchanged-check compares like-for-like (naive stored field to naive).
+        available_time_b.refresh_from_db()
+        start_before = available_time_b.start_time_tz_unaware
+        end_before = available_time_b.end_time_tz_unaware
+
         # Token scoped to provider A — must not update B's calendar
         system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
             org, membership_a, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
@@ -7830,11 +7836,10 @@ class TestScopedTokenAvailabilityWrites:
         missing_msg = missing_response.json()["data"]["updateAvailabilityWindow"]["errorMessage"]
         assert cross_msg == missing_msg
 
-        # The available time row must be unchanged
+        # The available time row must be unchanged (compare against pre-attempt values).
         available_time_b.refresh_from_db()
-        assert available_time_b.start_time_tz_unaware == datetime.datetime(
-            2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC
-        )
+        assert available_time_b.start_time_tz_unaware == start_before
+        assert available_time_b.end_time_tz_unaware == end_before
 
     # ------------------------------------------------------------------
     # deleteAvailabilityWindow — scoped happy path
@@ -8007,7 +8012,17 @@ class TestScopedTokenAvailabilityWrites:
         """
         org = self._setup_org()
         _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
         _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+
+        # Seed a pre-existing AvailableTime row on B's calendar so a partial
+        # update/delete (not just a stray create) would be detectable.
+        existing_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
+        existing_time_b.refresh_from_db()
+        existing_start_before = existing_time_b.start_time_tz_unaware
+        existing_end_before = existing_time_b.end_time_tz_unaware
 
         # Count rows on B's calendar before the cross-owner attempt (org-scoped query)
         rows_before = (
@@ -8024,7 +8039,12 @@ class TestScopedTokenAvailabilityWrites:
         create_start = datetime.datetime(2026, 12, 1, 9, 0, 0, tzinfo=datetime.UTC)
         create_end = datetime.datetime(2026, 12, 1, 17, 0, 0, tzinfo=datetime.UTC)
 
-        # Cross-owner attempt: calendar_id = B's calendar, batch includes a create op
+        update_start = datetime.datetime(2026, 12, 2, 9, 0, 0, tzinfo=datetime.UTC)
+        update_end = datetime.datetime(2026, 12, 2, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id = B's calendar, batch mixes create,
+        # update, and delete ops — an update/delete targets B's pre-existing row,
+        # so a partial write (not just a stray create) would be caught.
         cross_owner_response = self._post(
             _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
             system_user_a,
@@ -8040,7 +8060,17 @@ class TestScopedTokenAvailabilityWrites:
                             "startTime": create_start.isoformat(),
                             "endTime": create_end.isoformat(),
                             "timezone": "UTC",
-                        }
+                        },
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time_b.id,
+                            "startTime": update_start.isoformat(),
+                            "endTime": update_end.isoformat(),
+                        },
+                        {
+                            "action": "delete",
+                            "availableTimeId": existing_time_b.id,
+                        },
                     ],
                 }
             },
@@ -8063,7 +8093,17 @@ class TestScopedTokenAvailabilityWrites:
                             "startTime": create_start.isoformat(),
                             "endTime": create_end.isoformat(),
                             "timezone": "UTC",
-                        }
+                        },
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time_b.id,
+                            "startTime": update_start.isoformat(),
+                            "endTime": update_end.isoformat(),
+                        },
+                        {
+                            "action": "delete",
+                            "availableTimeId": existing_time_b.id,
+                        },
                     ],
                 }
             },
@@ -8096,6 +8136,21 @@ class TestScopedTokenAvailabilityWrites:
         assert rows_after == rows_before, (
             f"Partial write detected: row count on B's calendar changed from "
             f"{rows_before} to {rows_after}"
+        )
+
+        # The pre-existing B row must NOT have been updated or deleted: it still
+        # exists and retains its original field values.
+        assert (
+            AvailableTime.objects.filter_by_organization(org.id)
+            .filter(id=existing_time_b.id)
+            .exists()
+        ), "Partial write detected: pre-existing B row was deleted"
+        existing_time_b.refresh_from_db()
+        assert existing_time_b.start_time_tz_unaware == existing_start_before, (
+            "Partial write detected: pre-existing B row's start time was updated"
+        )
+        assert existing_time_b.end_time_tz_unaware == existing_end_before, (
+            "Partial write detected: pre-existing B row's end time was updated"
         )
 
     # ------------------------------------------------------------------

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -7392,4 +7392,984 @@ class TestScopedTokenBlockedTimeWrites:
         data = response.json()
         assert "errors" in data
         assert len(data["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# GraphQL query constants for scoped-availability-writes tests
+# ---------------------------------------------------------------------------
+
+_CREATE_AVAILABILITY_WINDOW_SCOPED = """
+mutation CreateAvailabilityWindow($input: CreateAvailableTimeInput!) {
+    createAvailabilityWindow(input: $input) {
+        success
+        errorMessage
+        availableTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_UPDATE_AVAILABILITY_WINDOW_SCOPED = """
+mutation UpdateAvailabilityWindow($input: UpdateAvailableTimeInput!) {
+    updateAvailabilityWindow(input: $input) {
+        success
+        errorMessage
+        availableTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_DELETE_AVAILABILITY_WINDOW_SCOPED = """
+mutation DeleteAvailabilityWindow($input: DeleteAvailableTimeInput!) {
+    deleteAvailabilityWindow(input: $input) {
+        success
+        errorMessage
+    }
+}
+"""
+
+_BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED = """
+mutation BatchUpdateAvailabilityWindows($input: BatchAvailabilityInput!) {
+    batchUpdateAvailabilityWindows(input: $input) {
+        success
+        errorMessage
+        availableTimes {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestScopedTokenAvailabilityWrites:
+    """Integration tests for owner-scoped availability-window mutations (Phase 2).
+
+    Coverage:
+    - Scoped token can create (no rrule + rrule) / update / delete / batch on its owned calendar.
+    - Cross-owner write returns the same not-found message as a genuinely missing
+      calendar, revealing nothing about the target's existence.
+    - Org-wide token is structurally unchanged (no-regression assertion).
+    - A scoped token missing the required resource grant is denied by the permission
+      class before the guard even runs.
+    - Batch: a cross-owner calendar_id rejects the whole batch atomically (no partial write).
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers — mirror TestScopedTokenBlockedTimeWrites exactly
+    # ------------------------------------------------------------------
+
+    def _setup_org(self):
+        """Create a base organization for the test scenario."""
+        return baker.make(Organization, name="Test Org")
+
+    def _make_owner_with_managing_calendar(self, org):
+        """Create a provider user, their membership, and a manage_available_windows=True calendar.
+
+        Returns (user, membership, calendar).
+        """
+        from calendar_integration.models import CalendarOwnership
+
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        owner = baker.make(user_model, email=f"avail_owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = baker.make(
+            Calendar,
+            organization=org,
+            name=f"Provider Avail Calendar {unique}",
+            external_id=f"avail-cal-{unique}",
+            manage_available_windows=True,
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=owner, organization=org)
+        return owner, membership, calendar
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        """Mint a scoped SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_avail_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_org_wide_system_user(self, org, resources):
+        """Mint an org-wide (unscoped) SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_avail_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _create_available_time_on_calendar(self, org, system_user, calendar):
+        """Create an AvailableTime row directly via the service (not the API).
+
+        Used to set up rows for update/delete/batch happy-path tests.
+        """
+        from di_core.containers import container
+
+        calendar_service: CalendarService = container.calendar_service()
+        calendar_service.initialize_without_provider(user_or_token=system_user, organization=org)
+        return calendar_service.create_available_time(
+            calendar=calendar,
+            start_time=datetime.datetime(2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2026, 10, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    # ------------------------------------------------------------------
+    # createAvailabilityWindow — scoped happy path (no rrule)
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_scoped_token_on_owned_calendar_succeeds_no_rrule(self):
+        """A scoped token creates a one-off available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+        at_id = int(result["availableTime"]["id"])
+
+        at = AvailableTime.objects.filter_by_organization(org.id).get(id=at_id)
+        assert at.calendar_fk_id == calendar.id
+        assert at.recurrence_rule is None
+
+    # ------------------------------------------------------------------
+    # createAvailabilityWindow — scoped happy path (with rrule)
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_scoped_token_on_owned_calendar_succeeds_with_rrule(self):
+        """A scoped token creates a recurring available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 6, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 6, 17, 0, 0, tzinfo=datetime.UTC)
+        rrule = "FREQ=WEEKLY;BYDAY=TU"
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                    "rruleString": rrule,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+        at_id = int(result["availableTime"]["id"])
+
+        at = AvailableTime.objects.filter_by_organization(org.id).get(id=at_id)
+        assert at.calendar_fk_id == calendar.id
+        assert at.recurrence_rule is not None
+
+    # ------------------------------------------------------------------
+    # createAvailabilityWindow — cross-owner not-found identical to missing calendar
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner createAvailabilityWindow returns identical not-found as a truly missing calendar.
+
+        A scoped token targeting another provider's calendar_id must get the same
+        success=False / errorMessage as a genuinely nonexistent calendar — revealing
+        nothing about the target's existence. No AvailableTime row is created.
+        """
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+
+        # Token scoped to provider A
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        # Attempt against provider B's calendar (cross-owner)
+        cross_owner_response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Attempt against a genuinely nonexistent calendar_id
+        nonexistent_id = 999994
+        missing_response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": nonexistent_id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["createAvailabilityWindow"]
+            assert r["success"] is False
+            assert r["errorMessage"] is not None
+
+        cross_msg = cross_owner_response.json()["data"]["createAvailabilityWindow"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["createAvailabilityWindow"]["errorMessage"]
+        assert cross_msg == missing_msg, (
+            f"Cross-owner error '{cross_msg}' must equal missing-calendar error '{missing_msg}'"
+        )
+
+        # No AvailableTime rows must have been created for the cross-owner calendar
+        assert not AvailableTime.objects.filter(calendar_fk_id=calendar_b.id).exists()
+
+    # ------------------------------------------------------------------
+    # updateAvailabilityWindow — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_update_availability_window_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token updates an available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _org_wide_token, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+
+        new_start = datetime.datetime(2026, 10, 2, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 2, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+
+    # ------------------------------------------------------------------
+    # updateAvailabilityWindow — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_update_availability_window_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner updateAvailabilityWindow returns identical not-found as a truly missing calendar."""
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+        available_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
+
+        # Token scoped to provider A — must not update B's calendar
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+
+        new_start = datetime.datetime(2026, 10, 3, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 3, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id belongs to B, not A
+        cross_owner_response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "availableTimeId": available_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Genuinely missing calendar_id attempt
+        missing_response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999993,
+                    "availableTimeId": available_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["updateAvailabilityWindow"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["updateAvailabilityWindow"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["updateAvailabilityWindow"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # The available time row must be unchanged
+        available_time_b.refresh_from_db()
+        assert available_time_b.start_time_tz_unaware == datetime.datetime(
+            2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC
+        )
+
+    # ------------------------------------------------------------------
+    # deleteAvailabilityWindow — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_delete_availability_window_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token deletes an available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+        at_id = available_time.id
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+
+        response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": at_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteAvailabilityWindow"]
+        assert result["success"] is True
+
+        # DB row must be gone
+        assert not AvailableTime.objects.filter(id=at_id).exists()
+
+    # ------------------------------------------------------------------
+    # deleteAvailabilityWindow — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_delete_availability_window_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner deleteAvailabilityWindow returns identical not-found as a truly missing calendar.
+
+        The AvailableTime row must NOT be deleted when the token targets a cross-owner calendar.
+        """
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+        available_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
+        at_b_id = available_time_b.id
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+
+        # Cross-owner attempt (calendar_b belongs to owner B)
+        cross_owner_response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "availableTimeId": at_b_id,
+                }
+            },
+        )
+
+        # Genuinely missing calendar attempt
+        missing_response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999992,
+                    "availableTimeId": at_b_id,
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["deleteAvailabilityWindow"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["deleteAvailabilityWindow"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["deleteAvailabilityWindow"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # Row must still exist — the cross-owner delete must NOT have succeeded
+        assert AvailableTime.objects.filter(id=at_b_id).exists()
+
+    # ------------------------------------------------------------------
+    # batchUpdateAvailabilityWindows — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_batch_update_availability_windows_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token applies a batch of availability operations on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+        existing_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+
+        new_start = datetime.datetime(2026, 11, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 1, 17, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["batchUpdateAvailabilityWindows"]
+        assert result["success"] is True
+        assert result["availableTimes"] is not None
+
+    # ------------------------------------------------------------------
+    # batchUpdateAvailabilityWindows — cross-owner not-found + no partial write
+    # ------------------------------------------------------------------
+
+    def test_batch_update_availability_windows_cross_owner_rejected_wholesale(self):
+        """Cross-owner batchUpdateAvailabilityWindows returns identical not-found as missing calendar.
+
+        The entire batch must be rejected atomically — no AvailableTime rows must be
+        created, updated, or deleted when the calendar_id is cross-owner. Because
+        BatchAvailabilityInput carries a single calendar_id shared by all operations
+        (individual BatchAvailabilityOperationInput entries have no per-op calendar_id),
+        one guard call at the top rejects the whole batch before any operation runs.
+        """
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+
+        # Count rows on B's calendar before the cross-owner attempt (org-scoped query)
+        rows_before = (
+            AvailableTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .count()
+        )
+
+        # Token scoped to provider A
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+
+        create_start = datetime.datetime(2026, 12, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        create_end = datetime.datetime(2026, 12, 1, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id = B's calendar, batch includes a create op
+        cross_owner_response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "startTime": create_start.isoformat(),
+                            "endTime": create_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Genuinely missing calendar attempt (same batch shape)
+        nonexistent_id = 999991
+        missing_response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": nonexistent_id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "startTime": create_start.isoformat(),
+                            "endTime": create_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["batchUpdateAvailabilityWindows"]
+            assert r["success"] is False
+            assert r["errorMessage"] is not None
+
+        cross_msg = cross_owner_response.json()["data"]["batchUpdateAvailabilityWindows"][
+            "errorMessage"
+        ]
+        missing_msg = missing_response.json()["data"]["batchUpdateAvailabilityWindows"][
+            "errorMessage"
+        ]
+        assert cross_msg == missing_msg, (
+            f"Cross-owner error '{cross_msg}' must equal missing-calendar error '{missing_msg}'"
+        )
+
+        # No AvailableTime rows must have been created on B's calendar (no partial write)
+        rows_after = (
+            AvailableTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .count()
+        )
+        assert rows_after == rows_before, (
+            f"Partial write detected: row count on B's calendar changed from "
+            f"{rows_before} to {rows_after}"
+        )
+
+    # ------------------------------------------------------------------
+    # Org-wide token — no-regression assertions for all four verbs
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can create available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 6, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 6, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+        at_id = int(result["availableTime"]["id"])
+        assert AvailableTime.objects.filter_by_organization(org.id).filter(id=at_id).exists()
+
+    def test_update_availability_window_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can update available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, system_user, calendar)
+
+        new_start = datetime.datetime(2026, 10, 7, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 7, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateAvailabilityWindow"]
+        assert result["success"] is True
+
+    def test_delete_availability_window_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can delete available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, system_user, calendar)
+        at_id = available_time.id
+
+        response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": at_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteAvailabilityWindow"]
+        assert result["success"] is True
+        assert not AvailableTime.objects.filter(id=at_id).exists()
+
+    def test_batch_update_availability_windows_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can batch-update available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+        existing_time = self._create_available_time_on_calendar(org, system_user, calendar)
+
+        new_start = datetime.datetime(2026, 11, 2, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 2, 17, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["batchUpdateAvailabilityWindows"]
+        assert result["success"] is True
+
+    # ------------------------------------------------------------------
+    # Missing resource grant — scoped token denied (permission class fires first)
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_scoped_token_missing_grant_denied(self):
+        """A scoped token without CREATE_AVAILABILITY_WINDOW grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        start = datetime.datetime(2026, 10, 8, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 8, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_update_availability_window_scoped_token_missing_grant_denied(self):
+        """A scoped token without UPDATE_AVAILABILITY_WINDOW grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_delete_availability_window_scoped_token_missing_grant_denied(self):
+        """A scoped token without DELETE_AVAILABILITY_WINDOW grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_batch_update_availability_windows_scoped_token_missing_grant_denied(self):
+        """A scoped token without BATCH_UPDATE_AVAILABILITY_WINDOWS grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "operations": [],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
         assert "don't have access" in str(data["errors"]).lower()


### PR DESCRIPTION
## Summary
Phase 2 of the **Per-Owner-Scoped Public API Token Writes** plan. Makes the four existing
availability-window write mutations — `createAvailabilityWindow`, `updateAvailabilityWindow`,
`deleteAvailabilityWindow`, `batchUpdateAvailabilityWindows` (all of which write `AvailableTime` rows)
— **owner-aware**: a provider-scoped token may only write availability on its owner's calendars;
org-wide tokens are byte-for-byte unchanged. Structurally a mirror of Phase 1 (blocked-time writes),
reusing the same shared guard.

## What changed
- **`public_api/mutations.py`**: `assert_calendar_in_owner_scope(...)` (the Phase-1 guard) is called in
  all four mutations, inside each existing `try/except Calendar.DoesNotExist`, before the calendar
  fetch and the service call — cross-owner → byte-identical not-found, no row touched. For
  `batchUpdateAvailabilityWindows` the single top-level `input.calendar_id` governs the whole atomic
  batch, so one guard up front rejects a cross-owner batch wholesale with no partial write.
- **`public_api/constants.py`**: `CREATE/UPDATE/DELETE_AVAILABILITY_WINDOW` and
  `BATCH_UPDATE_AVAILABILITY_WINDOWS` added to `PROVIDER_SCOPED_RESOURCES`.

## Plan reference
Plan `ai-plans/2026-06-18-PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES_IMPLEMENTATION_PLAN.md` — Phase 2.
Spec `ai-plans/2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md`: use-case 2 (provider manages its
owner's availability — recurring availability + specific dates) + use-case 3 (cross-owner refused).
Stacked on phase-1 (PR #138).

## Test plan
- `public_api/tests/test_mutations.py` (`TestScopedTokenAvailabilityWrites`, 17 tests) — per verb
  (create no-rrule/rrule, update, delete, batch): scoped token succeeds on its owned calendar;
  cross-owner `calendarId` not-found byte-identical to a genuinely-missing calendar AND no
  `AvailableTime` row created/changed/deleted; org-wide token unaffected; missing grant denied. The
  batch cross-owner test mixes create+update+delete ops against a seeded B row and asserts the whole
  batch is rejected with the B row unchanged (no partial write).
- The `available_time_id` second-vector (own calendar_id + foreign available_time_id) is constrained by
  the service (`filter(calendar_fk=calendar)` → `ValueError`), verified in review.
- Outer gate (docker): `check --deploy` + `pytest -n auto` → **2455 passed**.