### PR TITLE
feat(public_api): add owner-scoped scheduleEvent mutation

### DIFF
--- a/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
+++ b/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
@@ -43,11 +43,17 @@ merged plans). Phase 1 adds `0008_merge_20260619_0111` + `0009_alter_resourceacc
 - **Commits**: `a0242e1` (feat: guard 4 availability mutations), `18d2a78` (test: harden cross-owner row-unchanged assertions)
 - **Summary**: Added `assert_calendar_in_owner_scope` (the Phase-1 guard) to `create_availability_window`/`update_availability_window`/`delete_availability_window`/`batch_update_availability_windows`, inside each existing `try/except Calendar.DoesNotExist` (cross-owner → byte-identical not-found, no row touched). Confirmed `batch_update_availability_windows` uses a single top-level `calendar_id` for the whole atomic batch → one guard up front rejects a cross-owner batch wholesale with no partial write. The update/delete `available_time_id` second-vector is constrained by the service (`filter(calendar_fk=calendar)`). Added the 4 availability write resources to `PROVIDER_SCOPED_RESOURCES`. 17 integration tests (success no-rrule/rrule, cross-owner-indistinguishable+no-row, org-wide-unaffected, missing-grant per verb; batch wholesale-rejection with seeded create/update/delete ops). Full suite 2455 passed.
 
+### Phase 3 — scheduleEvent mutation + owner-scoped event allowance ✅
+- **Status**: complete, reviewed (Layers 1–3 clean; no BLOCKER/SHOULD-FIX; 2 NITs deferred — `organization_id` input field is unused but consistent with sibling write mutations; `EVENT_TITLE_MAX_LENGTH=255` hardcoded but correct/stable)
+- **Model**: claude-opus-4-8 (plan tier 4)
+- **Branch**: `plan/per-owner-scoped-public-api-token-writes/phase-3` (base phase-2)
+- **Commit**: `b11855c` (feat: owner-scoped scheduleEvent mutation)
+- **Summary**: Relaxed the blanket `SystemUser` `PermissionDenied` in `calendar_event_service.create_event` (the scheduleEvent path; left `update_event`/`delete_event` blocks intact) to allow ONLY an owner-scoped token whose owner independently owns the calendar — verified via `_scoped_system_user_owns_calendar` (a `CalendarOwnership` query filtered by the calendar's org, membership→user join; org-wide tokens return False → stay blocked). Bundle calendars rejected up front (avoids cross-provider fan-out). Skipped `can_perform_scheduling` ONLY on the verified-ownership path (`is_owner_scoped_system_user`) — that method is a pure token-permission gate, NOT availability enforcement (availability still runs at create_event:319-325). Fixed the on_commit audit actor (getattr-guard the permission token, fall back to the SystemUser). Added `scheduleEvent` mutation (`ScheduleEventInput`) guarded by `assert_calendar_in_owner_scope` (defense-in-depth; cross-owner/non-owned → "Calendar not found." identical to missing, BEFORE the service PermissionDenied can leak existence), de-duplicated active-org-member attendee validation, external-attendee translation, title-length guard, clean GraphQL error mapping. Mapped `scheduleEvent → CALENDAR_EVENT`. Tests: 4 service unit + 10 integration (scoped success/recurring/attendees, out-of-org attendee no-row, cross-owner not-found no-row, org-wide denied no-row, bundle no-row, no-availability error, missing-grant denied). Full suite 2469 passed.
+
 ## Current Phase
-Phase 3 — scheduleEvent mutation + owner-scoped event allowance.
+Phase 4 — Nested-field owner-scope sweep + security review.
 
 ## Remaining Phases
-- Phase 3 — scheduleEvent mutation + owner-scoped event allowance (Tier 4)
 - Phase 4 — Nested-field owner-scope sweep + security review (Tier 4)
 
 ## Deferred Phases

--- a/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
+++ b/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
@@ -11,12 +11,18 @@
 - `generate_inline_comments`: true
 - `use_worktree`: true (reusing existing worktree)
 - `worktree_path`: `.claude/worktrees/plan-per-owner-scoped-public-api-tokens`
-- `worktree_branch`: `plan/per-owner-scoped-public-api-tokens/phase-3` (this plan stacks on the original plan's phase-3 / PR #107, not main)
+- `worktree_branch`: `main` (the original plan's phases 1–3 merged to main mid-run — PRs #105/#106/#107 — so this plan now bases on `main`, not phase-3)
 - `commit_strategy_resolved`: stacked-branches
 
 ## Branch topology
-- Phase 1 base: `plan/per-owner-scoped-public-api-tokens/phase-3`
+- Phase 1 base: `main` (rebased after PRs #105–107 merged)
 - Branch pattern: `plan/per-owner-scoped-public-api-token-writes/phase-{id}`
+
+## Main-health fix carried in Phase 1
+`main` had a broken migration graph: two `0007` leaves in `public_api`
+(`0007_systemuser_scoped_to_membership` + `0007_add_webhook_configuration_resource`, from separate
+merged plans). Phase 1 adds `0008_merge_20260619_0111` + `0009_alter_resourceaccess_resource_name`
+(commit `099e67e`) to repair it. Cherry-pickable as a standalone hotfix.
 
 ## Completed Phases
 
@@ -24,15 +30,23 @@
 - **Status**: complete, reviewed (Layers 1–3 clean; 1 SHOULD-FIX applied)
 - **Model**: claude-sonnet-4-6 (plan tier 3)
 - **Branch**: `plan/per-owner-scoped-public-api-token-writes/phase-1`
-- **Base**: `plan/per-owner-scoped-public-api-tokens/phase-3`
-- **Commits**: `7d345b7` (feat: guard), `61d5efb` (test: id-calendar mismatch regression)
+- **Base**: `main` (rebased; PR #138)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/138
+- **Commits**: `a1e3c7b` (feat: guard), `ff9c26e` (test: id-calendar mismatch regression), `099e67e` (fix: merge conflicting 0007 migrations) — SHAs after rebase onto main
+- **Final gate**: full suite 2438 passed; `makemigrations --check` clean
 - **Summary**: Added shared write guard `assert_calendar_in_owner_scope(system_user, org, calendar_id)` to [public_api/scoping.py](../public_api/scoping.py) — no-op for `system_user=None` and org-wide tokens (`scoped_calendar_ids` → None), raises `Calendar.DoesNotExist("Calendar matching query does not exist.")` for a scoped token targeting an out-of-scope calendar. Wired it into `create_blocked_time`/`update_blocked_time`/`delete_blocked_time` INSIDE the existing `try/except Calendar.DoesNotExist`, so a cross-owner attempt is byte-identical to a genuinely-missing calendar (`"Calendar not found."`, success=False, no row touched). Added `CREATE/UPDATE/DELETE_BLOCKED_TIME` to `PROVIDER_SCOPED_RESOURCES`. Tests: 5 guard unit tests + 13 integration tests (success / cross-owner-indistinguishable+no-row / org-wide-unaffected / missing-grant per verb, plus a pinned id↔calendar-mismatch rejection test). Full suite 2392 passed.
 
+### Phase 2 — Owner-guard availability writes ✅
+- **Status**: complete, reviewed (Layers 1–3 clean; 2 SHOULD-FIX test-hardening applied)
+- **Model**: claude-sonnet-4-6 (plan tier 3)
+- **Branch**: `plan/per-owner-scoped-public-api-token-writes/phase-2` (base phase-1)
+- **Commits**: `a0242e1` (feat: guard 4 availability mutations), `18d2a78` (test: harden cross-owner row-unchanged assertions)
+- **Summary**: Added `assert_calendar_in_owner_scope` (the Phase-1 guard) to `create_availability_window`/`update_availability_window`/`delete_availability_window`/`batch_update_availability_windows`, inside each existing `try/except Calendar.DoesNotExist` (cross-owner → byte-identical not-found, no row touched). Confirmed `batch_update_availability_windows` uses a single top-level `calendar_id` for the whole atomic batch → one guard up front rejects a cross-owner batch wholesale with no partial write. The update/delete `available_time_id` second-vector is constrained by the service (`filter(calendar_fk=calendar)`). Added the 4 availability write resources to `PROVIDER_SCOPED_RESOURCES`. 17 integration tests (success no-rrule/rrule, cross-owner-indistinguishable+no-row, org-wide-unaffected, missing-grant per verb; batch wholesale-rejection with seeded create/update/delete ops). Full suite 2455 passed.
+
 ## Current Phase
-Phase 2 — Owner-guard availability writes.
+Phase 3 — scheduleEvent mutation + owner-scoped event allowance.
 
 ## Remaining Phases
-- Phase 2 — Owner-guard availability writes (Tier 3)
 - Phase 3 — scheduleEvent mutation + owner-scoped event allowance (Tier 4)
 - Phase 4 — Nested-field owner-scope sweep + security review (Tier 4)
 

--- a/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
+++ b/ai-plans/TRACKING_PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES.md
@@ -1,0 +1,40 @@
+# Tracking — Per-Owner-Scoped Public API Token Writes
+
+- **Plan**: [ai-plans/2026-06-18-PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES_IMPLEMENTATION_PLAN.md](2026-06-18-PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES_IMPLEMENTATION_PLAN.md)
+- **Spec**: [ai-plans/2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md](2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md)
+- **Started**: 2026-06-18
+- **Last updated**: 2026-06-18
+- **Feature flag**: none (owner-scope guard is a no-op for org-wide tokens)
+
+## run_options
+- `pause_between_phases`: false (auto-flow)
+- `generate_inline_comments`: true
+- `use_worktree`: true (reusing existing worktree)
+- `worktree_path`: `.claude/worktrees/plan-per-owner-scoped-public-api-tokens`
+- `worktree_branch`: `plan/per-owner-scoped-public-api-tokens/phase-3` (this plan stacks on the original plan's phase-3 / PR #107, not main)
+- `commit_strategy_resolved`: stacked-branches
+
+## Branch topology
+- Phase 1 base: `plan/per-owner-scoped-public-api-tokens/phase-3`
+- Branch pattern: `plan/per-owner-scoped-public-api-token-writes/phase-{id}`
+
+## Completed Phases
+
+### Phase 1 — Owner-guard blocked-time writes ✅
+- **Status**: complete, reviewed (Layers 1–3 clean; 1 SHOULD-FIX applied)
+- **Model**: claude-sonnet-4-6 (plan tier 3)
+- **Branch**: `plan/per-owner-scoped-public-api-token-writes/phase-1`
+- **Base**: `plan/per-owner-scoped-public-api-tokens/phase-3`
+- **Commits**: `7d345b7` (feat: guard), `61d5efb` (test: id-calendar mismatch regression)
+- **Summary**: Added shared write guard `assert_calendar_in_owner_scope(system_user, org, calendar_id)` to [public_api/scoping.py](../public_api/scoping.py) — no-op for `system_user=None` and org-wide tokens (`scoped_calendar_ids` → None), raises `Calendar.DoesNotExist("Calendar matching query does not exist.")` for a scoped token targeting an out-of-scope calendar. Wired it into `create_blocked_time`/`update_blocked_time`/`delete_blocked_time` INSIDE the existing `try/except Calendar.DoesNotExist`, so a cross-owner attempt is byte-identical to a genuinely-missing calendar (`"Calendar not found."`, success=False, no row touched). Added `CREATE/UPDATE/DELETE_BLOCKED_TIME` to `PROVIDER_SCOPED_RESOURCES`. Tests: 5 guard unit tests + 13 integration tests (success / cross-owner-indistinguishable+no-row / org-wide-unaffected / missing-grant per verb, plus a pinned id↔calendar-mismatch rejection test). Full suite 2392 passed.
+
+## Current Phase
+Phase 2 — Owner-guard availability writes.
+
+## Remaining Phases
+- Phase 2 — Owner-guard availability writes (Tier 3)
+- Phase 3 — scheduleEvent mutation + owner-scoped event allowance (Tier 4)
+- Phase 4 — Nested-field owner-scope sweep + security review (Tier 4)
+
+## Deferred Phases
+_(none — no cross-repo, no flag-removal)_

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -44,6 +44,7 @@ from calendar_integration.models import (
     Calendar,
     CalendarEvent,
     CalendarManagementToken,
+    CalendarOwnership,
     EventAttendance,
     EventBulkModification,
     EventExternalAttendance,
@@ -188,6 +189,39 @@ class CalendarEventService:
             context.organization,
         )
 
+    @staticmethod
+    def _scoped_system_user_owns_calendar(system_user: SystemUser, calendar: Calendar) -> bool:
+        """Independently verify the scoped token's owner owns ``calendar``.
+
+        This is the narrow, sanctioned event-creation allowance for owner-scoped public-API
+        tokens. The check does NOT trust anything supplied by the caller: it re-derives the
+        ownership relation from the database, scoped to the calendar's own organization, so a
+        cross-organization or cross-owner token can never pass.
+
+        Ownership is confirmed when a :class:`CalendarOwnership` row exists for ``calendar``
+        whose ``user`` is the member behind the token's ``scoped_to_membership`` (an
+        ``OrganizationMembership``). Org-wide tokens (``scoped_to_membership_fk_id is None``)
+        always return ``False`` — event creation stays blocked for them.
+
+        Args:
+            system_user: The token (``SystemUser``) attempting the write.
+            calendar: The target calendar the event would be created on.
+
+        Returns:
+            ``True`` only when the token is scoped AND its owner independently owns the
+            target calendar in that calendar's organization; ``False`` otherwise.
+        """
+        if system_user.scoped_to_membership_fk_id is None:
+            return False
+        return (
+            CalendarOwnership.objects.filter_by_organization(calendar.organization_id)
+            .filter(
+                calendar_fk_id=calendar.id,
+                user__organization_memberships=system_user.scoped_to_membership_fk_id,
+            )
+            .exists()
+        )
+
     def _serialize_event(self, event: CalendarEvent) -> CalendarEventData:
         """Build webhook payload for calendar event."""
         return _serialize_event_util(event)
@@ -237,6 +271,10 @@ class CalendarEventService:
 
         calendar = self._get_calendar_by_id(calendar_id)
 
+        # When True, authorization is granted by independently-verified calendar ownership
+        # (the owner-scoped public-API allowance) rather than by the permission-token flow.
+        is_owner_scoped_system_user = False
+
         if isinstance(context.user_or_token, User):
             context.calendar_permission_service.initialize_with_user(
                 context.user_or_token,
@@ -244,15 +282,34 @@ class CalendarEventService:
                 calendar_id=calendar_id,
             )
         elif isinstance(context.user_or_token, SystemUser):
-            raise PermissionDenied("Events cannot be created through the Public API.")
+            # Public-API event creation is blocked by default. The single sanctioned
+            # exception: an owner-scoped token whose owner *independently* owns the target
+            # calendar (verified against CalendarOwnership, NOT trusted from the caller).
+            # Org-wide tokens (scoped_to_membership_fk_id is None) stay blocked — they must
+            # route through single-use codes / public scheduling.
+            if not self._scoped_system_user_owns_calendar(context.user_or_token, calendar):
+                raise PermissionDenied("Events cannot be created through the Public API.")
+            # Bundle calendars are rejected for scoped tokens: create_event would recurse
+            # into per-child creates that span other providers' calendars, producing a
+            # confusing partial failure. Reject up front with a clear, scoped error.
+            if calendar.calendar_type == CalendarType.BUNDLE:
+                raise PermissionDenied(
+                    "Events cannot be scheduled on a bundle calendar through the Public API."
+                )
+            is_owner_scoped_system_user = True
 
-        if not context.calendar_permission_service.can_perform_scheduling(
-            calendar_id=calendar_id,
-            calendar_settings=CalendarSettingsData(
-                manage_available_windows=calendar.manage_available_windows,
-                accepts_public_scheduling=calendar.accepts_public_scheduling,
-            ),
-            event=event_data,
+        # The permission-token scheduling check applies to the User / token flows. The
+        # owner-scoped path's authorization is the independently-verified ownership above,
+        # so it bypasses this check (the permission service has no token initialized for it).
+        if not is_owner_scoped_system_user and (
+            not context.calendar_permission_service.can_perform_scheduling(
+                calendar_id=calendar_id,
+                calendar_settings=CalendarSettingsData(
+                    manage_available_windows=calendar.manage_available_windows,
+                    accepts_public_scheduling=calendar.accepts_public_scheduling,
+                ),
+                event=event_data,
+            )
         ):
             raise PermissionDenied("You do not have permission to update this event.")
 
@@ -402,17 +459,23 @@ class CalendarEventService:
         # Grant permissions to event attendees
         self._host._grant_event_attendee_permissions(event)
 
+        # Resolve the audit actor *before* queueing the post-commit side-effect.
+        # The owner-scoped public-API path never initializes a permission token, so
+        # ``calendar_permission_service.token`` may be unset entirely — read it through
+        # ``getattr`` to avoid an AttributeError after commit, and fall back to the
+        # SystemUser caller so owner-scoped events are never actor-less.
+        permission_token = getattr(context.calendar_permission_service, "token", None)
+        if permission_token is not None and permission_token.user:
+            audit_actor: Any = permission_token.user
+        elif permission_token is not None:
+            audit_actor = permission_token
+        else:
+            audit_actor = context.user_or_token
+
         transaction.on_commit(
             lambda: (
                 context.calendar_side_effects_service.on_create_event(
-                    actor=(
-                        context.calendar_permission_service.token.user
-                        if (
-                            context.calendar_permission_service.token
-                            and context.calendar_permission_service.token.user
-                        )
-                        else context.calendar_permission_service.token
-                    ),
+                    actor=audit_actor,
                     event=self._serialize_event(event),
                     organization=event.organization,
                 )

--- a/calendar_integration/tests/services/test_calendar_event_service.py
+++ b/calendar_integration/tests/services/test_calendar_event_service.py
@@ -325,3 +325,206 @@ def test_facade_create_event_delegates_to_event_service(
 
     assert result is sentinel
     fake_event_service.create_event.assert_called_once_with(123, sample_event_input_data)
+
+
+# ----------------------------------------------------------------------------------------
+# Owner-scoped public-API event-creation allowance (Phase 3)
+#
+# ``create_event`` hard-blocks all SystemUser callers EXCEPT a token that is owner-scoped
+# AND whose owner independently owns the target calendar (verified against CalendarOwnership,
+# not trusted from the caller). These tests pin that authorization boundary at the service
+# layer. The shared CalendarService facade (built via the DI container) supplies the wired
+# context; create_event is exercised through it.
+# ----------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scoped_event_setup(db):
+    """Build an org with a provider who owns a non-managed calendar.
+
+    Returns a dict with ``organization``, ``owner`` (User), ``membership``
+    (OrganizationMembership), and ``calendar`` (owned by ``owner``). The calendar has
+    ``manage_available_windows=False`` so the whole range is bookable (no window setup
+    needed) and no provider, so no external write adapter is invoked.
+    """
+    from calendar_integration.models import CalendarOwnership
+    from organizations.models import OrganizationMembership
+
+    organization = Organization.objects.create(name="Scoped Event Org", should_sync_rooms=False)
+    owner = User.objects.create_user(email="scoped-owner@example.com", password="testpass123")
+    Profile.objects.create(user=owner)
+    membership = OrganizationMembership.objects.create(
+        user=owner, organization=organization, is_active=True
+    )
+    calendar = Calendar.objects.create(
+        name="Owned Calendar",
+        external_id="owned_cal_1",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+    CalendarOwnership.objects.create(calendar=calendar, user=owner, organization=organization)
+    return {
+        "organization": organization,
+        "owner": owner,
+        "membership": membership,
+        "calendar": calendar,
+    }
+
+
+def _scoped_event_input():
+    return CalendarEventInputData(
+        title="Scoped Event",
+        description="Scheduled by an owner-scoped token",
+        start_time=datetime.datetime(2026, 7, 1, 10, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2026, 7, 1, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        attendances=[],
+        external_attendances=[],
+        resource_allocations=[],
+    )
+
+
+def _facade_for_system_user(system_user, organization):
+    """Return a DI-wired CalendarService facade initialized for the given SystemUser."""
+    from di_core.containers import container
+
+    service = container.calendar_service()
+    service.initialize_without_provider(user_or_token=system_user, organization=organization)
+    return service
+
+
+@pytest.mark.django_db
+def test_create_event_allows_owner_scoped_system_user_on_owned_calendar(scoped_event_setup):
+    """An owner-scoped token whose owner owns the calendar may create an event."""
+    from public_api.services import PublicAPIAuthService
+
+    org = scoped_event_setup["organization"]
+    calendar = scoped_event_setup["calendar"]
+    membership = scoped_event_setup["membership"]
+
+    system_user, _token = PublicAPIAuthService().create_system_user(
+        integration_name="scoped_event_svc_owned",
+        organization=org,
+        scoped_to_membership=membership,
+    )
+
+    facade = _facade_for_system_user(system_user, org)
+    event = facade.create_event(calendar.id, _scoped_event_input())
+
+    assert event.id is not None
+    assert event.calendar_fk_id == calendar.id
+    assert event.title == "Scoped Event"
+
+
+@pytest.mark.django_db
+def test_create_event_still_blocks_org_wide_system_user(scoped_event_setup):
+    """An org-wide (unscoped) token is still blocked from creating events."""
+    from django.core.exceptions import PermissionDenied
+
+    from public_api.services import PublicAPIAuthService
+
+    org = scoped_event_setup["organization"]
+    calendar = scoped_event_setup["calendar"]
+
+    system_user, _token = PublicAPIAuthService().create_system_user(
+        integration_name="org_wide_event_svc",
+        organization=org,
+    )
+
+    facade = _facade_for_system_user(system_user, org)
+    with pytest.raises(PermissionDenied, match="Events cannot be created through the Public API"):
+        facade.create_event(calendar.id, _scoped_event_input())
+
+    assert not CalendarEvent.objects.filter(
+        calendar_fk_id=calendar.id, organization_id=org.id
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_event_blocks_scoped_token_on_non_owned_calendar(scoped_event_setup):
+    """A scoped token may not create on a calendar its owner does not own.
+
+    The independent CalendarOwnership verification fails (no ownership row links the
+    token's owner to this other calendar), so the block stays in force.
+    """
+    from django.core.exceptions import PermissionDenied
+
+    from organizations.models import OrganizationMembership
+    from public_api.services import PublicAPIAuthService
+
+    org = scoped_event_setup["organization"]
+    membership = scoped_event_setup["membership"]
+
+    # A second provider's calendar with no ownership row for the first provider.
+    other_calendar = Calendar.objects.create(
+        name="Other Calendar",
+        external_id="other_cal_1",
+        provider=CalendarProvider.GOOGLE,
+        organization=org,
+    )
+    # (sanity: the token is scoped to a real membership but does NOT own other_calendar)
+    assert OrganizationMembership.objects.filter(id=membership.id).exists()
+
+    system_user, _token = PublicAPIAuthService().create_system_user(
+        integration_name="scoped_event_svc_foreign",
+        organization=org,
+        scoped_to_membership=membership,
+    )
+
+    facade = _facade_for_system_user(system_user, org)
+    with pytest.raises(PermissionDenied, match="Events cannot be created through the Public API"):
+        facade.create_event(other_calendar.id, _scoped_event_input())
+
+    assert not CalendarEvent.objects.filter(
+        calendar_fk_id=other_calendar.id, organization_id=org.id
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_create_event_owner_scoped_audit_actor_is_system_user(scoped_event_setup):
+    """The post-commit audit actor falls back to the SystemUser (no AttributeError).
+
+    The owner-scoped path never initializes a permission token, so the on_commit side
+    effect must read the (absent) token defensively and use the SystemUser as the actor.
+    Running with ``django_capture_on_commit_callbacks`` actually fires the callback, so a
+    regression to direct ``permission_service.token`` access would raise here.
+    """
+    from public_api.services import PublicAPIAuthService
+
+    org = scoped_event_setup["organization"]
+    calendar = scoped_event_setup["calendar"]
+    membership = scoped_event_setup["membership"]
+
+    system_user, _token = PublicAPIAuthService().create_system_user(
+        integration_name="scoped_event_svc_actor",
+        organization=org,
+        scoped_to_membership=membership,
+    )
+
+    facade = _facade_for_system_user(system_user, org)
+
+    recorded: list = []
+    side_effects = facade.calendar_side_effects_service
+    if side_effects is not None:
+        original = side_effects.on_create_event
+
+        def _spy(actor, event, organization):
+            recorded.append(actor)
+            return original(actor, event, organization)
+
+        side_effects.on_create_event = _spy  # type: ignore[method-assign]
+
+    try:
+        # Fire on_commit callbacks inline so the side effect actually runs (a transaction
+        # rollback in tests would otherwise swallow it and hide the actor-resolution bug).
+        with patch("django.db.transaction.on_commit", side_effect=lambda func: func()):
+            event = facade.create_event(calendar.id, _scoped_event_input())
+    finally:
+        if side_effects is not None:
+            side_effects.on_create_event = original  # type: ignore[method-assign]
+
+    assert event.id is not None
+    # The callback fired (patched on_commit ran it inline) and the actor is the SystemUser.
+    if side_effects is not None:
+        assert recorded, "on_create_event side effect did not fire"
+        assert recorded[0] == system_user

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -66,5 +66,9 @@ PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
         PublicAPIResources.CREATE_BLOCKED_TIME,
         PublicAPIResources.UPDATE_BLOCKED_TIME,
         PublicAPIResources.DELETE_BLOCKED_TIME,
+        PublicAPIResources.CREATE_AVAILABILITY_WINDOW,
+        PublicAPIResources.UPDATE_AVAILABILITY_WINDOW,
+        PublicAPIResources.DELETE_AVAILABILITY_WINDOW,
+        PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS,
     ]
 )

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -63,5 +63,8 @@ PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
         PublicAPIResources.AVAILABILITY_WINDOWS,
         PublicAPIResources.UNAVAILABLE_WINDOWS,
         PublicAPIResources.CALENDAR,
+        PublicAPIResources.CREATE_BLOCKED_TIME,
+        PublicAPIResources.UPDATE_BLOCKED_TIME,
+        PublicAPIResources.DELETE_BLOCKED_TIME,
     ]
 )

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1223,16 +1223,22 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.create_available_time with the supplied parameters.
-        4. Returns the created AvailableTime on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.create_available_time with the supplied parameters.
+        5. Returns the created AvailableTime on success, or success=False + errorMessage on failure.
            Note: the service raises ValueError if calendar.manage_available_windows is False.
 
         The token's OrganizationResourceAccess must include the CREATE_AVAILABILITY_WINDOW resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return CreateAvailabilityWindowResult(
@@ -1265,18 +1271,24 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Builds a single-op batch dict including only the fields provided in the input.
-        4. Delegates to CalendarService.batch_modify_available_times with the single op.
-        5. Finds the updated AvailableTime by id in the returned list and returns it.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Builds a single-op batch dict including only the fields provided in the input.
+        5. Delegates to CalendarService.batch_modify_available_times with the single op.
+        6. Finds the updated AvailableTime by id in the returned list and returns it.
            Note: a missing or cross-calendar available_time_id raises ValueError (success=False).
            Note: the service raises ValueError if calendar.manage_available_windows is False.
 
         The token's OrganizationResourceAccess must include the UPDATE_AVAILABILITY_WINDOW resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return UpdateAvailabilityWindowResult(
@@ -1328,9 +1340,10 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.batch_modify_available_times with a single delete op.
-        4. Returns success=True on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.batch_modify_available_times with a single delete op.
+        5. Returns success=True on success, or success=False + errorMessage on failure.
            Note: a missing or cross-calendar available_time_id raises ValueError (success=False).
            Note: the service raises ValueError if calendar.manage_available_windows is False.
            Note: the v2 doc proposed a deleteSeries argument, but batch_modify_available_times
@@ -1339,8 +1352,13 @@ class Mutation(CalendarGroupMutations):
         The token's OrganizationResourceAccess must include the DELETE_AVAILABILITY_WINDOW resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return DeleteAvailabilityWindowResult(
@@ -1366,12 +1384,16 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Validates every operation's action is one of {create, update, delete}.
-        4. Translates each BatchAvailabilityOperationInput into the service dict shape
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+           The single input.calendar_id governs the whole atomic batch; one guard call up front
+           rejects a cross-owner batch wholesale with no partial write (individual operations
+           share the same calendar_id — they carry no per-op calendar_id of their own).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Validates every operation's action is one of {create, update, delete}.
+        5. Translates each BatchAvailabilityOperationInput into the service dict shape
            (mapping available_time_id -> id; including only fields that are not None).
-        5. Delegates to CalendarService.batch_modify_available_times with the full ops list.
-        6. Returns the calendar's full AvailableTime list after the batch is applied.
+        6. Delegates to CalendarService.batch_modify_available_times with the full ops list.
+        7. Returns the calendar's full AvailableTime list after the batch is applied.
            The entire batch is rolled back if any operation fails (ATOMIC_REQUESTS = True
            means the request transaction wraps the whole mutation).
 
@@ -1381,8 +1403,15 @@ class Mutation(CalendarGroupMutations):
         _valid_actions = {"create", "update", "delete"}
 
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # One guard call covers the entire batch because all operations share this
+            # single calendar_id — individual BatchAvailabilityOperationInput entries carry
+            # no per-operation calendar_id. Raises Calendar.DoesNotExist (same as a genuinely
+            # missing calendar) so a cross-owner attempt reveals nothing about the target.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return BatchUpdateAvailabilityWindowsResult(

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Annotated, cast
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import URLValidator
 from django.db import IntegrityError, transaction
@@ -15,15 +16,25 @@ from dependency_injector.wiring import Provide, inject
 from graphql import GraphQLError
 
 from calendar_integration.constants import CalendarType
-from calendar_integration.exceptions import CalendarIntegrationError
+from calendar_integration.exceptions import (
+    CalendarIntegrationError,
+    NoAvailableTimeWindowsError,
+)
 from calendar_integration.graphql import (
     AvailableTimeGraphQLType,
     BlockedTimeGraphQLType,
     CalendarBundleGraphQLType,
+    CalendarEventGraphQLType,
     CalendarGraphQLType,
 )
 from calendar_integration.models import Calendar
 from calendar_integration.mutations import CalendarGroupMutations
+from calendar_integration.services.dataclasses import (
+    CalendarEventInputData,
+    EventAttendanceInputData,
+    EventExternalAttendanceInputData,
+    ExternalAttendeeInputData,
+)
 from organizations.exceptions import NoServiceAccountConfiguredError, UserAlreadyHasMembershipError
 from organizations.models import Organization, OrganizationBranding, OrganizationMembership
 from organizations.services import OrganizationService
@@ -65,6 +76,9 @@ if TYPE_CHECKING:
 # Module-scope constants for validation
 HEX_COLOR_PATTERN = re.compile(r"^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$")
 _url_validator = URLValidator(schemes=["http", "https"])
+# Mirrors CalendarEvent.title's max_length so an over-long title is rejected with a clean
+# GraphQL error rather than surfacing as a DB-level error after work has begun.
+EVENT_TITLE_MAX_LENGTH = 255
 
 
 @dataclass
@@ -515,6 +529,39 @@ class DisableCalendarBundleResult:
 
     success: bool
     error_message: str | None = None
+
+
+@strawberry.input
+class ScheduleEventExternalAttendeeInput:
+    """An external (non-user) attendee on a scheduled event: an email and optional name."""
+
+    email: str
+    name: str = ""
+
+
+@strawberry.input
+class ScheduleEventInput:
+    """Input for scheduling a calendar event on an owned calendar.
+
+    A scoped public-API token may schedule events only on calendars its owner owns. The
+    target calendar is identified by ``calendar_id``; ``attendee_user_ids`` are internal
+    org users (validated as active members of the caller's organization) and
+    ``external_attendees`` are email/name pairs. ``rrule_string`` (RFC-5545) makes the
+    event recurring.
+    """
+
+    organization_id: int
+    calendar_id: int
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+    title: str
+    description: str = ""
+    attendee_user_ids: list[int] = strawberry.field(default_factory=list)
+    external_attendees: list[ScheduleEventExternalAttendeeInput] = strawberry.field(
+        default_factory=list
+    )
+    rrule_string: str | None = None
 
 
 @strawberry.type
@@ -1780,3 +1827,99 @@ class Mutation(CalendarGroupMutations):
             return DisableCalendarBundleResult(success=False, error_message=str(e))
 
         return DisableCalendarBundleResult(success=True)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def schedule_event(
+        self,
+        info: strawberry.Info,
+        input: ScheduleEventInput,  # noqa: A002
+    ) -> CalendarEventGraphQLType:
+        """Schedule a calendar event on a calendar owned by the token's owner.
+
+        Event creation is blocked for org-wide public-API tokens; only an owner-scoped
+        token may schedule, and only on its owner's calendars. The mutation:
+        1. Resolves the organization and initializes the calendar service via the token.
+        2. Asserts the calendar is within the token owner's scope (defense in depth — the
+           service independently re-verifies ownership). A cross-owner / missing calendar
+           raises the same "Calendar not found." error, revealing nothing about the target.
+        3. Validates the title length and that every attendee_user_id is an ACTIVE member of
+           the caller's organization (a stray / out-of-org id is rejected before any write,
+           so it can never reach the DB as an opaque IntegrityError or attach an arbitrary
+           user).
+        4. Builds the event input (internal + external attendees, optional rrule) and
+           delegates to CalendarService.create_event, which enforces the sanctioned
+           owner-scoped allowance and rejects bundle calendars / org-wide tokens.
+        5. Maps service-layer errors (PermissionDenied, no-availability, malformed input) to
+           clean GraphQL errors — never a 500.
+
+        The token's OrganizationResourceAccess must include the CALENDAR_EVENT resource.
+        """
+        calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
+
+        try:
+            # Owner-scope guard (defense in depth): a scoped token may only target its
+            # owner's calendars. Raises Calendar.DoesNotExist — same as a genuinely missing
+            # calendar — so a cross-owner attempt reveals nothing about the target.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
+            Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
+        except Calendar.DoesNotExist as exc:
+            raise GraphQLError("Calendar not found.") from exc
+
+        if len(input.title) > EVENT_TITLE_MAX_LENGTH:
+            raise GraphQLError(f"Title must be at most {EVENT_TITLE_MAX_LENGTH} characters.")
+
+        # Pre-validate internal attendees: every id must be an ACTIVE member of this org.
+        # De-duplicate first so a repeated id doesn't skew the membership count check.
+        attendee_user_ids = list(dict.fromkeys(input.attendee_user_ids))
+        if attendee_user_ids:
+            active_member_ids = set(
+                OrganizationMembership.objects.filter(
+                    organization_id=org.id,
+                    is_active=True,
+                    user_id__in=attendee_user_ids,
+                ).values_list("user_id", flat=True)
+            )
+            missing = [uid for uid in attendee_user_ids if uid not in active_member_ids]
+            if missing:
+                raise GraphQLError(
+                    "One or more attendees are not active members of this organization."
+                )
+
+        event_input = CalendarEventInputData(
+            title=input.title,
+            description=input.description or "",
+            start_time=input.start_time,
+            end_time=input.end_time,
+            timezone=input.timezone,
+            attendances=[
+                EventAttendanceInputData(user_id=user_id) for user_id in attendee_user_ids
+            ],
+            external_attendances=[
+                EventExternalAttendanceInputData(
+                    external_attendee=ExternalAttendeeInputData(
+                        email=external.email,
+                        name=external.name,
+                    )
+                )
+                for external in input.external_attendees
+            ],
+            resource_allocations=[],
+            recurrence_rule=input.rrule_string,
+        )
+
+        try:
+            event = calendar_service.create_event(input.calendar_id, event_input)
+        except Calendar.DoesNotExist as exc:
+            # A race / direct service-level not-found must stay indistinguishable.
+            raise GraphQLError("Calendar not found.") from exc
+        except NoAvailableTimeWindowsError as exc:
+            raise GraphQLError("No available time window covers the requested event time.") from exc
+        except PermissionDenied as exc:
+            raise GraphQLError(
+                str(exc) or "You do not have permission to schedule this event."
+            ) from exc
+        except (ValueError, DjangoValidationError, CalendarIntegrationError) as exc:
+            raise GraphQLError(str(exc)) from exc
+
+        return event  # type: ignore[return-value]

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -31,6 +31,7 @@ from public_api.capabilities import assert_org_can_invite, assert_target_in_subt
 from public_api.constants import PROVIDER_SCOPED_RESOURCES, PublicAPIResources
 from public_api.models import ResourceAccess, SystemUser
 from public_api.permissions import IsAuthenticated, OrganizationResourceAccess
+from public_api.scoping import assert_calendar_in_owner_scope
 from public_api.services import PublicAPIAuthService
 from public_api.types import (
     BrandingResult,
@@ -1452,15 +1453,21 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.create_blocked_time with the supplied parameters.
-        4. Returns the created BlockedTime on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.create_blocked_time with the supplied parameters.
+        5. Returns the created BlockedTime on success, or success=False + errorMessage on failure.
 
         The token's OrganizationResourceAccess must include the CREATE_BLOCKED_TIME resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return CreateBlockedTimeResult(success=False, error_message="Calendar not found.")
@@ -1492,17 +1499,23 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.update_blocked_time with the supplied parameters.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.update_blocked_time with the supplied parameters.
            Only fields present (non-None) in the input are applied; others are left unchanged.
-        4. Returns the updated BlockedTime on success, or success=False + errorMessage on failure.
+        5. Returns the updated BlockedTime on success, or success=False + errorMessage on failure.
            Note: a missing or cross-calendar blocked_time_id raises ValueError (success=False).
 
         The token's OrganizationResourceAccess must include the UPDATE_BLOCKED_TIME resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return UpdateBlockedTimeResult(success=False, error_message="Calendar not found.")
@@ -1535,9 +1548,10 @@ class Mutation(CalendarGroupMutations):
 
         The mutation:
         1. Resolves the organization and initializes the calendar service via the system-user token.
-        2. Fetches the calendar org-scoped to prevent cross-org access.
-        3. Delegates to CalendarService.delete_blocked_time with the supplied blocked_time_id.
-        4. Returns success=True on success, or success=False + errorMessage on failure.
+        2. Asserts the calendar is within the token owner's scope (no-op for org-wide tokens).
+        3. Fetches the calendar org-scoped to prevent cross-org access.
+        4. Delegates to CalendarService.delete_blocked_time with the supplied blocked_time_id.
+        5. Returns success=True on success, or success=False + errorMessage on failure.
            Note: a missing or cross-calendar blocked_time_id raises ValueError (success=False).
 
         Note on recurrence: a recurring blocked time is stored as one row (rrule on
@@ -1549,8 +1563,13 @@ class Mutation(CalendarGroupMutations):
         The token's OrganizationResourceAccess must include the DELETE_BLOCKED_TIME resource.
         """
         calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
 
         try:
+            # Owner-scope guard: a scoped token may only write to its owner's calendars.
+            # Raises Calendar.DoesNotExist (same as a genuinely missing calendar) so a
+            # cross-owner attempt reveals nothing about the target's existence.
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
             calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
         except Calendar.DoesNotExist:
             return DeleteBlockedTimeResult(success=False, error_message="Calendar not found.")

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -67,6 +67,7 @@ class OrganizationResourceAccess(BasePermission):
         "createBlockedTime": PublicAPIResources.CREATE_BLOCKED_TIME,
         "updateBlockedTime": PublicAPIResources.UPDATE_BLOCKED_TIME,
         "deleteBlockedTime": PublicAPIResources.DELETE_BLOCKED_TIME,
+        "scheduleEvent": PublicAPIResources.CALENDAR_EVENT,
         "calendarBundles": PublicAPIResources.CALENDAR_BUNDLE,
         "createCalendarBundle": PublicAPIResources.CREATE_CALENDAR_BUNDLE,
         "updateCalendarBundle": PublicAPIResources.UPDATE_CALENDAR_BUNDLE,

--- a/public_api/scoping.py
+++ b/public_api/scoping.py
@@ -25,3 +25,34 @@ def scoped_calendar_ids(system_user: SystemUser, organization: Organization) -> 
         .distinct()
         .values_list("id", flat=True)
     )
+
+
+def assert_calendar_in_owner_scope(
+    system_user: SystemUser | None,
+    organization: Organization,
+    calendar_id: int,
+) -> None:
+    """Assert that the given calendar_id is accessible by the token's owner scope.
+
+    This is the shared write-side guard reused by all owner-guarded mutations.
+    It is a no-op when the system_user is None or when the token is org-wide
+    (scoped_calendar_ids returns None). When the token is scoped and calendar_id
+    is NOT in the allowed set, raises Calendar.DoesNotExist with the same message
+    that a genuinely-missing calendar produces — the caller must not reveal whether
+    the target exists.
+
+    Args:
+        system_user: The SystemUser (token) making the request, or None (no-op).
+        organization: The organization context.
+        calendar_id: The calendar ID targeted by the write operation.
+
+    Raises:
+        Calendar.DoesNotExist: When the token is scoped and calendar_id is outside
+            the owner's allowed calendar set. The message is intentionally identical
+            to a real not-found error to prevent existence leaks.
+    """
+    if system_user is None:
+        return
+    allowed_ids = scoped_calendar_ids(system_user, organization)
+    if allowed_ids is not None and calendar_id not in allowed_ids:
+        raise Calendar.DoesNotExist("Calendar matching query does not exist.")

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -7775,6 +7775,12 @@ class TestScopedTokenAvailabilityWrites:
         _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
         available_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
 
+        # Capture B's row field values BEFORE the cross-owner attempt so the
+        # unchanged-check compares like-for-like (naive stored field to naive).
+        available_time_b.refresh_from_db()
+        start_before = available_time_b.start_time_tz_unaware
+        end_before = available_time_b.end_time_tz_unaware
+
         # Token scoped to provider A — must not update B's calendar
         system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
             org, membership_a, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
@@ -7830,11 +7836,10 @@ class TestScopedTokenAvailabilityWrites:
         missing_msg = missing_response.json()["data"]["updateAvailabilityWindow"]["errorMessage"]
         assert cross_msg == missing_msg
 
-        # The available time row must be unchanged
+        # The available time row must be unchanged (compare against pre-attempt values).
         available_time_b.refresh_from_db()
-        assert available_time_b.start_time_tz_unaware == datetime.datetime(
-            2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC
-        )
+        assert available_time_b.start_time_tz_unaware == start_before
+        assert available_time_b.end_time_tz_unaware == end_before
 
     # ------------------------------------------------------------------
     # deleteAvailabilityWindow — scoped happy path
@@ -8007,7 +8012,17 @@ class TestScopedTokenAvailabilityWrites:
         """
         org = self._setup_org()
         _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
         _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+
+        # Seed a pre-existing AvailableTime row on B's calendar so a partial
+        # update/delete (not just a stray create) would be detectable.
+        existing_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
+        existing_time_b.refresh_from_db()
+        existing_start_before = existing_time_b.start_time_tz_unaware
+        existing_end_before = existing_time_b.end_time_tz_unaware
 
         # Count rows on B's calendar before the cross-owner attempt (org-scoped query)
         rows_before = (
@@ -8024,7 +8039,12 @@ class TestScopedTokenAvailabilityWrites:
         create_start = datetime.datetime(2026, 12, 1, 9, 0, 0, tzinfo=datetime.UTC)
         create_end = datetime.datetime(2026, 12, 1, 17, 0, 0, tzinfo=datetime.UTC)
 
-        # Cross-owner attempt: calendar_id = B's calendar, batch includes a create op
+        update_start = datetime.datetime(2026, 12, 2, 9, 0, 0, tzinfo=datetime.UTC)
+        update_end = datetime.datetime(2026, 12, 2, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id = B's calendar, batch mixes create,
+        # update, and delete ops — an update/delete targets B's pre-existing row,
+        # so a partial write (not just a stray create) would be caught.
         cross_owner_response = self._post(
             _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
             system_user_a,
@@ -8040,7 +8060,17 @@ class TestScopedTokenAvailabilityWrites:
                             "startTime": create_start.isoformat(),
                             "endTime": create_end.isoformat(),
                             "timezone": "UTC",
-                        }
+                        },
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time_b.id,
+                            "startTime": update_start.isoformat(),
+                            "endTime": update_end.isoformat(),
+                        },
+                        {
+                            "action": "delete",
+                            "availableTimeId": existing_time_b.id,
+                        },
                     ],
                 }
             },
@@ -8063,7 +8093,17 @@ class TestScopedTokenAvailabilityWrites:
                             "startTime": create_start.isoformat(),
                             "endTime": create_end.isoformat(),
                             "timezone": "UTC",
-                        }
+                        },
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time_b.id,
+                            "startTime": update_start.isoformat(),
+                            "endTime": update_end.isoformat(),
+                        },
+                        {
+                            "action": "delete",
+                            "availableTimeId": existing_time_b.id,
+                        },
                     ],
                 }
             },
@@ -8096,6 +8136,21 @@ class TestScopedTokenAvailabilityWrites:
         assert rows_after == rows_before, (
             f"Partial write detected: row count on B's calendar changed from "
             f"{rows_before} to {rows_after}"
+        )
+
+        # The pre-existing B row must NOT have been updated or deleted: it still
+        # exists and retains its original field values.
+        assert (
+            AvailableTime.objects.filter_by_organization(org.id)
+            .filter(id=existing_time_b.id)
+            .exists()
+        ), "Partial write detected: pre-existing B row was deleted"
+        existing_time_b.refresh_from_db()
+        assert existing_time_b.start_time_tz_unaware == existing_start_before, (
+            "Partial write detected: pre-existing B row's start time was updated"
+        )
+        assert existing_time_b.end_time_tz_unaware == existing_end_before, (
+            "Partial write detected: pre-existing B row's end time was updated"
         )
 
     # ------------------------------------------------------------------

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -8428,3 +8428,498 @@ class TestScopedTokenAvailabilityWrites:
         assert len(data["errors"]) > 0
         assert "don't have access" in str(data["errors"]).lower()
         assert "don't have access" in str(data["errors"]).lower()
+
+
+_SCHEDULE_EVENT_SCOPED = """
+mutation ScheduleEvent($input: ScheduleEventInput!) {
+    scheduleEvent(input: $input) {
+        id
+        title
+        description
+        attendances {
+            id
+        }
+        externalAttendances {
+            id
+        }
+    }
+}
+"""
+
+# recurrenceRule is a non-nullable field on CalendarEventGraphQLType, so only select it
+# when the event is actually recurring (the non-recurring path returns null for it).
+_SCHEDULE_EVENT_SCOPED_WITH_RRULE = """
+mutation ScheduleEvent($input: ScheduleEventInput!) {
+    scheduleEvent(input: $input) {
+        id
+        title
+        recurrenceRule {
+            id
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestScopedTokenScheduleEvent:
+    """Integration tests for the owner-scoped ``scheduleEvent`` mutation (Phase 3).
+
+    Coverage:
+    - Scoped token schedules on its owner's calendar (covering availability window) -> success.
+    - Recurring (rrule) event persists a recurrence rule.
+    - Internal + external attendees persisted.
+    - Out-of-org internal attendee -> clean error, no row.
+    - Cross-owner calendar -> not-found IDENTICAL to a missing calendar + no row.
+    - Org-wide token -> denied, no row (event creation stays blocked).
+    - Bundle calendar owned by the scoped owner -> clean error, no row.
+    - No availability window -> clean error.
+    - Title too long -> clean error.
+    - Missing CALENDAR_EVENT grant -> denied by the permission class.
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers — mirror the blocked-time / availability scoped-token classes
+    # ------------------------------------------------------------------
+
+    def _setup_org(self):
+        return baker.make(Organization, name="Schedule Event Org")
+
+    def _make_owner_with_managing_calendar(self, org):
+        """Create a provider user, membership, and a manage_available_windows=True calendar.
+
+        manage_available_windows=True so availability is governed by declared windows; the
+        happy path seeds a covering window, the no-availability test omits it.
+        Returns (user, membership, calendar).
+        """
+        from calendar_integration.models import CalendarOwnership
+
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        owner = baker.make(user_model, email=f"sched_owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = baker.make(
+            Calendar,
+            organization=org,
+            name=f"Provider Sched Calendar {unique}",
+            external_id=f"sched-cal-{unique}",
+            manage_available_windows=True,
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=owner, organization=org)
+        return owner, membership, calendar
+
+    def _make_owner_with_bundle_calendar(self, org):
+        """Create a provider who owns a BUNDLE calendar. Returns (user, membership, bundle)."""
+        from calendar_integration.models import CalendarOwnership
+
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        owner = baker.make(user_model, email=f"sched_bundle_owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        bundle = baker.make(
+            Calendar,
+            organization=org,
+            name=f"Bundle Calendar {unique}",
+            external_id=f"sched-bundle-{unique}",
+            calendar_type=CalendarType.BUNDLE,
+        )
+        baker.make(CalendarOwnership, calendar=bundle, user=owner, organization=org)
+        return owner, membership, bundle
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_sched_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_org_wide_system_user(self, org, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_sched_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _seed_window(self, org, system_user, calendar):
+        """Seed a covering AvailableTime window via the service (not the API)."""
+        from di_core.containers import container
+
+        calendar_service: CalendarService = container.calendar_service()
+        calendar_service.initialize_without_provider(user_or_token=system_user, organization=org)
+        return calendar_service.create_available_time(
+            calendar=calendar,
+            start_time=datetime.datetime(2026, 10, 1, 8, 0, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2026, 10, 1, 18, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def _input(self, org, calendar, **overrides):
+        base = {
+            "organizationId": org.id,
+            "calendarId": calendar.id,
+            "startTime": datetime.datetime(2026, 10, 1, 10, 0, 0, tzinfo=datetime.UTC).isoformat(),
+            "endTime": datetime.datetime(2026, 10, 1, 11, 0, 0, tzinfo=datetime.UTC).isoformat(),
+            "timezone": "UTC",
+            "title": "Scheduled Visit",
+        }
+        base.update(overrides)
+        return base
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_schedule_event_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token schedules an event on its owner's calendar with a covering window."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+        self._seed_window(org, system_user, calendar)
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, calendar)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["scheduleEvent"]
+        assert result is not None
+        assert result["title"] == "Scheduled Visit"
+        ev = CalendarEvent.objects.filter_by_organization(org.id).get(id=int(result["id"]))
+        assert ev.calendar_fk_id == calendar.id
+
+    def test_schedule_event_recurring_persists_recurrence_rule(self):
+        """A scoped token schedules a recurring event (rrule -> RecurrenceRule persisted)."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+        self._seed_window(org, system_user, calendar)
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED_WITH_RRULE,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, calendar, rruleString="RRULE:FREQ=WEEKLY;COUNT=4;BYDAY=TH")},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["scheduleEvent"]
+        assert result["recurrenceRule"] is not None
+        ev = CalendarEvent.objects.filter_by_organization(org.id).get(id=int(result["id"]))
+        assert ev.recurrence_rule_fk_id is not None
+
+    def test_schedule_event_persists_internal_and_external_attendees(self):
+        """Internal (active member) + external (email/name) attendees are persisted."""
+        from calendar_integration.models import EventAttendance, EventExternalAttendance
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+        self._seed_window(org, system_user, calendar)
+
+        user_model = get_user_model()
+        attendee = baker.make(user_model, email=f"attendee_{uuid.uuid4().hex[:8]}@example.com")
+        baker.make(OrganizationMembership, user=attendee, organization=org, is_active=True)
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._input(
+                    org,
+                    calendar,
+                    attendeeUserIds=[attendee.id],
+                    externalAttendees=[{"email": "guest@example.com", "name": "Guest"}],
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        ev_id = int(data["data"]["scheduleEvent"]["id"])
+        assert (
+            EventAttendance.objects.filter_by_organization(org.id)
+            .filter(event_fk_id=ev_id, user_id=attendee.id)
+            .exists()
+        )
+        assert (
+            EventExternalAttendance.objects.filter_by_organization(org.id)
+            .filter(event_fk_id=ev_id, external_attendee__email="guest@example.com")
+            .exists()
+        )
+
+    # ------------------------------------------------------------------
+    # Negative paths
+    # ------------------------------------------------------------------
+
+    def test_schedule_event_out_of_org_attendee_clean_error_no_row(self):
+        """An attendee who is not an active member of the org -> clean error, no event row."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+        self._seed_window(org, system_user, calendar)
+
+        other_org = baker.make(Organization, name="Other Org")
+        user_model = get_user_model()
+        outsider = baker.make(user_model, email=f"outsider_{uuid.uuid4().hex[:8]}@example.com")
+        baker.make(OrganizationMembership, user=outsider, organization=other_org, is_active=True)
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, calendar, attendeeUserIds=[outsider.id])},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "active members" in str(data["errors"]).lower()
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .exists()
+        )
+
+    def test_schedule_event_cross_owner_not_found_same_as_missing_calendar(self):
+        """Cross-owner calendar -> identical not-found as a genuinely missing calendar, no row."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        cross = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {"input": self._input(org, calendar_b)},
+        )
+        missing = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999997,
+                    "startTime": datetime.datetime(
+                        2026, 10, 1, 10, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "endTime": datetime.datetime(
+                        2026, 10, 1, 11, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "timezone": "UTC",
+                    "title": "Scheduled Visit",
+                }
+            },
+        )
+
+        cross_msg = cross.json()["errors"][0]["message"]
+        missing_msg = missing.json()["errors"][0]["message"]
+        assert cross_msg == missing_msg == "Calendar not found."
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .exists()
+        )
+
+    def test_schedule_event_org_wide_token_denied_no_row(self):
+        """An org-wide token is denied (event creation stays blocked) with no row."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, _membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.CALENDAR_EVENT]
+        )
+        self._seed_window(org, system_user, calendar)
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, calendar)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "public api" in str(data["errors"]).lower()
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .exists()
+        )
+
+    def test_schedule_event_bundle_calendar_clean_error_no_row(self):
+        """A bundle calendar owned by the scoped owner -> clean error, no row."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, membership, bundle = self._make_owner_with_bundle_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, bundle)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "bundle" in str(data["errors"]).lower()
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=bundle.id)
+            .exists()
+        )
+
+    def test_schedule_event_no_availability_window_clean_error(self):
+        """No covering availability window on a managed calendar -> clean error, no row."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+        # No window seeded -> manage_available_windows=True means nothing is bookable.
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, calendar)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "available time window" in str(data["errors"]).lower()
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .exists()
+        )
+
+    def test_schedule_event_title_too_long_clean_error(self):
+        """A title exceeding the model max_length -> clean error before any write."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+        self._seed_window(org, system_user, calendar)
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, calendar, title="x" * 256)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "at most" in str(data["errors"]).lower()
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .exists()
+        )
+
+    def test_schedule_event_missing_calendar_event_grant_denied(self):
+        """A scoped token without the CALENDAR_EVENT grant is denied by the permission class."""
+        from calendar_integration.models import CalendarEvent
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+        self._seed_window(org, system_user, calendar)
+
+        response = self._post(
+            _SCHEDULE_EVENT_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._input(org, calendar)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .exists()
+        )

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -7090,6 +7090,92 @@ class TestScopedTokenBlockedTimeWrites:
         assert BlockedTime.objects.filter(id=bt_b_id).exists()
 
     # ------------------------------------------------------------------
+    # blockedTimeId / calendarId mismatch — service-layer filter is load-bearing
+    # ------------------------------------------------------------------
+
+    def test_update_delete_blocked_time_in_scope_calendar_with_foreign_blocked_time_id_rejected(
+        self,
+    ):
+        """A scoped token passing its OWN calendar_id but a foreign blocked_time_id is rejected.
+
+        This pins the service-layer ``calendar_fk=calendar`` filter (the load-bearing
+        constraint for the new threat model). The new owner guard does NOT trip here
+        because ``calendarId`` is the token's in-scope calendar A; the only thing
+        rejecting the write is the service scoping the BlockedTime lookup to the
+        supplied calendar, so a foreign ``blocked_time_id`` on calendar B yields
+        ``success=False`` and leaves B's row untouched.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        # Provider A: scoped token, owns calendar A (in-scope for the token)
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        # Provider B: a different owner with a real BlockedTime row on calendar B
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME, PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        blocked_time_b = self._create_blocked_time_on_calendar(org, org_wide_su_b, calendar_b)
+        bt_b_id = blocked_time_b.id
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org,
+            membership_a,
+            [PublicAPIResources.UPDATE_BLOCKED_TIME, PublicAPIResources.DELETE_BLOCKED_TIME],
+        )
+
+        new_start = datetime.datetime(2026, 10, 9, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 9, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # updateBlockedTime: in-scope calendar A id, foreign blocked_time id on B
+        update_response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_a.id,
+                    "blockedTimeId": bt_b_id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert update_response.status_code == 200
+        update_data = update_response.json()
+        assert "errors" not in update_data or len(update_data.get("errors", [])) == 0
+        assert update_data["data"]["updateBlockedTime"]["success"] is False
+        # B's row must be unchanged by the rejected update
+        blocked_time_b.refresh_from_db()
+        assert blocked_time_b.reason == "Scoped test block"
+
+        # deleteBlockedTime: in-scope calendar A id, foreign blocked_time id on B
+        delete_response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_a.id,
+                    "blockedTimeId": bt_b_id,
+                }
+            },
+        )
+
+        assert delete_response.status_code == 200
+        delete_data = delete_response.json()
+        assert "errors" not in delete_data or len(delete_data.get("errors", [])) == 0
+        assert delete_data["data"]["deleteBlockedTime"]["success"] is False
+        # B's row must still exist — the foreign delete must NOT have succeeded
+        assert BlockedTime.objects.filter(id=bt_b_id).exists()
+
+    # ------------------------------------------------------------------
     # Org-wide token — no-regression assertions for all three verbs
     # ------------------------------------------------------------------
 

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -7392,4 +7392,984 @@ class TestScopedTokenBlockedTimeWrites:
         data = response.json()
         assert "errors" in data
         assert len(data["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# GraphQL query constants for scoped-availability-writes tests
+# ---------------------------------------------------------------------------
+
+_CREATE_AVAILABILITY_WINDOW_SCOPED = """
+mutation CreateAvailabilityWindow($input: CreateAvailableTimeInput!) {
+    createAvailabilityWindow(input: $input) {
+        success
+        errorMessage
+        availableTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_UPDATE_AVAILABILITY_WINDOW_SCOPED = """
+mutation UpdateAvailabilityWindow($input: UpdateAvailableTimeInput!) {
+    updateAvailabilityWindow(input: $input) {
+        success
+        errorMessage
+        availableTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_DELETE_AVAILABILITY_WINDOW_SCOPED = """
+mutation DeleteAvailabilityWindow($input: DeleteAvailableTimeInput!) {
+    deleteAvailabilityWindow(input: $input) {
+        success
+        errorMessage
+    }
+}
+"""
+
+_BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED = """
+mutation BatchUpdateAvailabilityWindows($input: BatchAvailabilityInput!) {
+    batchUpdateAvailabilityWindows(input: $input) {
+        success
+        errorMessage
+        availableTimes {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestScopedTokenAvailabilityWrites:
+    """Integration tests for owner-scoped availability-window mutations (Phase 2).
+
+    Coverage:
+    - Scoped token can create (no rrule + rrule) / update / delete / batch on its owned calendar.
+    - Cross-owner write returns the same not-found message as a genuinely missing
+      calendar, revealing nothing about the target's existence.
+    - Org-wide token is structurally unchanged (no-regression assertion).
+    - A scoped token missing the required resource grant is denied by the permission
+      class before the guard even runs.
+    - Batch: a cross-owner calendar_id rejects the whole batch atomically (no partial write).
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers — mirror TestScopedTokenBlockedTimeWrites exactly
+    # ------------------------------------------------------------------
+
+    def _setup_org(self):
+        """Create a base organization for the test scenario."""
+        return baker.make(Organization, name="Test Org")
+
+    def _make_owner_with_managing_calendar(self, org):
+        """Create a provider user, their membership, and a manage_available_windows=True calendar.
+
+        Returns (user, membership, calendar).
+        """
+        from calendar_integration.models import CalendarOwnership
+
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        owner = baker.make(user_model, email=f"avail_owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = baker.make(
+            Calendar,
+            organization=org,
+            name=f"Provider Avail Calendar {unique}",
+            external_id=f"avail-cal-{unique}",
+            manage_available_windows=True,
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=owner, organization=org)
+        return owner, membership, calendar
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        """Mint a scoped SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_avail_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_org_wide_system_user(self, org, resources):
+        """Mint an org-wide (unscoped) SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_avail_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _create_available_time_on_calendar(self, org, system_user, calendar):
+        """Create an AvailableTime row directly via the service (not the API).
+
+        Used to set up rows for update/delete/batch happy-path tests.
+        """
+        from di_core.containers import container
+
+        calendar_service: CalendarService = container.calendar_service()
+        calendar_service.initialize_without_provider(user_or_token=system_user, organization=org)
+        return calendar_service.create_available_time(
+            calendar=calendar,
+            start_time=datetime.datetime(2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2026, 10, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    # ------------------------------------------------------------------
+    # createAvailabilityWindow — scoped happy path (no rrule)
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_scoped_token_on_owned_calendar_succeeds_no_rrule(self):
+        """A scoped token creates a one-off available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+        at_id = int(result["availableTime"]["id"])
+
+        at = AvailableTime.objects.filter_by_organization(org.id).get(id=at_id)
+        assert at.calendar_fk_id == calendar.id
+        assert at.recurrence_rule is None
+
+    # ------------------------------------------------------------------
+    # createAvailabilityWindow — scoped happy path (with rrule)
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_scoped_token_on_owned_calendar_succeeds_with_rrule(self):
+        """A scoped token creates a recurring available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 6, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 6, 17, 0, 0, tzinfo=datetime.UTC)
+        rrule = "FREQ=WEEKLY;BYDAY=TU"
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                    "rruleString": rrule,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+        at_id = int(result["availableTime"]["id"])
+
+        at = AvailableTime.objects.filter_by_organization(org.id).get(id=at_id)
+        assert at.calendar_fk_id == calendar.id
+        assert at.recurrence_rule is not None
+
+    # ------------------------------------------------------------------
+    # createAvailabilityWindow — cross-owner not-found identical to missing calendar
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner createAvailabilityWindow returns identical not-found as a truly missing calendar.
+
+        A scoped token targeting another provider's calendar_id must get the same
+        success=False / errorMessage as a genuinely nonexistent calendar — revealing
+        nothing about the target's existence. No AvailableTime row is created.
+        """
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+
+        # Token scoped to provider A
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        # Attempt against provider B's calendar (cross-owner)
+        cross_owner_response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Attempt against a genuinely nonexistent calendar_id
+        nonexistent_id = 999994
+        missing_response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": nonexistent_id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["createAvailabilityWindow"]
+            assert r["success"] is False
+            assert r["errorMessage"] is not None
+
+        cross_msg = cross_owner_response.json()["data"]["createAvailabilityWindow"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["createAvailabilityWindow"]["errorMessage"]
+        assert cross_msg == missing_msg, (
+            f"Cross-owner error '{cross_msg}' must equal missing-calendar error '{missing_msg}'"
+        )
+
+        # No AvailableTime rows must have been created for the cross-owner calendar
+        assert not AvailableTime.objects.filter(calendar_fk_id=calendar_b.id).exists()
+
+    # ------------------------------------------------------------------
+    # updateAvailabilityWindow — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_update_availability_window_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token updates an available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _org_wide_token, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+
+        new_start = datetime.datetime(2026, 10, 2, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 2, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+
+    # ------------------------------------------------------------------
+    # updateAvailabilityWindow — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_update_availability_window_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner updateAvailabilityWindow returns identical not-found as a truly missing calendar."""
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+        available_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
+
+        # Token scoped to provider A — must not update B's calendar
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+
+        new_start = datetime.datetime(2026, 10, 3, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 3, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id belongs to B, not A
+        cross_owner_response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "availableTimeId": available_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Genuinely missing calendar_id attempt
+        missing_response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999993,
+                    "availableTimeId": available_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["updateAvailabilityWindow"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["updateAvailabilityWindow"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["updateAvailabilityWindow"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # The available time row must be unchanged
+        available_time_b.refresh_from_db()
+        assert available_time_b.start_time_tz_unaware == datetime.datetime(
+            2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC
+        )
+
+    # ------------------------------------------------------------------
+    # deleteAvailabilityWindow — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_delete_availability_window_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token deletes an available time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+        at_id = available_time.id
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+
+        response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": at_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteAvailabilityWindow"]
+        assert result["success"] is True
+
+        # DB row must be gone
+        assert not AvailableTime.objects.filter(id=at_id).exists()
+
+    # ------------------------------------------------------------------
+    # deleteAvailabilityWindow — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_delete_availability_window_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner deleteAvailabilityWindow returns identical not-found as a truly missing calendar.
+
+        The AvailableTime row must NOT be deleted when the token targets a cross-owner calendar.
+        """
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+        available_time_b = self._create_available_time_on_calendar(org, org_wide_su_b, calendar_b)
+        at_b_id = available_time_b.id
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+
+        # Cross-owner attempt (calendar_b belongs to owner B)
+        cross_owner_response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "availableTimeId": at_b_id,
+                }
+            },
+        )
+
+        # Genuinely missing calendar attempt
+        missing_response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999992,
+                    "availableTimeId": at_b_id,
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["deleteAvailabilityWindow"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["deleteAvailabilityWindow"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["deleteAvailabilityWindow"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # Row must still exist — the cross-owner delete must NOT have succeeded
+        assert AvailableTime.objects.filter(id=at_b_id).exists()
+
+    # ------------------------------------------------------------------
+    # batchUpdateAvailabilityWindows — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_batch_update_availability_windows_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token applies a batch of availability operations on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+        existing_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+
+        new_start = datetime.datetime(2026, 11, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 1, 17, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["batchUpdateAvailabilityWindows"]
+        assert result["success"] is True
+        assert result["availableTimes"] is not None
+
+    # ------------------------------------------------------------------
+    # batchUpdateAvailabilityWindows — cross-owner not-found + no partial write
+    # ------------------------------------------------------------------
+
+    def test_batch_update_availability_windows_cross_owner_rejected_wholesale(self):
+        """Cross-owner batchUpdateAvailabilityWindows returns identical not-found as missing calendar.
+
+        The entire batch must be rejected atomically — no AvailableTime rows must be
+        created, updated, or deleted when the calendar_id is cross-owner. Because
+        BatchAvailabilityInput carries a single calendar_id shared by all operations
+        (individual BatchAvailabilityOperationInput entries have no per-op calendar_id),
+        one guard call at the top rejects the whole batch before any operation runs.
+        """
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_managing_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_managing_calendar(org)
+
+        # Count rows on B's calendar before the cross-owner attempt (org-scoped query)
+        rows_before = (
+            AvailableTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .count()
+        )
+
+        # Token scoped to provider A
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+
+        create_start = datetime.datetime(2026, 12, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        create_end = datetime.datetime(2026, 12, 1, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id = B's calendar, batch includes a create op
+        cross_owner_response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "startTime": create_start.isoformat(),
+                            "endTime": create_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Genuinely missing calendar attempt (same batch shape)
+        nonexistent_id = 999991
+        missing_response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": nonexistent_id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "startTime": create_start.isoformat(),
+                            "endTime": create_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["batchUpdateAvailabilityWindows"]
+            assert r["success"] is False
+            assert r["errorMessage"] is not None
+
+        cross_msg = cross_owner_response.json()["data"]["batchUpdateAvailabilityWindows"][
+            "errorMessage"
+        ]
+        missing_msg = missing_response.json()["data"]["batchUpdateAvailabilityWindows"][
+            "errorMessage"
+        ]
+        assert cross_msg == missing_msg, (
+            f"Cross-owner error '{cross_msg}' must equal missing-calendar error '{missing_msg}'"
+        )
+
+        # No AvailableTime rows must have been created on B's calendar (no partial write)
+        rows_after = (
+            AvailableTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .count()
+        )
+        assert rows_after == rows_before, (
+            f"Partial write detected: row count on B's calendar changed from "
+            f"{rows_before} to {rows_after}"
+        )
+
+    # ------------------------------------------------------------------
+    # Org-wide token — no-regression assertions for all four verbs
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can create available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.CREATE_AVAILABILITY_WINDOW]
+        )
+
+        start = datetime.datetime(2026, 10, 6, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 6, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createAvailabilityWindow"]
+        assert result["success"] is True
+        assert result["availableTime"] is not None
+        at_id = int(result["availableTime"]["id"])
+        assert AvailableTime.objects.filter_by_organization(org.id).filter(id=at_id).exists()
+
+    def test_update_availability_window_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can update available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, system_user, calendar)
+
+        new_start = datetime.datetime(2026, 10, 7, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 7, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateAvailabilityWindow"]
+        assert result["success"] is True
+
+    def test_delete_availability_window_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can delete available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, system_user, calendar)
+        at_id = available_time.id
+
+        response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": at_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteAvailabilityWindow"]
+        assert result["success"] is True
+        assert not AvailableTime.objects.filter(id=at_id).exists()
+
+    def test_batch_update_availability_windows_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can batch-update available times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+        existing_time = self._create_available_time_on_calendar(org, system_user, calendar)
+
+        new_start = datetime.datetime(2026, 11, 2, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 2, 17, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            "availableTimeId": existing_time.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["batchUpdateAvailabilityWindows"]
+        assert result["success"] is True
+
+    # ------------------------------------------------------------------
+    # Missing resource grant — scoped token denied (permission class fires first)
+    # ------------------------------------------------------------------
+
+    def test_create_availability_window_scoped_token_missing_grant_denied(self):
+        """A scoped token without CREATE_AVAILABILITY_WINDOW grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        start = datetime.datetime(2026, 10, 8, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 8, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_update_availability_window_scoped_token_missing_grant_denied(self):
+        """A scoped token without UPDATE_AVAILABILITY_WINDOW grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _UPDATE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_delete_availability_window_scoped_token_missing_grant_denied(self):
+        """A scoped token without DELETE_AVAILABILITY_WINDOW grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_AVAILABILITY_WINDOW]
+        )
+        available_time = self._create_available_time_on_calendar(org, org_wide_su, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _DELETE_AVAILABILITY_WINDOW_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "availableTimeId": available_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_batch_update_availability_windows_scoped_token_missing_grant_denied(self):
+        """A scoped token without BATCH_UPDATE_AVAILABILITY_WINDOWS grant is denied."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_managing_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _BATCH_UPDATE_AVAILABILITY_WINDOWS_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "operations": [],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
         assert "don't have access" in str(data["errors"]).lower()

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -6578,3 +6578,732 @@ class TestCreateScopedSystemUserMutation:
 
         # No SystemUser or token row must have been created
         assert not SystemUser.objects.filter(integration_name="inactive_owner_provider").exists()
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Owner-guard blocked-time writes
+# ---------------------------------------------------------------------------
+#
+# GraphQL mutations reused from the existing blocked-time test sections.
+#
+_CREATE_BLOCKED_TIME_SCOPED = """
+mutation CreateBlockedTime($input: CreateBlockedTimeInput!) {
+    createBlockedTime(input: $input) {
+        success
+        errorMessage
+        blockedTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_UPDATE_BLOCKED_TIME_SCOPED = """
+mutation UpdateBlockedTime($input: UpdateBlockedTimeInput!) {
+    updateBlockedTime(input: $input) {
+        success
+        errorMessage
+        blockedTime {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+_DELETE_BLOCKED_TIME_SCOPED = """
+mutation DeleteBlockedTime($input: DeleteBlockedTimeInput!) {
+    deleteBlockedTime(input: $input) {
+        success
+        errorMessage
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestScopedTokenBlockedTimeWrites:
+    """Integration tests for owner-scoped blocked-time mutations (Phase 1).
+
+    Coverage:
+    - Scoped token can create/update/delete on its owned calendar (happy path).
+    - Cross-owner write returns the same not-found message as a genuinely missing
+      calendar, revealing nothing about the target's existence.
+    - Org-wide token is structurally unchanged (no-regression assertion).
+    - A scoped token missing the required resource grant is denied by the permission
+      class before the guard even runs.
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _setup_org(self):
+        """Create a base organization for the test scenario."""
+        return baker.make(Organization, name="Test Org")
+
+    def _make_owner_with_calendar(self, org):
+        """Create a provider user, their membership, and a calendar they own.
+
+        Returns (user, membership, calendar).
+        """
+        import uuid
+
+        from calendar_integration.models import CalendarOwnership
+
+        user_model = get_user_model()
+        unique = uuid.uuid4().hex[:8]
+        owner = baker.make(user_model, email=f"owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = baker.make(
+            Calendar,
+            organization=org,
+            name="Provider Calendar",
+            external_id=f"provider-cal-{unique}",
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=owner, organization=org)
+        return owner, membership, calendar
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        """Mint a scoped SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        import uuid
+
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_org_wide_system_user(self, org, resources):
+        """Mint an org-wide (unscoped) SystemUser with the given resource grants.
+
+        Returns (system_user, plaintext_token, auth_service).
+        """
+        import uuid
+
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _create_blocked_time_on_calendar(self, org, system_user, calendar):
+        """Create a BlockedTime row directly via the service (not the API).
+
+        Used to set up rows for update/delete happy-path tests.
+        """
+        from di_core.containers import container
+
+        calendar_service: CalendarService = container.calendar_service()
+        calendar_service.initialize_without_provider(user_or_token=system_user, organization=org)
+        return calendar_service.create_blocked_time(
+            calendar=calendar,
+            start_time=datetime.datetime(2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time=datetime.datetime(2026, 10, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            reason="Scoped test block",
+        )
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    # ------------------------------------------------------------------
+    # createBlockedTime — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token creates a blocked time on its owner's calendar."""
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                    "reason": "Scoped block",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createBlockedTime"]
+        assert result["success"] is True
+        assert result["blockedTime"] is not None
+        bt_id = int(result["blockedTime"]["id"])
+
+        # Verify the DB row exists and belongs to the correct calendar
+        bt = BlockedTime.objects.filter_by_organization(org.id).get(id=bt_id)
+        assert bt.calendar_fk_id == calendar.id
+        assert bt.reason == "Scoped block"
+
+    # ------------------------------------------------------------------
+    # createBlockedTime — cross-owner not-found is identical to missing calendar
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner createBlockedTime returns identical not-found as a truly missing calendar.
+
+        A scoped token targeting another provider's calendar_id must get the same
+        success=False / errorMessage as a genuinely nonexistent calendar — revealing
+        nothing about the target's existence.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        # Two independent providers in the same org
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+
+        # Token scoped to provider A
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+
+        start = datetime.datetime(2026, 10, 5, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 5, 16, 0, 0, tzinfo=datetime.UTC)
+
+        # Attempt against provider B's calendar (cross-owner)
+        cross_owner_response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Attempt against a genuinely nonexistent calendar_id
+        nonexistent_id = 999998
+        missing_response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": nonexistent_id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Both must be success=False, no errors list, and IDENTICAL errorMessage
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["createBlockedTime"]
+            assert r["success"] is False
+            assert r["errorMessage"] is not None
+
+        cross_msg = cross_owner_response.json()["data"]["createBlockedTime"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["createBlockedTime"]["errorMessage"]
+        assert cross_msg == missing_msg, (
+            f"Cross-owner error '{cross_msg}' must equal missing-calendar error '{missing_msg}'"
+        )
+
+        # No BlockedTime rows must have been created in either case
+        assert not BlockedTime.objects.filter(calendar_fk_id=calendar_b.id).exists()
+
+    # ------------------------------------------------------------------
+    # updateBlockedTime — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_update_blocked_time_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token updates a blocked time on its owner's calendar."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        # Create row via org-wide service call so the calendar service can initialize freely
+        org_wide_su, _org_wide_token, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+
+        new_start = datetime.datetime(2026, 10, 2, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 2, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateBlockedTime"]
+        assert result["success"] is True
+        assert result["blockedTime"] is not None
+
+    # ------------------------------------------------------------------
+    # updateBlockedTime — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_update_blocked_time_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner updateBlockedTime returns identical not-found as a truly missing calendar."""
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        # Create a blocked time on B's calendar using org-wide token
+        blocked_time_b = self._create_blocked_time_on_calendar(org, org_wide_su_b, calendar_b)
+
+        # Token scoped to provider A — must not update B's calendar
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+
+        new_start = datetime.datetime(2026, 10, 3, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 3, 17, 0, 0, tzinfo=datetime.UTC)
+
+        # Cross-owner attempt: calendar_id belongs to B, not A
+        cross_owner_response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "blockedTimeId": blocked_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Genuinely missing calendar_id attempt
+        missing_response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999997,
+                    "blockedTimeId": blocked_time_b.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["updateBlockedTime"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["updateBlockedTime"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["updateBlockedTime"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # The blocked time row must be unchanged
+        blocked_time_b.refresh_from_db()
+        assert blocked_time_b.reason == "Scoped test block"
+
+    # ------------------------------------------------------------------
+    # deleteBlockedTime — scoped happy path
+    # ------------------------------------------------------------------
+
+    def test_delete_blocked_time_scoped_token_on_owned_calendar_succeeds(self):
+        """A scoped token deletes a blocked time on its owner's calendar."""
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        org_wide_su, _, _org_wide_auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+        bt_id = blocked_time.id
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+
+        response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": bt_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteBlockedTime"]
+        assert result["success"] is True
+
+        # DB row must be gone
+        assert not BlockedTime.objects.filter(id=bt_id).exists()
+
+    # ------------------------------------------------------------------
+    # deleteBlockedTime — cross-owner not-found
+    # ------------------------------------------------------------------
+
+    def test_delete_blocked_time_cross_owner_same_not_found_as_missing_calendar(self):
+        """Cross-owner deleteBlockedTime returns identical not-found as a truly missing calendar.
+
+        The blocked-time row must NOT be deleted when the token targets a cross-owner calendar.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        org_wide_su_b, _, _org_wide_auth_b = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        blocked_time_b = self._create_blocked_time_on_calendar(org, org_wide_su_b, calendar_b)
+        bt_b_id = blocked_time_b.id
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+
+        # Cross-owner attempt (calendar_b belongs to owner B)
+        cross_owner_response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "blockedTimeId": bt_b_id,
+                }
+            },
+        )
+
+        # Genuinely missing calendar attempt
+        missing_response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999996,
+                    "blockedTimeId": bt_b_id,
+                }
+            },
+        )
+
+        for resp in [cross_owner_response, missing_response]:
+            assert resp.status_code == 200
+            d = resp.json()
+            assert "errors" not in d or len(d.get("errors", [])) == 0
+            r = d["data"]["deleteBlockedTime"]
+            assert r["success"] is False
+
+        cross_msg = cross_owner_response.json()["data"]["deleteBlockedTime"]["errorMessage"]
+        missing_msg = missing_response.json()["data"]["deleteBlockedTime"]["errorMessage"]
+        assert cross_msg == missing_msg
+
+        # Row must still exist — the cross-owner delete must NOT have succeeded
+        assert BlockedTime.objects.filter(id=bt_b_id).exists()
+
+    # ------------------------------------------------------------------
+    # Org-wide token — no-regression assertions for all three verbs
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can create blocked times on any calendar (guard is no-op).
+
+        This is the no-regression assertion: the guard must be a structural no-op for
+        org-wide tokens, leaving their behavior byte-for-byte unchanged.
+        """
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        # Calendar owned by a different provider — org-wide should not be blocked
+        _other_owner, _other_membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+
+        start = datetime.datetime(2026, 10, 6, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 6, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["createBlockedTime"]
+        assert result["success"] is True
+        assert result["blockedTime"] is not None
+        bt_id = int(result["blockedTime"]["id"])
+        assert BlockedTime.objects.filter_by_organization(org.id).filter(id=bt_id).exists()
+
+    def test_update_blocked_time_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can update blocked times on any calendar (guard is no-op)."""
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, system_user, calendar)
+
+        new_start = datetime.datetime(2026, 10, 7, 10, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 7, 18, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                    "startTime": new_start.isoformat(),
+                    "endTime": new_end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["updateBlockedTime"]
+        assert result["success"] is True
+
+    def test_delete_blocked_time_org_wide_token_unaffected_by_guard(self):
+        """An org-wide token can delete blocked times on any calendar (guard is no-op)."""
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        _other_owner, _other_membership, calendar = self._make_owner_with_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, system_user, calendar)
+        bt_id = blocked_time.id
+
+        response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": bt_id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["deleteBlockedTime"]
+        assert result["success"] is True
+        assert not BlockedTime.objects.filter(id=bt_id).exists()
+
+    # ------------------------------------------------------------------
+    # Missing resource grant — scoped token denied
+    # ------------------------------------------------------------------
+
+    def test_create_blocked_time_scoped_token_missing_grant_denied(self):
+        """A scoped token without CREATE_BLOCKED_TIME grant is denied by the permission class."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        # Grant CALENDAR instead of CREATE_BLOCKED_TIME
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        start = datetime.datetime(2026, 10, 8, 8, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 10, 8, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _CREATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "startTime": start.isoformat(),
+                    "endTime": end.isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_update_blocked_time_scoped_token_missing_grant_denied(self):
+        """A scoped token without UPDATE_BLOCKED_TIME grant is denied by the permission class."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        # Create row first using org-wide token
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.UPDATE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+        # Scoped token with wrong resource
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _UPDATE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_delete_blocked_time_scoped_token_missing_grant_denied(self):
+        """A scoped token without DELETE_BLOCKED_TIME grant is denied by the permission class."""
+        org = self._setup_org()
+        _owner, membership, calendar = self._make_owner_with_calendar(org)
+        org_wide_su, _, _auth = self._make_org_wide_system_user(
+            org, [PublicAPIResources.DELETE_BLOCKED_TIME]
+        )
+        blocked_time = self._create_blocked_time_on_calendar(org, org_wide_su, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR]
+        )
+
+        response = self._post(
+            _DELETE_BLOCKED_TIME_SCOPED,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "blockedTimeId": blocked_time.id,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()

--- a/public_api/tests/test_scoping.py
+++ b/public_api/tests/test_scoping.py
@@ -4,7 +4,7 @@ from model_bakery import baker
 from calendar_integration.models import Calendar, CalendarOwnership
 from organizations.models import Organization, OrganizationMembership
 from public_api.models import SystemUser
-from public_api.scoping import scoped_calendar_ids
+from public_api.scoping import assert_calendar_in_owner_scope, scoped_calendar_ids
 from public_api.services import PublicAPIAuthService
 from users.models import User
 
@@ -198,3 +198,116 @@ class TestScopedCalendarIds:
         assert system_user.organization_id == membership.organization_id
         # The scalar id is always accessible regardless of the FK join path.
         assert system_user.scoped_to_membership_fk_id == membership.id
+
+
+@pytest.mark.django_db
+class TestAssertCalendarInOwnerScope:
+    """Unit tests for the assert_calendar_in_owner_scope write-side guard."""
+
+    @pytest.fixture
+    def organization(self):
+        """Create a test organization."""
+        return baker.make(Organization, name="Test Organization")
+
+    @pytest.fixture
+    def user(self, organization):
+        """Create a test user."""
+        return baker.make(User, email="provider@example.com")
+
+    @pytest.fixture
+    def other_user(self, organization):
+        """Create another test user (different provider)."""
+        return baker.make(User, email="other_provider@example.com")
+
+    @pytest.fixture
+    def membership(self, organization, user):
+        """Create an active membership for the main user."""
+        return baker.make(
+            OrganizationMembership, user=user, organization=organization, is_active=True
+        )
+
+    @pytest.fixture
+    def other_membership(self, organization, other_user):
+        """Create an active membership for the other user."""
+        return baker.make(
+            OrganizationMembership, user=other_user, organization=organization, is_active=True
+        )
+
+    @pytest.fixture
+    def owned_calendar(self, organization, user):
+        """Create a calendar owned by the main user."""
+        calendar = baker.make(
+            Calendar, organization=organization, name="Owned Calendar", external_id="owned-cal"
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=user, organization=organization)
+        return calendar
+
+    @pytest.fixture
+    def other_calendar(self, organization, other_user):
+        """Create a calendar owned by the other user (cross-owner target)."""
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            name="Other Calendar",
+            external_id="other-cal",
+        )
+        baker.make(CalendarOwnership, calendar=calendar, user=other_user, organization=organization)
+        return calendar
+
+    @pytest.fixture
+    def org_wide_system_user(self, organization):
+        """Create an org-wide system user (no owner scope)."""
+        auth_service = PublicAPIAuthService()
+        system_user, _ = auth_service.create_system_user(
+            integration_name="org_wide_write_token", organization=organization
+        )
+        return system_user
+
+    @pytest.fixture
+    def scoped_system_user(self, organization, membership):
+        """Create a system user scoped to the main user's membership."""
+        return baker.make(
+            SystemUser,
+            organization=organization,
+            scoped_to_membership_fk=membership,
+            integration_name="scoped_write_token",
+        )
+
+    def test_no_raise_when_system_user_is_none(self, organization, owned_calendar):
+        """Guard is a no-op when system_user is None (no auth context)."""
+        # Must not raise regardless of calendar_id
+        assert_calendar_in_owner_scope(None, organization, owned_calendar.id)
+
+    def test_no_raise_for_org_wide_token(self, org_wide_system_user, organization, other_calendar):
+        """Guard is a no-op for org-wide tokens (scoped_calendar_ids returns None).
+
+        An org-wide token can target any calendar without the guard raising — this is
+        the no-regression assertion that ensures org-wide behavior is structurally unchanged.
+        """
+        assert_calendar_in_owner_scope(org_wide_system_user, organization, other_calendar.id)
+
+    def test_no_raise_for_in_scope_calendar(self, scoped_system_user, organization, owned_calendar):
+        """Guard does not raise when the calendar is within the token owner's scope."""
+        assert_calendar_in_owner_scope(scoped_system_user, organization, owned_calendar.id)
+
+    def test_raises_does_not_exist_for_out_of_scope_calendar(
+        self, scoped_system_user, organization, other_calendar
+    ):
+        """Guard raises Calendar.DoesNotExist for a cross-owner calendar_id when scoped.
+
+        The raised exception uses the same message as a genuinely missing calendar to
+        prevent existence leaks.
+        """
+        with pytest.raises(
+            Calendar.DoesNotExist, match=r"Calendar matching query does not exist\."
+        ):
+            assert_calendar_in_owner_scope(scoped_system_user, organization, other_calendar.id)
+
+    def test_raises_for_nonexistent_calendar_id_when_scoped(self, scoped_system_user, organization):
+        """Guard raises Calendar.DoesNotExist for a nonexistent calendar_id when scoped.
+
+        A nonexistent id is not in the allowed set, so the same exception is raised.
+        """
+        nonexistent_id = 999999
+        with pytest.raises(Calendar.DoesNotExist):
+            assert_calendar_in_owner_scope(scoped_system_user, organization, nonexistent_id)


### PR DESCRIPTION
## Summary
Phase 3 of the **Per-Owner-Scoped Public API Token Writes** plan — the only net-new mutation. A
provider-scoped token can now **schedule events on its owner's calendars** via `scheduleEvent`. This
required a narrow, sanctioned relaxation of `CalendarEventService.create_event`, which previously
hard-blocked ALL public-API (`SystemUser`) event creation.

## Why the service changed
`create_event` raised `PermissionDenied("Events cannot be created through the Public API.")` for every
`SystemUser`. This phase relaxes ONLY the `create_event` site (the `scheduleEvent` path —
`update_event`/`delete_event` blocks are untouched) to allow event creation when, and only when:
- the token is owner-scoped (`scoped_to_membership_fk_id is not None`), AND
- an **independent** `CalendarOwnership` lookup (filtered by the calendar's own organization) confirms
  the token's owner owns the target calendar — nothing from the caller is trusted.

Org-wide tokens stay blocked (event creation still routes through single-use codes / public scheduling).
Bundle calendars are rejected for scoped tokens (avoids confusing cross-provider fan-out).

## What changed
- **`calendar_integration/services/calendar_event_service.py`**: `_scoped_system_user_owns_calendar`
  helper (independent ownership verification); owner-scoped allowance + bundle rejection in
  `create_event`; skip `can_perform_scheduling` ONLY on the verified-ownership path (that method is a
  pure token-permission gate, not availability enforcement — availability still runs); fixed the
  post-commit audit actor to `getattr`-guard the permission token and fall back to the `SystemUser`.
- **`public_api/mutations.py`**: new `scheduleEvent` mutation (`ScheduleEventInput`), owner-guarded via
  `assert_calendar_in_owner_scope` (defense in depth); de-duplicated active-org-member attendee
  validation; external-attendee translation; title-length guard; clean GraphQL error mapping.
- **`public_api/permissions.py`**: `scheduleEvent → CALENDAR_EVENT` (already in `PROVIDER_SCOPED_RESOURCES`).

## Plan reference
Plan `ai-plans/2026-06-18-PER_OWNER_SCOPED_PUBLIC_API_TOKEN_WRITES_IMPLEMENTATION_PLAN.md` — Phase 3.
Spec `ai-plans/2026-06-17-PER_OWNER_SCOPED_PUBLIC_API_TOKENS_SPEC.md`: use-case 2 (schedule-event write)
+ use-case 3 (cross-owner refused). Stacked on phase-2 (PR #139).

## Test plan
- `public_api/tests/test_mutations.py` (`TestScopedTokenScheduleEvent`, 10 tests) — scoped owner
  schedules on a default (non-public) owned calendar with a covering availability window → success;
  recurring; internal + external attendees persisted; out-of-org attendee → clean error, no row;
  cross-owner calendar → not-found identical to missing + no row; **org-wide token → denied, no row**;
  bundle → clean error, no row; no availability window → clean error; missing `CALENDAR_EVENT` → denied.
- `calendar_integration/tests/services/test_calendar_event_service.py` (4 tests) — `create_event` allows
  an owner-scoped `SystemUser` on an owned calendar; still blocks an org-wide `SystemUser`; still blocks
  a scoped token on a non-owned calendar; the on_commit audit actor falls back to the `SystemUser`.
- Outer gate (docker): `check --deploy` + `makemigrations --check` (no changes) + `pytest -n auto` →
  **2469 passed**.