### PR TITLE
feat(audit): Implement audit logging

### DIFF
--- a/audit/services.py
+++ b/audit/services.py
@@ -129,6 +129,103 @@ class AuditService:
             actor_id=None,
         )
 
+    @staticmethod
+    def actor_from_user(user: object, organization_id: int) -> ActorSnapshot:
+        """Resolve a ``User`` acting within an organization to an actor snapshot.
+
+        Looks up the OrganizationMembership identifying this user in the org and,
+        when present, returns a MEMBERSHIP actor capturing its role. Falls back to
+        a SYSTEM actor when the user has no membership in the organization — this
+        mirrors the orphan-ownership guard (a non-member acting leaves no
+        membership FK to point at), so the record is still emitted with a stable
+        actor rather than a dangling membership reference.
+
+        Args:
+            user: A users.User instance (the acting principal).
+            organization_id: The organization the action happens in.
+
+        Returns:
+            A MEMBERSHIP ActorSnapshot when a membership exists, else a SYSTEM one.
+        """
+        # Lazy import: audit is a leaf app; importing organizations at module load
+        # would create an import cycle (organizations services import audit_service).
+        from organizations.models import OrganizationMembership
+
+        membership = OrganizationMembership.objects.filter(
+            user_id=user.id,  # type: ignore[attr-defined]
+            organization_id=organization_id,
+        ).first()
+        if membership is None:
+            return AuditService.system_actor()
+        return AuditService.actor_from_membership(membership)
+
+    @staticmethod
+    def actor_from_user_or_token(
+        user_or_token: object,
+        organization_id: int,
+        single_use_token: object | None = None,
+    ) -> ActorSnapshot:
+        """Resolve a calendar service ``user_or_token`` value to an actor snapshot.
+
+        The calendar services carry a ``user_or_token`` of ``User | str | SystemUser
+        | None`` on their auth context. This maps each variant to the right actor:
+
+        - ``User``      -> membership actor (or system, via actor_from_user)
+        - ``SystemUser`` -> system-user actor with scopes
+        - ``str``       -> a single-use CalendarManagementToken *code*. When the
+          resolved token row is supplied via ``single_use_token`` (the calendar
+          permission service resolves the code and exposes the row), attribute the
+          action to that token (SINGLE_USE_CODE); otherwise fall back to system.
+        - ``None``      -> system actor.
+
+        Args:
+            user_or_token: The context principal (User, SystemUser, token str, None).
+            organization_id: The organization the action happens in.
+            single_use_token: The resolved CalendarManagementToken row backing a
+                ``str`` code, when available. Ignored for non-str principals.
+
+        Returns:
+            The most specific ActorSnapshot resolvable from the principal.
+        """
+        # Lazy imports for the same import-cycle reason as actor_from_user.
+        from public_api.models import SystemUser
+        from users.models import User
+
+        if isinstance(user_or_token, User):
+            return AuditService.actor_from_user(user_or_token, organization_id)
+        if isinstance(user_or_token, SystemUser):
+            return AuditService.actor_from_system_user(user_or_token)
+        if isinstance(user_or_token, str) and single_use_token is not None:
+            return AuditService.actor_from_single_use_code(single_use_token)
+        return AuditService.system_actor()
+
+    @staticmethod
+    def subject_from_instance(instance: object, label: str | None = None) -> SubjectRef:
+        """Build a SubjectRef from a Django model instance.
+
+        Derives ``subject_type`` as ``"<app_label>.<ModelName>"`` and ``subject_id``
+        from the instance pk, so call sites don't repeat the soft-reference shape.
+
+        ``subject_label`` is left ``None`` unless a caller passes one. We deliberately
+        do NOT default to ``str(instance)``: a model ``__str__`` can dereference
+        related rows (e.g. a profile) and raise, and building the audit payload must
+        never break the business action it describes. Pass a cheap label explicitly
+        (a name already in memory) when a human-readable label is worthwhile.
+
+        Args:
+            instance: A Django model instance (must have ``_meta`` and ``pk``).
+            label: Optional human-readable label; not auto-computed from ``str()``.
+
+        Returns:
+            A SubjectRef referencing the instance.
+        """
+        meta = instance._meta  # type: ignore[attr-defined]
+        return SubjectRef(
+            subject_type=f"{meta.app_label}.{instance.__class__.__name__}",
+            subject_id=str(instance.pk),  # type: ignore[attr-defined]
+            subject_label=label,
+        )
+
     # ------------------------------------------------------------------
     # Write path
     # ------------------------------------------------------------------

--- a/audit/tests/test_service.py
+++ b/audit/tests/test_service.py
@@ -250,6 +250,108 @@ class TestActorFromSingleUseCode:
         assert snapshot.system_user_scoped_to_membership is None
 
 
+@pytest.mark.django_db
+class TestActorFromUser:
+    """actor_from_user resolves a User to a membership actor, else system."""
+
+    def test_membership_actor_when_user_is_member(self) -> None:
+        org = baker.make(Organization)
+        user = baker.make("users.User")
+        membership = OrganizationMembership.objects.create(
+            user=user, organization=org, role=OrganizationRole.ADMIN
+        )
+
+        snapshot = AuditService.actor_from_user(user, org.pk)
+
+        assert snapshot.actor_type == AuditActorType.MEMBERSHIP
+        assert snapshot.actor_id == membership.user_id
+        assert snapshot.actor_role == OrganizationRole.ADMIN
+
+    def test_system_actor_when_user_not_member(self) -> None:
+        org = baker.make(Organization)
+        user = baker.make("users.User")  # no membership in org
+
+        snapshot = AuditService.actor_from_user(user, org.pk)
+
+        assert snapshot.actor_type == AuditActorType.SYSTEM
+        assert snapshot.actor_id is None
+
+
+@pytest.mark.django_db
+class TestActorFromUserOrToken:
+    """actor_from_user_or_token dispatches on the principal type."""
+
+    def test_user_resolves_to_membership(self) -> None:
+        org = baker.make(Organization)
+        user = baker.make("users.User")
+        OrganizationMembership.objects.create(
+            user=user, organization=org, role=OrganizationRole.MEMBER
+        )
+
+        snapshot = AuditService.actor_from_user_or_token(user, org.pk)
+
+        assert snapshot.actor_type == AuditActorType.MEMBERSHIP
+
+    def test_system_user_resolves_to_system_user_actor(self) -> None:
+        from public_api.models import SystemUser
+
+        org = baker.make(Organization)
+        system_user = SystemUser.objects.create(
+            organization=org,
+            integration_name="audit_dispatch",
+            long_lived_token_hash="abc123",
+        )
+
+        snapshot = AuditService.actor_from_user_or_token(system_user, org.pk)
+
+        assert snapshot.actor_type == AuditActorType.SYSTEM_USER
+        assert snapshot.actor_id == system_user.id
+
+    def test_token_string_without_resolved_token_is_system_actor(self) -> None:
+        # A raw code with no resolved token row falls back to system.
+        snapshot = AuditService.actor_from_user_or_token("raw-token", 1)
+        assert snapshot.actor_type == AuditActorType.SYSTEM
+
+    def test_token_string_with_resolved_token_is_single_use_code(self) -> None:
+        from calendar_integration.models import CalendarManagementToken
+
+        org = baker.make(Organization)
+        token = baker.make(CalendarManagementToken, organization=org)
+
+        snapshot = AuditService.actor_from_user_or_token(
+            "raw-token", org.pk, single_use_token=token
+        )
+
+        assert snapshot.actor_type == AuditActorType.SINGLE_USE_CODE
+        assert snapshot.actor_id == token.id
+
+    def test_none_resolves_to_system_actor(self) -> None:
+        snapshot = AuditService.actor_from_user_or_token(None, 1)
+        assert snapshot.actor_type == AuditActorType.SYSTEM
+
+
+@pytest.mark.django_db
+class TestSubjectFromInstance:
+    """subject_from_instance derives a SubjectRef from a model instance."""
+
+    def test_derives_type_and_id_no_auto_label(self) -> None:
+        org = baker.make(Organization, name="ACME")
+
+        subject = AuditService.subject_from_instance(org)
+
+        assert subject.subject_type == "organizations.Organization"
+        assert subject.subject_id == str(org.pk)
+        # Label is NOT auto-computed from str(instance) — stays None unless passed.
+        assert subject.subject_label is None
+
+    def test_label_override(self) -> None:
+        org = baker.make(Organization)
+
+        subject = AuditService.subject_from_instance(org, label="custom")
+
+        assert subject.subject_label == "custom"
+
+
 class TestSystemActor:
     """system_actor returns a SYSTEM snapshot with actor_id=None."""
 

--- a/calendar_integration/services/availability_service.py
+++ b/calendar_integration/services/availability_service.py
@@ -47,6 +47,8 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 from django.db import transaction
 from django.db.models import Q
 
+from audit.constants import AuditAction
+from audit.diff import compute_diff
 from calendar_integration.constants import CalendarType
 from calendar_integration.models import (
     AvailableTime,
@@ -59,6 +61,9 @@ from calendar_integration.models import (
     CalendarEvent,
     RecurrenceRule,
     RecurringMixin,
+)
+from calendar_integration.services.calendar_service_utils import (
+    resolve_acting_single_use_token,
 )
 from calendar_integration.services.calendar_service_utils import (
     serialize_event as _serialize_event_util,
@@ -138,6 +143,41 @@ class AvailabilityService:
         # recurrence-rule helper are reached through the host (the facade).
         # See ``AvailabilityServiceHost``.
         self._host = host
+
+    def _audit_availability_write(
+        self,
+        action: str,
+        subject_instance: BlockedTime | AvailableTime,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for an availability-level business write.
+
+        Resolves the actor from the context's ``user_or_token`` auth state. A no-op
+        when no ``audit_service`` or ``organization`` is bound (e.g. a context built
+        directly in a test without DI), so instrumentation never breaks a write path.
+
+        ``BlockedTime`` carries a cheap in-memory ``reason`` scalar used as the subject
+        label; ``AvailableTime`` has no human-readable scalar so no label is passed.
+        """
+        audit_service = self._context.audit_service
+        organization = self._context.organization
+        if audit_service is None or organization is None:
+            return
+
+        label = subject_instance.reason if isinstance(subject_instance, BlockedTime) else None
+        audit_service.record(
+            organization_id=organization.id,
+            action=action,
+            actor=audit_service.actor_from_user_or_token(
+                self._context.user_or_token,
+                organization.id,
+                single_use_token=resolve_acting_single_use_token(
+                    self._context.user_or_token, self._context.calendar_permission_service
+                ),
+            ),
+            subject=audit_service.subject_from_instance(subject_instance, label=label),
+            diff=diff,
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -438,6 +478,7 @@ class AvailabilityService:
         if not calendar.manage_available_windows:
             raise ValueError("This calendar does not manage available windows.")
 
+        # NOTE: batch availability writes are not individually audited (see audit rollout)
         availability_windows_to_create = []
 
         for start_time, end_time, timezone, rrule_string in availability_windows:
@@ -481,6 +522,7 @@ class AvailabilityService:
         if not calendar.manage_available_windows:
             raise ValueError("This calendar does not manage available windows.")
 
+        # NOTE: batch availability writes are not individually audited (see audit rollout)
         scoped = AvailableTime.objects.filter_by_organization(context.organization.id).filter(
             calendar_fk=calendar
         )
@@ -545,7 +587,9 @@ class AvailabilityService:
         result = self.bulk_create_availability_windows(
             calendar=calendar, availability_windows=[(start_time, end_time, timezone, rrule_string)]
         )
-        return next(iter(result))
+        available_time = next(iter(result))
+        self._audit_availability_write(AuditAction.CREATE, available_time)
+        return available_time
 
     def get_available_times_expanded(
         self,
@@ -620,7 +664,9 @@ class AvailabilityService:
             calendar=calendar,
             blocked_times=[(start_time, end_time, timezone, reason, rrule_string)],
         )
-        return next(iter(result))
+        blocked_time = next(iter(result))
+        self._audit_availability_write(AuditAction.CREATE, blocked_time)
+        return blocked_time
 
     @transaction.atomic()
     def update_blocked_time(
@@ -658,6 +704,14 @@ class AvailabilityService:
         except BlockedTime.DoesNotExist as e:
             raise ValueError(f"Blocked time {blocked_time_id} not found in this calendar.") from e
 
+        # Capture the cheap, comparable scalar BEFORE mutation so we can emit a
+        # field-level diff. Only ``reason`` is diffed here: ``start_time`` /
+        # ``end_time`` are db-persisted GeneratedFields whose stored (IANA-local)
+        # representation isn't directly comparable to the tz-unaware inputs, so a
+        # field-level time diff would be misleading. A pure time/timezone change is
+        # still captured by the UPDATE action + subject with diff=None.
+        before_scalars = {"reason": blocked_time.reason}
+
         if start_time is not None:
             blocked_time.start_time_tz_unaware = start_time
         if end_time is not None:
@@ -672,6 +726,13 @@ class AvailabilityService:
             )
 
         blocked_time.save()
+
+        after_scalars = {"reason": blocked_time.reason}
+        self._audit_availability_write(
+            AuditAction.UPDATE,
+            blocked_time,
+            diff=compute_diff(before_scalars, after_scalars),
+        )
         return blocked_time
 
     @transaction.atomic()
@@ -700,9 +761,16 @@ class AvailabilityService:
         )
 
         try:
-            scoped.get(id=blocked_time_id).delete()
+            blocked_time = scoped.get(id=blocked_time_id)
         except BlockedTime.DoesNotExist as e:
             raise ValueError(f"Blocked time {blocked_time_id} not found in this calendar.") from e
+
+        # Build the audit subject from the instance BEFORE the delete, while its pk
+        # is still authoritative (subject_from_instance reads the pk). record() itself
+        # only fires on transaction commit, so ordering relative to the delete below
+        # is irrelevant to persistence.
+        self._audit_availability_write(AuditAction.DELETE, blocked_time)
+        blocked_time.delete()
 
     def get_blocked_times_expanded(
         self,
@@ -859,6 +927,10 @@ class AvailabilityService:
             exception_manager_update_callback=update_exception_manager,
             exception_manager_delete_callback=delete_exception_manager,
         )
+        # An exception modifies the recurring series; record an UPDATE against the
+        # parent series. The change spans new/cancelled occurrence rows with no single
+        # comparable before/after, so diff=None.
+        self._audit_availability_write(AuditAction.UPDATE, parent_blocked_time, diff=None)
         return cast(BlockedTime, result) if result else None
 
     def create_recurring_available_time_exception(
@@ -947,6 +1019,10 @@ class AvailabilityService:
             exception_manager_update_callback=update_exception_manager,
             exception_manager_delete_callback=delete_exception_manager,
         )
+        # An exception modifies the recurring series; record an UPDATE against the
+        # parent series. The change spans new/cancelled occurrence rows with no single
+        # comparable before/after, so diff=None.
+        self._audit_availability_write(AuditAction.UPDATE, parent_available_time, diff=None)
         return cast(AvailableTime, result) if result else None
 
     def create_recurring_blocked_time_bulk_modification(
@@ -1029,6 +1105,10 @@ class AvailabilityService:
             bulk_modification_record_callback=record_bulk,
             modification_rrule_string=modification_rrule_string,
         )
+        # Bulk modification truncates the parent series and may spawn a continuation;
+        # record an UPDATE against the parent series. No single comparable before/after
+        # spans the truncate + continuation, so diff=None.
+        self._audit_availability_write(AuditAction.UPDATE, parent_blocked_time, diff=None)
         return cast(BlockedTime, result) if result else None
 
     def create_recurring_available_time_bulk_modification(
@@ -1108,6 +1188,10 @@ class AvailabilityService:
             bulk_modification_record_callback=record_bulk,
             modification_rrule_string=modification_rrule_string,
         )
+        # Bulk modification truncates the parent series and may spawn a continuation;
+        # record an UPDATE against the parent series. No single comparable before/after
+        # spans the truncate + continuation, so diff=None.
+        self._audit_availability_write(AuditAction.UPDATE, parent_available_time, diff=None)
         return cast(AvailableTime, result) if result else None
 
     def modify_recurring_blocked_time_from_date(

--- a/calendar_integration/services/calendar_bundle_service.py
+++ b/calendar_integration/services/calendar_bundle_service.py
@@ -49,6 +49,8 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 from django.db import transaction
 
+from audit.constants import AuditAction, AuditActorType
+from audit.diff import compute_diff
 from calendar_integration.constants import CalendarProvider, CalendarType
 from calendar_integration.models import (
     BlockedTime,
@@ -59,6 +61,9 @@ from calendar_integration.models import (
 )
 from calendar_integration.services.calendar_service_utils import (
     convert_naive_utc_datetime_to_timezone as _convert_naive_utc_datetime_to_timezone,
+)
+from calendar_integration.services.calendar_service_utils import (
+    resolve_acting_single_use_token,
 )
 from calendar_integration.services.dataclasses import (
     CalendarEventInputData,
@@ -138,6 +143,55 @@ class CalendarBundleService:
         # write-adapter / permission helpers are reached through the host (the facade).
         # See ``BundleServiceHost``.
         self._host = host
+
+    def _audit_bundle_write(
+        self,
+        action: str,
+        subject_instance: Calendar | CalendarEvent,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a bundle-level business write.
+
+        Resolves the actor from the context's ``user_or_token`` auth state. A no-op
+        when no ``audit_service`` or ``organization`` is bound (e.g. a context built
+        directly in a test without DI), so instrumentation never breaks a write path.
+        """
+        audit_service = self._context.audit_service
+        organization = self._context.organization
+        if audit_service is None or organization is None:
+            return
+
+        label = (
+            subject_instance.name
+            if isinstance(subject_instance, Calendar)
+            else subject_instance.title
+        )
+        actor = audit_service.actor_from_user_or_token(
+            self._context.user_or_token,
+            organization.id,
+            single_use_token=resolve_acting_single_use_token(
+                self._context.user_or_token, self._context.calendar_permission_service
+            ),
+        )
+        # For bundle EVENTS, carry the affected memberships (internal attendees plus
+        # the acting member). Bundle CALENDARS have no attendees, so the set is empty.
+        affected: set[int] = set()
+        if isinstance(subject_instance, CalendarEvent):
+            affected = set(
+                subject_instance.attendances.filter(membership_user_id__isnull=False).values_list(
+                    "membership_user_id", flat=True
+                )
+            )
+            if actor.actor_type == AuditActorType.MEMBERSHIP and actor.actor_id is not None:
+                affected.add(actor.actor_id)
+        audit_service.record(
+            organization_id=organization.id,
+            action=action,
+            actor=actor,
+            subject=audit_service.subject_from_instance(subject_instance, label=label),
+            affected_membership_ids=sorted(affected),
+            diff=diff,
+        )
 
     # ------------------------------------------------------------------
     # Bundle calendar CRUD
@@ -226,6 +280,8 @@ class CalendarBundleService:
         # Grant permissions to calendar owners
         self._host._grant_calendar_owner_permissions(bundle_calendar)
 
+        self._audit_bundle_write(AuditAction.CREATE, bundle_calendar)
+
         return bundle_calendar
 
     @transaction.atomic()
@@ -311,6 +367,11 @@ class CalendarBundleService:
                 organization=context.organization,
                 child_calendar_fk_id=primary_calendar.id,
             ).update(is_primary=True)
+
+        # This method only reconciles child relationships; it never mutates scalar
+        # fields on the bundle Calendar, so the action + subject capture the change
+        # with no field-level diff.
+        self._audit_bundle_write(AuditAction.UPDATE, bundle_calendar, diff=None)
 
         return bundle_calendar
 
@@ -421,6 +482,8 @@ class CalendarBundleService:
                     bundle_primary_event=primary_event,
                 )
 
+        self._audit_bundle_write(AuditAction.CREATE, primary_event)
+
         return primary_event
 
     def update_bundle_event(
@@ -442,6 +505,25 @@ class CalendarBundleService:
             raise ValueError("Event must be a bundle primary event")
 
         bundle_calendar = bundle_event.bundle_calendar
+
+        # Capture the primary event's own scalar fields BEFORE the update so we can
+        # emit a cheap, in-memory diff. Only the plain-text scalars (title,
+        # description, timezone) are diffed here: ``start_time`` / ``end_time`` are
+        # db-persisted GeneratedFields whose stored representation (IANA-local, via
+        # ``convert_naive_utc_to_timezone``) is NOT directly comparable to the
+        # tz-aware UTC instants on ``event_data``, so comparing them would emit
+        # misleading "changes". The time change is still captured by the UPDATE
+        # action + subject; only the field-level time diff is intentionally omitted.
+        before_scalars = {
+            "title": bundle_event.title,
+            "description": bundle_event.description,
+            "timezone": bundle_event.timezone,
+        }
+        after_scalars = {
+            "title": event_data.title,
+            "description": event_data.description,
+            "timezone": event_data.timezone,
+        }
 
         # Update the primary event
         updated_primary = self._host.update_event(
@@ -488,6 +570,12 @@ class CalendarBundleService:
                 update_fields=["start_time_tz_unaware", "end_time_tz_unaware", "reason"]
             )
 
+        self._audit_bundle_write(
+            AuditAction.UPDATE,
+            updated_primary,
+            diff=compute_diff(before_scalars, after_scalars),
+        )
+
         return updated_primary
 
     def delete_bundle_event(self, bundle_event: CalendarEvent) -> None:
@@ -502,6 +590,13 @@ class CalendarBundleService:
 
         if not bundle_event.is_bundle_primary:
             raise ValueError("Event must be a bundle primary event")
+
+        # Emit the audit record BEFORE deleting the primary row, while the instance's
+        # pk and title are still authoritative (subject_from_instance reads the pk).
+        # record() itself only fires on transaction commit, so ordering relative to
+        # the deletes below is irrelevant to persistence — but building the subject
+        # here keeps the soft-reference correct regardless of in-memory pk lifecycle.
+        self._audit_bundle_write(AuditAction.DELETE, bundle_event)
 
         # Delete all representation events
         representation_events = CalendarEvent.objects.filter(

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -38,6 +38,8 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Q
 
+from audit.constants import AuditAction, AuditActorType
+from audit.diff import compute_diff
 from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import NoAvailableTimeWindowsError
 from calendar_integration.models import (
@@ -59,6 +61,9 @@ from calendar_integration.services.calendar_service_utils import (
 )
 from calendar_integration.services.calendar_service_utils import (
     get_calendar_by_id as _get_calendar_by_id_util,
+)
+from calendar_integration.services.calendar_service_utils import (
+    resolve_acting_single_use_token,
 )
 from calendar_integration.services.calendar_service_utils import (
     resolve_member_user_ids as _resolve_member_user_ids,
@@ -203,6 +208,84 @@ class CalendarEventService:
     # ------------------------------------------------------------------
     # Internal helpers (event-write concern)
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _event_audit_scalar_snapshot(event: CalendarEvent) -> dict[str, Any]:
+        """Capture the event's own scalar fields that ``update_event`` mutates.
+
+        Datetimes are rendered to ISO strings so the resulting diff is JSON-safe for
+        the audit Celery payload. Only the event's direct fields are captured — never
+        attendees or resources.
+        """
+
+        def _iso(value: datetime.datetime | None) -> str | None:
+            return value.isoformat() if value is not None else None
+
+        return {
+            "title": event.title,
+            "description": event.description,
+            "start_time_tz_unaware": _iso(event.start_time_tz_unaware),
+            "end_time_tz_unaware": _iso(event.end_time_tz_unaware),
+            "timezone": event.timezone,
+        }
+
+    @staticmethod
+    def _event_attendee_membership_ids(event: CalendarEvent) -> set[int]:
+        """Org-scoped user_ids of the event's internal (member) attendees.
+
+        Reads the event's ``EventAttendance`` rows; orphan attendances
+        (``membership_user_id IS NULL`` — non-members) carry no membership identity
+        and are excluded. Must be called while the rows still exist (before a delete).
+        """
+        return set(
+            event.attendances.filter(membership_user_id__isnull=False).values_list(
+                "membership_user_id", flat=True
+            )
+        )
+
+    def _audit_event_write(
+        self,
+        action: str,
+        event: CalendarEvent,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for an event-level business write.
+
+        Resolves the actor from the context's ``user_or_token`` auth snapshot. A no-op
+        when no ``audit_service`` or ``organization`` is bound (e.g. a service built
+        directly in a test without DI), so instrumentation never breaks a write path.
+        Mirrors ``CalendarService._audit_calendar_write``.
+
+        ``affected_membership_ids`` carries the memberships touched by the change: the
+        event's internal attendees plus the acting member (the host/organizer), when
+        the actor resolves to a membership. These are org-scoped user_ids per the
+        OrganizationMembershipForeignKey convention.
+        """
+        audit_service = self._context.audit_service
+        organization = self._context.organization
+        if audit_service is None or organization is None:
+            return
+        actor = audit_service.actor_from_user_or_token(
+            self._context.user_or_token,
+            organization.id,
+            single_use_token=resolve_acting_single_use_token(
+                self._context.user_or_token, self._context.calendar_permission_service
+            ),
+        )
+        affected = self._event_attendee_membership_ids(event)
+        # The acting member is an affected party (the host/organizer). actor_from_user
+        # only yields a MEMBERSHIP actor when a real membership exists, so actor_id is a
+        # valid membership user_id to include.
+        if actor.actor_type == AuditActorType.MEMBERSHIP and actor.actor_id is not None:
+            affected.add(actor.actor_id)
+        audit_service.record(
+            organization_id=organization.id,
+            action=action,
+            actor=actor,
+            subject=audit_service.subject_from_instance(event, label=event.title),
+            affected_membership_ids=sorted(affected),
+            diff=diff,
+        )
 
     def _get_calendar_by_id(self, calendar_id: int) -> Calendar:
         context = cast("BaseCalendarService", self._context)
@@ -508,6 +591,8 @@ class CalendarEventService:
         # Grant permissions to event attendees
         self._host._grant_event_attendee_permissions(event)
 
+        self._audit_event_write(AuditAction.CREATE, event)
+
         # Resolve the audit actor *before* queueing the post-commit side-effect.
         # The owner-scoped public-API path never initializes a permission token, so
         # ``calendar_permission_service.token`` may be unset entirely — read it through
@@ -642,6 +727,12 @@ class CalendarEventService:
             )
             original_payload = updated_event.original_payload or {}
 
+        # Snapshot the event's OWN scalar fields BEFORE mutation so the audit diff
+        # captures exactly what this method changes (attendees/resources are excluded).
+        # Datetimes are serialized to ISO strings so the diff is JSON-safe for the
+        # audit Celery payload.
+        audit_before = self._event_audit_scalar_snapshot(event)
+
         event.title = event_data.title
         event.description = event_data.description
         # ``start_time`` / ``end_time`` are DB-generated fields (``GeneratedField``
@@ -675,6 +766,12 @@ class CalendarEventService:
             event.recurrence_rule = None
 
         event.save()
+
+        self._audit_event_write(
+            AuditAction.UPDATE,
+            event,
+            diff=compute_diff(audit_before, self._event_audit_scalar_snapshot(event)),
+        )
 
         existing_attendances = {a.membership_user_id: a for a in event.attendances.all()}
         existing_external_attendances = {
@@ -1415,6 +1512,12 @@ class CalendarEventService:
                 )
 
         serialized_event = self._serialize_event(event)
+
+        # Capture the audit subject (needs the pk) BEFORE the row is deleted. This
+        # records one DELETE for the event the caller asked to delete, covering both
+        # the single-event and recurring-series delete paths (the series' child rows /
+        # exceptions / rule are mechanical sync writes and are intentionally not audited).
+        self._audit_event_write(AuditAction.DELETE, event)
 
         event.delete()
 

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -9,6 +9,8 @@ from django.utils import timezone
 
 from dependency_injector.wiring import Provide, inject
 
+from audit.constants import AuditAction
+from audit.diff import compute_diff
 from calendar_integration.constants import CalendarProvider, CalendarType
 from calendar_integration.exceptions import (
     CalendarGroupHasFutureEventsError,
@@ -32,6 +34,9 @@ from calendar_integration.services.calendar_permission_service import CalendarPe
 from calendar_integration.services.calendar_service_utils import (
     convert_naive_utc_datetime_to_timezone as _convert_naive_utc_datetime_to_timezone,
 )
+from calendar_integration.services.calendar_service_utils import (
+    resolve_acting_single_use_token,
+)
 from calendar_integration.services.dataclasses import (
     BookableSlotProposal,
     CalendarEventInputData,
@@ -50,6 +55,7 @@ from users.models import User
 
 
 if TYPE_CHECKING:
+    from audit.services import AuditService
     from calendar_integration.services.calendar_service import CalendarService
 
 
@@ -72,10 +78,41 @@ class CalendarGroupService:
         calendar_permission_service: Annotated[
             "CalendarPermissionService | None", Provide["calendar_permission_service"]
         ] = None,
+        audit_service: Annotated["AuditService | None", Provide["audit_service"]] = None,
     ) -> None:
         self.organization = None
         self.calendar_service = calendar_service
         self.calendar_permission_service = calendar_permission_service
+        self.audit_service = audit_service
+
+    def _audit_group_write(
+        self,
+        action: str,
+        subject_instance: object,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a calendar-group business write.
+
+        The acting principal is taken from the bound ``calendar_service``'s auth
+        context (the facade carries ``user_or_token``); when unavailable the actor
+        resolves to the system. No-op when no ``audit_service`` / ``organization`` is
+        bound, so instrumentation never breaks a write path.
+        """
+        if self.audit_service is None or self.organization is None:
+            return
+        user_or_token = getattr(self.calendar_service, "user_or_token", None)
+        permission_service = getattr(self.calendar_service, "calendar_permission_service", None)
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=action,
+            actor=self.audit_service.actor_from_user_or_token(
+                user_or_token,
+                self.organization.id,
+                single_use_token=resolve_acting_single_use_token(user_or_token, permission_service),
+            ),
+            subject=self.audit_service.subject_from_instance(subject_instance),
+            diff=diff,
+        )
 
     def initialize(self, organization: Organization) -> None:
         """Initialize the service with the tenant organization.
@@ -196,6 +233,7 @@ class CalendarGroupService:
             accepts_public_scheduling=accepts_public_scheduling,
         )
         self._create_slots(group, slots_data)
+        self._audit_group_write(AuditAction.CREATE, group)
         return group
 
     @transaction.atomic()
@@ -209,6 +247,11 @@ class CalendarGroupService:
         group = self._get_group_by_id(group_id)
         slots_data, _ = self._validate_slots_input(data.slots)
 
+        before = {
+            "name": group.name,
+            "description": group.description,
+            "accepts_public_scheduling": group.accepts_public_scheduling,
+        }
         group.name = data.name
         group.description = data.description
         # Only update accepts_public_scheduling if it is provided (not None).
@@ -236,6 +279,13 @@ class CalendarGroupService:
             else:
                 self._create_slots(group, [slot_data])
 
+        after = {
+            "name": group.name,
+            "description": group.description,
+            "accepts_public_scheduling": group.accepts_public_scheduling,
+        }
+        self._audit_group_write(AuditAction.UPDATE, group, diff=compute_diff(before, after))
+
         return group
 
     @transaction.atomic()
@@ -254,6 +304,8 @@ class CalendarGroupService:
                 "Cannot delete CalendarGroup because it has bookings."
             )
 
+        # Build the audit subject before the row is deleted (pk is needed).
+        self._audit_group_write(AuditAction.DELETE, group)
         group.delete()
 
     def _create_slots(

--- a/calendar_integration/services/calendar_permission_service.py
+++ b/calendar_integration/services/calendar_permission_service.py
@@ -1,10 +1,13 @@
 import base64
 import datetime
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from django.utils import timezone
 
+from dependency_injector.wiring import Provide, inject
+
+from audit.constants import AuditAction
 from calendar_integration.exceptions import (
     InvalidParameterCombinationError,
     InvalidTokenError,
@@ -39,6 +42,7 @@ from users.models import User
 
 
 if TYPE_CHECKING:
+    from audit.services import AuditService
     from public_api.models import SystemUser
 
 
@@ -89,6 +93,37 @@ DEFAULT_EXTERNAL_ATTENDEE_PERMISSIONS = [
 
 class CalendarPermissionService:
     token: CalendarManagementToken | None
+
+    @inject
+    def __init__(
+        self,
+        audit_service: Annotated["AuditService | None", Provide["audit_service"]] = None,
+    ) -> None:
+        self.token = None
+        self.audit_service = audit_service
+
+    def _audit_token_write(
+        self,
+        action: str,
+        token: CalendarManagementToken,
+        organization_id: int,
+        actor: object,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a CalendarManagementToken lifecycle write.
+
+        No-op when no ``audit_service`` is bound, so token minting/revocation never
+        breaks if the service was built without DI (e.g. directly in a test).
+        """
+        if self.audit_service is None:
+            return
+        self.audit_service.record(
+            organization_id=organization_id,
+            action=action,
+            actor=actor,  # type: ignore[arg-type]
+            subject=self.audit_service.subject_from_instance(token),
+            diff=diff,
+        )
 
     def initialize_with_token(self, token_str_base64: str, organization_id: int):
         try:
@@ -486,6 +521,14 @@ class CalendarPermissionService:
         for perm in permissions:
             token.permissions.create(permission=perm, organization_id=organization_id)
 
+        if self.audit_service is not None:
+            self._audit_token_write(
+                AuditAction.CREATE,
+                token,
+                organization_id,
+                self.audit_service.actor_from_user_or_token(user, organization_id),
+            )
+
         return token
 
     def create_attendee_token(
@@ -520,6 +563,14 @@ class CalendarPermissionService:
         for perm in permissions:
             token.permissions.create(permission=perm, organization_id=organization_id)
 
+        if self.audit_service is not None:
+            self._audit_token_write(
+                AuditAction.CREATE,
+                token,
+                organization_id,
+                self.audit_service.actor_from_user_or_token(user, organization_id),
+            )
+
         return token
 
     def create_external_attendee_update_token(
@@ -553,6 +604,14 @@ class CalendarPermissionService:
         for perm in permissions:
             token.permissions.create(permission=perm, organization_id=organization_id)
 
+        if self.audit_service is not None:
+            self._audit_token_write(
+                AuditAction.CREATE,
+                token,
+                organization_id,
+                self.audit_service.system_actor(),
+            )
+
         return token
 
     def create_external_attendee_schedule_token(
@@ -578,6 +637,14 @@ class CalendarPermissionService:
         token.permissions.create(
             permission=EventManagementPermissions.CREATE, organization_id=organization_id
         )
+
+        if self.audit_service is not None:
+            self._audit_token_write(
+                AuditAction.CREATE,
+                token,
+                organization_id,
+                self.audit_service.system_actor(),
+            )
 
         return token
 
@@ -652,6 +719,14 @@ class CalendarPermissionService:
 
         for perm in permissions:
             token.permissions.create(permission=perm, organization_id=organization_id)
+
+        if self.audit_service is not None:
+            self._audit_token_write(
+                AuditAction.CREATE,
+                token,
+                organization_id,
+                self.audit_service.actor_from_user_or_token(minted_by, organization_id),
+            )
 
         # Encode as "<id>:<raw>" in base64, matching initialize_with_token's decode logic.
         plaintext_code = base64.b64encode(f"{token.pk}:{token_str}".encode()).decode("utf-8")
@@ -807,5 +882,14 @@ class CalendarPermissionService:
         if token.revoked_at is None:
             token.revoked_at = timezone.now()
             token.save(update_fields=["revoked_at"])
+
+            if self.audit_service is not None:
+                self._audit_token_write(
+                    AuditAction.UPDATE,
+                    token,
+                    organization_id,
+                    self.audit_service.system_actor(),
+                    diff={"revoked_at": {"old": None, "new": token.revoked_at.isoformat()}},
+                )
 
         return True

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -32,7 +32,7 @@ services such as ``CalendarGroupService``.
 import datetime
 import logging
 from collections.abc import Callable, Iterable
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from django.db import transaction
 from django.db.models import QuerySet
@@ -41,6 +41,8 @@ from django.http import HttpRequest
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from dependency_injector.wiring import Provide, inject
 
+from audit.constants import AuditAction
+from audit.diff import compute_diff
 from calendar_integration.constants import (
     CalendarProvider,
     CalendarSyncTriggerSource,
@@ -87,6 +89,9 @@ from calendar_integration.services.calendar_service_utils import (
     grant_event_attendee_permissions as _grant_event_attendee_permissions_util,
 )
 from calendar_integration.services.calendar_service_utils import (
+    resolve_acting_single_use_token as _resolve_acting_single_use_token,
+)
+from calendar_integration.services.calendar_service_utils import (
     serialize_event as _serialize_event_util,
 )
 from calendar_integration.services.calendar_service_utils import (
@@ -131,6 +136,10 @@ from public_api.models import SystemUser
 from users.models import User
 
 
+if TYPE_CHECKING:
+    from audit.services import AuditService
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -167,6 +176,7 @@ class CalendarService(BaseCalendarService):
         calendar_permission_service: Annotated[
             "CalendarPermissionService | None", Provide["calendar_permission_service"]
         ] = None,
+        audit_service: Annotated["AuditService | None", Provide["audit_service"]] = None,
     ) -> None:
         """Initialize a CalendarService instance. Call authenticate() before using calendar operations."""
         self.organization = None
@@ -175,6 +185,7 @@ class CalendarService(BaseCalendarService):
         self.calendar_adapter = None
         self.calendar_side_effects_service = calendar_side_effects_service
         self.calendar_permission_service = calendar_permission_service
+        self.audit_service = audit_service
         # Per-instance calendar lookup cache: keyed on (organization_id, id_or_external_id).
         # This replaces the @lru_cache approach which was keyed only on id/external_id and
         # could return a cached Calendar from a different organization when the service
@@ -185,6 +196,34 @@ class CalendarService(BaseCalendarService):
         # Stateless recurrence engine shared by event/blocked-time/available-time methods.
         # Constructed once; it holds no auth state (everything arrives as method params).
         self._recurrence_manager = RecurrenceManager()
+
+    def _audit_calendar_write(
+        self,
+        action: str,
+        calendar: Calendar,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a calendar-level business write.
+
+        Resolves the actor from the facade's ``user_or_token`` auth context. A no-op
+        when no ``audit_service`` or ``organization`` is bound (e.g. a service built
+        directly in a test without DI), so instrumentation never breaks a write path.
+        """
+        if self.audit_service is None or self.organization is None:
+            return
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=action,
+            actor=self.audit_service.actor_from_user_or_token(
+                self.user_or_token,
+                self.organization.id,
+                single_use_token=_resolve_acting_single_use_token(
+                    self.user_or_token, self.calendar_permission_service
+                ),
+            ),
+            subject=self.audit_service.subject_from_instance(calendar, label=calendar.name),
+            diff=diff,
+        )
 
     def _grant_calendar_owner_permissions(self, calendar: Calendar) -> None:
         """
@@ -363,6 +402,7 @@ class CalendarService(BaseCalendarService):
             calendar_adapter=self.calendar_adapter,
             calendar_permission_service=self.calendar_permission_service,
             calendar_side_effects_service=self.calendar_side_effects_service,
+            audit_service=self.audit_service,
         )
 
     def initialize_without_provider(
@@ -399,6 +439,7 @@ class CalendarService(BaseCalendarService):
             calendar_adapter=self.calendar_adapter,
             calendar_permission_service=self.calendar_permission_service,
             calendar_side_effects_service=self.calendar_side_effects_service,
+            audit_service=self.audit_service,
         )
 
     def _build_context_snapshot(self) -> CalendarServiceContext:
@@ -417,6 +458,7 @@ class CalendarService(BaseCalendarService):
             calendar_adapter=self.calendar_adapter,
             calendar_permission_service=self.calendar_permission_service,
             calendar_side_effects_service=self.calendar_side_effects_service,
+            audit_service=self.audit_service,
         )
 
     def _get_event_service(self) -> CalendarEventService:
@@ -599,6 +641,8 @@ class CalendarService(BaseCalendarService):
         # Grant permissions to calendar owners
         self._grant_calendar_owner_permissions(calendar)
 
+        self._audit_calendar_write(AuditAction.CREATE, calendar)
+
         return created_calendar
 
     def _get_calendar_by_external_id(self, calendar_external_id: str) -> Calendar:
@@ -684,6 +728,8 @@ class CalendarService(BaseCalendarService):
         # Grant permissions to calendar owners
         self._grant_calendar_owner_permissions(calendar)
 
+        self._audit_calendar_write(AuditAction.CREATE, calendar)
+
         return calendar
 
     @transaction.atomic()
@@ -741,6 +787,8 @@ class CalendarService(BaseCalendarService):
         # Grant permissions to calendar owners
         self._grant_calendar_owner_permissions(calendar)
 
+        self._audit_calendar_write(AuditAction.CREATE, calendar)
+
         return calendar
 
     @transaction.atomic()
@@ -791,6 +839,8 @@ class CalendarService(BaseCalendarService):
         # Grant permissions to calendar owners
         self._grant_calendar_owner_permissions(calendar)
 
+        self._audit_calendar_write(AuditAction.CREATE, calendar)
+
         return calendar
 
     @transaction.atomic()
@@ -826,6 +876,11 @@ class CalendarService(BaseCalendarService):
                 f"(type={calendar.calendar_type})."
             )
 
+        before = {
+            "name": calendar.name,
+            "description": calendar.description,
+            "accepts_public_scheduling": calendar.accepts_public_scheduling,
+        }
         update_fields: list[str] = []
         if name is not None:
             calendar.name = name
@@ -838,6 +893,14 @@ class CalendarService(BaseCalendarService):
             update_fields.append("accepts_public_scheduling")
         if update_fields:
             calendar.save(update_fields=update_fields)
+            after = {
+                "name": calendar.name,
+                "description": calendar.description,
+                "accepts_public_scheduling": calendar.accepts_public_scheduling,
+            }
+            self._audit_calendar_write(
+                AuditAction.UPDATE, calendar, diff=compute_diff(before, after)
+            )
 
         return calendar
 
@@ -863,8 +926,15 @@ class CalendarService(BaseCalendarService):
                 f"(type={calendar.calendar_type})."
             )
 
+        old_visibility = calendar.visibility
         calendar.visibility = CalendarVisibility.INACTIVE
         calendar.save(update_fields=["visibility"])
+
+        self._audit_calendar_write(
+            AuditAction.UPDATE,
+            calendar,
+            diff={"visibility": {"old": old_visibility, "new": calendar.visibility}},
+        )
 
         return calendar
 
@@ -889,8 +959,15 @@ class CalendarService(BaseCalendarService):
                 f"Calendar {bundle_id} is not a bundle calendar (type={calendar.calendar_type})."
             )
 
+        old_visibility = calendar.visibility
         calendar.visibility = CalendarVisibility.INACTIVE
         calendar.save(update_fields=["visibility"])
+
+        self._audit_calendar_write(
+            AuditAction.UPDATE,
+            calendar,
+            diff={"visibility": {"old": old_visibility, "new": calendar.visibility}},
+        )
 
         return calendar
 

--- a/calendar_integration/services/calendar_service_context.py
+++ b/calendar_integration/services/calendar_service_context.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from allauth.socialaccount.models import SocialAccount
 
+    from audit.services import AuditService
     from calendar_integration.models import GoogleCalendarServiceAccount
     from calendar_integration.services.calendar_permission_service import CalendarPermissionService
     from calendar_integration.services.calendar_side_effects_service import (
@@ -47,3 +48,7 @@ class CalendarServiceContext:
     calendar_adapter: CalendarAdapter | None
     calendar_permission_service: CalendarPermissionService | None
     calendar_side_effects_service: CalendarSideEffectsService | None
+    # Audit trail recorder, threaded from the facade so sub-services can emit audit
+    # records for the business writes they perform. Defaults to None so contexts built
+    # directly in tests (without DI) still construct.
+    audit_service: AuditService | None = None

--- a/calendar_integration/services/calendar_service_utils.py
+++ b/calendar_integration/services/calendar_service_utils.py
@@ -39,6 +39,24 @@ from organizations.models import OrganizationMembership
 from users.models import User
 
 
+def resolve_acting_single_use_token(
+    user_or_token: object,
+    permission_service: object | None,
+) -> CalendarManagementToken | None:
+    """Return the resolved single-use token backing a ``str`` ``user_or_token``.
+
+    When the caller acts via a single-use code, ``user_or_token`` is the raw code
+    string and the permission service has already resolved it into a
+    ``CalendarManagementToken`` row (``permission_service.token``). Audit actor
+    resolution uses that row to attribute the action to SINGLE_USE_CODE. Returns
+    ``None`` for non-token principals (User / SystemUser / None) or when no token
+    has been resolved.
+    """
+    if not isinstance(user_or_token, str) or permission_service is None:
+        return None
+    return getattr(permission_service, "token", None)
+
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 

--- a/calendar_integration/services/protocols/initializer_or_authenticated_calendar_service.py
+++ b/calendar_integration/services/protocols/initializer_or_authenticated_calendar_service.py
@@ -203,6 +203,10 @@ class InitializedOrAuthenticatedCalendarService(Protocol):
 
     def _grant_calendar_owner_permissions(self, calendar: Calendar) -> None: ...
 
+    def _audit_calendar_write(
+        self, action: str, calendar: Calendar, diff: dict | None = None
+    ) -> None: ...
+
     def _grant_event_attendee_permissions(self, event: CalendarEvent) -> None: ...
 
     def request_calendar_sync(

--- a/calendar_integration/tests/services/test_availability_service_audit.py
+++ b/calendar_integration/tests/services/test_availability_service_audit.py
@@ -1,0 +1,453 @@
+"""Audit-emission tests for AvailabilityService business write paths.
+
+Each test constructs a real AvailabilityService (with a real AuditService bound on
+the context) and asserts that the expected audit record(s) are enqueued. We patch
+``audit.services.persist_audit_record`` and execute the on_commit callbacks so the
+enqueue happens, then inspect the serialized payloads.
+
+The AvailabilityService is built directly (bypassing the CalendarService facade)
+using a real CalendarServiceContext plus the lightweight FakeHost from
+test_availability_service.py.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from audit.constants import AuditAction
+from audit.services import AuditService
+from calendar_integration.constants import CalendarProvider
+from calendar_integration.models import BlockedTime, Calendar
+from calendar_integration.services.availability_service import AvailabilityService
+from calendar_integration.services.calendar_service_context import CalendarServiceContext
+from calendar_integration.services.recurrence_manager import RecurrenceManager
+from calendar_integration.tests.services.test_availability_service import FakeHost
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payloads(mock_task) -> list[dict]:
+    return [call.args[0] for call in mock_task.delay.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Audit Test Org")
+
+
+@pytest.fixture
+def user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="audit_avail@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.ADMIN
+    )
+    return u
+
+
+@pytest.fixture
+def audit_service() -> AuditService:
+    from di_core.containers import container
+
+    return container.audit_service()
+
+
+@pytest.fixture
+def calendar(db: Any, organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        name="Audit Calendar",
+        external_id="audit_cal_001",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def managed_calendar(db: Any, organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        name="Audit Managed Calendar",
+        external_id="audit_cal_managed",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def context(
+    organization: Organization, user: User, audit_service: AuditService
+) -> CalendarServiceContext:
+    return CalendarServiceContext(
+        organization=organization,
+        user_or_token=user,
+        account=None,
+        calendar_adapter=None,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+        audit_service=audit_service,
+    )
+
+
+@pytest.fixture
+def service(context: CalendarServiceContext, organization: Organization) -> AvailabilityService:
+    host = FakeHost(organization=organization)
+    return AvailabilityService(context=context, recurrence_manager=RecurrenceManager(), host=host)
+
+
+def _utc(year: int, month: int, day: int, hour: int) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# create_blocked_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_blocked_time_records_create(
+    service: AvailabilityService,
+    calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            bt = service.create_blocked_time(
+                calendar=calendar,
+                start_time=_utc(2025, 7, 1, 9),
+                end_time=_utc(2025, 7, 1, 10),
+                timezone="UTC",
+                reason="Focus",
+            )
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    assert payloads[0]["action"] == AuditAction.CREATE
+    assert payloads[0]["subject"]["subject_type"] == "calendar_integration.BlockedTime"
+    assert payloads[0]["subject"]["subject_id"] == str(bt.pk)
+    assert payloads[0]["subject"]["subject_label"] == "Focus"
+
+
+# ---------------------------------------------------------------------------
+# update_blocked_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_update_blocked_time_records_update_with_reason_diff(
+    service: AvailabilityService,
+    calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    bt = service.create_blocked_time(
+        calendar=calendar,
+        start_time=_utc(2025, 7, 1, 9),
+        end_time=_utc(2025, 7, 1, 10),
+        timezone="UTC",
+        reason="Old reason",
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.update_blocked_time(
+                calendar=calendar,
+                blocked_time_id=bt.pk,
+                reason="New reason",
+            )
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    assert payloads[0]["action"] == AuditAction.UPDATE
+    assert payloads[0]["subject"]["subject_type"] == "calendar_integration.BlockedTime"
+    assert payloads[0]["diff"] == {"reason": {"old": "Old reason", "new": "New reason"}}
+
+
+@pytest.mark.django_db
+def test_update_blocked_time_time_only_records_update_with_null_diff(
+    service: AvailabilityService,
+    calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    bt = service.create_blocked_time(
+        calendar=calendar,
+        start_time=_utc(2025, 7, 1, 9),
+        end_time=_utc(2025, 7, 1, 10),
+        timezone="UTC",
+        reason="Same",
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.update_blocked_time(
+                calendar=calendar,
+                blocked_time_id=bt.pk,
+                start_time=_utc(2025, 7, 1, 11),
+                end_time=_utc(2025, 7, 1, 12),
+            )
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    assert payloads[0]["action"] == AuditAction.UPDATE
+    # reason unchanged -> compute_diff returns None.
+    assert payloads[0]["diff"] is None
+
+
+# ---------------------------------------------------------------------------
+# delete_blocked_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_delete_blocked_time_records_delete(
+    service: AvailabilityService,
+    calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    bt = service.create_blocked_time(
+        calendar=calendar,
+        start_time=_utc(2025, 7, 1, 9),
+        end_time=_utc(2025, 7, 1, 10),
+        timezone="UTC",
+        reason="To delete",
+    )
+    bt_pk = bt.pk
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.delete_blocked_time(calendar=calendar, blocked_time_id=bt_pk)
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    assert payloads[0]["action"] == AuditAction.DELETE
+    assert payloads[0]["subject"]["subject_type"] == "calendar_integration.BlockedTime"
+    assert payloads[0]["subject"]["subject_id"] == str(bt_pk)
+    assert not BlockedTime.objects.filter(pk=bt_pk).exists()
+
+
+# ---------------------------------------------------------------------------
+# create_available_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_available_time_records_create(
+    service: AvailabilityService,
+    managed_calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            at = service.create_available_time(
+                calendar=managed_calendar,
+                start_time=_utc(2025, 7, 1, 10),
+                end_time=_utc(2025, 7, 1, 12),
+                timezone="UTC",
+            )
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    assert payloads[0]["action"] == AuditAction.CREATE
+    assert payloads[0]["subject"]["subject_type"] == "calendar_integration.AvailableTime"
+    assert payloads[0]["subject"]["subject_id"] == str(at.pk)
+    # AvailableTime has no human-readable scalar -> no label.
+    assert payloads[0]["subject"]["subject_label"] is None
+
+
+# ---------------------------------------------------------------------------
+# recurring exceptions / bulk modifications -> UPDATE on the parent, diff=None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_recurring_blocked_time_exception_records_update_on_parent(
+    service: AvailabilityService,
+    calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    parent = service.create_blocked_time(
+        calendar=calendar,
+        start_time=_utc(2025, 7, 1, 9),
+        end_time=_utc(2025, 7, 1, 10),
+        timezone="UTC",
+        reason="Recurring block",
+        rrule_string="RRULE:FREQ=DAILY;COUNT=5",
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.create_recurring_blocked_time_exception(
+                parent_blocked_time=parent,
+                exception_date=datetime.date(2025, 7, 3),
+                is_cancelled=True,
+            )
+
+    # The parent series gets an UPDATE record. Nested create_blocked_time calls (from
+    # the recurrence engine split) may also emit CREATE records; assert the parent
+    # UPDATE is present.
+    parent_subject_id = str(parent.pk)
+    update_records = [
+        p
+        for p in _payloads(mock_task)
+        if p["action"] == AuditAction.UPDATE
+        and p["subject"]["subject_type"] == "calendar_integration.BlockedTime"
+        and p["subject"]["subject_id"] == parent_subject_id
+    ]
+    assert len(update_records) == 1
+    assert update_records[0]["diff"] is None
+
+
+@pytest.mark.django_db
+def test_create_recurring_available_time_exception_records_update_on_parent(
+    service: AvailabilityService,
+    managed_calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    parent = service.create_available_time(
+        calendar=managed_calendar,
+        start_time=_utc(2025, 7, 1, 10),
+        end_time=_utc(2025, 7, 1, 12),
+        timezone="UTC",
+        rrule_string="RRULE:FREQ=DAILY;COUNT=5",
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.create_recurring_available_time_exception(
+                parent_available_time=parent,
+                exception_date=datetime.date(2025, 7, 3),
+                is_cancelled=True,
+            )
+
+    parent_subject_id = str(parent.pk)
+    update_records = [
+        p
+        for p in _payloads(mock_task)
+        if p["action"] == AuditAction.UPDATE
+        and p["subject"]["subject_type"] == "calendar_integration.AvailableTime"
+        and p["subject"]["subject_id"] == parent_subject_id
+    ]
+    assert len(update_records) == 1
+    assert update_records[0]["diff"] is None
+
+
+@pytest.mark.django_db
+def test_create_recurring_blocked_time_bulk_modification_records_update_on_parent(
+    service: AvailabilityService,
+    calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    parent = service.create_blocked_time(
+        calendar=calendar,
+        start_time=_utc(2025, 7, 1, 9),
+        end_time=_utc(2025, 7, 1, 10),
+        timezone="UTC",
+        reason="Recurring block",
+        rrule_string="RRULE:FREQ=DAILY;COUNT=5",
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.create_recurring_blocked_time_bulk_modification(
+                parent_blocked_time=parent,
+                modification_start_date=_utc(2025, 7, 3, 9),
+                is_bulk_cancelled=True,
+            )
+
+    parent_subject_id = str(parent.pk)
+    update_records = [
+        p
+        for p in _payloads(mock_task)
+        if p["action"] == AuditAction.UPDATE
+        and p["subject"]["subject_type"] == "calendar_integration.BlockedTime"
+        and p["subject"]["subject_id"] == parent_subject_id
+    ]
+    assert len(update_records) == 1
+    assert update_records[0]["diff"] is None
+
+
+@pytest.mark.django_db
+def test_create_recurring_available_time_bulk_modification_records_update_on_parent(
+    service: AvailabilityService,
+    managed_calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    parent = service.create_available_time(
+        calendar=managed_calendar,
+        start_time=_utc(2025, 7, 1, 10),
+        end_time=_utc(2025, 7, 1, 12),
+        timezone="UTC",
+        rrule_string="RRULE:FREQ=DAILY;COUNT=5",
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.create_recurring_available_time_bulk_modification(
+                parent_available_time=parent,
+                modification_start_date=_utc(2025, 7, 3, 10),
+                is_bulk_cancelled=True,
+            )
+
+    parent_subject_id = str(parent.pk)
+    update_records = [
+        p
+        for p in _payloads(mock_task)
+        if p["action"] == AuditAction.UPDATE
+        and p["subject"]["subject_type"] == "calendar_integration.AvailableTime"
+        and p["subject"]["subject_id"] == parent_subject_id
+    ]
+    assert len(update_records) == 1
+    assert update_records[0]["diff"] is None
+
+
+# ---------------------------------------------------------------------------
+# None-guard: no audit_service on context -> no emission, no error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_no_audit_service_skips_emission(
+    organization: Organization,
+    user: User,
+    calendar: Calendar,
+    django_capture_on_commit_callbacks,
+) -> None:
+    context = CalendarServiceContext(
+        organization=organization,
+        user_or_token=user,
+        account=None,
+        calendar_adapter=None,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+        audit_service=None,
+    )
+    service = AvailabilityService(
+        context=context,
+        recurrence_manager=RecurrenceManager(),
+        host=FakeHost(organization=organization),
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            bt = service.create_blocked_time(
+                calendar=calendar,
+                start_time=_utc(2025, 7, 1, 9),
+                end_time=_utc(2025, 7, 1, 10),
+                timezone="UTC",
+                reason="No audit",
+            )
+
+    assert bt.pk is not None
+    mock_task.delay.assert_not_called()

--- a/calendar_integration/tests/services/test_calendar_bundle_service_audit.py
+++ b/calendar_integration/tests/services/test_calendar_bundle_service_audit.py
@@ -1,0 +1,389 @@
+"""Audit-emission tests for ``CalendarBundleService`` business writes.
+
+Each test drives the real bundle sub-service (its auth context carries the
+DI-injected ``audit_service``) and asserts that the expected audit record is
+enqueued for the business write. We patch ``audit.services.persist_audit_record``
+and execute the on_commit callbacks (the record() write path only fires on
+transaction commit), then inspect the serialized payloads.
+
+Only the five instrumented BUSINESS writes are asserted here:
+``create_bundle_calendar`` / ``update_bundle_calendar`` (Calendar subject) and
+``create_bundle_event`` / ``update_bundle_event`` / ``delete_bundle_event``
+(CalendarEvent subject). The mechanical fan-out (child relationships, BlockedTime
+representations) is intentionally NOT audited, so each public call must emit
+exactly one business record.
+"""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    Calendar,
+    CalendarEvent,
+    ChildrenCalendarRelationship,
+)
+from calendar_integration.services.calendar_bundle_service import CalendarBundleService
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import (
+    AvailableTimeWindow,
+    CalendarEventInputData,
+)
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db):
+    return Organization.objects.create(name="Bundle Audit Org", should_sync_rooms=False)
+
+
+@pytest.fixture
+def child_calendar_internal(organization, db):
+    return Calendar.objects.create(
+        name="Internal Child Calendar",
+        external_id="audit-internal-child-1",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def child_calendar_google(organization, db):
+    return Calendar.objects.create(
+        name="Google Child Calendar",
+        external_id="audit-google-child-1",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def initialized_facade(organization):
+    service = CalendarService()
+    service.initialize_without_provider(organization=organization)
+    return service
+
+
+@pytest.fixture
+def bundle_service(initialized_facade):
+    return CalendarBundleService(
+        context=initialized_facade._build_context_snapshot(),
+        host=initialized_facade,
+    )
+
+
+@pytest.fixture
+def bundle_calendar(initialized_facade, child_calendar_internal, child_calendar_google):
+    return initialized_facade.create_bundle_calendar(
+        name="Audit Bundle Calendar",
+        description="A bundle calendar",
+        child_calendars=[child_calendar_internal, child_calendar_google],
+        primary_calendar=child_calendar_google,
+    )
+
+
+@pytest.fixture
+def bundle_event_data():
+    return CalendarEventInputData(
+        title="Bundle Meeting",
+        description="A meeting created through bundle calendar",
+        start_time=datetime.datetime(2025, 6, 22, 10, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2025, 6, 22, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        attendances=[],
+        external_attendances=[],
+        resource_allocations=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payloads(mock_task) -> list[dict]:
+    return [call.args[0] for call in mock_task.delay.call_args_list]
+
+
+def _make_primary_event(
+    organization: Organization,
+    calendar: Calendar,
+    bundle_calendar: Calendar,
+    external_id: str = "audit-primary-event-1",
+) -> CalendarEvent:
+    return CalendarEvent.objects.create(
+        title="Original Title",
+        description="Original description",
+        start_time_tz_unaware=datetime.datetime(2025, 6, 22, 10, 0, tzinfo=datetime.UTC),
+        end_time_tz_unaware=datetime.datetime(2025, 6, 22, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        calendar=calendar,
+        organization=organization,
+        external_id=external_id,
+        is_bundle_primary=True,
+        bundle_calendar=bundle_calendar,
+    )
+
+
+# ===========================================================================
+# create_bundle_calendar
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_create_bundle_calendar_records_create(
+    bundle_service,
+    organization,
+    child_calendar_internal,
+    child_calendar_google,
+    django_capture_on_commit_callbacks,
+):
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            cal = bundle_service.create_bundle_calendar(
+                name="Audited Bundle",
+                child_calendars=[child_calendar_internal, child_calendar_google],
+                primary_calendar=child_calendar_google,
+            )
+
+    payloads = _payloads(mock_task)
+    # Exactly one BUSINESS record: the bundle Calendar create. Child relationship
+    # rows are mechanical and must NOT be audited.
+    assert len(payloads) == 1
+    record = payloads[0]
+    assert record["organization_id"] == organization.id
+    assert record["action"] == "create"
+    assert record["subject"]["subject_type"] == "calendar_integration.Calendar"
+    assert record["subject"]["subject_id"] == str(cal.id)
+    assert record["subject"]["subject_label"] == "Audited Bundle"
+    assert record["diff"] is None
+
+
+# ===========================================================================
+# update_bundle_calendar
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_update_bundle_calendar_records_update(
+    bundle_service,
+    organization,
+    bundle_calendar,
+    child_calendar_internal,
+    child_calendar_google,
+    django_capture_on_commit_callbacks,
+):
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            bundle_service.update_bundle_calendar(
+                bundle_calendar=bundle_calendar,
+                child_calendars=[child_calendar_google],
+                primary_calendar=child_calendar_google,
+            )
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    record = payloads[0]
+    assert record["organization_id"] == organization.id
+    assert record["action"] == "update"
+    assert record["subject"]["subject_type"] == "calendar_integration.Calendar"
+    assert record["subject"]["subject_id"] == str(bundle_calendar.id)
+    # This method only reconciles child relationships -> no field-level diff.
+    assert record["diff"] is None
+    # Relationship reconciliation itself is not audited.
+    assert ChildrenCalendarRelationship.objects.filter(bundle_calendar=bundle_calendar).count() == 1
+
+
+# ===========================================================================
+# create_bundle_event
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_create_bundle_event_records_single_create(
+    initialized_facade,
+    organization,
+    bundle_calendar,
+    child_calendar_google,
+    bundle_event_data,
+    django_capture_on_commit_callbacks,
+):
+    service = CalendarBundleService(
+        context=initialized_facade._build_context_snapshot(),
+        host=initialized_facade,
+    )
+
+    availability_window = [
+        AvailableTimeWindow(
+            start_time=bundle_event_data.start_time,
+            end_time=bundle_event_data.end_time,
+        )
+    ]
+
+    counter = {"n": 0}
+
+    def fake_create_event(calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
+        counter["n"] += 1
+        cal = Calendar.objects.get(id=calendar_id, organization=organization)
+        evt = CalendarEvent(
+            title=event_data.title,
+            calendar=cal,
+            organization=organization,
+            start_time_tz_unaware=event_data.start_time,
+            end_time_tz_unaware=event_data.end_time,
+            timezone="UTC",
+            external_id=f"audit-fake-{counter['n']}",
+        )
+        evt.save()
+        return evt
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            with patch.object(
+                initialized_facade,
+                "get_availability_windows_in_range",
+                return_value=availability_window,
+            ):
+                with patch.object(
+                    initialized_facade, "create_event", side_effect=fake_create_event
+                ):
+                    primary_event = service.create_bundle_event(bundle_calendar, bundle_event_data)
+
+    payloads = _payloads(mock_task)
+    # Exactly one BUSINESS record: the primary CalendarEvent. The fanned-out
+    # representation events / BlockedTimes are mechanical and not audited here
+    # (create_event is stubbed, so the child event service does not emit either).
+    assert len(payloads) == 1
+    record = payloads[0]
+    assert record["organization_id"] == organization.id
+    assert record["action"] == "create"
+    assert record["subject"]["subject_type"] == "calendar_integration.CalendarEvent"
+    assert record["subject"]["subject_id"] == str(primary_event.id)
+    assert record["subject"]["subject_label"] == primary_event.title
+
+
+# ===========================================================================
+# update_bundle_event
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_update_bundle_event_records_update(
+    initialized_facade,
+    organization,
+    bundle_calendar,
+    django_capture_on_commit_callbacks,
+):
+    service = CalendarBundleService(
+        context=initialized_facade._build_context_snapshot(),
+        host=initialized_facade,
+    )
+
+    primary_cal = Calendar.objects.create(
+        name="Primary Calendar",
+        external_id="audit-primary-up-1",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+    primary_event = _make_primary_event(
+        organization, primary_cal, bundle_calendar, "audit-pev-up-1"
+    )
+
+    event_data = CalendarEventInputData(
+        title="Updated Title",
+        description="Updated description",
+        start_time=datetime.datetime(2025, 6, 22, 14, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2025, 6, 22, 15, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        attendances=[],
+        external_attendances=[],
+        resource_allocations=[],
+    )
+
+    def fake_update_event(
+        calendar_id: int, event_id: int, data: CalendarEventInputData
+    ) -> CalendarEvent:
+        evt = CalendarEvent.objects.get(id=event_id, organization=organization)
+        evt.title = data.title
+        evt.description = data.description
+        evt.save(update_fields=["title", "description"])
+        return evt
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            with patch.object(initialized_facade, "update_event", side_effect=fake_update_event):
+                service.update_bundle_event(primary_event, event_data)
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    record = payloads[0]
+    assert record["organization_id"] == organization.id
+    assert record["action"] == "update"
+    assert record["subject"]["subject_type"] == "calendar_integration.CalendarEvent"
+    assert record["subject"]["subject_id"] == str(primary_event.id)
+    # title + description changed; timezone unchanged. start/end intentionally omitted.
+    assert record["diff"] is not None
+    assert record["diff"]["title"] == {"old": "Original Title", "new": "Updated Title"}
+    assert record["diff"]["description"] == {
+        "old": "Original description",
+        "new": "Updated description",
+    }
+    assert "timezone" not in record["diff"]
+    assert "start_time" not in record["diff"]
+    assert "end_time" not in record["diff"]
+
+
+# ===========================================================================
+# delete_bundle_event
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_delete_bundle_event_records_delete(
+    initialized_facade,
+    organization,
+    bundle_calendar,
+    django_capture_on_commit_callbacks,
+):
+    service = CalendarBundleService(
+        context=initialized_facade._build_context_snapshot(),
+        host=initialized_facade,
+    )
+
+    primary_cal = Calendar.objects.create(
+        name="Primary Calendar",
+        external_id="audit-primary-del-1",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+    primary_event = _make_primary_event(
+        organization, primary_cal, bundle_calendar, "audit-pev-del-1"
+    )
+    primary_event_id = primary_event.id
+
+    def fake_delete_event(calendar_id: int, event_id: int, delete_series: bool = False) -> None:
+        CalendarEvent.objects.filter(id=event_id, organization=organization).delete()
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            with patch.object(initialized_facade, "delete_event", side_effect=fake_delete_event):
+                service.delete_bundle_event(primary_event)
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    record = payloads[0]
+    assert record["organization_id"] == organization.id
+    assert record["action"] == "delete"
+    assert record["subject"]["subject_type"] == "calendar_integration.CalendarEvent"
+    # Subject pk must reference the now-deleted primary event row.
+    assert record["subject"]["subject_id"] == str(primary_event_id)
+    assert record["subject"]["subject_label"] == "Original Title"

--- a/calendar_integration/tests/services/test_calendar_event_service_audit.py
+++ b/calendar_integration/tests/services/test_calendar_event_service_audit.py
@@ -1,0 +1,331 @@
+"""Audit-emission tests for ``CalendarEventService`` business writes.
+
+These drive the real event sub-service (built from a facade whose ``audit_service``
+is injected via the DI container, exactly as the production wiring does) and assert
+that ``create_event`` / ``update_event`` / ``delete_event`` enqueue the expected audit
+records. We patch ``audit.services.persist_audit_record`` and execute the on_commit
+callbacks so the enqueue happens, then inspect the serialized payloads. Mechanical /
+sync writes (attendees, resources, recurrence rule) are intentionally NOT audited and
+must not appear in the payloads.
+"""
+
+import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from allauth.socialaccount.models import SocialAccount, SocialToken
+
+from audit.constants import AuditAction
+from calendar_integration.constants import CalendarProvider
+from calendar_integration.models import Calendar, CalendarManagementToken
+from calendar_integration.services.calendar_event_service import CalendarEventService
+from calendar_integration.services.calendar_permission_service import (
+    DEFAULT_CALENDAR_OWNER_PERMISSIONS,
+)
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import (
+    CalendarEventAdapterOutputData,
+    CalendarEventInputData,
+    EventAttendanceInputData,
+)
+from organizations.models import Organization, OrganizationMembership
+from users.models import Profile, User
+
+
+@pytest.fixture
+def mock_google_adapter():
+    with patch(
+        "calendar_integration.services.calendar_adapters.google_calendar_adapter.GoogleCalendarAdapter"
+    ) as mock_adapter_class:
+        mock_adapter = Mock()
+        mock_adapter.provider = CalendarProvider.GOOGLE
+        del mock_adapter.resolve_expression
+        del mock_adapter.get_source_expressions
+        mock_adapter_class.return_value = mock_adapter
+        mock_adapter_class.from_service_account_credentials.return_value = mock_adapter
+        yield mock_adapter
+
+
+@pytest.fixture
+def organization(db):
+    return Organization.objects.create(name="Event Audit Org", should_sync_rooms=False)
+
+
+@pytest.fixture
+def social_account(db):
+    user = User.objects.create_user(email="event-audit@example.com", password="testpass123")
+    Profile.objects.create(user=user)
+    return SocialAccount.objects.create(user=user, provider=CalendarProvider.GOOGLE, uid="88888")
+
+
+@pytest.fixture
+def social_token(social_account):
+    return SocialToken.objects.create(
+        account=social_account,
+        token="test_access_token",
+        token_secret="test_refresh_token",
+        expires_at=datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1),
+    )
+
+
+@pytest.fixture
+def calendar(db, organization):
+    return Calendar.objects.create(
+        name="Event Audit Calendar",
+        description="A test calendar",
+        external_id="evt_audit_cal_1",
+        provider=CalendarProvider.GOOGLE,
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def calendar_management_token(db, calendar, social_account):
+    OrganizationMembership.objects.get_or_create(
+        user=social_account.user, organization=calendar.organization
+    )
+    token = CalendarManagementToken.objects.create(
+        calendar=calendar,
+        membership_user_id=social_account.user.id,
+        token_hash="evt_audit_token_hash",
+        organization=calendar.organization,
+    )
+    token.permissions.all().delete()
+    for permission_str in DEFAULT_CALENDAR_OWNER_PERMISSIONS:
+        token.permissions.create(
+            permission=permission_str,
+            organization_id=calendar.organization_id,
+        )
+    return token
+
+
+@pytest.fixture
+def authenticated_facade(social_account, social_token, mock_google_adapter, calendar):
+    service = CalendarService()
+    service.authenticate(account=social_account.user, organization=calendar.organization)
+    return service
+
+
+@pytest.fixture
+def event_service(authenticated_facade):
+    return CalendarEventService(
+        context=authenticated_facade._context,
+        recurrence_manager=authenticated_facade._recurrence_manager,
+        calendar_cache=authenticated_facade._calendar_cache,
+        host=authenticated_facade,
+    )
+
+
+def _grant_event_owner_token(event, user, organization):
+    OrganizationMembership.objects.get_or_create(user=user, organization=organization)
+    token = CalendarManagementToken.objects.create(
+        event_fk=event,
+        membership_user_id=user.id,
+        token_hash=f"evt_audit_token_{event.id}",
+        organization=organization,
+    )
+    token.permissions.all().delete()
+    for permission_str in DEFAULT_CALENDAR_OWNER_PERMISSIONS:
+        token.permissions.create(
+            permission=permission_str,
+            organization_id=organization.id,
+        )
+    return token
+
+
+@pytest.fixture
+def sample_event_input_data():
+    return CalendarEventInputData(
+        title="Audit Event",
+        description="An audited event",
+        start_time=datetime.datetime(2025, 6, 22, 10, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2025, 6, 22, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        attendances=[],
+        external_attendances=[],
+        resource_allocations=[],
+    )
+
+
+def _adapter_output(external_id: str):
+    return CalendarEventAdapterOutputData(
+        calendar_external_id="evt_audit_cal_1",
+        external_id=external_id,
+        title="Audit Event",
+        description="An audited event",
+        start_time=datetime.datetime(2025, 6, 22, 10, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2025, 6, 22, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        attendees=[],
+        resources=[],
+        original_payload={},
+        recurrence_rule=None,
+    )
+
+
+def _payloads(mock_task) -> list[dict]:
+    return [call.args[0] for call in mock_task.delay.call_args_list]
+
+
+@pytest.mark.django_db
+def test_create_event_records_create(
+    event_service,
+    mock_google_adapter,
+    calendar,
+    calendar_management_token,
+    sample_event_input_data,
+    social_account,
+    django_capture_on_commit_callbacks,
+):
+    mock_google_adapter.create_event.return_value = _adapter_output("event_audit_create")
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            event = event_service.create_event(calendar.id, sample_event_input_data)
+
+    payloads = _payloads(mock_task)
+    event_payloads = [
+        p for p in payloads if p["subject"]["subject_type"] == "calendar_integration.CalendarEvent"
+    ]
+    assert len(event_payloads) == 1
+    payload = event_payloads[0]
+    assert payload["action"] == AuditAction.CREATE
+    assert payload["subject"]["subject_id"] == str(event.id)
+    assert payload["subject"]["subject_label"] == "Audit Event"
+    assert payload["organization_id"] == calendar.organization_id
+    assert payload["actor"]["actor_type"] == "membership"
+    assert payload["actor"]["actor_id"] == social_account.user.id
+    assert payload["diff"] is None
+    # With no attendees, the acting member (organizer/host) is the only affected party.
+    assert payload["affected_membership_ids"] == [social_account.user.id]
+
+
+@pytest.mark.django_db
+def test_create_event_affected_memberships_include_organizer_and_attendees(
+    event_service,
+    mock_google_adapter,
+    calendar,
+    calendar_management_token,
+    social_account,
+    django_capture_on_commit_callbacks,
+):
+    """affected_membership_ids = the acting member (organizer) + internal attendees."""
+    # A second org member who attends the event.
+    attendee_user = User.objects.create_user(email="attendee@example.com", password="pw12345")
+    Profile.objects.create(user=attendee_user)
+    OrganizationMembership.objects.create(user=attendee_user, organization=calendar.organization)
+
+    event_input = CalendarEventInputData(
+        title="Audit Event",
+        description="An audited event",
+        start_time=datetime.datetime(2025, 6, 22, 10, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2025, 6, 22, 11, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        attendances=[EventAttendanceInputData(user_id=attendee_user.id)],
+        external_attendances=[],
+        resource_allocations=[],
+    )
+    mock_google_adapter.create_event.return_value = _adapter_output("event_audit_affected")
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            event_service.create_event(calendar.id, event_input)
+
+    event_payloads = [
+        p
+        for p in _payloads(mock_task)
+        if p["subject"]["subject_type"] == "calendar_integration.CalendarEvent"
+    ]
+    assert len(event_payloads) == 1
+    affected = event_payloads[0]["affected_membership_ids"]
+    # Both the organizer (acting member) and the internal attendee are affected.
+    assert affected == sorted({social_account.user.id, attendee_user.id})
+
+
+@pytest.mark.django_db
+def test_update_event_records_update_with_diff(
+    event_service,
+    mock_google_adapter,
+    calendar,
+    calendar_management_token,
+    sample_event_input_data,
+    social_account,
+    django_capture_on_commit_callbacks,
+):
+    mock_google_adapter.create_event.return_value = _adapter_output("event_audit_update")
+    mock_google_adapter.update_event.return_value = _adapter_output("event_audit_update")
+
+    created = event_service.create_event(calendar.id, sample_event_input_data)
+    _grant_event_owner_token(created, social_account.user, calendar.organization)
+
+    updated_input = CalendarEventInputData(
+        title="Updated Title",
+        description="Updated description",
+        start_time=datetime.datetime(2025, 6, 22, 12, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2025, 6, 22, 13, 0, tzinfo=datetime.UTC),
+        timezone="UTC",
+        attendances=[],
+        external_attendances=[],
+        resource_allocations=[],
+    )
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            event_service.update_event(calendar.id, created.id, updated_input)
+
+    event_payloads = [
+        p
+        for p in _payloads(mock_task)
+        if p["subject"]["subject_type"] == "calendar_integration.CalendarEvent"
+    ]
+    assert len(event_payloads) == 1
+    payload = event_payloads[0]
+    assert payload["action"] == AuditAction.UPDATE
+    assert payload["subject"]["subject_id"] == str(created.id)
+    diff = payload["diff"]
+    assert diff is not None
+    assert diff["title"] == {"old": "Audit Event", "new": "Updated Title"}
+    assert diff["description"] == {"old": "An audited event", "new": "Updated description"}
+    # Datetime fields are serialized to ISO strings so the diff stays JSON-safe.
+    assert "start_time_tz_unaware" in diff
+    assert "end_time_tz_unaware" in diff
+    # No attendee / resource keys leak into the event diff.
+    assert set(diff.keys()) <= {
+        "title",
+        "description",
+        "start_time_tz_unaware",
+        "end_time_tz_unaware",
+        "timezone",
+    }
+
+
+@pytest.mark.django_db
+def test_delete_event_records_delete(
+    event_service,
+    mock_google_adapter,
+    calendar,
+    calendar_management_token,
+    sample_event_input_data,
+    social_account,
+    django_capture_on_commit_callbacks,
+):
+    mock_google_adapter.create_event.return_value = _adapter_output("event_audit_delete")
+
+    created = event_service.create_event(calendar.id, sample_event_input_data)
+    created_id = created.id
+    _grant_event_owner_token(created, social_account.user, calendar.organization)
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            event_service.delete_event(calendar.id, created_id)
+
+    event_payloads = [
+        p
+        for p in _payloads(mock_task)
+        if p["subject"]["subject_type"] == "calendar_integration.CalendarEvent"
+    ]
+    assert len(event_payloads) == 1
+    payload = event_payloads[0]
+    assert payload["action"] == AuditAction.DELETE
+    assert payload["subject"]["subject_id"] == str(created_id)
+    assert payload["organization_id"] == calendar.organization_id

--- a/calendar_integration/tests/services/test_calendar_service.py
+++ b/calendar_integration/tests/services/test_calendar_service.py
@@ -1007,10 +1007,12 @@ def test_create_application_calendar(
             # Task must NOT fire before commit.
             mock_task.assert_not_called()
 
-        assert len(captured_callbacks) == 1
-        # Simulate commit: invoke the callback inside the patch context so the
-        # delay mock is still active when the lambda calls sync_calendar_task.delay.
-        captured_callbacks[0]()
+        # The sync-task on_commit is registered first; the audit trail registers an
+        # additional on_commit (its enqueue is exception-isolated). Fire all callbacks
+        # to simulate commit; only the sync task targets this mock.
+        assert len(captured_callbacks) >= 1
+        for callback in captured_callbacks:
+            callback()
 
         # Verify task was called
         mock_task.assert_called_once()
@@ -8017,7 +8019,10 @@ def test_create_event_calls_side_effects(
         "calendar_integration.services.calendar_service.transaction.on_commit"
     ) as mock_on_commit:
         result = service.create_event(calendar.id, sample_event_input_data)
-        mock_on_commit.assert_called_once()
+        # The audit trail also schedules an on_commit (registered first), so an exact
+        # count is no longer asserted; the side-effect callback is the last one
+        # registered. That the side effect fires exactly once is asserted below.
+        assert mock_on_commit.called
         side_effects = mock_on_commit.call_args[0][0]
         side_effects()
 
@@ -8106,7 +8111,10 @@ def test_update_event_calls_side_effects(
         "calendar_integration.services.calendar_service.transaction.on_commit"
     ) as mock_on_commit:
         result = service.update_event(calendar.id, event.id, update_data)
-        mock_on_commit.assert_called_once()
+        # The audit trail also schedules an on_commit (registered first), so an exact
+        # count is no longer asserted; the side-effect callback is the last one
+        # registered. That the side effect fires exactly once is asserted below.
+        assert mock_on_commit.called
         side_effects = mock_on_commit.call_args[0][0]
         side_effects()
 
@@ -8171,7 +8179,10 @@ def test_delete_event_calls_side_effects(
         "calendar_integration.services.calendar_service.transaction.on_commit"
     ) as mock_on_commit:
         service.delete_event(calendar.id, event_id)
-        mock_on_commit.assert_called_once()
+        # The audit trail also schedules an on_commit (registered first), so an exact
+        # count is no longer asserted; the side-effect callback is the last one
+        # registered. That the side effect fires exactly once is asserted below.
+        assert mock_on_commit.called
         side_effects = mock_on_commit.call_args[0][0]
         side_effects()
 

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -112,28 +112,33 @@ class AppContainer(containers.DeclarativeContainer):
 
     calendar_permission_service = providers.Factory(
         CalendarPermissionService,
+        audit_service=audit_service,
     )
 
     calendar_service = providers.Factory(
         CalendarService,
         calendar_side_effects_service=calendar_side_effects_service,
         calendar_permission_service=calendar_permission_service,
+        audit_service=audit_service,
     )
 
     calendar_group_service = providers.Factory(
         CalendarGroupService,
         calendar_service=calendar_service,
         calendar_permission_service=calendar_permission_service,
+        audit_service=audit_service,
     )
 
     organization_service = providers.Factory(
         OrganizationService,
         calendar_service=calendar_service,
         webhook_membership_side_effects_service=webhook_membership_side_effects_service,
+        audit_service=audit_service,
     )
 
     public_api_auth_service = providers.Factory(
         PublicAPIAuthService,
+        audit_service=audit_service,
     )
 
 

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -13,6 +13,9 @@ from vintasend.services.notification_service import (
     NotificationTypes,
 )
 
+from audit.constants import AuditAction
+from audit.diff import compute_diff
+from audit.services import AuditService
 from calendar_integration.constants import CalendarSyncTriggerSource
 from calendar_integration.models import (
     Calendar,
@@ -55,10 +58,12 @@ class OrganizationService:
             WebhookMembershipSideEffectsService,
             Provide["webhook_membership_side_effects_service"],
         ],
+        audit_service: Annotated[AuditService, Provide["audit_service"]],
     ):
         self.calendar_service = calendar_service
         self.notification_service = notification_service
         self.webhook_membership_side_effects_service = webhook_membership_side_effects_service
+        self.audit_service = audit_service
 
     def create_organization(
         self, creator: User, name: str, should_sync_rooms: bool = False
@@ -81,6 +86,23 @@ class OrganizationService:
             role=OrganizationRole.ADMIN,
         )
         self.webhook_membership_side_effects_service.on_member_created(admin_membership)
+
+        # Audit: the creator (now the org's first admin) is the actor for both the
+        # organization creation and their own admin membership.
+        actor = self.audit_service.actor_from_membership(admin_membership)
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=AuditAction.CREATE,
+            actor=actor,
+            subject=self.audit_service.subject_from_instance(self.organization),
+        )
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=AuditAction.CREATE,
+            actor=actor,
+            subject=self.audit_service.subject_from_instance(admin_membership),
+            affected_membership_ids=[admin_membership.user_id],
+        )
 
         if should_sync_rooms:
             # A newly created organization cannot have a service account yet, so
@@ -259,7 +281,15 @@ class OrganizationService:
             # Handle the case where the invitation with this email already exists
             raise DuplicateInvitationError() from e
 
+        diff = None
         if not created:
+            before = {
+                "expires_at": invitation.expires_at.isoformat() if invitation.expires_at else None,
+                "role": invitation.role,
+                "accepted_at": invitation.accepted_at.isoformat()
+                if invitation.accepted_at
+                else None,
+            }
             invitation.token_hash = token_hash
             invitation.expires_at = seven_days_from_now
             invitation.invited_by = invited_by
@@ -269,6 +299,28 @@ class OrganizationService:
             invitation.accepted_at = None
             invitation.membership_user_id = None
             invitation.save()
+            after = {
+                "expires_at": seven_days_from_now.isoformat(),
+                "role": role,
+                "accepted_at": None,
+            }
+            diff = compute_diff(before, after)
+
+        # Audit: an admin (or an API-level actor with no Django User) invites a user.
+        # A fresh invitation is a CREATE; reusing an existing pending row is an UPDATE
+        # (token/expiry/role reset).
+        actor = (
+            self.audit_service.actor_from_user(invited_by, organization.id)
+            if invited_by is not None
+            else self.audit_service.system_actor()
+        )
+        self.audit_service.record(
+            organization_id=organization.id,
+            action=AuditAction.CREATE if created else AuditAction.UPDATE,
+            actor=actor,
+            subject=self.audit_service.subject_from_instance(invitation),
+            diff=diff,
+        )
 
         # Attach the raw token as a transient attribute so the caller can surface it once.
         # It is never persisted — only token_hash is stored in the DB row.
@@ -348,6 +400,24 @@ class OrganizationService:
                 invitation.membership_user_id = membership.user_id
                 invitation.save()
                 self.webhook_membership_side_effects_service.on_member_created(membership)
+
+                # Audit: the accepting user joins the org (new membership) and the
+                # invitation transitions to accepted. The user is the actor for both.
+                actor = self.audit_service.actor_from_membership(membership)
+                self.audit_service.record(
+                    organization_id=invitation.organization_id,
+                    action=AuditAction.CREATE,
+                    actor=actor,
+                    subject=self.audit_service.subject_from_instance(membership),
+                    affected_membership_ids=[membership.user_id],
+                )
+                self.audit_service.record(
+                    organization_id=invitation.organization_id,
+                    action=AuditAction.UPDATE,
+                    actor=actor,
+                    subject=self.audit_service.subject_from_instance(invitation),
+                    diff={"accepted_at": {"old": None, "new": now.isoformat()}},
+                )
                 return membership
 
         raise InvalidInvitationTokenError()
@@ -416,6 +486,24 @@ class OrganizationService:
             pending_invitation.membership_user_id = membership.user_id
             pending_invitation.save()
             self.webhook_membership_side_effects_service.on_member_created(membership)
+
+            # Audit: user joins the inviting org via the signup path; same shape as
+            # accept_invitation (membership CREATE + invitation accepted UPDATE).
+            actor = self.audit_service.actor_from_membership(membership)
+            self.audit_service.record(
+                organization_id=pending_invitation.organization_id,
+                action=AuditAction.CREATE,
+                actor=actor,
+                subject=self.audit_service.subject_from_instance(membership),
+                affected_membership_ids=[membership.user_id],
+            )
+            self.audit_service.record(
+                organization_id=pending_invitation.organization_id,
+                action=AuditAction.UPDATE,
+                actor=actor,
+                subject=self.audit_service.subject_from_instance(pending_invitation),
+                diff={"accepted_at": {"old": None, "new": now.isoformat()}},
+            )
             return membership
 
         if organization_name:
@@ -440,7 +528,24 @@ class OrganizationService:
         """
         try:
             invitation = OrganizationInvitation.objects.get(id=invitation_id)
-            invitation.expires_at = datetime.datetime.now(tz=datetime.UTC)
+            old_expires_at = invitation.expires_at
+            now = datetime.datetime.now(tz=datetime.UTC)
+            invitation.expires_at = now
             invitation.save()
         except OrganizationInvitation.DoesNotExist as e:
             raise InvitationNotFoundError() from e
+
+        # Audit: revoking an invitation expires it immediately. No acting User is
+        # threaded into this method, so the actor is the system.
+        self.audit_service.record(
+            organization_id=invitation.organization_id,
+            action=AuditAction.UPDATE,
+            actor=self.audit_service.system_actor(),
+            subject=self.audit_service.subject_from_instance(invitation),
+            diff={
+                "expires_at": {
+                    "old": old_expires_at.isoformat() if old_expires_at else None,
+                    "new": now.isoformat(),
+                }
+            },
+        )

--- a/organizations/tests/test_audit.py
+++ b/organizations/tests/test_audit.py
@@ -1,0 +1,150 @@
+"""Audit-emission tests for OrganizationService write paths.
+
+Each test drives a real OrganizationService (audit_service injected via the DI
+container) and asserts that the expected audit record(s) are enqueued. We patch
+``audit.services.persist_audit_record`` and execute the on_commit callbacks so the
+enqueue happens, then inspect the serialized payloads.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from model_bakery import baker
+
+from audit.constants import AuditAction
+from organizations.models import (
+    Organization,
+    OrganizationInvitation,
+    OrganizationRole,
+)
+from organizations.services import OrganizationService
+
+
+def _payloads(mock_task) -> list[dict]:
+    return [call.args[0] for call in mock_task.delay.call_args_list]
+
+
+def _subjects(mock_task) -> set[str]:
+    return {p["subject"]["subject_type"] for p in _payloads(mock_task)}
+
+
+@pytest.mark.django_db
+class TestOrganizationServiceAudit:
+    def _service(self) -> OrganizationService:
+        from di_core.containers import container
+
+        with container.calendar_service.override(Mock()):
+            return OrganizationService()
+
+    def test_create_organization_records_org_and_membership(
+        self, django_capture_on_commit_callbacks
+    ) -> None:
+        user = baker.make("users.User")
+        service = self._service()
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                org = service.create_organization(creator=user, name="ACME")
+
+        payloads = _payloads(mock_task)
+        assert _subjects(mock_task) == {
+            "organizations.Organization",
+            "organizations.OrganizationMembership",
+        }
+        # Actor is the creator's freshly-minted admin membership.
+        for p in payloads:
+            assert p["organization_id"] == org.id
+            assert p["action"] == AuditAction.CREATE
+            assert p["actor"]["actor_type"] == "membership"
+            assert p["actor"]["actor_id"] == user.id
+            assert p["actor"]["actor_role"] == OrganizationRole.ADMIN
+
+    def test_invite_user_records_create(self, django_capture_on_commit_callbacks) -> None:
+        org = baker.make(Organization)
+        inviter = baker.make("users.User")
+        baker.make(
+            "organizations.OrganizationMembership",
+            user=inviter,
+            organization=org,
+            role=OrganizationRole.ADMIN,
+        )
+        service = self._service()
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                service.invite_user_to_organization(
+                    email="new@example.com",
+                    organization=org,
+                    invited_by=inviter,
+                    first_name="New",
+                    last_name="User",
+                    send_email=False,
+                )
+
+        payloads = _payloads(mock_task)
+        assert len(payloads) == 1
+        assert payloads[0]["subject"]["subject_type"] == "organizations.OrganizationInvitation"
+        assert payloads[0]["action"] == AuditAction.CREATE
+        assert payloads[0]["actor"]["actor_id"] == inviter.id
+
+    def test_accept_invitation_records_membership_and_invitation(
+        self, django_capture_on_commit_callbacks
+    ) -> None:
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        org = baker.make(Organization)
+        user = baker.make("users.User", email="joiner@example.com")
+        raw = generate_long_lived_token()
+        import datetime
+
+        invitation = OrganizationInvitation.objects.create(
+            email="joiner@example.com",
+            organization=org,
+            token_hash=hash_long_lived_token(raw),
+            role=OrganizationRole.MEMBER,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=1),
+        )
+        service = self._service()
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                service.accept_invitation(token=raw, user=user)
+
+        assert _subjects(mock_task) == {
+            "organizations.OrganizationMembership",
+            "organizations.OrganizationInvitation",
+        }
+        for p in _payloads(mock_task):
+            assert p["organization_id"] == org.id
+            assert p["actor"]["actor_id"] == user.id
+        assert invitation.organization_id == org.id
+
+    def test_revoke_invitation_records_update_with_system_actor(
+        self, django_capture_on_commit_callbacks
+    ) -> None:
+        import datetime
+
+        org = baker.make(Organization)
+        invitation = OrganizationInvitation.objects.create(
+            email="x@example.com",
+            organization=org,
+            token_hash="hash",
+            role=OrganizationRole.MEMBER,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=5),
+        )
+        service = self._service()
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                service.revoke_invitation(invitation_id=str(invitation.id))
+
+        payloads = _payloads(mock_task)
+        assert len(payloads) == 1
+        assert payloads[0]["action"] == AuditAction.UPDATE
+        assert payloads[0]["actor"]["actor_type"] == "system"
+        assert "expires_at" in payloads[0]["diff"]

--- a/public_api/services.py
+++ b/public_api/services.py
@@ -1,5 +1,9 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
+from dependency_injector.wiring import Provide, inject
+
+from audit.constants import AuditAction
+from audit.services import AuditService
 from common.utils.authentication_utils import (
     generate_long_lived_token,
     hash_long_lived_token,
@@ -13,6 +17,13 @@ if TYPE_CHECKING:
 
 
 class PublicAPIAuthService:
+    @inject
+    def __init__(
+        self,
+        audit_service: Annotated[AuditService, Provide["audit_service"]],
+    ) -> None:
+        self.audit_service = audit_service
+
     def check_system_user_token(self, system_user_id: int, token: str) -> tuple[SystemUser, bool]:
         """
         Check if the provided token matches the system user's long-lived token.
@@ -61,4 +72,17 @@ class PublicAPIAuthService:
         if scoped_to_membership is not None:
             create_kwargs["scoped_to_membership_user_id"] = scoped_to_membership.user_id
         system_user = SystemUser.objects.create(**create_kwargs)
+
+        # Audit: a system-user (API integration credential) is provisioned for the org.
+        # No acting Django User is threaded here, so the actor is the system; when the
+        # token is membership-scoped, that membership is the affected party.
+        self.audit_service.record(
+            organization_id=organization.id,
+            action=AuditAction.CREATE,
+            actor=self.audit_service.system_actor(),
+            subject=self.audit_service.subject_from_instance(system_user),
+            affected_membership_ids=(
+                [scoped_to_membership.user_id] if scoped_to_membership is not None else []
+            ),
+        )
         return system_user, token

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -776,7 +776,7 @@ class TestCreateInvitationMutation:
         its own UI.
 
         Asserts:
-        - transaction.on_commit is NOT called (no email scheduled).
+        - the invitation email is NOT scheduled (no notification created).
         - token and inviteUrl are non-null in the response.
         - inviteUrl contains the raw token.
         """
@@ -788,7 +788,9 @@ class TestCreateInvitationMutation:
 
         with (
             container.public_api_auth_service.override(auth_service),
-            patch("organizations.services.transaction.on_commit") as mock_on_commit,
+            patch(
+                "organizations.services.NotificationService.create_one_off_notification"
+            ) as mock_send_email,
         ):
             response = self.client.post(
                 "/graphql/",
@@ -818,8 +820,10 @@ class TestCreateInvitationMutation:
         # inviteUrl must embed the raw token
         assert returned_token in invite_url
 
-        # transaction.on_commit must NOT have been called — no email was scheduled
-        mock_on_commit.assert_not_called()
+        # The invitation email must NOT be scheduled when sendEmail=false. (Asserting
+        # on the notification directly rather than transaction.on_commit, since the
+        # audit trail now also schedules an on_commit to enqueue its record.)
+        mock_send_email.assert_not_called()
 
     def test_send_email_false_returned_token_validates_via_accept_invitation(self):
         """The raw token returned when sendEmail=false must be usable with accept_invitation.

--- a/public_api/tests/test_provisioning_flow.py
+++ b/public_api/tests/test_provisioning_flow.py
@@ -531,7 +531,9 @@ class TestCreateInvitationProvisioning:
 
         with (
             container.public_api_auth_service.override(auth_service),
-            patch("organizations.services.transaction.on_commit") as mock_on_commit,
+            patch(
+                "organizations.services.NotificationService.create_one_off_notification"
+            ) as mock_send_email,
         ):
             response = self.client.post(
                 "/graphql/",
@@ -552,8 +554,10 @@ class TestCreateInvitationProvisioning:
         assert response.status_code == 200
         data = response.json()
         assert "errors" not in data or len(data.get("errors", [])) == 0
-        # transaction.on_commit must NOT have been called — no email was scheduled
-        mock_on_commit.assert_not_called()
+        # The invitation email must NOT be scheduled when sendEmail=False. (We assert
+        # on the notification directly rather than transaction.on_commit, since the
+        # audit trail now also schedules an on_commit to enqueue its record.)
+        mock_send_email.assert_not_called()
 
 
 CREATE_SYSTEM_USER_TOKEN_MUTATION = """


### PR DESCRIPTION
- Added audit-emission tests for CalendarBundleService and CalendarEventService to ensure correct audit records are created for business writes.
- Enhanced OrganizationService to include audit logging for organization creation, user invitations, and invitation acceptance/revocation.
- Integrated AuditService into PublicAPIAuthService for auditing system user provisioning.
- Updated test cases to verify that audit records are generated correctly during various service operations.
- Refactored service methods to include audit logging, capturing relevant actions, actors, and diffs where applicable.