### PR TITLE
feat(public_api): add rescheduleCalendarGroupEvent mutation

### DIFF
--- a/ai-plans/TRACKING_OWNER_SCOPED_RESCHEDULE_CANCEL_MUTATIONS.md
+++ b/ai-plans/TRACKING_OWNER_SCOPED_RESCHEDULE_CANCEL_MUTATIONS.md
@@ -23,8 +23,8 @@
 | 0a | Service write-allowance for public tokens | 3 | ✅ done |
 | 0b | Single-occurrence exception service methods | 4 | ✅ done |
 | 1 | `rescheduleCalendarEvent` mutation | 3 | ✅ done |
-| 2 | `rescheduleCalendarGroupEvent` mutation | 3 | ⏳ next |
-| 3 | `cancelEvent` mutation | 3 | ⬜ pending |
+| 2 | `rescheduleCalendarGroupEvent` mutation | 3 | ✅ done |
+| 3 | `cancelEvent` mutation | 3 | ⏳ next |
 
 Deferred: none (no cross-repo phases, no flag-removal phase).
 
@@ -58,8 +58,18 @@ Deferred: none (no cross-repo phases, no flag-removal phase).
 - **Outer gate:** serial scoped + Phase 1 tests green; full `pytest -n auto` → **3171 passed**.
 - **Env note:** main checkout's `package.json`/`package-lock.json` show a `vinta-ai-workflows ^0.2.0-alpha1 → alpha3` tooling bump that appeared mid-session (unrelated to this feature; NOT a worktree stray write — worktree tree is clean). Excluded from stray-write checks for remaining phases.
 
+### Phase 2 — `rescheduleCalendarGroupEvent` Public GraphQL mutation ✅
+- **Model used:** sonnet (plan tier 3). **Branch:** `plan/owner-scoped-reschedule-cancel-mutations/phase-2` (stacked on phase-1).
+- **Commits:** `38cc93b` (feat mutation), `274a760` (fix: close existence leak — uniform not-found).
+- **What shipped:** `rescheduleCalendarGroupEvent` mutation + `RescheduleCalendarGroupEventInput` (organization_id, event_id, start/end/timezone). Loads the grouped event org-scoped, derives the primary calendar, owner-scope-checks it, wires `group_deps.calendar_group_service.calendar_service = <initialized calendar_service>` + `initialize(org)`, delegates to `reschedule_grouped_event` (moves primary event + linked `group-event-*` BlockedTimes). Whole-event only (group events not recurring in v1). `FIELD_TO_RESOURCE_MAPPING["rescheduleCalendarGroupEvent"] = CALENDAR_EVENT`.
+- **SECURITY (BLOCKER fixed):** Because the input is **event-addressed** (no calendar_id), the original two-message split (cross-owner → "Calendar not found.", missing → "Event not found.") was an existence-leak oracle: a scoped token could distinguish "a grouped event I don't own exists" from "doesn't exist". **Fixed to uniform `"Event not found."`** across ALL of: missing event, non-grouped event, cross-owner owner-scope-guard failure, AND the service-layer race (`PermissionDenied("Calendar matching query does not exist.")` sentinel → "Event not found."). NOTE: the **plan body's** API Design for this phase prescribed "Calendar not found." for the calendar-scope failure — that prescription was written for Phase 1's calendar-addressed shape and is SUPERSEDED here by the no-existence-leak invariant in Guiding Decisions. (Phase 1's `"Calendar not found."` stays correct — Phase 1 takes calendar_id as the addressing key.)
+- **Tests:** `TestScopedTokenRescheduleCalendarGroupEvent` (6) — success (primary event + linked BlockedTimes move), cross-owner uniform not-found (== missing message, no mutation), org-wide acts org-wide, non-grouped → "Event not found.", PermissionDenied-sentinel → "Event not found." (defense-in-depth), service `CalendarGroupValidationError` → clean GraphQLError (no 500).
+- **Review:** Layer 1/2/3. Reviewer flagged the existence leak as BLOCKER (confirmed); fixed. NITs (redundant Calendar.get dropped; organization_id-ignored comment) applied.
+- **Outer gate:** serial 6 passed; full `pytest -n auto` → **3177 passed**.
+- **DI note for Phase 3:** `get_calendar_mutation_dependencies()` returns FRESH `Factory` instances; wire the initialized `calendar_service` into the group service before `initialize(org)` (mirror the `*WithCode` group wiring). `cancel_grouped_event(event_id, delete_series=…)` is the group cancel path.
+
 ## Current Phase
-**Phase 2** — `rescheduleCalendarGroupEvent` Public GraphQL mutation.
+**Phase 3** — `cancelEvent` Public GraphQL mutation (single + grouped, deleteSeries + recurrenceId).
 
 ## Remaining Phases
-2 (next), 3.
+3 (next, final).

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -2267,8 +2267,8 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
 
         Authorization:
         - Owner-scoped token: restricted to grouped events whose primary calendar is
-          owned by the token's owner; cross-owner → ``"Calendar not found."`` (same
-          as missing — no existence leak).
+          owned by the token's owner; cross-owner → ``"Event not found."`` (same
+          as missing event — no existence leak).
         - Org-wide token: acts org-wide.
         - The service independently re-verifies ownership as defense-in-depth.
 
@@ -2276,8 +2276,16 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         """
         from calendar_integration.exceptions import CalendarGroupValidationError
 
+        # Sentinel emitted by CalendarEventService.update_event when a SystemUser's
+        # scoped calendar can't be found (racing cross-owner path). Map it to the
+        # uniform not-found message to prevent a discriminating oracle.
+        calendar_not_found_sentinel = "Calendar matching query does not exist."
+
         calendar_service, org = _get_org_and_init_calendar_service(info)
         request: PublicApiHttpRequest = info.context.request
+
+        # input.organization_id is intentionally ignored: org is derived from the
+        # authenticated request context, not from caller-supplied input.
 
         # Load the grouped event scoped to the organization to derive the primary
         # calendar and validate that it is actually a grouped event.
@@ -2297,13 +2305,15 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         primary_calendar_id: int = grouped_event.calendar_fk_id  # type: ignore[assignment]
 
         # Owner-scope guard on the PRIMARY calendar: a scoped token may only target
-        # grouped events whose primary calendar its owner owns. Cross-owner and missing
-        # calendars return the identical error — no existence leak.
+        # grouped events whose primary calendar its owner owns. The grouped event was
+        # already loaded org-scoped with select_related("calendar"), so the derived
+        # primary calendar provably exists — only the ownership check can fail here.
+        # Map Calendar.DoesNotExist (cross-owner) to "Event not found." — uniform
+        # not-found, no existence leak.
         try:
             assert_calendar_in_owner_scope(request.public_api_system_user, org, primary_calendar_id)
-            Calendar.objects.filter_by_organization(org.id).get(id=primary_calendar_id)
         except Calendar.DoesNotExist as exc:
-            raise GraphQLError("Calendar not found.") from exc
+            raise GraphQLError("Event not found.") from exc
 
         # Wire the group service: inject the already-initialized calendar_service so
         # that the public-token auth context flows into reschedule_grouped_event →
@@ -2321,10 +2331,16 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                 tz=input.timezone,
             )
         except Calendar.DoesNotExist as exc:
-            raise GraphQLError("Calendar not found.") from exc
+            # Derived-calendar miss must not leak existence either (caller addresses by event).
+            raise GraphQLError("Event not found.") from exc
         except CalendarEvent.DoesNotExist as exc:
             raise GraphQLError("Event not found.") from exc
         except PermissionDenied as exc:
+            # Defense-in-depth: update_event raises PermissionDenied with the sentinel
+            # message when a racing cross-owner SystemUser calendar lookup fails.
+            # Surface it as the uniform not-found rather than the distinct sentinel.
+            if str(exc) == calendar_not_found_sentinel:
+                raise GraphQLError("Event not found.") from exc
             raise GraphQLError(
                 str(exc) or "You do not have permission to reschedule this event."
             ) from exc

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -656,6 +656,27 @@ class RescheduleCalendarEventInput:
     recurrence_id: datetime.datetime | None = None
 
 
+@strawberry.input
+class RescheduleCalendarGroupEventInput:
+    """Input for rescheduling a grouped calendar event via a public-API token.
+
+    Grouped events consist of a primary ``CalendarEvent`` on the primary calendar plus
+    linked non-primary ``BlockedTime`` rows on each additional calendar in the group.
+    All of them move together when this mutation succeeds.
+
+    Whole-event only — group events are not recurring in v1 (no ``recurrenceId``).
+
+    An owner-scoped token may only reschedule grouped events whose primary calendar is
+    owned by the token's owner; an org-wide token acts org-wide.
+    """
+
+    organization_id: int
+    event_id: int
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+
+
 @strawberry.type
 class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
     @strawberry.mutation
@@ -2224,6 +2245,91 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
             raise GraphQLError(
                 str(exc) or "You do not have permission to reschedule this event."
             ) from exc
+        except (ValueError, DjangoValidationError, CalendarIntegrationError) as exc:
+            raise GraphQLError(str(exc)) from exc
+
+        return event  # type: ignore[return-value]
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def reschedule_calendar_group_event(
+        self,
+        info: strawberry.Info,
+        input: RescheduleCalendarGroupEventInput,  # noqa: A002
+    ) -> CalendarEventGraphQLType:
+        """Reschedule a grouped event's times while preserving all other details.
+
+        Moves the primary ``CalendarEvent`` on the primary calendar AND the linked
+        non-primary ``BlockedTime`` rows (identified by the
+        ``group-event-{event_id}-cal-{cid}`` external_id convention) to the new
+        start/end/timezone simultaneously.
+
+        Whole-event only — group events are not recurring in v1 (no ``recurrenceId``).
+
+        Authorization:
+        - Owner-scoped token: restricted to grouped events whose primary calendar is
+          owned by the token's owner; cross-owner → ``"Calendar not found."`` (same
+          as missing — no existence leak).
+        - Org-wide token: acts org-wide.
+        - The service independently re-verifies ownership as defense-in-depth.
+
+        Returns the updated primary ``CalendarEvent``.
+        """
+        from calendar_integration.exceptions import CalendarGroupValidationError
+
+        calendar_service, org = _get_org_and_init_calendar_service(info)
+        request: PublicApiHttpRequest = info.context.request
+
+        # Load the grouped event scoped to the organization to derive the primary
+        # calendar and validate that it is actually a grouped event.
+        try:
+            grouped_event = (
+                CalendarEvent.objects.filter_by_organization(org.id)
+                .select_related("calendar")
+                .get(id=input.event_id)
+            )
+        except CalendarEvent.DoesNotExist as exc:
+            raise GraphQLError("Event not found.") from exc
+
+        if grouped_event.calendar_group_fk_id is None:
+            # Non-grouped event — uniform not-found, no existence leak.
+            raise GraphQLError("Event not found.")
+
+        primary_calendar_id: int = grouped_event.calendar_fk_id  # type: ignore[assignment]
+
+        # Owner-scope guard on the PRIMARY calendar: a scoped token may only target
+        # grouped events whose primary calendar its owner owns. Cross-owner and missing
+        # calendars return the identical error — no existence leak.
+        try:
+            assert_calendar_in_owner_scope(request.public_api_system_user, org, primary_calendar_id)
+            Calendar.objects.filter_by_organization(org.id).get(id=primary_calendar_id)
+        except Calendar.DoesNotExist as exc:
+            raise GraphQLError("Calendar not found.") from exc
+
+        # Wire the group service: inject the already-initialized calendar_service so
+        # that the public-token auth context flows into reschedule_grouped_event →
+        # update_event. This mirrors exactly how rescheduleCalendarGroupEventWithCode
+        # wires its deps (deps.calendar_group_service.calendar_service = deps.calendar_service).
+        group_deps = get_calendar_mutation_dependencies()
+        group_deps.calendar_group_service.calendar_service = calendar_service
+        group_deps.calendar_group_service.initialize(organization=org)
+
+        try:
+            event = group_deps.calendar_group_service.reschedule_grouped_event(
+                event_id=input.event_id,
+                start_time=input.start_time,
+                end_time=input.end_time,
+                tz=input.timezone,
+            )
+        except Calendar.DoesNotExist as exc:
+            raise GraphQLError("Calendar not found.") from exc
+        except CalendarEvent.DoesNotExist as exc:
+            raise GraphQLError("Event not found.") from exc
+        except PermissionDenied as exc:
+            raise GraphQLError(
+                str(exc) or "You do not have permission to reschedule this event."
+            ) from exc
+        except CalendarGroupValidationError as exc:
+            raise GraphQLError(str(exc)) from exc
         except (ValueError, DjangoValidationError, CalendarIntegrationError) as exc:
             raise GraphQLError(str(exc)) from exc
 

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -72,6 +72,7 @@ class OrganizationResourceAccess(BasePermission):
         "deleteBlockedTime": PublicAPIResources.DELETE_BLOCKED_TIME,
         "scheduleEvent": PublicAPIResources.CALENDAR_EVENT,
         "rescheduleCalendarEvent": PublicAPIResources.CALENDAR_EVENT,
+        "rescheduleCalendarGroupEvent": PublicAPIResources.CALENDAR_EVENT,
         "calendarBundles": PublicAPIResources.CALENDAR_BUNDLE,
         "createCalendarBundle": PublicAPIResources.CREATE_CALENDAR_BUNDLE,
         "updateCalendarBundle": PublicAPIResources.UPDATE_CALENDAR_BUNDLE,

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -10058,3 +10058,390 @@ class TestScopedTokenRescheduleCalendarEvent:
         assert event.start_time_tz_unaware.replace(tzinfo=None) == original_start.replace(
             tzinfo=None
         )
+
+
+# ---------------------------------------------------------------------------
+# GraphQL mutation string for rescheduleCalendarGroupEvent
+# ---------------------------------------------------------------------------
+
+_RESCHEDULE_CALENDAR_GROUP_EVENT = """
+mutation RescheduleCalendarGroupEvent($input: RescheduleCalendarGroupEventInput!) {
+    rescheduleCalendarGroupEvent(input: $input) {
+        id
+        title
+        startTime
+        endTime
+    }
+}
+"""
+
+
+def _make_grouped_event(org, group, primary_calendar, secondary_calendar):
+    """Create a primary CalendarEvent with a linked non-primary BlockedTime.
+
+    The primary event has ``calendar_group_fk`` set to the given group.  The
+    secondary calendar receives a ``BlockedTime`` following the canonical
+    ``group-event-{event_id}-cal-{cid}`` external_id convention used by
+    ``_create_non_primary_blocked_times`` and ``reschedule_grouped_event``.
+
+    Returns (primary_event, blocked_time).
+    """
+    from calendar_integration.models import BlockedTime as _BlockedTime
+    from calendar_integration.models import CalendarEvent as _CalendarEvent
+
+    event = baker.make(
+        _CalendarEvent,
+        organization=org,
+        calendar=primary_calendar,
+        calendar_group=group,
+        title="Group Meeting",
+        description="Group description.",
+        timezone="UTC",
+        start_time_tz_unaware=datetime.datetime(2026, 11, 5, 10, 0),
+        end_time_tz_unaware=datetime.datetime(2026, 11, 5, 11, 0),
+        external_id=f"grp-evt-{uuid.uuid4().hex[:8]}",
+    )
+    blocked_time = baker.make(
+        _BlockedTime,
+        organization=org,
+        calendar=secondary_calendar,
+        start_time_tz_unaware=datetime.datetime(2026, 11, 5, 10, 0),
+        end_time_tz_unaware=datetime.datetime(2026, 11, 5, 11, 0),
+        timezone="UTC",
+        reason=f"Group booking: {event.title}",
+        external_id=f"group-event-{event.id}-cal-{secondary_calendar.id}",
+    )
+    return event, blocked_time
+
+
+@pytest.mark.django_db
+class TestScopedTokenRescheduleCalendarGroupEvent:
+    """Integration tests for the owner-scoped ``rescheduleCalendarGroupEvent`` mutation (Phase 2).
+
+    Coverage:
+    - Scoped token reschedules its own grouped event → primary event times change AND
+      the linked ``group-event-*`` ``BlockedTime``s are updated to the new times.
+    - Cross-owner denial: scoped token A targeting a grouped event whose primary
+      calendar is owned by owner B → uniform not-found (``"Calendar not found."``),
+      no mutation (no existence leak).
+    - Org-wide token acts org-wide → can reschedule any grouped event in the org.
+    - Non-grouped event_id → ``"Event not found."`` (no leak), no mutation.
+    """
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_grp_resched_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_org_wide_system_user(self, org, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_grp_resched_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def _reschedule_group_input(self, org, event, **overrides):
+        base = {
+            "organizationId": org.id,
+            "eventId": event.id,
+            "startTime": datetime.datetime(2026, 11, 5, 14, 0, 0, tzinfo=datetime.UTC).isoformat(),
+            "endTime": datetime.datetime(2026, 11, 5, 15, 0, 0, tzinfo=datetime.UTC).isoformat(),
+            "timezone": "UTC",
+        }
+        base.update(overrides)
+        return base
+
+    def _make_group_setup(self, org):
+        """Create a CalendarGroup with primary + secondary calendars and a CalendarOwnership.
+
+        Returns (owner_user, membership, primary_calendar, secondary_calendar, group).
+        """
+        from calendar_integration.models import CalendarGroup, CalendarOwnership
+
+        unique = uuid.uuid4().hex[:8]
+        user_model = get_user_model()
+        owner = baker.make(user_model, email=f"grp_owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        primary_calendar = baker.make(
+            Calendar,
+            organization=org,
+            name=f"Primary Cal {unique}",
+            external_id=f"primary-cal-{unique}",
+            manage_available_windows=False,
+        )
+        baker.make(
+            CalendarOwnership,
+            calendar=primary_calendar,
+            membership_user_id=owner.id,
+            organization=org,
+        )
+        secondary_calendar = baker.make(
+            Calendar,
+            organization=org,
+            name=f"Secondary Cal {unique}",
+            external_id=f"secondary-cal-{unique}",
+            manage_available_windows=False,
+        )
+        group = baker.make(CalendarGroup, organization=org, name=f"Test Group {unique}")
+        return owner, membership, primary_calendar, secondary_calendar, group
+
+    # ------------------------------------------------------------------
+    # Happy path — scoped token reschedules its own grouped event
+    # ------------------------------------------------------------------
+
+    def test_reschedule_grouped_event_times_change_blocked_times_updated(self):
+        """Scoped token reschedules its own grouped event: primary event times change AND
+        the linked non-primary BlockedTime rows are updated to the new times.
+        """
+        from calendar_integration.models import BlockedTime as _BlockedTime
+        from calendar_integration.models import CalendarEvent as _CalendarEvent
+
+        org = baker.make(Organization, name="GroupResched Org")
+        _owner, membership, primary_cal, secondary_cal, group = self._make_group_setup(org)
+        grouped_event, blocked_time = _make_grouped_event(org, group, primary_cal, secondary_cal)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        new_start = datetime.datetime(2026, 11, 5, 14, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 5, 15, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_GROUP_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {"input": self._reschedule_group_input(org, grouped_event)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarGroupEvent"]
+        assert result is not None
+        assert result["title"] == "Group Meeting"
+        assert int(result["id"]) == grouped_event.id
+
+        # Primary event times changed.
+        updated_event = _CalendarEvent.objects.filter_by_organization(org.id).get(
+            id=grouped_event.id
+        )
+        assert updated_event.start_time_tz_unaware.replace(tzinfo=None) == new_start.replace(
+            tzinfo=None
+        )
+        assert updated_event.end_time_tz_unaware.replace(tzinfo=None) == new_end.replace(
+            tzinfo=None
+        )
+
+        # Linked BlockedTime rows also updated.
+        updated_bt = _BlockedTime.objects.filter_by_organization(org.id).get(id=blocked_time.id)
+        assert updated_bt.start_time_tz_unaware.replace(tzinfo=None) == new_start.replace(
+            tzinfo=None
+        )
+        assert updated_bt.end_time_tz_unaware.replace(tzinfo=None) == new_end.replace(tzinfo=None)
+
+    # ------------------------------------------------------------------
+    # Cross-owner denial — no existence leak
+    # ------------------------------------------------------------------
+
+    def test_reschedule_grouped_event_cross_owner_not_found_no_mutation(self):
+        """Cross-owner grouped event: uniform 'Calendar not found.' — same as missing calendar.
+
+        Owner A's scoped token targets a grouped event on owner B's primary calendar.
+        The response error must be identical to a genuinely missing calendar, and
+        neither the primary event nor the linked BlockedTime may change.
+        """
+        from calendar_integration.models import BlockedTime as _BlockedTime
+
+        org = baker.make(Organization, name="GroupResched CrossOwner Org")
+        # Owner A: just used for token scoping.
+        _owner_a, membership_a, _primary_cal_a, _secondary_cal_a, _group_a = self._make_group_setup(
+            org
+        )
+        # Owner B: owns the primary calendar of the grouped event.
+        _owner_b, _membership_b, primary_cal_b, secondary_cal_b, group_b = self._make_group_setup(
+            org
+        )
+        grouped_event_b, blocked_time_b = _make_grouped_event(
+            org, group_b, primary_cal_b, secondary_cal_b
+        )
+        original_start = grouped_event_b.start_time_tz_unaware
+        original_bt_start = blocked_time_b.start_time_tz_unaware
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        # Attempt to reschedule B's grouped event from A's scoped token.
+        cross_response = self._post(
+            _RESCHEDULE_CALENDAR_GROUP_EVENT,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "eventId": grouped_event_b.id,
+                    "startTime": datetime.datetime(
+                        2026, 11, 5, 14, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "endTime": datetime.datetime(
+                        2026, 11, 5, 15, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        # Attempt with a genuinely missing calendar's event_id.
+        missing_response = self._post(
+            _RESCHEDULE_CALENDAR_GROUP_EVENT,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "eventId": 999990,  # non-existent event
+                    "startTime": datetime.datetime(
+                        2026, 11, 5, 14, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "endTime": datetime.datetime(
+                        2026, 11, 5, 15, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        cross_msg = cross_response.json()["errors"][0]["message"]
+        # For a non-existent event_id, the resolver raises "Event not found.".
+        # For cross-owner, the guard fires on the primary calendar → "Calendar not found.".
+        # Both are opaque not-found messages — no existence leak.
+        assert cross_msg == "Calendar not found."
+        assert missing_response.json()["errors"][0]["message"] == "Event not found."
+
+        # B's event and blocked time must be unmodified.
+        grouped_event_b.refresh_from_db()
+        assert grouped_event_b.start_time_tz_unaware.replace(tzinfo=None) == original_start.replace(
+            tzinfo=None
+        )
+        updated_bt = _BlockedTime.objects.filter_by_organization(org.id).get(id=blocked_time_b.id)
+        assert updated_bt.start_time_tz_unaware.replace(tzinfo=None) == original_bt_start.replace(
+            tzinfo=None
+        )
+
+    # ------------------------------------------------------------------
+    # Org-wide token acts org-wide
+    # ------------------------------------------------------------------
+
+    def test_reschedule_grouped_event_org_wide_token_acts_org_wide(self):
+        """An org-wide token can reschedule any grouped event in the org."""
+        from calendar_integration.models import CalendarEvent as _CalendarEvent
+
+        org = baker.make(Organization, name="GroupResched OrgWide Org")
+        _owner, _membership, primary_cal, secondary_cal, group = self._make_group_setup(org)
+        grouped_event, _blocked_time = _make_grouped_event(org, group, primary_cal, secondary_cal)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        new_start = datetime.datetime(2026, 11, 5, 16, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 5, 17, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_GROUP_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": self._reschedule_group_input(
+                    org, grouped_event, startTime=new_start.isoformat(), endTime=new_end.isoformat()
+                )
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+        result = data["data"]["rescheduleCalendarGroupEvent"]
+        assert result is not None
+
+        updated_event = _CalendarEvent.objects.filter_by_organization(org.id).get(
+            id=grouped_event.id
+        )
+        assert updated_event.start_time_tz_unaware.replace(tzinfo=None) == new_start.replace(
+            tzinfo=None
+        )
+
+    # ------------------------------------------------------------------
+    # Non-grouped event → "Event not found."
+    # ------------------------------------------------------------------
+
+    def test_reschedule_non_grouped_event_returns_event_not_found(self):
+        """Passing a non-grouped event_id returns 'Event not found.' with no mutation."""
+        org = baker.make(Organization, name="GroupResched NonGrouped Org")
+        _owner, membership, calendar, _secondary_cal, _group = self._make_group_setup(org)
+        # Regular non-grouped event (calendar_group_fk is None).
+        non_grouped_event = _make_event_on_calendar(org, calendar, title="Plain Event")
+        original_start = non_grouped_event.start_time_tz_unaware
+
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        response = self._post(
+            _RESCHEDULE_CALENDAR_GROUP_EVENT,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "eventId": non_grouped_event.id,
+                    "startTime": datetime.datetime(
+                        2026, 11, 5, 14, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "endTime": datetime.datetime(
+                        2026, 11, 5, 15, 0, 0, tzinfo=datetime.UTC
+                    ).isoformat(),
+                    "timezone": "UTC",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == "Event not found."
+
+        # Event must be unchanged.
+        non_grouped_event.refresh_from_db()
+        assert non_grouped_event.start_time_tz_unaware.replace(
+            tzinfo=None
+        ) == original_start.replace(tzinfo=None)

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -10270,10 +10270,10 @@ class TestScopedTokenRescheduleCalendarGroupEvent:
     # ------------------------------------------------------------------
 
     def test_reschedule_grouped_event_cross_owner_not_found_no_mutation(self):
-        """Cross-owner grouped event: uniform 'Calendar not found.' — same as missing calendar.
+        """Cross-owner grouped event: uniform 'Event not found.' — same as missing event.
 
         Owner A's scoped token targets a grouped event on owner B's primary calendar.
-        The response error must be identical to a genuinely missing calendar, and
+        The response error must be identical to a genuinely missing event, and
         neither the primary event nor the linked BlockedTime may change.
         """
         from calendar_integration.models import BlockedTime as _BlockedTime
@@ -10340,11 +10340,13 @@ class TestScopedTokenRescheduleCalendarGroupEvent:
         )
 
         cross_msg = cross_response.json()["errors"][0]["message"]
-        # For a non-existent event_id, the resolver raises "Event not found.".
-        # For cross-owner, the guard fires on the primary calendar → "Calendar not found.".
-        # Both are opaque not-found messages — no existence leak.
-        assert cross_msg == "Calendar not found."
-        assert missing_response.json()["errors"][0]["message"] == "Event not found."
+        missing_msg = missing_response.json()["errors"][0]["message"]
+        # Both cross-owner and missing-event cases must return the identical message —
+        # no existence leak (a cross-owner grouped event must be indistinguishable from
+        # a genuinely missing event_id).
+        assert cross_msg == "Event not found."
+        assert missing_msg == "Event not found."
+        assert cross_msg == missing_msg
 
         # B's event and blocked time must be unmodified.
         grouped_event_b.refresh_from_db()
@@ -10445,3 +10447,93 @@ class TestScopedTokenRescheduleCalendarGroupEvent:
         assert non_grouped_event.start_time_tz_unaware.replace(
             tzinfo=None
         ) == original_start.replace(tzinfo=None)
+
+    # ------------------------------------------------------------------
+    # SHOULD-FIX: PermissionDenied sentinel mapping (defense-in-depth)
+    # ------------------------------------------------------------------
+
+    def test_permission_denied_calendar_sentinel_maps_to_event_not_found(self):
+        """PermissionDenied('Calendar matching query does not exist.') from the service
+        layer maps to 'Event not found.' — not the distinct sentinel string.
+
+        This guards against a future regression in the resolver guard that might silently
+        reopen the third-string existence leak (the sentinel emitted by
+        CalendarEventService.update_event for a racing cross-owner SystemUser).
+
+        Approach: monkeypatch ``reschedule_grouped_event`` to raise the sentinel
+        PermissionDenied and assert the resolver returns the uniform not-found message.
+        """
+        from unittest.mock import patch
+
+        from django.core.exceptions import PermissionDenied as _PermissionDenied
+
+        org = baker.make(Organization, name="GroupResched Sentinel Org")
+        _owner, membership, primary_cal, secondary_cal, group = self._make_group_setup(org)
+        grouped_event, _blocked_time = _make_grouped_event(org, group, primary_cal, secondary_cal)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        sentinel = "Calendar matching query does not exist."
+
+        with patch(
+            "calendar_integration.services.calendar_group_service.CalendarGroupService"
+            ".reschedule_grouped_event",
+            side_effect=_PermissionDenied(sentinel),
+        ):
+            response = self._post(
+                _RESCHEDULE_CALENDAR_GROUP_EVENT,
+                system_user,
+                token,
+                auth_service,
+                {"input": self._reschedule_group_input(org, grouped_event)},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        msg = data["errors"][0]["message"]
+        # Must be the uniform not-found — not the raw sentinel.
+        assert msg == "Event not found."
+        assert msg != sentinel
+
+    # ------------------------------------------------------------------
+    # SHOULD-FIX: error-mapping branch coverage (no 500 on service error)
+    # ------------------------------------------------------------------
+
+    def test_service_validation_error_returns_clean_graphql_error(self):
+        """A CalendarGroupValidationError from the service layer returns a clean
+        GraphQL error (not a 500) with the service message.
+
+        Monkeypatches ``reschedule_grouped_event`` to raise the validation error.
+        """
+        from unittest.mock import patch
+
+        from calendar_integration.exceptions import CalendarGroupValidationError
+
+        org = baker.make(Organization, name="GroupResched ValidationErr Org")
+        _owner, membership, primary_cal, secondary_cal, group = self._make_group_setup(org)
+        grouped_event, _blocked_time = _make_grouped_event(org, group, primary_cal, secondary_cal)
+        system_user, token, auth_service = self._make_scoped_system_user(
+            org, membership, [PublicAPIResources.CALENDAR_EVENT]
+        )
+
+        service_message = "New time conflicts with an existing group event."
+
+        with patch(
+            "calendar_integration.services.calendar_group_service.CalendarGroupService"
+            ".reschedule_grouped_event",
+            side_effect=CalendarGroupValidationError(service_message),
+        ):
+            response = self._post(
+                _RESCHEDULE_CALENDAR_GROUP_EVENT,
+                system_user,
+                token,
+                auth_service,
+                {"input": self._reschedule_group_input(org, grouped_event)},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data and len(data["errors"]) > 0
+        assert data["errors"][0]["message"] == service_message


### PR DESCRIPTION
## Summary
Phase 2 of the **Owner-Scoped Public Reschedule / Cancel Mutations** plan. Adds `rescheduleCalendarGroupEvent` — reschedules a grouped event (the primary `CalendarEvent` plus the linked non-primary `BlockedTime` rows, `group-event-{event_id}-cal-{cid}`) to a new time, all moving together. Whole-event only (group events aren't recurring in v1).

The resolver takes only `event_id` (no `calendar_id` — the primary calendar is derived server-side), loads the grouped event org-scoped, owner-scope-checks its **primary** calendar, wires the public-token-initialized `calendar_service` into the group service, and delegates to `CalendarGroupService.reschedule_grouped_event`. Owner-scoped tokens may only reschedule grouped events whose primary calendar their owner owns; org-wide acts org-wide.

### Security: uniform not-found (no existence leak)
Because the input is **event-addressed**, every not-found/forbidden case returns the **identical** `"Event not found."`:
- missing `event_id`
- non-grouped event
- cross-owner grouped event (owner-scope guard)
- cross-owner service-layer race (`PermissionDenied("Calendar matching query does not exist.")` sentinel)

This deliberately supersedes the plan body's per-phase prescription (which named `"Calendar not found."` for the scope failure — correct for Phase 1's calendar-addressed input, but a discriminating oracle here). A scoped token cannot tell "a grouped event I don't own exists" from "doesn't exist."

The `*WithCode` group reschedule mutation is untouched (negative scope).

## Plan reference
`ai-plans/2026-06-22-OWNER_SCOPED_RESCHEDULE_CANCEL_MUTATIONS_IMPLEMENTATION_PLAN.md` — **Phase 2** (stacked on Phase 1 / PR #163). No feature flag. No migrations.

## Test plan
- `docker compose run --rm api uv run pytest public_api/tests/test_mutations.py -k RescheduleCalendarGroup -p no:randomly` — `TestScopedTokenRescheduleCalendarGroupEvent` (6): success (primary event + linked BlockedTimes move), cross-owner uniform not-found (== missing message, no mutation), org-wide acts org-wide, non-grouped → "Event not found.", PermissionDenied-sentinel → "Event not found." (defense-in-depth), service validation error → clean GraphQLError (no 500).
- Outer gate: full `pytest -n auto` → **3177 passed**.