### PR TITLE
feat(public_api): add rescheduleCalendarEvent mutation

### DIFF
--- a/ai-plans/TRACKING_OWNER_SCOPED_RESCHEDULE_CANCEL_MUTATIONS.md
+++ b/ai-plans/TRACKING_OWNER_SCOPED_RESCHEDULE_CANCEL_MUTATIONS.md
@@ -22,8 +22,8 @@
 |---|---|---|---|
 | 0a | Service write-allowance for public tokens | 3 | ✅ done |
 | 0b | Single-occurrence exception service methods | 4 | ✅ done |
-| 1 | `rescheduleCalendarEvent` mutation | 3 | ⏳ next |
-| 2 | `rescheduleCalendarGroupEvent` mutation | 3 | ⬜ pending |
+| 1 | `rescheduleCalendarEvent` mutation | 3 | ✅ done |
+| 2 | `rescheduleCalendarGroupEvent` mutation | 3 | ⏳ next |
 | 3 | `cancelEvent` mutation | 3 | ⬜ pending |
 
 Deferred: none (no cross-repo phases, no flag-removal phase).
@@ -49,8 +49,17 @@ Deferred: none (no cross-repo phases, no flag-removal phase).
 - **Outer gate:** serial scoped module 35 passed; clean full `pytest -n auto` → **3161 passed**. NOTE: shared compose `db` is contended by concurrent worktree suites — full-suite `EEEE` clusters at teardown are ENVIRONMENTAL; verify suspects via serial `-p no:randomly`.
 - **For later phases:** Phase 1 wraps `reschedule_event_occurrence` (when `recurrenceId` given) + `update_event` (whole/series) for `rescheduleCalendarEvent`. Phase 3 wraps `cancel_event_occurrence` (`recurrenceId`) + `delete_event` (`deleteSeries`) for `cancelEvent`. Facade methods: `calendar_service.reschedule_event_occurrence(...)`, `calendar_service.cancel_event_occurrence(...)`.
 
+### Phase 1 — `rescheduleCalendarEvent` Public GraphQL mutation ✅
+- **Model used:** sonnet (plan tier 3). **Branch:** `plan/owner-scoped-reschedule-cancel-mutations/phase-1` (stacked on phase-0b).
+- **Commits:** `e9b9167` (feat mutation), `3ccb67d` (test: preservation + non-recurring guard, docstring).
+- **What shipped:** `rescheduleCalendarEvent` mutation on the `Mutation` class in `public_api/mutations.py` + `RescheduleCalendarEventInput` (organization_id, calendar_id, event_id, start/end/timezone, optional rrule_string, optional recurrence_id). Decorated `[IsAuthenticated, OrganizationResourceAccess]`, returns `CalendarEventGraphQLType`, raises `GraphQLError`. Owner-scope guard mirrors `schedule_event` (`assert_calendar_in_owner_scope` + Calendar load → `"Calendar not found."` parity). Event load → `"Event not found."`. `recurrence_id` set → `reschedule_event_occurrence` (Phase 0b); else whole/series via `update_event` preserving title/description/attendances/external/resources, with **rrule preservation** (`input.rrule_string` → existing `recurrence_rule.to_rrule_string()` → None). `FIELD_TO_RESOURCE_MAPPING["rescheduleCalendarEvent"] = CALENDAR_EVENT` (already provider-scoped).
+- **Tests:** `public_api/tests/test_mutations.py::TestScopedTokenRescheduleCalendarEvent` (10) — whole-event success, field/attendee/resource/description preservation, series rule preserved (no rrule) + replaced (explicit rrule), single-occurrence creates exception/master untouched, non-recurring+recurrenceId clean error, cross-owner not-found parity (no mutation), org-wide acts org-wide, missing-event.
+- **Review:** Layer 1/2/3 clean. No BLOCKERs; reviewer verified `to_rrule_string`/`from_rrule_string` symmetry + `update_event` preserves rule id (no series strip). SHOULD-FIX (preservation asserted title-only; non-recurring guard untested) applied; NITs (naive-dt factory, redundant prefetch) skipped as pre-existing/harmless.
+- **Outer gate:** serial scoped + Phase 1 tests green; full `pytest -n auto` → **3171 passed**.
+- **Env note:** main checkout's `package.json`/`package-lock.json` show a `vinta-ai-workflows ^0.2.0-alpha1 → alpha3` tooling bump that appeared mid-session (unrelated to this feature; NOT a worktree stray write — worktree tree is clean). Excluded from stray-write checks for remaining phases.
+
 ## Current Phase
-**Phase 1** — `rescheduleCalendarEvent` Public GraphQL mutation.
+**Phase 2** — `rescheduleCalendarGroupEvent` Public GraphQL mutation.
 
 ## Remaining Phases
-1 (next), 2, 3.
+2 (next), 3.

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -27,7 +27,7 @@ from calendar_integration.graphql import (
     CalendarEventGraphQLType,
     CalendarGraphQLType,
 )
-from calendar_integration.models import Calendar
+from calendar_integration.models import Calendar, CalendarEvent
 from calendar_integration.mutations import (
     CalendarGroupMutations,
     ExternalEventChangeRequestMutations,
@@ -37,6 +37,7 @@ from calendar_integration.services.dataclasses import (
     EventAttendanceInputData,
     EventExternalAttendanceInputData,
     ExternalAttendeeInputData,
+    ResourceAllocationInputData,
 )
 from organizations.exceptions import NoServiceAccountConfiguredError, UserAlreadyHasMembershipError
 from organizations.models import Organization, OrganizationBranding, OrganizationMembership
@@ -622,6 +623,37 @@ class ScheduleEventInput:
         default_factory=list
     )
     rrule_string: str | None = None
+
+
+@strawberry.input
+class RescheduleCalendarEventInput:
+    """Input for rescheduling a single-calendar event via a public-API token.
+
+    Supports three modes:
+    - **Whole event / series** (``recurrence_id`` omitted): updates the event's time fields
+      and, optionally, its recurrence rule. The existing rule is preserved when
+      ``rrule_string`` is omitted — callers must not strip the series accidentally.
+    - **Series with new rule** (``recurrence_id`` omitted, ``rrule_string`` provided):
+      moves the event AND updates the recurrence pattern.
+    - **Single occurrence** (``recurrence_id`` provided): reschedules exactly the
+      occurrence whose original start equals ``recurrence_id`` without touching the
+      master or any other occurrence.
+
+    An owner-scoped token may only reschedule events on calendars its owner owns;
+    an org-wide token acts org-wide.
+    """
+
+    organization_id: int
+    calendar_id: int
+    event_id: int
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+    # Optional: change the series' recurrence pattern. Omit to PRESERVE the existing rule.
+    rrule_string: str | None = None
+    # Optional: when set, reschedule ONLY this occurrence of a recurring series
+    # (the occurrence's original start == CalendarEvent.recurrence_id). Omit for whole event/series.
+    recurrence_id: datetime.datetime | None = None
 
 
 @strawberry.type
@@ -2053,6 +2085,140 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         except PermissionDenied as exc:
             raise GraphQLError(
                 str(exc) or "You do not have permission to schedule this event."
+            ) from exc
+        except (ValueError, DjangoValidationError, CalendarIntegrationError) as exc:
+            raise GraphQLError(str(exc)) from exc
+
+        return event  # type: ignore[return-value]
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def reschedule_calendar_event(
+        self,
+        info: strawberry.Info,
+        input: RescheduleCalendarEventInput,  # noqa: A002
+    ) -> CalendarEventGraphQLType:
+        """Reschedule a single-calendar event (whole, series-preserving, or single-occurrence).
+
+        Three distinct paths share a single resolver:
+
+        1. **Single-occurrence** (``input.recurrence_id`` is set): delegates to
+           ``CalendarService.reschedule_event_occurrence``, which creates or updates a
+           modified-occurrence ``EventRecurrenceException`` without touching the master or the
+           series rule.
+
+        2. **Whole event / series** (``input.recurrence_id`` is None): builds a
+           ``CalendarEventInputData`` that preserves the existing event's non-time fields
+           (title, description, attendances, external attendances, resource allocations) while
+           overriding start/end/timezone and the recurrence rule.  **Rule preservation:** if
+           ``input.rrule_string`` is omitted, the master's existing rule string is re-passed so
+           ``update_event`` does not silently strip the series.
+
+        Authorization:
+        - Owner-scoped token: ``assert_calendar_in_owner_scope`` restricts to calendars owned
+          by the token's owner; cross-owner → ``"Calendar not found."`` (same as missing).
+        - Org-wide token: ``assert_calendar_in_owner_scope`` is a no-op → acts org-wide.
+        - The service independently re-verifies ownership as defense-in-depth.
+        """
+        calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
+
+        # Owner-scope guard: a scoped token may only target its owner's calendars.
+        # Cross-owner and missing calendars return the identical error — no existence leak.
+        try:
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, input.calendar_id)
+            Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
+        except Calendar.DoesNotExist as exc:
+            raise GraphQLError("Calendar not found.") from exc
+
+        # Load the event — needed for the whole-event/series path (to preserve non-time
+        # fields) and to validate ownership independently of the calendar guard.
+        try:
+            existing_event = (
+                CalendarEvent.objects.filter_by_organization(org.id)
+                .select_related("calendar", "recurrence_rule")
+                .prefetch_related(
+                    "attendances",
+                    "external_attendances__external_attendee",
+                    "resource_allocations",
+                )
+                .get(id=input.event_id, calendar_fk_id=input.calendar_id)
+            )
+        except CalendarEvent.DoesNotExist as exc:
+            raise GraphQLError("Event not found.") from exc
+
+        try:
+            if input.recurrence_id is not None:
+                # Single-occurrence path: create / update a modified exception for exactly
+                # this one occurrence; master and series rule are untouched.
+                event = calendar_service.reschedule_event_occurrence(
+                    calendar_id=input.calendar_id,
+                    master_event_id=input.event_id,
+                    recurrence_id=input.recurrence_id,
+                    start_time=input.start_time,
+                    end_time=input.end_time,
+                    timezone=input.timezone,
+                )
+            else:
+                # Whole-event / series path: preserve all non-time fields from the existing
+                # event and override only start/end/timezone (+ optionally the rrule).
+
+                # Preserve internal attendances.
+                preserved_attendances = [
+                    EventAttendanceInputData(user_id=attendance.membership_user_id)
+                    for attendance in existing_event.attendances.all()
+                    if attendance.membership_user_id is not None
+                ]
+
+                # Preserve external attendances — carry the ExternalAttendee id so that
+                # update_event can correlate status and detect "no change" correctly.
+                preserved_external_attendances = [
+                    EventExternalAttendanceInputData(
+                        external_attendee=ExternalAttendeeInputData(
+                            email=ea.external_attendee.email,
+                            name=ea.external_attendee.name or "",
+                            id=ea.external_attendee_fk_id,
+                        )
+                    )
+                    for ea in existing_event.external_attendances.all()
+                    if ea.external_attendee_fk_id is not None
+                ]
+
+                # Preserve resource allocations.
+                preserved_resource_allocations = [
+                    ResourceAllocationInputData(resource_id=ra.calendar_fk_id)  # type: ignore[arg-type]
+                    for ra in existing_event.resource_allocations.all()
+                    if ra.calendar_fk_id
+                ]
+
+                # Recurrence rule preservation: if the caller omits rrule_string, re-pass
+                # the existing rule string so update_event does NOT strip the series.
+                # (update_event deletes the rule when recurrence_rule=None.)
+                if input.rrule_string is not None:
+                    recurrence_rule = input.rrule_string
+                elif existing_event.is_recurring:
+                    recurrence_rule = existing_event.recurrence_rule.to_rrule_string()
+                else:
+                    recurrence_rule = None
+
+                event_data = CalendarEventInputData(
+                    title=existing_event.title,
+                    description=existing_event.description or "",
+                    start_time=input.start_time,
+                    end_time=input.end_time,
+                    timezone=input.timezone,
+                    attendances=preserved_attendances,
+                    external_attendances=preserved_external_attendances,
+                    resource_allocations=preserved_resource_allocations,
+                    recurrence_rule=recurrence_rule,
+                )
+                event = calendar_service.update_event(input.calendar_id, input.event_id, event_data)
+        except Calendar.DoesNotExist as exc:
+            raise GraphQLError("Calendar not found.") from exc
+        except CalendarEvent.DoesNotExist as exc:
+            raise GraphQLError("Event not found.") from exc
+        except PermissionDenied as exc:
+            raise GraphQLError(
+                str(exc) or "You do not have permission to reschedule this event."
             ) from exc
         except (ValueError, DjangoValidationError, CalendarIntegrationError) as exc:
             raise GraphQLError(str(exc)) from exc

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -2109,9 +2109,13 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         2. **Whole event / series** (``input.recurrence_id`` is None): builds a
            ``CalendarEventInputData`` that preserves the existing event's non-time fields
            (title, description, attendances, external attendances, resource allocations) while
-           overriding start/end/timezone and the recurrence rule.  **Rule preservation:** if
-           ``input.rrule_string`` is omitted, the master's existing rule string is re-passed so
-           ``update_event`` does not silently strip the series.
+           overriding start/end/timezone and the recurrence rule.
+
+           - **Series-preserving sub-case** (``input.rrule_string`` is None): the master's
+             existing rule string is re-passed so ``update_event`` does not silently strip the
+             series.
+           - **Explicit-new-rule sub-case** (``input.rrule_string`` provided): the new rule
+             replaces the existing one.
 
         Authorization:
         - Owner-scoped token: ``assert_calendar_in_owner_scope`` restricts to calendars owned

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -71,6 +71,7 @@ class OrganizationResourceAccess(BasePermission):
         "updateBlockedTime": PublicAPIResources.UPDATE_BLOCKED_TIME,
         "deleteBlockedTime": PublicAPIResources.DELETE_BLOCKED_TIME,
         "scheduleEvent": PublicAPIResources.CALENDAR_EVENT,
+        "rescheduleCalendarEvent": PublicAPIResources.CALENDAR_EVENT,
         "calendarBundles": PublicAPIResources.CALENDAR_BUNDLE,
         "createCalendarBundle": PublicAPIResources.CREATE_CALENDAR_BUNDLE,
         "updateCalendarBundle": PublicAPIResources.UPDATE_CALENDAR_BUNDLE,

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -9341,3 +9341,535 @@ class TestScopedTokenScheduleEvent:
             .filter(calendar_fk_id=calendar.id)
             .exists()
         )
+
+
+# ---------------------------------------------------------------------------
+# rescheduleCalendarEvent mutation tests
+# ---------------------------------------------------------------------------
+
+
+_RESCHEDULE_CALENDAR_EVENT = """
+mutation RescheduleCalendarEvent($input: RescheduleCalendarEventInput!) {
+    rescheduleCalendarEvent(input: $input) {
+        id
+        title
+        description
+        startTime
+        endTime
+    }
+}
+"""
+
+_RESCHEDULE_CALENDAR_EVENT_WITH_RRULE = """
+mutation RescheduleCalendarEvent($input: RescheduleCalendarEventInput!) {
+    rescheduleCalendarEvent(input: $input) {
+        id
+        title
+        recurrenceRule {
+            id
+            rruleString
+        }
+        startTime
+        endTime
+    }
+}
+"""
+
+
+def _make_calendar_with_ownership(org) -> tuple:
+    """Create a provider user, membership, and a plain (no availability) calendar.
+
+    Returns (owner_user, membership, calendar).
+    """
+    from calendar_integration.models import CalendarOwnership
+
+    unique = uuid.uuid4().hex[:8]
+    user_model = get_user_model()
+    owner = baker.make(user_model, email=f"resched_owner_{unique}@example.com")
+    membership = baker.make(OrganizationMembership, user=owner, organization=org, is_active=True)
+    calendar = baker.make(
+        Calendar,
+        organization=org,
+        name=f"Provider Resched Calendar {unique}",
+        external_id=f"resched-cal-{unique}",
+        manage_available_windows=False,
+    )
+    baker.make(
+        CalendarOwnership,
+        calendar=calendar,
+        membership_user_id=owner.id,
+        organization=org,
+    )
+    return owner, membership, calendar
+
+
+def _make_event_on_calendar(org, calendar, *, title="Meeting", **extra):
+    """Create a minimal CalendarEvent on the given calendar via baker."""
+    from calendar_integration.models import CalendarEvent as _CalendarEvent
+
+    return baker.make(
+        _CalendarEvent,
+        organization=org,
+        calendar=calendar,
+        title=title,
+        external_id=f"evt-{uuid.uuid4().hex[:10]}",
+        start_time_tz_unaware=datetime.datetime(2026, 10, 1, 10, 0, 0),
+        end_time_tz_unaware=datetime.datetime(2026, 10, 1, 11, 0, 0),
+        timezone="UTC",
+        **extra,
+    )
+
+
+def _make_recurring_event_on_calendar(org, calendar) -> tuple:
+    """Create a recurring master CalendarEvent (weekly, 4 occurrences) directly in DB.
+
+    Returns (master_event, recurrence_rule).
+    """
+    from calendar_integration.models import CalendarEvent as _CalendarEvent
+    from calendar_integration.models import RecurrenceRule
+
+    rule = RecurrenceRule.from_rrule_string("FREQ=WEEKLY;COUNT=4;BYDAY=TH", organization=org)
+    rule.save()
+    master = _CalendarEvent.objects.create(
+        title="Weekly Standup",
+        description="Recurring meeting",
+        start_time_tz_unaware=datetime.datetime(2026, 10, 2, 10, 0, 0),
+        end_time_tz_unaware=datetime.datetime(2026, 10, 2, 11, 0, 0),
+        timezone="UTC",
+        external_id=f"recurring-{uuid.uuid4().hex[:8]}",
+        calendar=calendar,
+        organization=org,
+    )
+    master.recurrence_rule = rule
+    master.save()
+    return master, rule
+
+
+@pytest.mark.django_db
+class TestScopedTokenRescheduleCalendarEvent:
+    """Integration tests for the owner-scoped ``rescheduleCalendarEvent`` mutation (Phase 1).
+
+    Coverage:
+    - Scoped token reschedules its own event (whole event) → times change, title preserved.
+    - Recurring master rescheduled WITHOUT rruleString → recurrence rule is preserved (id
+      unchanged, only times move).
+    - Recurring master rescheduled WITH explicit rruleString → rule is updated.
+    - Single occurrence (recurrenceId set) → modified EventRecurrenceException created, master
+      and its rule untouched.
+    - Cross-owner denial → identical ``"Calendar not found."`` as a genuinely missing calendar
+      + no mutation occurs (no existence leak).
+    - Org-wide token acts org-wide → can reschedule any event in the org.
+    - Wrong event_id (valid owned calendar, non-existent event) → ``"Event not found."``.
+    - Missing CALENDAR_EVENT grant → denied by permission class.
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_resched_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_org_wide_system_user(self, org, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_resched_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def _reschedule_input(self, org, calendar, event, **overrides):
+        base = {
+            "organizationId": org.id,
+            "calendarId": calendar.id,
+            "eventId": event.id,
+            "startTime": datetime.datetime(2026, 10, 5, 10, 0, 0, tzinfo=datetime.UTC).isoformat(),
+            "endTime": datetime.datetime(2026, 10, 5, 11, 0, 0, tzinfo=datetime.UTC).isoformat(),
+            "timezone": "UTC",
+        }
+        base.update(overrides)
+        return base
+
+    # ------------------------------------------------------------------
+    # Happy path — whole event
+    # ------------------------------------------------------------------
+
+    def test_reschedule_whole_event_times_change_title_preserved(self):
+        """Scoped token reschedules its own event: times update, non-time fields preserved."""
+        from calendar_integration.models import CalendarEvent as _CalendarEvent
+
+        org = baker.make(Organization, name="Resched Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+        event = _make_event_on_calendar(org, calendar, title="Original Title")
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        new_start = datetime.datetime(2026, 10, 5, 14, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 5, 15, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_input(
+                    org,
+                    calendar,
+                    event,
+                    startTime=new_start.isoformat(),
+                    endTime=new_end.isoformat(),
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarEvent"]
+        assert result is not None
+        assert result["title"] == "Original Title"
+        # Confirm the DB row was updated: compare naive values (Django may return the field
+        # as UTC-aware under USE_TZ=True, so strip tzinfo from both sides before comparing).
+        updated = _CalendarEvent.objects.filter_by_organization(org.id).get(id=int(result["id"]))
+        assert updated.start_time_tz_unaware.replace(tzinfo=None) == new_start.replace(tzinfo=None)
+        assert updated.end_time_tz_unaware.replace(tzinfo=None) == new_end.replace(tzinfo=None)
+
+    # ------------------------------------------------------------------
+    # Recurrence rule preservation
+    # ------------------------------------------------------------------
+
+    def test_reschedule_recurring_without_rrule_string_preserves_rule(self):
+        """Rescheduling a recurring master WITHOUT rruleString preserves the recurrence rule.
+
+        The rule id must be unchanged and only the times move — no silent series strip.
+        """
+        org = baker.make(Organization, name="Resched Rrule Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+        master, rule = _make_recurring_event_on_calendar(org, calendar)
+        original_rule_id = rule.id
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT_WITH_RRULE,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_input(
+                    org,
+                    calendar,
+                    master,
+                    startTime=datetime.datetime(
+                        2026, 10, 9, 10, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    endTime=datetime.datetime(
+                        2026, 10, 9, 11, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    # rruleString is deliberately omitted → rule must be preserved
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarEvent"]
+        assert result["recurrenceRule"] is not None
+        # Rule id must be unchanged (no strip, no new rule object created)
+        master.refresh_from_db()
+        assert master.recurrence_rule_fk_id == original_rule_id
+
+    def test_reschedule_recurring_with_explicit_rrule_string_updates_rule(self):
+        """Rescheduling a recurring master WITH an explicit rruleString updates the rule."""
+        org = baker.make(Organization, name="Resched Rrule Update Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+        master, _rule = _make_recurring_event_on_calendar(org, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT_WITH_RRULE,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_input(
+                    org,
+                    calendar,
+                    master,
+                    startTime=datetime.datetime(
+                        2026, 10, 9, 10, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    endTime=datetime.datetime(
+                        2026, 10, 9, 11, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    rruleString="RRULE:FREQ=DAILY;COUNT=3",
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarEvent"]
+        assert result["recurrenceRule"] is not None
+        # The rrule string must reflect the new rule, not the original WEEKLY one
+        assert "DAILY" in result["recurrenceRule"]["rruleString"]
+
+    # ------------------------------------------------------------------
+    # Single-occurrence reschedule
+    # ------------------------------------------------------------------
+
+    def test_reschedule_single_occurrence_creates_exception_master_untouched(self):
+        """Rescheduling with recurrenceId creates a modified EventRecurrenceException.
+
+        The master event and its series rule must remain unchanged.
+        """
+        from calendar_integration.models import EventRecurrenceException
+
+        org = baker.make(Organization, name="Resched Occurrence Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+        master, rule = _make_recurring_event_on_calendar(org, calendar)
+        original_rule_id = rule.id
+        # recurrence_id is the original start of the occurrence we want to reschedule
+        recurrence_id = datetime.datetime(2026, 10, 2, 10, 0, 0, tzinfo=datetime.UTC)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        new_start = datetime.datetime(2026, 10, 3, 14, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 3, 15, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_input(
+                    org,
+                    calendar,
+                    master,
+                    startTime=new_start.isoformat(),
+                    endTime=new_end.isoformat(),
+                    recurrenceId=recurrence_id.isoformat(),
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarEvent"]
+        assert result is not None
+
+        # An EventRecurrenceException for this occurrence must now exist
+        exc = EventRecurrenceException.objects.filter_by_organization(org.id).get(
+            parent_event_fk_id=master.id,
+        )
+        assert exc.is_cancelled is False
+        assert exc.modified_event is not None
+
+        # Master and series rule are untouched
+        master.refresh_from_db()
+        assert master.recurrence_rule_fk_id == original_rule_id
+
+    # ------------------------------------------------------------------
+    # Cross-owner denial (no existence leak)
+    # ------------------------------------------------------------------
+
+    def test_reschedule_cross_owner_not_found_same_as_missing_calendar(self):
+        """Cross-owner calendar yields identical 'Calendar not found.' as a missing calendar.
+
+        No event is modified; the attacker learns nothing about the target's existence.
+        """
+        org = baker.make(Organization, name="Resched CrossOwner Org")
+        _owner_a, membership_a, _calendar_a = _make_calendar_with_ownership(org)
+        _owner_b, _membership_b, calendar_b = _make_calendar_with_ownership(org)
+        event_b = _make_event_on_calendar(org, calendar_b, title="B's Event")
+        original_start = event_b.start_time_tz_unaware
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        # Attempt to reschedule B's event from A's scoped token
+        cross_response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar_b.id,
+                    "eventId": event_b.id,
+                    "startTime": datetime.datetime(
+                        2026, 10, 5, 14, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "endTime": datetime.datetime(
+                        2026, 10, 5, 15, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Attempt to reschedule a genuinely missing calendar
+        missing_response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": 999996,
+                    "eventId": event_b.id,
+                    "startTime": datetime.datetime(
+                        2026, 10, 5, 14, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "endTime": datetime.datetime(
+                        2026, 10, 5, 15, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        cross_msg = cross_response.json()["errors"][0]["message"]
+        missing_msg = missing_response.json()["errors"][0]["message"]
+        assert cross_msg == missing_msg == "Calendar not found."
+
+        # B's event must be unmodified — compare naive values (Django USE_TZ may add UTC info)
+        event_b.refresh_from_db()
+        assert event_b.start_time_tz_unaware.replace(tzinfo=None) == original_start.replace(
+            tzinfo=None
+        )
+
+    # ------------------------------------------------------------------
+    # Org-wide token
+    # ------------------------------------------------------------------
+
+    def test_reschedule_org_wide_token_acts_org_wide(self):
+        """An org-wide token can reschedule any event in the org."""
+        from calendar_integration.models import CalendarEvent as _CalendarEvent
+
+        org = baker.make(Organization, name="Resched OrgWide Org")
+        _owner, _membership, calendar = _make_calendar_with_ownership(org)
+        event = _make_event_on_calendar(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        new_start = datetime.datetime(2026, 10, 5, 14, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 10, 5, 15, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_input(
+                    org,
+                    calendar,
+                    event,
+                    startTime=new_start.isoformat(),
+                    endTime=new_end.isoformat(),
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarEvent"]
+        assert result is not None
+        updated = _CalendarEvent.objects.filter_by_organization(org.id).get(id=int(result["id"]))
+        assert updated.start_time_tz_unaware.replace(tzinfo=None) == new_start.replace(tzinfo=None)
+
+    # ------------------------------------------------------------------
+    # Negative paths
+    # ------------------------------------------------------------------
+
+    def test_reschedule_event_not_found_clean_error(self):
+        """Valid owned calendar but non-existent event_id → clean 'Event not found.' error."""
+        org = baker.make(Organization, name="Resched EventNotFound Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "eventId": 999995,
+                    "startTime": datetime.datetime(
+                        2026, 10, 5, 14, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "endTime": datetime.datetime(
+                        2026, 10, 5, 15, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Event not found."
+
+    def test_reschedule_missing_calendar_event_grant_denied(self):
+        """A token without the CALENDAR_EVENT grant is denied by the permission class."""
+        org = baker.make(Organization, name="Resched NoGrant Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+        event = _make_event_on_calendar(org, calendar)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CREATE_BLOCKED_TIME]
+        )
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._reschedule_input(org, calendar, event)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -9873,3 +9873,188 @@ class TestScopedTokenRescheduleCalendarEvent:
         data = response.json()
         assert "errors" in data and len(data["errors"]) > 0
         assert "don't have access" in str(data["errors"]).lower()
+
+    # ------------------------------------------------------------------
+    # Field-preservation: attendances, external attendances, resources, description
+    # ------------------------------------------------------------------
+
+    def test_reschedule_whole_event_preserves_attendances_resources_description(self):
+        """Whole-event reschedule keeps internal attendances, external attendances,
+        resource allocations, and description — only times change."""
+        from calendar_integration.models import (
+            EventAttendance,
+            EventExternalAttendance,
+            ExternalAttendee,
+            ResourceAllocation,
+        )
+        from users.models import Profile
+
+        org = baker.make(Organization, name="Resched Preserve Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+
+        # Create a second org member who will be an internal attendee on the event.
+        # A Profile row is required because update_event serializes attendee names.
+        user_model = get_user_model()
+        attendee_user = baker.make(
+            user_model, email=f"attendee_preserve_{uuid.uuid4().hex[:8]}@example.com"
+        )
+        baker.make(Profile, user=attendee_user, first_name="Attendee", last_name="Person")
+        baker.make(OrganizationMembership, user=attendee_user, organization=org, is_active=True)
+
+        # Create a resource (room/equipment) calendar to allocate.
+        resource_calendar = baker.make(
+            Calendar,
+            organization=org,
+            name=f"Resource Room {uuid.uuid4().hex[:8]}",
+            external_id=f"room-{uuid.uuid4().hex[:8]}",
+        )
+
+        # Create the event with a description.
+        event = _make_event_on_calendar(
+            org, calendar, title="Preservation Test", description="Keep this description"
+        )
+
+        # Attach one internal attendance (membership_user_id denormalized column).
+        baker.make(
+            EventAttendance,
+            event=event,
+            organization=org,
+            membership_user_id=attendee_user.id,
+        )
+
+        # Attach one external attendance.
+        external_attendee = baker.make(
+            ExternalAttendee,
+            organization=org,
+            email="external_preserve@example.com",
+            name="External Person",
+        )
+        baker.make(
+            EventExternalAttendance,
+            event=event,
+            organization=org,
+            external_attendee=external_attendee,
+        )
+
+        # Attach one resource allocation.
+        baker.make(
+            ResourceAllocation,
+            event=event,
+            organization=org,
+            calendar=resource_calendar,
+        )
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        new_start = datetime.datetime(2026, 11, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 1, 10, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_input(
+                    org,
+                    calendar,
+                    event,
+                    startTime=new_start.isoformat(),
+                    endTime=new_end.isoformat(),
+                    # No recurrenceId → whole-event path; no rruleString → preserve rule.
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarEvent"]
+        assert result is not None
+
+        event_id = int(result["id"])
+
+        # Times changed.
+        from calendar_integration.models import CalendarEvent as _CalendarEvent
+
+        updated = _CalendarEvent.objects.filter_by_organization(org.id).get(id=event_id)
+        assert updated.start_time_tz_unaware.replace(tzinfo=None) == new_start.replace(tzinfo=None)
+        assert updated.end_time_tz_unaware.replace(tzinfo=None) == new_end.replace(tzinfo=None)
+
+        # Description survived.
+        assert updated.description == "Keep this description"
+
+        # Internal attendance (membership_user_id) survived — count + id.
+        surviving_internal = list(
+            EventAttendance.objects.filter_by_organization(org.id).filter(event_fk_id=event_id)
+        )
+        assert len(surviving_internal) == 1
+        assert surviving_internal[0].membership_user_id == attendee_user.id
+
+        # External attendance survived — count + ExternalAttendee FK.
+        surviving_external = list(
+            EventExternalAttendance.objects.filter_by_organization(org.id).filter(
+                event_fk_id=event_id
+            )
+        )
+        assert len(surviving_external) == 1
+        assert surviving_external[0].external_attendee_fk_id == external_attendee.id
+
+        # Resource allocation survived — count + resource calendar FK.
+        surviving_resources = list(
+            ResourceAllocation.objects.filter_by_organization(org.id).filter(event_fk_id=event_id)
+        )
+        assert len(surviving_resources) == 1
+        assert surviving_resources[0].calendar_fk_id == resource_calendar.id
+
+    # ------------------------------------------------------------------
+    # Non-recurring event with recurrenceId → clean GraphQL error
+    # ------------------------------------------------------------------
+
+    def test_reschedule_non_recurring_event_with_recurrence_id_clean_error(self):
+        """Passing recurrenceId on a non-recurring event raises a clean GraphQL error.
+
+        The service raises ValueError which is mapped to GraphQLError — no 500, no
+        unhandled exception.  The event must be unchanged after the attempt.
+        """
+        org = baker.make(Organization, name="Resched NonRecurring Org")
+        _owner, membership, calendar = _make_calendar_with_ownership(org)
+        event = _make_event_on_calendar(org, calendar, title="Non-Recurring Event")
+        original_start = event.start_time_tz_unaware
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        # Pass an arbitrary recurrenceId on a non-recurring event.
+        fake_recurrence_id = datetime.datetime(2026, 10, 1, 10, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_input(
+                    org,
+                    calendar,
+                    event,
+                    recurrenceId=fake_recurrence_id.isoformat(),
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Must be a clean GraphQL error, not a 500.
+        assert "errors" in data and len(data["errors"]) > 0
+        error_message = data["errors"][0]["message"]
+        assert "non-recurring" in error_message.lower()
+
+        # Event must be unchanged.
+        event.refresh_from_db()
+        assert event.start_time_tz_unaware.replace(tzinfo=None) == original_start.replace(
+            tzinfo=None
+        )


### PR DESCRIPTION
## Summary
Phase 1 of the **Owner-Scoped Public Reschedule / Cancel Mutations** plan — the first GraphQL surface. Adds the authenticated public mutation `rescheduleCalendarEvent`, a thin owner-scoped wrapper over the Phase 0a/0b service methods.

Three modes via one resolver:
- **Whole event** (`recurrenceId` omitted, `rruleString` omitted): moves start/end/timezone, preserving every non-time field (title, description, attendances, external attendances, resource allocations) AND the recurrence rule.
- **Series with new rule** (`recurrenceId` omitted, `rruleString` set): moves the event and replaces the recurrence pattern.
- **Single occurrence** (`recurrenceId` set): reschedules exactly that occurrence via `CalendarService.reschedule_event_occurrence` (Phase 0b) — a modified-occurrence exception, master untouched.

Owner-scope guard mirrors `scheduleEvent`: an owner-scoped token may only reschedule events on calendars its owner owns (cross-owner → the identical `"Calendar not found."` as a genuinely missing calendar — no existence leak); an org-wide token acts org-wide. Returns `CalendarEventGraphQLType` directly and raises `GraphQLError` on failure (mirrors `scheduleEvent`). `"rescheduleCalendarEvent"` maps to `CALENDAR_EVENT` (already in `PROVIDER_SCOPED_RESOURCES`).

The `*WithCode` reschedule mutations are untouched (negative scope).

## Plan reference
`ai-plans/2026-06-22-OWNER_SCOPED_RESCHEDULE_CANCEL_MUTATIONS_IMPLEMENTATION_PLAN.md` — **Phase 1** (stacked on Phase 0b / PR #162). No feature flag. No migrations. No REST/OpenAPI schema change (GraphQL schema is generated at runtime by Strawberry).

## Test plan
- `docker compose run --rm api uv run pytest public_api/tests/test_mutations.py -k Reschedule -p no:randomly` — `TestScopedTokenRescheduleCalendarEvent` (10): whole-event success + field/attendee/resource/description preservation, series rule preserved (no rrule) and replaced (explicit rrule), single-occurrence creates the exception with master untouched, non-recurring + `recurrenceId` → clean error (no 500), cross-owner not-found parity (no mutation), org-wide acts org-wide, missing event.
- Outer gate: full `pytest -n auto` → **3171 passed**.