### PR TITLE
refactor(membership)!: convert remaining real membership FKs to (org,user) ForeignObject

### DIFF
--- a/accounts/tests/test_base_forms.py
+++ b/accounts/tests/test_base_forms.py
@@ -65,7 +65,7 @@ class TestBaseVintaScheduleSignupFormUnit:
             invited_by=inviter,
             expires_at=timezone.now() + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         form = _make_form(organization_name="Should Be Ignored")
@@ -86,7 +86,7 @@ class TestBaseVintaScheduleSignupFormUnit:
             invited_by=inviter,
             expires_at=timezone.now() - datetime.timedelta(days=1),  # already expired
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         form = _make_form(
@@ -126,7 +126,7 @@ class TestBaseVintaScheduleSignupFormUnit:
             invited_by=inviter,
             expires_at=timezone.now() + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         form = _make_form(organization_name="Should Be Ignored Due To Case-Insensitive Match")
@@ -212,7 +212,7 @@ class TestBaseVintaScheduleSignupFormIntegration:
             invited_by=inviter,
             expires_at=timezone.now() + datetime.timedelta(days=3),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         form = _make_form(

--- a/accounts/tests/test_email_branding.py
+++ b/accounts/tests/test_email_branding.py
@@ -79,7 +79,7 @@ class TestEmailBranding:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         from organizations.notification_contexts import organization_invitation_context
@@ -115,7 +115,7 @@ class TestEmailBranding:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         from organizations.notification_contexts import organization_invitation_context
@@ -155,7 +155,7 @@ class TestEmailBranding:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         from organizations.notification_contexts import organization_invitation_context
@@ -299,7 +299,7 @@ class TestInvitationTemplateRendering:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         from organizations.notification_contexts import organization_invitation_context
@@ -353,7 +353,7 @@ class TestPublicApiInviteInvitedByNone:
             last_name="Customer",
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         from organizations.notification_contexts import organization_invitation_context
@@ -388,7 +388,7 @@ class TestPublicApiInviteInvitedByNone:
             last_name="Customer",
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         from organizations.notification_contexts import organization_invitation_context

--- a/accounts/tests/test_email_confirmation_provisioning.py
+++ b/accounts/tests/test_email_confirmation_provisioning.py
@@ -142,7 +142,7 @@ class TestProvisionOnEmailConfirmation:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         email_address = _create_email_address(invited_user)

--- a/accounts/tests/test_email_invite_autojoin.py
+++ b/accounts/tests/test_email_invite_autojoin.py
@@ -77,7 +77,7 @@ def _pending_invitation(
         invited_by=inviter,
         expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
         accepted_at=None,
-        membership=None,
+        membership_user_id=None,
     )
 
 
@@ -150,7 +150,7 @@ class TestInvitedEmailAutoJoin:
         invitation.refresh_from_db()
         assert invitation.accepted_at is not None, "Invitation accepted_at must be set"
         assert invitation.membership is not None, "Invitation must be linked to the membership"
-        assert invitation.membership_id == membership.pk
+        assert invitation.membership_user_id == membership.user_id
 
     def test_invite_wins_over_pending_organization_name(self, rf):
         """
@@ -226,7 +226,7 @@ class TestInvitedEmailAutoJoin:
         # Invitation is properly accepted.
         invitation.refresh_from_db()
         assert invitation.accepted_at is not None
-        assert invitation.membership_id == membership.pk
+        assert invitation.membership_user_id == membership.user_id
 
     def test_invitation_marked_accepted_after_autojoin(self, rf):
         """

--- a/accounts/tests/test_social_gated_onboarding.py
+++ b/accounts/tests/test_social_gated_onboarding.py
@@ -311,7 +311,7 @@ class TestSocialSignupCrossOrgInviteAccept:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Refresh so the related manager cache is warm.

--- a/accounts/tests/test_social_invite_autojoin.py
+++ b/accounts/tests/test_social_invite_autojoin.py
@@ -82,7 +82,7 @@ def _pending_invitation(
         invited_by=inviter,
         expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
         accepted_at=None,
-        membership=None,
+        membership_user_id=None,
     )
 
 
@@ -135,7 +135,7 @@ class TestSocialInviteAutojoin:
         invitation.refresh_from_db()
         assert invitation.accepted_at is not None, "invitation.accepted_at must be set"
         assert invitation.membership is not None, "invitation.membership FK must be linked"
-        assert invitation.membership_id == membership.pk
+        assert invitation.membership_user_id == membership.user_id
 
     # ------------------------------------------------------------------
     # Scenario 2 — uninvited social signup stays gated (Phase 5 regression)
@@ -191,7 +191,7 @@ class TestSocialInviteAutojoin:
 
         invitation.refresh_from_db()
         assert invitation.accepted_at is not None
-        assert invitation.membership_id == membership.pk
+        assert invitation.membership_user_id == membership.user_id
 
     # ------------------------------------------------------------------
     # Scenario 4 — re-entry / already-member is a no-op

--- a/ai-plans/TRACKING_membership-scoped-calendar-references.md
+++ b/ai-plans/TRACKING_membership-scoped-calendar-references.md
@@ -171,13 +171,29 @@ PK provides a unique index on the SAME columns, but Postgres FKs bind to a speci
 the composite PK BEFORE dropping the old unique (or the 3 FKs lose their referenced target). Verify all 3 FKs still
 valid post-swap. Composite PK column order must be (user_id, organization_id) to match the FK references.
 
+### Phase 7a — De-FK OrganizationMembership + rewrite .id refs ✅
+- **Status**: merged-ready (PR open). **Model**: claude-opus (T4) · implementer + reviewer (no blocker/should-fix; 2 perf NITs skipped).
+- **Branch**: `…/phase-7a` (stacked on 6) · **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/155
+- **Summary**: Converted `OrganizationInvitation.membership` (OneToOne) + `public_api.SystemUser.scoped_to_membership`
+  (OrganizationForeignKey) → `OrganizationMembershipForeignKey` (org,user ForeignObject); partial unique preserves the
+  invitation OneToOne. Rewrote all `membership.id/.pk/membership_id` → (user_id, organization_id)/membership_user_id.
+  Migrations 0012 (organizations) + 0008 (public_api) drop the legacy real-FK columns (`membership_id`,
+  `scoped_to_membership_fk_id`) — unblocking 7b. Reviewer confirmed token-scoping has NO cross-org leak (middleware
+  forces org == system_user.organization). Webhook payload → {user_id, organization_id} shape. 2671 passed. Both
+  acceptance greps ZERO non-test; membership still has id PK.
+
+## Phase 7b sequencing (VERIFIED dependencies)
+- 3 raw FKs reference organization_membership + depend on `uniq_membership_user_organization` (UNIQUE on user_id,
+  organization_id): `calownership_membership_protect_fk`, `evattendance_membership_protect_fk`, `calmgmttoken_membership_protect_fk`.
+- Current: PK on `id`; unique on (user_id, organization_id). Goal: PK = (user_id, organization_id), drop `id`.
+- The composite PK provides a unique index on the same columns. To avoid orphaning the 3 FKs: EITHER keep
+  `uniq_membership_user_organization` (FK-safe, redundant) IF Django makemigrations/check stay clean, OR rebind FKs
+  to the PK (drop 3 FKs → drop unique → swap PK → re-add 3 deferrable FKs) via one raw-SQL migration.
+
 ## Current phase
-- Phase 7a — Convert OrganizationInvitation.membership (OneToOne) + public_api.SystemUser.scoped_to_membership (FK)
-  off real FKs to OrganizationMembership; rewrite all membership.id/.pk/membership_id refs (incl. public_api/scoping.py
-  `ownerships__membership__id=` from Phase 2a). Enables the composite PK. (next)
+- Phase 7b — OrganizationMembership composite PK (FINAL) (next)
 
 ## Remaining phases
-- Phase 7a — FK conversions + .id rewrites (T4 · implementer)
 - Phase 7b — OrganizationMembership composite PK (T4 · migration-author)
 - Phase 6 — CalendarManagementToken cutover (T4 · implementer/migration-author) [likely split 6a/6b]
 - Phase 7a — FK conversions (OrganizationInvitation.membership + public_api.SystemUser.scoped_to_membership) + .id rewrites (T4)

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -225,8 +225,8 @@ class CalendarEventService:
         cross-organization or cross-owner token can never pass.
 
         Ownership is confirmed when a :class:`CalendarOwnership` row exists for ``calendar``
-        whose ``user`` is the member behind the token's ``scoped_to_membership`` (an
-        ``OrganizationMembership``). Org-wide tokens (``scoped_to_membership_fk_id is None``)
+        whose member is the one behind the token's ``scoped_to_membership`` (an
+        ``OrganizationMembership``). Org-wide tokens (``scoped_to_membership_user_id is None``)
         always return ``False`` — event creation stays blocked for them.
 
         Args:
@@ -237,13 +237,16 @@ class CalendarEventService:
             ``True`` only when the token is scoped AND its owner independently owns the
             target calendar in that calendar's organization; ``False`` otherwise.
         """
-        if system_user.scoped_to_membership_fk_id is None:
+        if system_user.scoped_to_membership_user_id is None:
             return False
+        # The queryset is already org-scoped via filter_by_organization, so filtering
+        # ownerships by membership_user_id is equivalent to the full (organization_id,
+        # user_id) membership identity — the org is fixed to the calendar's org.
         return (
             CalendarOwnership.objects.filter_by_organization(calendar.organization_id)
             .filter(
                 calendar_fk_id=calendar.id,
-                membership__id=system_user.scoped_to_membership_fk_id,
+                membership_user_id=system_user.scoped_to_membership_user_id,
             )
             .exists()
         )
@@ -311,7 +314,7 @@ class CalendarEventService:
             # Public-API event creation is blocked by default. The single sanctioned
             # exception: an owner-scoped token whose owner *independently* owns the target
             # calendar (verified against CalendarOwnership, NOT trusted from the caller).
-            # Org-wide tokens (scoped_to_membership_fk_id is None) stay blocked — they must
+            # Org-wide tokens (scoped_to_membership_user_id is None) stay blocked — they must
             # route through single-use codes / public scheduling.
             if not self._scoped_system_user_owns_calendar(context.user_or_token, calendar):
                 raise PermissionDenied("Events cannot be created through the Public API.")

--- a/organizations/migrations/0012_organizationinvitation_membership_user_id_and_more.py
+++ b/organizations/migrations/0012_organizationinvitation_membership_user_id_and_more.py
@@ -1,0 +1,110 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+def backfill_membership_user_id(apps, schema_editor):
+    """Copy the accepted membership's user_id from the legacy ``membership_id`` FK.
+
+    The legacy ``membership`` OneToOneField stored ``membership_id`` referencing
+    ``OrganizationMembership.id``. The new ``(organization_id, membership_user_id)``
+    join needs the membership's ``user_id`` denormalized onto the invitation row.
+    """
+    OrganizationInvitation = apps.get_model("organizations", "OrganizationInvitation")
+    OrganizationMembership = apps.get_model("organizations", "OrganizationMembership")
+    membership_user_by_id = dict(OrganizationMembership.objects.values_list("id", "user_id"))
+    for invitation_id, membership_id in OrganizationInvitation.objects.filter(
+        membership_id__isnull=False
+    ).values_list("id", "membership_id"):
+        user_id = membership_user_by_id.get(membership_id)
+        if user_id is not None:
+            OrganizationInvitation.objects.filter(id=invitation_id).update(
+                membership_user_id=user_id
+            )
+
+
+def noop_reverse(apps, schema_editor):
+    """No-op reverse: the legacy membership_id column is re-added + backfilled by RunSQL."""
+
+
+# Drop the legacy OneToOne column. Reverse re-adds ``membership_id`` as a NULLABLE
+# column and best-effort backfills it by resolving the membership from the retained
+# (organization_id, membership_user_id) pair. Re-added nullable (not NOT NULL) because
+# the original OneToOne was nullable anyway; Django's auto-reverse of RemoveField on a
+# OneToOne FK would attempt a constraint that does not match the composite-PK target.
+DROP_MEMBERSHIP_FK_COLUMN = """
+ALTER TABLE organizations_organizationinvitation
+  DROP COLUMN IF EXISTS membership_id;
+"""
+
+READD_MEMBERSHIP_FK_COLUMN_NULLABLE_AND_BACKFILL = """
+ALTER TABLE organizations_organizationinvitation
+  ADD COLUMN IF NOT EXISTS membership_id bigint NULL;
+UPDATE organizations_organizationinvitation AS oi
+  SET membership_id = om.id
+  FROM organizations_organizationmembership AS om
+  WHERE oi.membership_user_id IS NOT NULL
+    AND om.organization_id = oi.organization_id
+    AND om.user_id = oi.membership_user_id;
+"""
+
+
+class Migration(migrations.Migration):
+    """Phase 7a: convert OrganizationInvitation.membership off the real OneToOne.
+
+    Replaces the ``membership`` OneToOneField (real FK to ``OrganizationMembership.id``)
+    with the ``(organization_id, membership_user_id)`` ForeignObject pattern so the
+    relation survives Phase 7b's composite-PK swap. OneToOne semantics are preserved by
+    a partial unique constraint on ``(organization, membership_user_id)``.
+    """
+
+    dependencies = [
+        ("organizations", "0011_organizationbranding"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # 1. Add the denormalized membership_user_id column (nullable).
+        migrations.AddField(
+            model_name="organizationinvitation",
+            name="membership_user_id",
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        # 2. Backfill it from the legacy membership FK's user_id before the FK is dropped.
+        migrations.RunPython(backfill_membership_user_id, noop_reverse),
+        # 3. Swap the ``membership`` field: state replaces the OneToOneField with the
+        #    (org, user) ForeignObject; DB drops the legacy ``membership_id`` FK column
+        #    (reverse re-adds it nullable + best-effort backfill).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="organizationinvitation",
+                    name="membership",
+                    field=models.ForeignObject(
+                        editable=False,
+                        from_fields=("membership_user_id", "organization_id"),
+                        null=True,
+                        on_delete=django.db.models.deletion.DO_NOTHING,
+                        related_name="invitation",
+                        to="organizations.organizationmembership",
+                        to_fields=("user_id", "organization_id"),
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql=DROP_MEMBERSHIP_FK_COLUMN,
+                    reverse_sql=READD_MEMBERSHIP_FK_COLUMN_NULLABLE_AND_BACKFILL,
+                ),
+            ],
+        ),
+        # 4. Preserve OneToOne semantics via a partial unique constraint.
+        migrations.AddConstraint(
+            model_name="organizationinvitation",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("membership_user_id__isnull", False)),
+                fields=("organization", "membership_user_id"),
+                name="uniq_invitation_membership_user_per_org",
+            ),
+        ),
+    ]

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -7,7 +7,11 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.db import models
 
-from common.fields import TenantSafeForeignKey, TenantSafeOneToOneField
+from common.fields import (
+    OrganizationMembershipForeignKey,
+    TenantSafeForeignKey,
+    TenantSafeOneToOneField,
+)
 from common.models import BaseModel
 from organizations.managers import BaseOrganizationModelManager, OrganizationMembershipManager
 
@@ -309,8 +313,14 @@ class OrganizationInvitation(BaseModel):
     accepted_at = models.DateTimeField(null=True, blank=True)
     token_hash = models.TextField()
     expires_at = models.DateTimeField()
-    membership = models.OneToOneField(
-        OrganizationMembership,
+    # Membership reference via the (organization_id, membership_user_id) composite join
+    # rather than a real FK. Django 6 forbids a real FK to a composite-PK model
+    # (OrganizationMembership becomes composite-PK in Phase 7b). This contributes a
+    # concrete ``membership_user_id`` column plus a ForeignObject descriptor ``membership``.
+    # OneToOne semantics are preserved by the partial UniqueConstraint below
+    # (one accepted invitation per membership). ``related_name="invitation"`` keeps the
+    # ``membership.invitation`` reverse accessor (now a reverse manager).
+    membership = OrganizationMembershipForeignKey(
         on_delete=models.CASCADE,
         related_name="invitation",
         null=True,
@@ -322,6 +332,11 @@ class OrganizationInvitation(BaseModel):
             models.UniqueConstraint(
                 fields=["email", "organization"],
                 name="uniq_invitation_email_organization",
+            ),
+            models.UniqueConstraint(
+                fields=["organization", "membership_user_id"],
+                condition=models.Q(membership_user_id__isnull=False),
+                name="uniq_invitation_membership_user_per_org",
             ),
         ]
 

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -245,7 +245,7 @@ class OrganizationService:
                 email=email,
                 organization=organization,
                 accepted_at__isnull=True,
-                membership__isnull=True,
+                membership_user_id__isnull=True,
                 defaults={
                     "invited_by": invited_by,
                     "first_name": first_name,
@@ -267,7 +267,7 @@ class OrganizationService:
             invitation.last_name = last_name
             invitation.role = role
             invitation.accepted_at = None
-            invitation.membership = None
+            invitation.membership_user_id = None
             invitation.save()
 
         # Attach the raw token as a transient attribute so the caller can surface it once.
@@ -345,7 +345,7 @@ class OrganizationService:
                 except IntegrityError as e:
                     raise UserAlreadyHasMembershipError() from e
                 invitation.accepted_at = now
-                invitation.membership = membership
+                invitation.membership_user_id = membership.user_id
                 invitation.save()
                 self.webhook_membership_side_effects_service.on_member_created(membership)
                 return membership
@@ -393,7 +393,7 @@ class OrganizationService:
             email__iexact=user.email,
             expires_at__gt=now,
             accepted_at__isnull=True,
-            membership__isnull=True,
+            membership_user_id__isnull=True,
         ).first()
 
         if pending_invitation is not None:
@@ -413,7 +413,7 @@ class OrganizationService:
             except IntegrityError as e:
                 raise UserAlreadyHasMembershipError() from e
             pending_invitation.accepted_at = now
-            pending_invitation.membership = membership
+            pending_invitation.membership_user_id = membership.user_id
             pending_invitation.save()
             self.webhook_membership_side_effects_service.on_member_created(membership)
             return membership

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -317,7 +317,7 @@ class TestOrganizationService:
             token_hash=old_token_hash,
             expires_at=old_expires_at,
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Mock transaction.on_commit so the notification fires synchronously
@@ -369,7 +369,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Accept the invitation
@@ -406,7 +406,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
             role=OrganizationRole.ADMIN,
         )
 
@@ -431,7 +431,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
             role=OrganizationRole.MEMBER,
         )
 
@@ -457,7 +457,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Try to accept with wrong token
@@ -483,7 +483,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Try to accept expired invitation
@@ -514,7 +514,7 @@ class TestOrganizationService:
             invited_by=user,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Revoke the invitation
@@ -556,7 +556,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=datetime.datetime.now(tz=datetime.UTC),
-            membership=membership,
+            membership_user_id=membership.user_id,
         )
 
         # The hardened path now raises UserAlreadyHasMembershipError, not IntegrityError.
@@ -591,7 +591,7 @@ class TestOrganizationService:
             invited_by=invited_by,
             expires_at=expires_at,
             accepted_at=now if accepted else None,
-            membership=membership,
+            membership_user_id=membership.user_id if membership is not None else None,
         )
 
     def test_provision_tenant_for_user_with_pending_invite(
@@ -704,7 +704,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Phase 4: this must SUCCEED — user joins other_org as their second org.
@@ -734,7 +734,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         with pytest.raises(UserAlreadyHasMembershipError):
@@ -867,7 +867,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         with patch.object(
@@ -1019,7 +1019,7 @@ class TestOrganizationService:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
         baker.make(
             OrganizationInvitation,
@@ -1028,7 +1028,7 @@ class TestOrganizationService:
             invited_by=inviter,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # Both invitation rows coexist — the constraint only prevents duplicates per org.
@@ -1153,7 +1153,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         # The guard checks membership(organization=...) without is_active=True, so even an
@@ -1232,7 +1232,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
             role=OrganizationRole.MEMBER,
         )
 
@@ -1268,7 +1268,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
             role=OrganizationRole.ADMIN,
         )
 
@@ -1309,7 +1309,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         with container.calendar_service.override(Mock()):
@@ -1352,7 +1352,7 @@ class TestOrganizationService:
             token_hash=token_hash,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
             role=OrganizationRole.MEMBER,
         )
         baker.make(
@@ -1371,7 +1371,7 @@ class TestOrganizationService:
 
         with patch("webhooks.services.webhook_service.process_webhook_event.delay"):
             with django_capture_on_commit_callbacks(execute=True):
-                membership = service.accept_invitation(token=token, user=invitee)
+                service.accept_invitation(token=token, user=invitee)
 
         events = WebhookEvent.objects.filter(
             organization=organization,
@@ -1386,7 +1386,6 @@ class TestOrganizationService:
         assert event.payload["organization_id"] == organization.id
         assert event.payload["organization_name"] == organization.name
         assert event.payload["membership_role"] == OrganizationRole.MEMBER
-        assert event.payload["membership_id"] == membership.id
 
     # -----------------------------------------------------------------------
     # Phase 3 — organization_member_created webhook emission on create_organization
@@ -1546,7 +1545,6 @@ class TestOrganizationService:
         assert event.payload["email"] == invitee.email
         assert event.payload["organization_id"] == organization.id
         assert event.payload["membership_role"] == OrganizationRole.MEMBER
-        assert event.payload["membership_id"] == membership.id
 
     def test_provision_org_creation_emits_exactly_once_not_twice(
         self,

--- a/public_api/migrations/0008_remove_systemuser_scoped_to_membership_fk_and_more.py
+++ b/public_api/migrations/0008_remove_systemuser_scoped_to_membership_fk_and_more.py
@@ -1,0 +1,114 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def backfill_scoped_to_membership_user_id(apps, schema_editor):
+    """Copy the scoped membership's user_id from the legacy ``scoped_to_membership_fk_id``.
+
+    The legacy ``scoped_to_membership_fk`` FK stored a reference to
+    ``OrganizationMembership.id``. The new ``(organization_id, scoped_to_membership_user_id)``
+    join needs the membership's ``user_id`` denormalized onto the SystemUser row.
+    NULL stays NULL (organization-wide token).
+    """
+    SystemUser = apps.get_model("public_api", "SystemUser")
+    OrganizationMembership = apps.get_model("organizations", "OrganizationMembership")
+    membership_user_by_id = dict(OrganizationMembership.objects.values_list("id", "user_id"))
+    for system_user_id, membership_id in SystemUser.objects.filter(
+        scoped_to_membership_fk_id__isnull=False
+    ).values_list("id", "scoped_to_membership_fk_id"):
+        user_id = membership_user_by_id.get(membership_id)
+        if user_id is not None:
+            SystemUser.objects.filter(id=system_user_id).update(
+                scoped_to_membership_user_id=user_id
+            )
+
+
+def noop_reverse(apps, schema_editor):
+    """No-op reverse: the legacy FK column is re-added + backfilled by RunSQL."""
+
+
+# Drop the legacy scoped_to_membership_fk_id column. Reverse re-adds it as a NULLABLE
+# column and best-effort backfills by resolving the membership from the retained
+# (organization_id, scoped_to_membership_user_id) pair. Re-added nullable to match the
+# original (the FK was null=True); a NULL value means organization-wide token.
+DROP_SCOPED_FK_COLUMN = """
+ALTER TABLE public_api_systemuser
+  DROP COLUMN IF EXISTS scoped_to_membership_fk_id;
+"""
+
+READD_SCOPED_FK_COLUMN_NULLABLE_AND_BACKFILL = """
+ALTER TABLE public_api_systemuser
+  ADD COLUMN IF NOT EXISTS scoped_to_membership_fk_id bigint NULL;
+UPDATE public_api_systemuser AS su
+  SET scoped_to_membership_fk_id = om.id
+  FROM organizations_organizationmembership AS om
+  WHERE su.scoped_to_membership_user_id IS NOT NULL
+    AND om.organization_id = su.organization_id
+    AND om.user_id = su.scoped_to_membership_user_id;
+"""
+
+
+class Migration(migrations.Migration):
+    """Phase 7a: convert SystemUser.scoped_to_membership off the real FK.
+
+    Replaces the ``scoped_to_membership_fk`` FK (real FK to ``OrganizationMembership.id``)
+    with the ``(organization_id, scoped_to_membership_user_id)`` ForeignObject pattern so
+    the per-owner-token scoping relation survives Phase 7b's composite-PK swap. NULL still
+    means an organization-wide token.
+    """
+
+    dependencies = [
+        ("organizations", "0012_organizationinvitation_membership_user_id_and_more"),
+        ("public_api", "0007_systemuser_scoped_to_membership"),
+    ]
+
+    operations = [
+        # 1. Add the denormalized scoped_to_membership_user_id column (nullable).
+        migrations.AddField(
+            model_name="systemuser",
+            name="scoped_to_membership_user_id",
+            field=models.BigIntegerField(
+                blank=True,
+                help_text=(
+                    "When set, this token may only read/write data belonging to calendars "
+                    "owned by this organization membership's user. NULL = organization-wide "
+                    "token (legacy default)."
+                ),
+                null=True,
+            ),
+        ),
+        # 2. Backfill it from the legacy FK's user_id before the FK is dropped.
+        migrations.RunPython(backfill_scoped_to_membership_user_id, noop_reverse),
+        # 3. Swap the ``scoped_to_membership`` field: state replaces the legacy
+        #    ForeignObject (joining on scoped_to_membership_fk) with the (org, user)
+        #    ForeignObject and drops the concrete ``scoped_to_membership_fk`` FK from
+        #    state; DB drops the legacy ``scoped_to_membership_fk_id`` column (reverse
+        #    re-adds it nullable + best-effort backfill).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="systemuser",
+                    name="scoped_to_membership_fk",
+                ),
+                migrations.AlterField(
+                    model_name="systemuser",
+                    name="scoped_to_membership",
+                    field=models.ForeignObject(
+                        editable=False,
+                        from_fields=("scoped_to_membership_user_id", "organization_id"),
+                        null=True,
+                        on_delete=django.db.models.deletion.DO_NOTHING,
+                        related_name="scoped_system_users",
+                        to="organizations.organizationmembership",
+                        to_fields=("user_id", "organization_id"),
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql=DROP_SCOPED_FK_COLUMN,
+                    reverse_sql=READD_SCOPED_FK_COLUMN_NULLABLE_AND_BACKFILL,
+                ),
+            ],
+        ),
+    ]

--- a/public_api/models.py
+++ b/public_api/models.py
@@ -2,8 +2,9 @@ from typing import ClassVar
 
 from django.db import models
 
+from common.fields import OrganizationMembershipForeignKey
 from common.models import BaseModel
-from organizations.models import OrganizationForeignKey, OrganizationModel
+from organizations.models import OrganizationModel
 from public_api.constants import PublicAPIResources
 
 
@@ -20,8 +21,12 @@ class SystemUser(OrganizationModel):
         null=True,
         blank=True,
     )
-    scoped_to_membership = OrganizationForeignKey(
-        "organizations.OrganizationMembership",
+    # Membership reference via the (organization_id, scoped_to_membership_user_id)
+    # composite join rather than a real FK. Django 6 forbids a real FK to a
+    # composite-PK model (OrganizationMembership becomes composite-PK in Phase 7b).
+    # This contributes a concrete ``scoped_to_membership_user_id`` column plus a
+    # ForeignObject descriptor ``scoped_to_membership``. NULL = organization-wide token.
+    scoped_to_membership = OrganizationMembershipForeignKey(
         related_name="scoped_system_users",
         on_delete=models.CASCADE,
         null=True,

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -986,8 +986,9 @@ class Mutation(CalendarGroupMutations):
             )
         )
 
-        # scoped_to_membership_fk_id is always set here — we passed membership to create_system_user above.
-        assert system_user.scoped_to_membership_fk_id is not None  # noqa: S101
+        # scoped_to_membership_user_id is always set here — we passed membership to
+        # create_system_user above.
+        assert system_user.scoped_to_membership_user_id is not None  # noqa: S101
 
         return CreateScopedSystemUserResult(
             id=system_user.id,

--- a/public_api/scoping.py
+++ b/public_api/scoping.py
@@ -14,14 +14,17 @@ def scoped_calendar_ids(system_user: SystemUser, organization: Organization) -> 
         organization: The organization context.
 
     Returns:
-        None if the token is org-wide (scoped_to_membership_fk is None);
+        None if the token is org-wide (scoped_to_membership_user_id is None);
         a set of calendar IDs (possibly empty) if scoped to a membership.
     """
-    if system_user.scoped_to_membership_fk_id is None:
+    if system_user.scoped_to_membership_user_id is None:
         return None
+    # The queryset is already org-scoped via filter_by_organization, so filtering
+    # ownerships by the membership's user_id is equivalent to the full
+    # (organization_id, user_id) membership identity — the org is fixed.
     return set(
         Calendar.objects.filter_by_organization(organization.id)
-        .filter(ownerships__membership__id=system_user.scoped_to_membership_fk_id)
+        .filter(ownerships__membership_user_id=system_user.scoped_to_membership_user_id)
         .distinct()
         .values_list("id", flat=True)
     )

--- a/public_api/serializers.py
+++ b/public_api/serializers.py
@@ -1,4 +1,4 @@
-from typing import Annotated, cast
+from typing import Annotated
 
 from django.db import IntegrityError, transaction
 
@@ -154,9 +154,9 @@ class SystemUserTokenResponseSerializer(serializers.ModelSerializer):
 
     Includes the write-once ``token`` field (sourced from the view) and
     ``available_resources`` (derived from the related ``ResourceAccess`` rows).
-    Exposes ``scoped_to_user`` as the owner's User id derived from the stored membership FK
-    (null for org-wide tokens).  The REST field name ``scoped_to_user`` is kept for API
-    stability; the value is resolved via ``scoped_to_membership_fk.user_id``.
+    Exposes ``scoped_to_user`` as the owner's User id derived from the stored membership
+    reference (null for org-wide tokens).  The REST field name ``scoped_to_user`` is kept
+    for API stability; the value is the denormalized ``scoped_to_membership_user_id``.
     Never exposes ``long_lived_token_hash``.
     """
 
@@ -183,14 +183,12 @@ class SystemUserTokenResponseSerializer(serializers.ModelSerializer):
         )
 
     def get_scoped_to_user(self, obj: SystemUser) -> int | None:
-        """Return the owner's User id derived from the stored membership FK, or None."""
-        if not obj.scoped_to_membership_fk_id:
-            return None
-        return (
-            OrganizationMembership.objects.filter(pk=obj.scoped_to_membership_fk_id)
-            .values_list("user_id", flat=True)
-            .first()
-        )
+        """Return the owner's User id from the denormalized membership column, or None.
+
+        ``scoped_to_membership_user_id`` already stores the membership's user_id, so the
+        value is returned directly with no extra query.
+        """
+        return obj.scoped_to_membership_user_id
 
 
 class SystemUserTokenSerializer(serializers.ModelSerializer):
@@ -198,14 +196,14 @@ class SystemUserTokenSerializer(serializers.ModelSerializer):
 
     Exposes ``id``, ``integration_name``, ``is_active``, ``available_resources``
     (list of resource_name strings from the related ``ResourceAccess`` rows), and
-    ``scoped_to_user`` (the owner's User id derived from the membership FK, null for
-    org-wide tokens).  The REST field name ``scoped_to_user`` is kept for API stability;
-    the value is resolved via ``scoped_to_membership_fk.user_id``.
+    ``scoped_to_user`` (the owner's User id from the denormalized membership column, null
+    for org-wide tokens).  The REST field name ``scoped_to_user`` is kept for API stability;
+    the value is the denormalized ``scoped_to_membership_user_id``.
     Never exposes ``long_lived_token_hash`` or ``token``.
 
-    Optimized for list queries: uses prefetched ``available_resources`` and
-    ``select_related("scoped_to_membership_fk")`` from the viewset's ``get_queryset``
-    to avoid N+1 queries.
+    Optimized for list queries: uses prefetched ``available_resources`` from the viewset's
+    ``get_queryset`` to avoid N+1 queries.  ``scoped_to_membership_user_id`` is a concrete
+    column on the row, so it needs no join.
     """
 
     available_resources = serializers.SerializerMethodField()
@@ -221,25 +219,12 @@ class SystemUserTokenSerializer(serializers.ModelSerializer):
         return [ra.resource_name for ra in obj.available_resources.all()]
 
     def get_scoped_to_user(self, obj: SystemUser) -> int | None:
-        """Return the owner's User id from the queryset annotation when present.
+        """Return the owner's User id from the denormalized membership column, or None.
 
-        For list/retrieve the viewset annotates ``scoped_to_user_id_value`` via an
-        F-expression JOIN, so no extra query is issued per token.  For any other
-        call path (e.g. the revoke action that constructs the serializer from a
-        freshly-fetched instance without the annotation) we fall back to a single
-        membership lookup.
+        ``scoped_to_membership_user_id`` is a concrete column already storing the
+        membership's user_id, so the value is returned directly with no extra query.
         """
-        _missing = object()
-        annotated = getattr(obj, "scoped_to_user_id_value", _missing)
-        if annotated is not _missing:
-            return cast("int | None", annotated)
-        if not obj.scoped_to_membership_fk_id:
-            return None
-        return (
-            OrganizationMembership.objects.filter(pk=obj.scoped_to_membership_fk_id)
-            .values_list("user_id", flat=True)
-            .first()
-        )
+        return obj.scoped_to_membership_user_id
 
 
 class SystemUserTokenUpdateSerializer(serializers.Serializer):

--- a/public_api/services.py
+++ b/public_api/services.py
@@ -59,6 +59,6 @@ class PublicAPIAuthService:
             "is_active": True,
         }
         if scoped_to_membership is not None:
-            create_kwargs["scoped_to_membership_fk"] = scoped_to_membership
+            create_kwargs["scoped_to_membership_user_id"] = scoped_to_membership.user_id
         system_user = SystemUser.objects.create(**create_kwargs)
         return system_user, token

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -6604,10 +6604,9 @@ class TestCreateScopedSystemUserMutation:
         assert returned_token is not None
         assert len(returned_token) > 0
 
-        # Verify persisted SystemUser has the correct owner (stored as membership FK)
+        # Verify persisted SystemUser has the correct owner (denormalized membership column)
         minted = SystemUser.original_manager.get(id=int(result["id"]))
-        assert minted.scoped_to_membership_fk.user_id == owner.id
-        assert minted.scoped_to_membership_fk.organization_id == org.id
+        assert minted.scoped_to_membership_user_id == owner.id
         assert minted.organization_id == org.id
 
         # Verify ResourceAccess rows exactly match the request

--- a/public_api/tests/test_provisioning_flow.py
+++ b/public_api/tests/test_provisioning_flow.py
@@ -362,7 +362,7 @@ class TestCreateInvitationProvisioning:
             email=invited_email,
             organization=child_org,
             accepted_at__isnull=True,
-            membership__isnull=True,
+            membership_user_id__isnull=True,
         )
         assert pending_invites.count() == 1
         invite = pending_invites.first()
@@ -394,7 +394,7 @@ class TestCreateInvitationProvisioning:
             role=OrganizationRole.ADMIN,
             expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
             accepted_at=None,
-            membership=None,
+            membership_user_id=None,
         )
 
         org_count_before = Organization.objects.count()
@@ -416,7 +416,7 @@ class TestCreateInvitationProvisioning:
         # The invitation should be marked accepted.
         invite = OrganizationInvitation.objects.get(email=invited_email, organization=child_org)
         assert invite.accepted_at is not None
-        assert invite.membership_id == membership.pk
+        assert invite.membership_user_id == membership.user_id
 
     # -------------------------------------------------------------------------
     # Phase 4: self-managed invitation (sendEmail=false) integration tests

--- a/public_api/tests/test_queries.py
+++ b/public_api/tests/test_queries.py
@@ -3179,7 +3179,7 @@ def _make_all_resource_grants(system_user: SystemUser) -> None:
 
 
 def _make_org_wide_client(organization: Organization) -> tuple[APIClient, SystemUser]:
-    """Create an org-wide (scoped_to_membership_fk IS NULL) API client with all resource grants."""
+    """Create an org-wide (scoped_to_membership_user_id IS NULL) API client with all resource grants."""
     auth_service = PublicAPIAuthService()
     system_user, token = auth_service.create_system_user(
         integration_name=f"org_wide_{organization.pk}", organization=organization
@@ -3191,7 +3191,7 @@ def _make_org_wide_client(organization: Organization) -> tuple[APIClient, System
 
 
 def _make_scoped_client(organization: Organization, owner: User) -> tuple[APIClient, SystemUser]:
-    """Create a scoped API client (scoped_to_membership_fk=membership) with all resource grants."""
+    """Create a scoped API client (scoped_to_membership_user_id=owner) with all grants."""
     membership, _ = OrganizationMembership.objects.get_or_create(
         user=owner, organization=organization, defaults={"is_active": True}
     )
@@ -3199,7 +3199,7 @@ def _make_scoped_client(organization: Organization, owner: User) -> tuple[APICli
     system_user = baker.make(
         SystemUser,
         organization=organization,
-        scoped_to_membership_fk=membership,
+        scoped_to_membership_user_id=membership.user_id,
         integration_name=f"scoped_{organization.pk}_{owner.pk}",
         long_lived_token_hash=hash_long_lived_token(token),
         is_active=True,
@@ -3312,7 +3312,7 @@ class TestOwnerScopedTokenReadEnforcement:
     def test_org_wide_token_sees_all_calendars(
         self, mock_rate_limiter, organization, owner_calendar, other_calendar
     ):
-        """Org-wide token (scoped_to_membership_fk IS NULL) returns all org calendars unchanged."""
+        """Org-wide token (scoped_to_membership_user_id IS NULL) returns all org calendars unchanged."""
         mock_rate_limiter.return_value = iter([None])
 
         client, _ = _make_org_wide_client(organization)
@@ -3441,7 +3441,7 @@ class TestOwnerScopedTokenReadEnforcement:
     def test_org_wide_token_sees_all_calendar_events(
         self, mock_rate_limiter, organization, owner_calendar, other_calendar
     ):
-        """Org-wide token (scoped_to_membership_fk IS NULL) can read events on any calendar."""
+        """Org-wide token (scoped_to_membership_user_id IS NULL) can read events on any calendar."""
         mock_rate_limiter.return_value = iter([None])
 
         owner_event = baker.make(

--- a/public_api/tests/test_scoping.py
+++ b/public_api/tests/test_scoping.py
@@ -113,7 +113,7 @@ class TestScopedCalendarIds:
         system_user = baker.make(
             SystemUser,
             organization=organization,
-            scoped_to_membership_fk=membership,
+            scoped_to_membership_user_id=membership.user_id,
             integration_name="scoped_token",
         )
         return system_user
@@ -124,7 +124,7 @@ class TestScopedCalendarIds:
         system_user = baker.make(
             SystemUser,
             organization=organization,
-            scoped_to_membership_fk=another_membership,
+            scoped_to_membership_user_id=another_membership.user_id,
             integration_name="scoped_token_no_calendars",
         )
         return system_user
@@ -215,14 +215,14 @@ class TestScopedCalendarIds:
         system_user = baker.make(
             SystemUser,
             organization=organization,
-            scoped_to_membership_fk=membership,
+            scoped_to_membership_user_id=membership.user_id,
             integration_name="scoped_token_org_check",
         )
         # SystemUser.organization must match the membership's organization for the
-        # OrganizationForeignKey tenant join to resolve correctly.
+        # (organization_id, user_id) membership join to resolve correctly.
         assert system_user.organization_id == membership.organization_id
-        # The scalar id is always accessible regardless of the FK join path.
-        assert system_user.scoped_to_membership_fk_id == membership.id
+        # The denormalized membership user_id is always accessible on the row.
+        assert system_user.scoped_to_membership_user_id == membership.user_id
 
 
 @pytest.mark.django_db
@@ -306,7 +306,7 @@ class TestAssertCalendarInOwnerScope:
         return baker.make(
             SystemUser,
             organization=organization,
-            scoped_to_membership_fk=membership,
+            scoped_to_membership_user_id=membership.user_id,
             integration_name="scoped_write_token",
         )
 

--- a/public_api/tests/test_views.py
+++ b/public_api/tests/test_views.py
@@ -478,10 +478,10 @@ class TestSystemUserTokenViewSetList:
     ):
         """Listing N scoped tokens must NOT issue N extra membership queries.
 
-        The viewset annotates ``scoped_to_user_id_value`` via a JOIN so the
-        serializer never executes a per-token OrganizationMembership lookup.
-        We create 3 scoped tokens and assert the total query count is bounded
-        by a small constant that cannot scale with the number of tokens.
+        ``scoped_to_membership_user_id`` is a concrete column on the SystemUser row,
+        so the serializer returns it directly and never executes a per-token
+        OrganizationMembership lookup. We create 3 scoped tokens and assert the total
+        query count is bounded by a small constant that cannot scale with token count.
         """
         # Create the owner membership used for all scoped tokens
         owner_user = baker.make(User, email="perf_owner@example.com")
@@ -500,7 +500,7 @@ class TestSystemUserTokenViewSetList:
                 SystemUser,
                 organization=organization,
                 is_active=True,
-                scoped_to_membership_fk=owner_membership,
+                scoped_to_membership_user_id=owner_membership.user_id,
             )
             baker.make(ResourceAccess, system_user=su, resource_name=PublicAPIResources.CALENDAR)
 
@@ -1319,12 +1319,10 @@ class TestSystemUserTokenViewSetScopedCreate:
         response = admin_client.post(self._url(), payload, format="json")
         assert_response_status_code(response, status.HTTP_201_CREATED)
         data = response.json()
-        # DB row must reference the owner via the membership FK
-        system_user = SystemUser.original_manager.select_related("scoped_to_membership_fk").get(
-            integration_name="scoped_db_check"
-        )
-        assert system_user.scoped_to_membership_fk.user_id == provider_user.id
-        assert system_user.scoped_to_membership_fk.organization_id == organization.id
+        # DB row must reference the owner via the denormalized membership column
+        system_user = SystemUser.original_manager.get(integration_name="scoped_db_check")
+        assert system_user.scoped_to_membership_user_id == provider_user.id
+        assert system_user.organization_id == organization.id
         # Plaintext token must be present in response exactly once
         assert "token" in data
         assert data["token"]  # non-empty string
@@ -1485,11 +1483,9 @@ class TestSystemUserTokenViewSetScopedCreate:
         )
         assert_response_status_code(put_response, status.HTTP_200_OK)
 
-        # Owner must remain the original provider_user (checked via the membership FK)
-        system_user = SystemUser.original_manager.select_related("scoped_to_membership_fk").get(
-            pk=token_id
-        )
-        assert system_user.scoped_to_membership_fk.user_id == provider_user.id
+        # Owner must remain the original provider_user (denormalized membership column)
+        system_user = SystemUser.original_manager.get(pk=token_id)
+        assert system_user.scoped_to_membership_user_id == provider_user.id
 
     def test_patch_cannot_change_owner(self, admin_client, organization, provider_user):
         """PATCH with a different scoped_to_user in the body must not change the stored owner."""
@@ -1527,11 +1523,9 @@ class TestSystemUserTokenViewSetScopedCreate:
         )
         assert_response_status_code(patch_response, status.HTTP_200_OK)
 
-        # Owner must remain the original provider_user (checked via the membership FK)
-        system_user = SystemUser.original_manager.select_related("scoped_to_membership_fk").get(
-            pk=token_id
-        )
-        assert system_user.scoped_to_membership_fk.user_id == provider_user.id
+        # Owner must remain the original provider_user (denormalized membership column)
+        system_user = SystemUser.original_manager.get(pk=token_id)
+        assert system_user.scoped_to_membership_user_id == provider_user.id
 
 
 @pytest.mark.django_db
@@ -1624,7 +1618,7 @@ class TestSystemUserTokenUpdateEscalationGuard:
         non_provider_resource = PublicAPIResources.USER
         assert non_provider_resource not in PROVIDER_SCOPED_RESOURCES
 
-        # Create an org-wide token (no scoped_to_membership_fk).
+        # Create an org-wide token (scoped_to_membership_user_id IS NULL).
         system_user = baker.make(SystemUser, organization=organization, is_active=True)
         baker.make(
             ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.db import transaction
-from django.db.models import F
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -55,14 +54,10 @@ class SystemUserTokenViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet)
             return SystemUser.objects.none()
         membership = get_active_organization_membership(user)
         if membership:
-            return (
-                SystemUser.objects.filter(
-                    organization_id=membership.organization_id,
-                    deleted_at__isnull=True,
-                )
-                .annotate(scoped_to_user_id_value=F("scoped_to_membership_fk__user_id"))
-                .prefetch_related("available_resources")
-            )
+            return SystemUser.objects.filter(
+                organization_id=membership.organization_id,
+                deleted_at__isnull=True,
+            ).prefetch_related("available_resources")
         return SystemUser.objects.none()
 
     def get_serializer_class(self):  # type: ignore[override]
@@ -150,7 +145,7 @@ class SystemUserTokenViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet)
         desired_resources: list[str] = input_serializer.validated_data["available_resources"]
 
         # Guard: scoped tokens may not be updated with resources outside PROVIDER_SCOPED_RESOURCES.
-        if system_user.scoped_to_membership_fk_id is not None:
+        if system_user.scoped_to_membership_user_id is not None:
             over_grant = [r for r in desired_resources if r not in PROVIDER_SCOPED_RESOURCES]
             if over_grant:
                 raise ValidationError(

--- a/schema.yml
+++ b/schema.yml
@@ -13326,14 +13326,14 @@ components:
 
         Exposes ``id``, ``integration_name``, ``is_active``, ``available_resources``
         (list of resource_name strings from the related ``ResourceAccess`` rows), and
-        ``scoped_to_user`` (the owner's User id derived from the membership FK, null for
-        org-wide tokens).  The REST field name ``scoped_to_user`` is kept for API stability;
-        the value is resolved via ``scoped_to_membership_fk.user_id``.
+        ``scoped_to_user`` (the owner's User id from the denormalized membership column, null
+        for org-wide tokens).  The REST field name ``scoped_to_user`` is kept for API stability;
+        the value is the denormalized ``scoped_to_membership_user_id``.
         Never exposes ``long_lived_token_hash`` or ``token``.
 
-        Optimized for list queries: uses prefetched ``available_resources`` and
-        ``select_related("scoped_to_membership_fk")`` from the viewset's ``get_queryset``
-        to avoid N+1 queries.
+        Optimized for list queries: uses prefetched ``available_resources`` from the viewset's
+        ``get_queryset`` to avoid N+1 queries.  ``scoped_to_membership_user_id`` is a concrete
+        column on the row, so it needs no join.
       properties:
         id:
           type: integer
@@ -13356,13 +13356,10 @@ components:
           type: integer
           nullable: true
           description: |-
-            Return the owner's User id from the queryset annotation when present.
+            Return the owner's User id from the denormalized membership column, or None.
 
-            For list/retrieve the viewset annotates ``scoped_to_user_id_value`` via an
-            F-expression JOIN, so no extra query is issued per token.  For any other
-            call path (e.g. the revoke action that constructs the serializer from a
-            freshly-fetched instance without the annotation) we fall back to a single
-            membership lookup.
+            ``scoped_to_membership_user_id`` is a concrete column already storing the
+            membership's user_id, so the value is returned directly with no extra query.
           readOnly: true
       required:
       - available_resources
@@ -13407,9 +13404,9 @@ components:
 
         Includes the write-once ``token`` field (sourced from the view) and
         ``available_resources`` (derived from the related ``ResourceAccess`` rows).
-        Exposes ``scoped_to_user`` as the owner's User id derived from the stored membership FK
-        (null for org-wide tokens).  The REST field name ``scoped_to_user`` is kept for API
-        stability; the value is resolved via ``scoped_to_membership_fk.user_id``.
+        Exposes ``scoped_to_user`` as the owner's User id derived from the stored membership
+        reference (null for org-wide tokens).  The REST field name ``scoped_to_user`` is kept
+        for API stability; the value is the denormalized ``scoped_to_membership_user_id``.
         Never exposes ``long_lived_token_hash``.
       properties:
         id:
@@ -13432,8 +13429,11 @@ components:
         scoped_to_user:
           type: integer
           nullable: true
-          description: Return the owner's User id derived from the stored membership
-            FK, or None.
+          description: |-
+            Return the owner's User id from the denormalized membership column, or None.
+
+            ``scoped_to_membership_user_id`` already stores the membership's user_id, so the
+            value is returned directly with no extra query.
           readOnly: true
         token:
           type: string

--- a/webhooks/services/payloads.py
+++ b/webhooks/services/payloads.py
@@ -27,7 +27,6 @@ class OrganizationMemberCreatedWebhookPayload(TypedDict):
     organization_id: int
     organization_name: str
     membership_role: str
-    membership_id: int
 
 
 class WebhookEnvelope(TypedDict):

--- a/webhooks/services/webhook_membership_side_effects.py
+++ b/webhooks/services/webhook_membership_side_effects.py
@@ -29,7 +29,6 @@ class WebhookMembershipSideEffectsService:
             "organization_id": membership.organization_id,
             "organization_name": membership.organization.name,
             "membership_role": membership.role,
-            "membership_id": membership.id,
         }
 
     def on_member_created(self, membership: OrganizationMembership) -> None:
@@ -40,9 +39,10 @@ class WebhookMembershipSideEffectsService:
 
         Args:
             membership: The newly created OrganizationMembership. Must have
-                ``user``, ``organization``, ``role``, and ``id`` accessible
-                (i.e. already saved to the DB and related objects pre-loaded or
-                accessible via FK lookup).
+                ``user``, ``organization``, and ``role`` accessible (i.e. already
+                saved to the DB and related objects pre-loaded or accessible via
+                FK lookup). The membership identity in the payload is the
+                ``(user_id, organization_id)`` pair — no scalar membership id.
         """
         if not membership.is_active:
             return

--- a/webhooks/tests/test_membership_side_effects.py
+++ b/webhooks/tests/test_membership_side_effects.py
@@ -56,7 +56,6 @@ class TestWebhookMembershipSideEffectsService:
                 "organization_id": organization.id,
                 "organization_name": organization.name,
                 "membership_role": OrganizationRole.MEMBER,
-                "membership_id": membership.id,
             },
         )
 
@@ -121,7 +120,7 @@ class TestWebhookMembershipSideEffectsService:
         assert payload["organization_id"] == organization.id
         assert payload["organization_name"] == organization.name
         assert payload["membership_role"] == OrganizationRole.MEMBER
-        assert payload["membership_id"] == membership.id
+        # Membership identity is the (user_id, organization_id) pair — no scalar id.
         # Ensure no extra fields sneak in
         assert set(payload.keys()) == {
             "user_id",
@@ -129,7 +128,6 @@ class TestWebhookMembershipSideEffectsService:
             "organization_id",
             "organization_name",
             "membership_role",
-            "membership_id",
         }
 
     def test_on_member_created_organization_scoped_to_membership_org(


### PR DESCRIPTION
## Summary
Phase 7a — the enabling step before Phase 7b makes `OrganizationMembership`'s PK composite. Django 6 forbids
a real FK to a composite-PK model, so the two remaining real references are converted to the
`(organization_id, user_id)` ForeignObject pattern, and every scalar `membership.id`/`.pk`/`membership_id`
consumer is rewritten. `OrganizationMembership` STILL has its `id` PK this phase (composite PK is 7b).

## What changed
- **`OrganizationInvitation.membership`** (was `OneToOneField`) → `OrganizationMembershipForeignKey`. OneToOne
  semantics preserved by a partial `UniqueConstraint(organization, membership_user_id) WHERE membership_user_id
  IS NOT NULL`; `membership.invitation` reverse accessor kept (now a reverse manager — no code relied on
  single-object semantics).
- **`public_api.SystemUser.scoped_to_membership`** (was `OrganizationForeignKey`, a real FK to `membership.id`)
  → `OrganizationMembershipForeignKey`. NULL still = org-wide token.
- **All `membership.id`/`.pk`/`membership_id` rewritten** to `(user_id, organization_id)` / `membership_user_id`
  across `organizations/services.py`, `public_api/*`, `webhooks/services/*`, `calendar_event_service.py`.
- Two migrations (`organizations/0012`, `public_api/0008`): add `*_user_id`, backfill from the legacy FK's
  `.user_id`, drop the legacy real-FK columns via `SeparateDatabaseAndState` (reverse re-adds nullable +
  backfills) — this drops `membership_id` + `scoped_to_membership_fk_id`, unblocking Phase 7b's PK swap.

## Security — token scoping (verified equal-or-stricter, no cross-org leak)
`scoped_calendar_ids` / `_scoped_system_user_owns_calendar` changed from `ownerships__membership__id=fk_id`
to `ownerships__membership_user_id=scoped_to_membership_user_id` within `filter_by_organization(org)`. This is
equivalent because the `organization` is always the token's own org (the public-API middleware sets it from
`system_user.organization`) and `scoped_to_membership` is always a membership in that org (constrained at
token-creation). A user who is a member of multiple orgs cannot leak across orgs — the org is fixed.

## Consumer-visible
- Webhook `OrganizationMemberCreatedWebhookPayload` drops the scalar `membership_id`; membership identity is the
  `{user_id, organization_id}` pair (+ `membership_role`) — Open Question #1 default. REST `scoped_to_user`
  contract unchanged (still the owner int user-id).

## Plan reference
Plan `…2026-06-19-…_IMPLEMENTATION_PLAN.md` — Phase 7a. Stacked on phase-6 (PR #154).

## Test plan
- Invitation accept/auto-join (`accounts/tests/*`, `organizations/tests/test_services.py`), scoped-token
  scoping (`public_api/tests/test_scoping.py` incl. same-user-different-org exclusion), provisioning, webhook
  side-effects — all retargeted off the dropped fields.
- Gate: `pytest -n auto` → 2671 passed; migrate forward/reverse/forward clean; `makemigrations --check` clean;
  both acceptance greps (membership.id refs; real FK→membership) ZERO non-test.