### PR TITLE
feat(calendar): add EffectivePolicy resolver + BookingPolicy write service

### DIFF
--- a/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
+++ b/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
@@ -2,7 +2,7 @@
 
 - **Plan**: `ai-plans/2026-06-26-BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY_IMPLEMENTATION_PLAN.md`
 - **Started**: 2026-06-27
-- **Last updated**: 2026-06-27
+- **Last updated**: 2026-06-28
 - **Feature flag**: none — data-presence gate (no policy ⇒ unchanged behavior).
 
 ## Run options
@@ -17,6 +17,7 @@
 
 ## Branch stack
 - Phase 1: `plan/bookable-slots-single-calendar-and-booking-policy/phase-1` (base `main`)
+- Phase 2: `plan/bookable-slots-single-calendar-and-booking-policy/phase-2` (base phase-1)
 
 ## Completed phases
 
@@ -31,11 +32,22 @@
 - **Gates**: ruff clean; mypy baseline unchanged (298, no new); `makemigrations --check` clean; `check --deploy` 0 errors; full `pytest -n auto` → 3244 passed (order-flakes confirmed pre-existing). Migration round-trip verified.
 - **Acceptance**: ✅ migration applies + reverses; single-target enforced; duplicate/multi-target inserts raise IntegrityError; membership integrity enforced at commit.
 
+### Phase 2 — Effective-policy resolver service ✅
+- **Status**: DONE (reviewed, fixed, pushed, PR open)
+- **Model used**: sonnet (plan tier T3) — implementer + sonnet fixer
+- **Branch**: `plan/bookable-slots-single-calendar-and-booking-policy/phase-2` (base phase-1)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/167
+- **Commits**: `e0e79f6` (impl) + `ae265d4` (review fixes)
+- **Summary**: `EffectivePolicy` frozen dataclass (`unconstrained`/`from_model` [horizon 0→None]/`most_restrictive` [max lead+buffers, min finite horizon]) in `services/dataclasses.py`. `BookingPolicyService` (`services/booking_policy_service.py`): `resolve_for_calendar` (calendar→owning-membership [lone/`is_default`/skip]→org-default→unconstrained), `resolve_for_bundle`/`resolve_for_group` (explicit→most-restrictive across all participants via `resolve_for_calendar`→unconstrained), create/update/delete (exactly-one-target, `DuplicateBookingPolicyError`, immutable targets, idempotent delete-absent, AuditService records w/ diffs). DI Factory `booking_policy_service` in `di_core/containers.py`. 63 service tests.
+- **Review findings fixed**: no BLOCKERs. SHOULD-FIX — moved `DuplicateBookingPolicyError` to `exceptions.py` (subclass `CalendarIntegrationError`); annotated `get_all_policies -> BookingPolicyQuerySet`; added tests (no-change `diff is None`, bundle-unconstrained-with-owners, membership/group delete-absent no-ops). NIT — late-import rationale comment, `_actor: ActorSnapshot | None` typing.
+- **Confirmed-intended behavior** (reviewer flagged, no change): bundle/group resolution inherits the org-default via participant `resolve_for_calendar`, so a bundle/group is never truly unconstrained while an org-default exists. Matches plan ("never offer a slot a participant would reject"); annotated in PR + asserted by `test_child_inherits_org_default_if_no_direct_policy`. Phase 5/7 consumers depend on this.
+- **Gates**: ruff clean; mypy baseline unchanged; `makemigrations --check` clean (no migration); `check --deploy` 0 errors; full `pytest -n auto` → 3307 passed.
+- **Acceptance**: ✅ `resolve_for_*` returns spec-correct `EffectivePolicy` across the full matrix; unconstrained when nothing applies.
+
 ## Current phase
-Phase 2 — Effective-policy resolver service (next).
+Phase 3 — Policy CRUD private REST (next).
 
 ## Remaining phases
-- Phase 2 — Effective-policy resolver service (T3 / sonnet)
 - Phase 3 — Policy CRUD private REST (T2 / haiku)
 - Phase 4 — Policy CRUD public GraphQL (T3 / sonnet)
 - Phase 5 — calendar_bookable_slots single+bundle (T4 / opus)

--- a/calendar_integration/exceptions.py
+++ b/calendar_integration/exceptions.py
@@ -333,3 +333,14 @@ class CalendarGroupHasFutureEventsError(CalendarGroupError):
     """Raised when a group cannot be deleted because it has future bookings."""
 
     default_message = "Cannot delete CalendarGroup because it has future bookings."
+
+
+# Booking Policy Errors
+class DuplicateBookingPolicyError(CalendarIntegrationError):
+    """Raised when a second BookingPolicy is created for the same target/org.
+
+    Callers (REST serializers, GraphQL mutations) should map this to a 400 /
+    validation error with the message surfaced to the client.
+    """
+
+    pass

--- a/calendar_integration/managers.py
+++ b/calendar_integration/managers.py
@@ -154,6 +154,14 @@ class CalendarManager(BaseOrganizationModelManager):
             ranges=ranges
         )
 
+    def annotate_effective_policy(self) -> CalendarQuerySet:
+        """Annotate the four ``effective_*_seconds`` booking-policy columns.
+
+        Delegates to the queryset; resolves the whole-policy precedence chain
+        (calendar → owning-membership → org-default → unconstrained) in SQL.
+        """
+        return self.get_queryset().annotate_effective_policy()
+
 
 class CalendarEventManager(BaseOrganizationModelManager, RecurringManagerMixin):
     """Custom manager for CalendarEvent model to handle specific queries."""
@@ -221,6 +229,15 @@ class CalendarGroupManager(BaseOrganizationModelManager):
         return self.get_queryset().only_groups_bookable_in_ranges_with_bulk_modifications(
             ranges=ranges
         )
+
+    def annotate_effective_policy(self) -> CalendarGroupQuerySet:
+        """Annotate the four ``effective_*_seconds`` booking-policy columns.
+
+        Delegates to the queryset; resolves the group precedence chain (explicit
+        group policy → most_restrictive across participant calendars →
+        unconstrained) in SQL.
+        """
+        return self.get_queryset().annotate_effective_policy()
 
 
 class CalendarGroupSlotManager(BaseOrganizationModelManager):

--- a/calendar_integration/querysets.py
+++ b/calendar_integration/querysets.py
@@ -436,7 +436,7 @@ def _owning_membership_uid_expression(calendar_id_ref: OuterRef, org_id_ref: Out
 
 
 def _winning_calendar_policy_id_expression(
-    calendar_id_ref: OuterRef, org_id_ref: OuterRef, membership_uid_ref
+    calendar_id_ref: OuterRef, org_id_ref: OuterRef, membership_uid_ref: OuterRef
 ) -> Coalesce:
     """Resolve, in SQL, the id of the BookingPolicy that governs a single calendar.
 

--- a/calendar_integration/querysets.py
+++ b/calendar_integration/querysets.py
@@ -2,7 +2,22 @@ import datetime
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q, Subquery
+from django.db.models import (
+    Case,
+    Count,
+    Exists,
+    F,
+    IntegerField,
+    Max,
+    Min,
+    OuterRef,
+    Prefetch,
+    Q,
+    Subquery,
+    Value,
+    When,
+)
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from calendar_integration.constants import (
@@ -344,6 +359,154 @@ class CalendarQuerySet(BaseOrganizationModelQuerySet):
 
         return self.filter(combined_query)
 
+    def annotate_effective_policy(self) -> "CalendarQuerySet":
+        """Annotate the four ``effective_*_seconds`` booking-policy columns.
+
+        Resolves, in a single query, the whole-policy precedence chain for each
+        calendar — calendar policy → owning-membership policy → org-default →
+        unconstrained — entirely in SQL. The first existing layer wins and all
+        four of its fields are read together (no per-field COALESCE across
+        layers). Decode the result with ``EffectivePolicy.from_annotation(row)``.
+
+        The chain is org-scoped: every inner subquery filters on the calendar's
+        own ``organization_id``, so the annotation is safe on a queryset spanning
+        a single tenant (the manager always pre-filters by organization).
+        """
+        qs = self.annotate(
+            _owning_membership_uid=_owning_membership_uid_expression(
+                OuterRef("pk"), OuterRef("organization_id")
+            )
+        )
+        qs = qs.annotate(
+            _effective_policy_id=_winning_calendar_policy_id_expression(
+                OuterRef("pk"),
+                OuterRef("organization_id"),
+                OuterRef("_owning_membership_uid"),
+            )
+        )
+        return qs.annotate(
+            **_policy_field_subqueries(
+                OuterRef("_effective_policy_id"), OuterRef("organization_id")
+            )
+        )
+
+
+def _owning_membership_uid_expression(calendar_id_ref: OuterRef, org_id_ref: OuterRef) -> Coalesce:
+    """Resolve, in SQL, the single owning-membership user id for a calendar.
+
+    Matches ``BookingPolicyService._resolve_owning_membership_user_id`` exactly:
+    among ``CalendarOwnership`` rows for this calendar+org with non-NULL
+    ``membership_user_id`` —
+
+    - prefer the ``is_default=True`` owner,
+    - else the lone owner (only when there is exactly one),
+    - else NULL (multiple owners, no default → skip the membership layer).
+
+    Encoded as ``COALESCE(default_owner_uid, lone_owner_uid)``:
+
+    - 0 owners → both NULL → NULL.
+    - 1 owner (default or not) → ``lone_owner_uid`` resolves; default may too.
+    - multiple with a default → ``default_owner_uid`` resolves, lone is NULL.
+    - multiple without a default → both NULL → NULL.
+
+    Correlated to the calendar through ``calendar_id_ref`` / ``org_id_ref`` so the
+    refs must point at the calendar row, not at an intervening subquery.
+    """
+    from calendar_integration.models import CalendarOwnership
+
+    owners = (
+        CalendarOwnership.objects.get_queryset()
+        .filter(organization_id=org_id_ref, calendar_fk_id=calendar_id_ref)
+        .exclude(membership_user_id__isnull=True)
+    )
+    default_owner_uid = owners.filter(is_default=True).values("membership_user_id")[:1]
+    # Lone owner: the single owner's membership_user_id, but only when the total
+    # owner count is exactly 1 (HAVING COUNT(*) = 1).
+    lone_owner_uid = (
+        owners.values("calendar_fk_id")
+        .annotate(_cnt=Count("id"), _uid=Max("membership_user_id"))
+        .filter(_cnt=1)
+        .values("_uid")[:1]
+    )
+    return Coalesce(
+        Subquery(default_owner_uid, output_field=IntegerField()),
+        Subquery(lone_owner_uid, output_field=IntegerField()),
+        output_field=IntegerField(),
+    )
+
+
+def _winning_calendar_policy_id_expression(
+    calendar_id_ref: OuterRef, org_id_ref: OuterRef, membership_uid_ref
+) -> Coalesce:
+    """Resolve, in SQL, the id of the BookingPolicy that governs a single calendar.
+
+    Mirrors ``BookingPolicyService.resolve_for_calendar`` precedence **exactly**:
+
+    1. Calendar-level policy (``calendar_fk_id == calendar``).
+    2. Owning-membership policy, keyed on the pre-resolved ``membership_uid_ref``
+       (see ``_owning_membership_uid_expression``).
+    3. Organization-default policy (``is_organization_default``).
+
+    The whole-policy precedence is preserved: the FIRST existing layer wins and
+    its id is returned; the caller reads all four fields from *that* policy. No
+    per-field COALESCE across layers. Every subquery is org-scoped through
+    ``org_id_ref`` so no cross-tenant row can leak in.
+
+    ``membership_uid_ref`` is an expression (typically ``OuterRef`` of a
+    pre-computed annotation) that already resolves the owning membership for the
+    calendar — passing it in (rather than nesting the owner resolution here)
+    keeps every correlation pointed at the calendar row.
+    """
+    from calendar_integration.models import BookingPolicy
+
+    calendar_policy_id = (
+        BookingPolicy.objects.get_queryset()
+        .filter(organization_id=org_id_ref, calendar_fk_id=calendar_id_ref)
+        .values("id")[:1]
+    )
+    membership_policy_id = (
+        BookingPolicy.objects.get_queryset()
+        .filter(organization_id=org_id_ref, membership_user_id=membership_uid_ref)
+        .values("id")[:1]
+    )
+    org_default_policy_id = (
+        BookingPolicy.objects.get_queryset()
+        .filter(organization_id=org_id_ref, is_organization_default=True)
+        .values("id")[:1]
+    )
+    return Coalesce(
+        Subquery(calendar_policy_id, output_field=IntegerField()),
+        Subquery(membership_policy_id, output_field=IntegerField()),
+        Subquery(org_default_policy_id, output_field=IntegerField()),
+        output_field=IntegerField(),
+    )
+
+
+def _policy_field_subqueries(winning_policy_id_ref: OuterRef, org_id_ref: OuterRef) -> dict:
+    """Build the four ``effective_*_seconds`` field reads from a winning policy id.
+
+    Reads all four guardrail columns from the single BookingPolicy identified by
+    ``winning_policy_id_ref``. When no policy won (NULL id) every read is NULL,
+    which ``EffectivePolicy.from_annotation`` decodes as unconstrained. Scoped to
+    ``org_id_ref`` for defense-in-depth (the id is already org-resolved).
+    """
+    from calendar_integration.models import BookingPolicy
+
+    def _field(column: str) -> Subquery:
+        return Subquery(
+            BookingPolicy.objects.get_queryset()
+            .filter(organization_id=org_id_ref, id=winning_policy_id_ref)
+            .values(column)[:1],
+            output_field=IntegerField(),
+        )
+
+    return {
+        "effective_lead_time_seconds": _field("lead_time_seconds"),
+        "effective_max_horizon_seconds": _field("max_horizon_seconds"),
+        "effective_buffer_before_seconds": _field("buffer_before_seconds"),
+        "effective_buffer_after_seconds": _field("buffer_after_seconds"),
+    }
+
 
 class CalendarEventQuerySet(BaseOrganizationModelQuerySet, RecurringQuerySetMixin):
     """
@@ -500,6 +663,131 @@ class CalendarGroupQuerySet(BaseOrganizationModelQuerySet):
             qs = qs.filter(~Exists(unsatisfied_slot))
 
         return qs
+
+    def annotate_effective_policy(self) -> "CalendarGroupQuerySet":
+        """Annotate the four ``effective_*_seconds`` booking-policy columns.
+
+        Resolves, in a single query, the group precedence chain entirely in SQL:
+
+        1. Explicit group policy (``calendar_group_fk == group``) — read whole.
+        2. ``most_restrictive`` aggregate across every distinct participant
+           calendar (across all slots of the group), where each participant is
+           resolved via the single-calendar chain
+           (``_winning_calendar_policy_id_subquery``): ``MAX`` of lead /
+           buffer_before / buffer_after, and ``MIN`` over the POSITIVE horizons
+           (0/unbounded participants excluded; the group horizon is unbounded
+           only when every participant is unbounded).
+        3. Unconstrained (all NULL) when neither a group policy nor any
+           participant constraint exists.
+
+        Decode with ``EffectivePolicy.from_annotation(row)``. Org-scoped: the
+        group policy lookup, the participant traversal, and every per-participant
+        calendar subquery all filter by the group's own ``organization_id``.
+        """
+        from calendar_integration.models import BookingPolicy, CalendarGroupSlotMembership
+
+        org_ref = OuterRef("organization_id")
+        group_ref = OuterRef("pk")
+
+        # Layer 1: explicit group-level policy id (whole-policy precedence — when
+        # present, ALL four fields are read from it, never mixed with the
+        # participant aggregate).
+        group_policy_id = Subquery(
+            BookingPolicy.objects.get_queryset()
+            .filter(organization_id=org_ref, calendar_group_fk_id=group_ref)
+            .values("id")[:1],
+            output_field=IntegerField(),
+        )
+
+        def _group_policy_field(column: str) -> Subquery:
+            return Subquery(
+                BookingPolicy.objects.get_queryset()
+                .filter(
+                    organization_id=OuterRef("organization_id"),
+                    id=OuterRef("_group_policy_id"),
+                )
+                .values(column)[:1],
+                output_field=IntegerField(),
+            )
+
+        # Layer 2: most_restrictive over participant calendars. Each participant's
+        # effective field is resolved through the single-calendar chain, then
+        # aggregated across the distinct participant calendars of the group.
+        def _participant_base():
+            # One row per (slot-membership) participant. Each participant's
+            # effective policy is resolved through the single-calendar chain,
+            # correlated to the membership row's own calendar + org.
+            return (
+                CalendarGroupSlotMembership.objects.get_queryset()
+                .filter(
+                    organization_id=OuterRef("organization_id"),
+                    slot_fk__group_fk_id=OuterRef("pk"),
+                )
+                .annotate(
+                    _p_owning_uid=_owning_membership_uid_expression(
+                        OuterRef("calendar_fk_id"), OuterRef("organization_id")
+                    ),
+                )
+                .annotate(
+                    _p_policy_id=_winning_calendar_policy_id_expression(
+                        OuterRef("calendar_fk_id"),
+                        OuterRef("organization_id"),
+                        OuterRef("_p_owning_uid"),
+                    ),
+                )
+            )
+
+        def _participant_field(column: str):
+            return Subquery(
+                BookingPolicy.objects.get_queryset()
+                .filter(
+                    organization_id=OuterRef("organization_id"),
+                    id=OuterRef("_p_policy_id"),
+                )
+                .values(column)[:1],
+                output_field=IntegerField(),
+            )
+
+        def _participant_aggregate(column: str, *, positive_only: bool) -> Subquery:
+            participants = _participant_base().annotate(_p_value=_participant_field(column))
+            aggregate: Min | Max
+            if positive_only:
+                participants = participants.filter(_p_value__gt=0)
+                aggregate = Min("_p_value")
+            else:
+                aggregate = Max("_p_value")
+            return Subquery(
+                participants.values("organization_id").annotate(_agg=aggregate).values("_agg")[:1],
+                output_field=IntegerField(),
+            )
+
+        def _effective(column: str, *, positive_only: bool = False):
+            # Whole-policy precedence: when a group policy exists every field is
+            # read from it; otherwise the most_restrictive participant aggregate
+            # applies. ``Value(0)`` provides the unconstrained fallback so the
+            # column is never NULL.
+            return Case(
+                When(
+                    _group_policy_id__isnull=False,
+                    then=Coalesce(
+                        _group_policy_field(column), Value(0), output_field=IntegerField()
+                    ),
+                ),
+                default=Coalesce(
+                    _participant_aggregate(column, positive_only=positive_only),
+                    Value(0),
+                    output_field=IntegerField(),
+                ),
+                output_field=IntegerField(),
+            )
+
+        qs = self.annotate(_group_policy_id=group_policy_id)
+        return qs.annotate(
+            effective_lead_time_seconds=_effective("lead_time_seconds"),
+            effective_max_horizon_seconds=_effective("max_horizon_seconds", positive_only=True),
+            effective_buffer_before_seconds=_effective("buffer_before_seconds"),
+            effective_buffer_after_seconds=_effective("buffer_after_seconds"),
+        )
 
 
 class CalendarGroupSlotQuerySet(BaseOrganizationModelQuerySet):

--- a/calendar_integration/services/booking_policy_service.py
+++ b/calendar_integration/services/booking_policy_service.py
@@ -29,6 +29,7 @@ from audit.constants import AuditAction
 from audit.diff import compute_diff
 from calendar_integration.exceptions import (
     CalendarServiceOrganizationNotSetError,
+    DuplicateBookingPolicyError,
 )
 from calendar_integration.models import (
     BookingPolicy,
@@ -44,16 +45,8 @@ from organizations.models import Organization
 
 if TYPE_CHECKING:
     from audit.services import AuditService
-
-
-class DuplicateBookingPolicyError(Exception):
-    """Raised when a second BookingPolicy is created for the same target/org.
-
-    Callers (REST serializers, GraphQL mutations) should map this to a 400 /
-    validation error with the message surfaced to the client.
-    """
-
-    pass
+    from audit.types import ActorSnapshot
+    from calendar_integration.querysets import BookingPolicyQuerySet
 
 
 class BookingPolicyService:
@@ -76,7 +69,7 @@ class BookingPolicyService:
         # Optional actor context for audit records — set by the caller via
         # ``set_actor`` when the acting principal is known (e.g. a REST view or
         # GraphQL mutation that has an authenticated user/system-user).
-        self._actor: object | None = None
+        self._actor: ActorSnapshot | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -86,7 +79,7 @@ class BookingPolicyService:
         """Bind this service instance to a tenant organization."""
         self.organization = organization
 
-    def set_actor(self, actor: object) -> None:
+    def set_actor(self, actor: "ActorSnapshot") -> None:
         """Capture the acting principal for audit records.
 
         Pass the resolved ``ActorSnapshot`` from the calling layer (REST view or
@@ -121,15 +114,16 @@ class BookingPolicyService:
         """
         if self.audit_service is None or self.organization is None:
             return
+        # Runtime import: AuditService is TYPE_CHECKING-only at module top to avoid the di_core import cycle.
         from audit.services import AuditService
 
-        actor = self._actor
-        if actor is None:
-            actor = AuditService.system_actor()
+        actor: ActorSnapshot = (
+            self._actor if self._actor is not None else AuditService.system_actor()
+        )
         self.audit_service.record(
             organization_id=self.organization.id,
             action=action,
-            actor=actor,  # type: ignore[arg-type]
+            actor=actor,
             subject=self.audit_service.subject_from_instance(policy),
             diff=diff,
         )
@@ -494,7 +488,7 @@ class BookingPolicyService:
     # Fetch helpers (for REST / GraphQL read paths)
     # ------------------------------------------------------------------
 
-    def get_all_policies(self):  # type: ignore[return]
+    def get_all_policies(self) -> "BookingPolicyQuerySet":
         """Return an org-scoped queryset of all BookingPolicy rows."""
         self._assert_initialized()
         return BookingPolicy.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]

--- a/calendar_integration/services/booking_policy_service.py
+++ b/calendar_integration/services/booking_policy_service.py
@@ -1,0 +1,500 @@
+"""BookingPolicyService — resolver and CRUD for BookingPolicy.
+
+Resolves the effective booking policy for a single calendar, a bundle calendar,
+or a calendar group via the deterministic precedence chain defined in the plan:
+
+- **Single calendar**: calendar policy → owning-membership policy → org-default
+  policy → unconstrained.  Owning membership is resolved through
+  ``CalendarOwnership``: lone owner, else ``is_default=True`` when there are
+  multiple, else skip the membership layer.
+
+- **Bundle calendar**: explicit bundle/calendar policy (the bundle *calendar*
+  itself is looked up by calendar FK) → most-restrictive combination across all
+  ``bundle_children`` via ``most_restrictive(EffectivePolicy.from_model(p) ...)``
+  → unconstrained.
+
+- **Calendar group**: explicit group policy (looked up by calendar_group FK) →
+  most-restrictive combination across all calendars that belong to any slot in
+  the group → unconstrained.
+
+All write paths (create / update / delete) emit ``AuditService`` records and
+enforce the uniqueness contract (one policy per target per org).
+"""
+
+from typing import TYPE_CHECKING, Annotated
+
+from dependency_injector.wiring import Provide, inject
+
+from audit.constants import AuditAction
+from audit.diff import compute_diff
+from calendar_integration.exceptions import (
+    CalendarServiceOrganizationNotSetError,
+)
+from calendar_integration.models import (
+    BookingPolicy,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlotMembership,
+    CalendarOwnership,
+    ChildrenCalendarRelationship,
+)
+from calendar_integration.services.dataclasses import EffectivePolicy
+from organizations.models import Organization
+
+
+if TYPE_CHECKING:
+    from audit.services import AuditService
+
+
+class DuplicateBookingPolicyError(Exception):
+    """Raised when a second BookingPolicy is created for the same target/org.
+
+    Callers (REST serializers, GraphQL mutations) should map this to a 400 /
+    validation error with the message surfaced to the client.
+    """
+
+    pass
+
+
+class BookingPolicyService:
+    """Service for booking-policy resolution and CRUD.
+
+    Must be initialized with ``initialize(organization)`` before use.  All query
+    paths are fully organization-scoped through the ``BookingPolicyManager``
+    helpers introduced in Phase 1 — no raw or unscoped queries are made.
+    """
+
+    organization: Organization | None
+
+    @inject
+    def __init__(
+        self,
+        audit_service: Annotated["AuditService | None", Provide["audit_service"]] = None,
+    ) -> None:
+        self.organization = None
+        self.audit_service = audit_service
+        # Optional actor context for audit records — set by the caller via
+        # ``set_actor`` when the acting principal is known (e.g. a REST view or
+        # GraphQL mutation that has an authenticated user/system-user).
+        self._actor: object | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def initialize(self, organization: Organization) -> None:
+        """Bind this service instance to a tenant organization."""
+        self.organization = organization
+
+    def set_actor(self, actor: object) -> None:
+        """Capture the acting principal for audit records.
+
+        Pass the resolved ``ActorSnapshot`` from the calling layer (REST view or
+        GraphQL resolver) so the audit trail records the right actor.  When not
+        called, ``_actor`` stays ``None`` and the audit helper falls back to the
+        system actor.
+        """
+        self._actor = actor
+
+    def _assert_initialized(self) -> None:
+        if self.organization is None:
+            raise CalendarServiceOrganizationNotSetError(
+                "BookingPolicyService requires an organization. Call initialize()."
+            )
+
+    # ------------------------------------------------------------------
+    # Audit helper
+    # ------------------------------------------------------------------
+
+    def _audit_write(
+        self,
+        action: str,
+        policy: BookingPolicy,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a booking-policy business write.
+
+        No-op when ``audit_service`` or ``organization`` is not bound — so
+        instrumentation never breaks a write path (mirrors the pattern used by
+        ``CalendarService._audit_calendar_write`` and
+        ``CalendarGroupService._audit_group_write``).
+        """
+        if self.audit_service is None or self.organization is None:
+            return
+        from audit.services import AuditService
+
+        actor = self._actor
+        if actor is None:
+            actor = AuditService.system_actor()
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=action,
+            actor=actor,  # type: ignore[arg-type]
+            subject=self.audit_service.subject_from_instance(policy),
+            diff=diff,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal query helpers (all org-scoped via manager)
+    # ------------------------------------------------------------------
+
+    def _policy_for_calendar(self, calendar_id: int) -> BookingPolicy | None:
+        """Return the calendar-level policy for ``calendar_id``, or ``None``."""
+        return BookingPolicy.objects.for_target(
+            self.organization.id,  # type: ignore[union-attr]
+            calendar_id=calendar_id,
+        )
+
+    def _policy_for_membership(self, membership_user_id: int) -> BookingPolicy | None:
+        """Return the membership-level policy for ``membership_user_id``, or ``None``."""
+        return BookingPolicy.objects.for_target(
+            self.organization.id,  # type: ignore[union-attr]
+            membership_user_id=membership_user_id,
+        )
+
+    def _policy_for_group(self, calendar_group_id: int) -> BookingPolicy | None:
+        """Return the group-level policy for ``calendar_group_id``, or ``None``."""
+        return BookingPolicy.objects.for_target(
+            self.organization.id,  # type: ignore[union-attr]
+            calendar_group_id=calendar_group_id,
+        )
+
+    def _org_default_policy(self) -> BookingPolicy | None:
+        """Return the organization-default policy, or ``None``."""
+        return BookingPolicy.objects.org_default(self.organization.id)  # type: ignore[union-attr]
+
+    # ------------------------------------------------------------------
+    # Owning-membership resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_owning_membership_user_id(self, calendar: Calendar) -> int | None:
+        """Resolve the single owning-membership user id for ``calendar``.
+
+        Rules (from the plan's Guiding Decisions):
+        1. Exactly one ``CalendarOwnership`` with non-NULL ``membership_user_id``
+           → return that user id.
+        2. Multiple ownerships → return the ``is_default=True`` one's user id.
+        3. Zero non-NULL ownerships → return ``None`` (skip the membership layer;
+           resource / shared calendars).
+
+        Orphan ownerships (``membership_user_id IS NULL``) are excluded from the
+        count and from the resolution (they carry no membership FK and therefore
+        no membership policy can be attached to them).
+        """
+        # Filter to ownerships that belong to this org and have a real membership.
+        # We read through the CalendarOwnership manager which is an OrganizationModel
+        # so we must use filter_by_organization.
+        ownerships = list(
+            CalendarOwnership.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
+            .filter(calendar_fk_id=calendar.id)
+            .exclude(membership_user_id__isnull=True)
+            .values_list("membership_user_id", "is_default")
+        )
+
+        if not ownerships:
+            return None
+        if len(ownerships) == 1:
+            membership_user_id, _ = ownerships[0]
+            return membership_user_id
+
+        # Multiple ownerships — pick the is_default=True one.
+        for membership_user_id, is_default in ownerships:
+            if is_default:
+                return membership_user_id
+
+        # Multiple ownerships with no is_default=True → skip the membership layer.
+        return None
+
+    # ------------------------------------------------------------------
+    # Resolution API
+    # ------------------------------------------------------------------
+
+    def resolve_for_calendar(self, calendar: Calendar) -> EffectivePolicy:
+        """Resolve the effective booking policy for a single (non-bundle) calendar.
+
+        Precedence:
+        1. Calendar-level policy.
+        2. Owning-membership policy (lone owner, or ``is_default`` owner when
+           several; otherwise skip).
+        3. Org-default policy.
+        4. ``EffectivePolicy.unconstrained()``.
+        """
+        self._assert_initialized()
+
+        # 1. Calendar-level policy.
+        cal_policy = self._policy_for_calendar(calendar.id)
+        if cal_policy is not None:
+            return EffectivePolicy.from_model(cal_policy)
+
+        # 2. Owning-membership policy.
+        owning_user_id = self._resolve_owning_membership_user_id(calendar)
+        if owning_user_id is not None:
+            mem_policy = self._policy_for_membership(owning_user_id)
+            if mem_policy is not None:
+                return EffectivePolicy.from_model(mem_policy)
+
+        # 3. Org-default policy.
+        default_policy = self._org_default_policy()
+        if default_policy is not None:
+            return EffectivePolicy.from_model(default_policy)
+
+        # 4. No policy anywhere → unconstrained.
+        return EffectivePolicy.unconstrained()
+
+    def resolve_for_bundle(self, bundle_calendar: Calendar) -> EffectivePolicy:
+        """Resolve the effective booking policy for a bundle calendar.
+
+        Precedence:
+        1. Explicit policy attached directly to the bundle calendar (calendar FK).
+        2. ``most_restrictive`` combination across all ``bundle_children``
+           calendars, where each child's policy is resolved via
+           ``resolve_for_calendar``.
+        3. ``EffectivePolicy.unconstrained()``.
+        """
+        self._assert_initialized()
+
+        # 1. Explicit bundle-calendar policy.
+        bundle_policy = self._policy_for_calendar(bundle_calendar.id)
+        if bundle_policy is not None:
+            return EffectivePolicy.from_model(bundle_policy)
+
+        # 2. Most-restrictive across all child calendars.
+        child_calendar_ids = list(
+            ChildrenCalendarRelationship.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
+            .filter(bundle_calendar_fk_id=bundle_calendar.pk)
+            .values_list("child_calendar_fk_id", flat=True)
+        )
+        if child_calendar_ids:
+            child_calendars = list(
+                Calendar.objects.filter_by_organization(self.organization.id).filter(  # type: ignore[union-attr]
+                    id__in=child_calendar_ids
+                )
+            )
+            child_policies = [self.resolve_for_calendar(cal) for cal in child_calendars]
+            combined = EffectivePolicy.most_restrictive(child_policies)
+            if combined != EffectivePolicy.unconstrained():
+                return combined
+
+        # 3. Unconstrained.
+        return EffectivePolicy.unconstrained()
+
+    def resolve_for_group(self, group: CalendarGroup) -> EffectivePolicy:
+        """Resolve the effective booking policy for a calendar group.
+
+        Precedence:
+        1. Explicit policy attached to the group (calendar_group FK).
+        2. ``most_restrictive`` combination across all calendars that belong to
+           any slot in the group, each resolved via ``resolve_for_calendar``.
+        3. ``EffectivePolicy.unconstrained()``.
+        """
+        self._assert_initialized()
+
+        # 1. Explicit group policy.
+        group_policy = self._policy_for_group(group.id)
+        if group_policy is not None:
+            return EffectivePolicy.from_model(group_policy)
+
+        # 2. Most-restrictive across all participant calendars.
+        # Collect all distinct calendar IDs across every slot of the group.
+        # Use slot_fk__group_fk_id to traverse the concrete FK columns.
+        participant_calendar_ids = list(
+            CalendarGroupSlotMembership.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
+            .filter(slot_fk__group_fk_id=group.id)
+            .values_list("calendar_fk_id", flat=True)
+            .distinct()
+        )
+        if participant_calendar_ids:
+            participant_calendars = list(
+                Calendar.objects.filter_by_organization(self.organization.id).filter(  # type: ignore[union-attr]
+                    id__in=participant_calendar_ids
+                )
+            )
+            participant_policies = [self.resolve_for_calendar(cal) for cal in participant_calendars]
+            combined = EffectivePolicy.most_restrictive(participant_policies)
+            if combined != EffectivePolicy.unconstrained():
+                return combined
+
+        # 3. Unconstrained.
+        return EffectivePolicy.unconstrained()
+
+    # ------------------------------------------------------------------
+    # Write API (create / update / delete)
+    # ------------------------------------------------------------------
+
+    def create_booking_policy(
+        self,
+        *,
+        calendar: Calendar | None = None,
+        membership_user_id: int | None = None,
+        calendar_group: CalendarGroup | None = None,
+        is_organization_default: bool = False,
+        lead_time_seconds: int = 0,
+        max_horizon_seconds: int = 0,
+        buffer_before_seconds: int = 0,
+        buffer_after_seconds: int = 0,
+    ) -> BookingPolicy:
+        """Create a new BookingPolicy for the bound organization.
+
+        Exactly one target must be specified.  Raises ``DuplicateBookingPolicyError``
+        when a policy already exists for the same target (mirroring the DB's
+        partial-unique-index constraint, but caught earlier with a clear message).
+        Emits an ``AuditService`` CREATE record on success.
+        """
+        self._assert_initialized()
+
+        targets_set = [
+            calendar is not None,
+            membership_user_id is not None,
+            calendar_group is not None,
+            is_organization_default,
+        ]
+        if sum(targets_set) != 1:
+            raise ValueError(
+                "create_booking_policy requires exactly one target: calendar, "
+                "membership_user_id, calendar_group, or is_organization_default."
+            )
+
+        org_id = self.organization.id  # type: ignore[union-attr]
+        org = self.organization  # type: ignore[assignment]
+
+        # Check uniqueness before hitting the DB constraint to provide a clear error.
+        if calendar is not None and self._policy_for_calendar(calendar.id) is not None:
+            raise DuplicateBookingPolicyError(
+                f"A BookingPolicy already exists for calendar {calendar.id} "
+                f"in organization {org_id}."
+            )
+        if (
+            membership_user_id is not None
+            and self._policy_for_membership(membership_user_id) is not None
+        ):
+            raise DuplicateBookingPolicyError(
+                f"A BookingPolicy already exists for membership {membership_user_id} "
+                f"in organization {org_id}."
+            )
+        if calendar_group is not None and self._policy_for_group(calendar_group.id) is not None:
+            raise DuplicateBookingPolicyError(
+                f"A BookingPolicy already exists for calendar group {calendar_group.id} "
+                f"in organization {org_id}."
+            )
+        if is_organization_default and self._org_default_policy() is not None:
+            raise DuplicateBookingPolicyError(
+                f"An organization-default BookingPolicy already exists for organization {org_id}."
+            )
+
+        policy = BookingPolicy.objects.create(
+            organization=org,
+            calendar=calendar,
+            membership_user_id=membership_user_id,
+            calendar_group=calendar_group,
+            is_organization_default=is_organization_default,
+            lead_time_seconds=lead_time_seconds,
+            max_horizon_seconds=max_horizon_seconds,
+            buffer_before_seconds=buffer_before_seconds,
+            buffer_after_seconds=buffer_after_seconds,
+        )
+        self._audit_write(AuditAction.CREATE, policy)
+        return policy
+
+    def update_booking_policy(
+        self,
+        policy: BookingPolicy,
+        *,
+        lead_time_seconds: int | None = None,
+        max_horizon_seconds: int | None = None,
+        buffer_before_seconds: int | None = None,
+        buffer_after_seconds: int | None = None,
+    ) -> BookingPolicy:
+        """Update the rule-fields of an existing BookingPolicy.
+
+        Target fields (calendar, membership, calendar_group, is_organization_default)
+        are intentionally not updatable — to change a target, delete and re-create.
+        Emits an ``AuditService`` UPDATE record with field diffs on success.
+        """
+        self._assert_initialized()
+
+        # Capture the before-state for the diff.
+        before = {
+            "lead_time_seconds": policy.lead_time_seconds,
+            "max_horizon_seconds": policy.max_horizon_seconds,
+            "buffer_before_seconds": policy.buffer_before_seconds,
+            "buffer_after_seconds": policy.buffer_after_seconds,
+        }
+
+        fields_to_update: list[str] = []
+        if lead_time_seconds is not None:
+            policy.lead_time_seconds = lead_time_seconds
+            fields_to_update.append("lead_time_seconds")
+        if max_horizon_seconds is not None:
+            policy.max_horizon_seconds = max_horizon_seconds
+            fields_to_update.append("max_horizon_seconds")
+        if buffer_before_seconds is not None:
+            policy.buffer_before_seconds = buffer_before_seconds
+            fields_to_update.append("buffer_before_seconds")
+        if buffer_after_seconds is not None:
+            policy.buffer_after_seconds = buffer_after_seconds
+            fields_to_update.append("buffer_after_seconds")
+
+        if fields_to_update:
+            policy.save(update_fields=fields_to_update)
+
+        after = {
+            "lead_time_seconds": policy.lead_time_seconds,
+            "max_horizon_seconds": policy.max_horizon_seconds,
+            "buffer_before_seconds": policy.buffer_before_seconds,
+            "buffer_after_seconds": policy.buffer_after_seconds,
+        }
+        diff = compute_diff(before, after)
+        self._audit_write(AuditAction.UPDATE, policy, diff=diff)
+        return policy
+
+    def delete_booking_policy(self, policy: BookingPolicy | None) -> None:
+        """Delete a BookingPolicy.
+
+        Idempotent no-op when ``policy`` is ``None`` (delete-absent semantics from
+        the plan's Guiding Decisions).  Emits an ``AuditService`` DELETE record
+        when an actual row is deleted.
+        """
+        self._assert_initialized()
+
+        if policy is None:
+            return
+
+        self._audit_write(AuditAction.DELETE, policy)
+        policy.delete()
+
+    # ------------------------------------------------------------------
+    # Convenience: fetch-then-delete helpers for the REST / GraphQL layers
+    # ------------------------------------------------------------------
+
+    def delete_policy_for_calendar(self, calendar: Calendar) -> None:
+        """Delete the policy attached to ``calendar``, or no-op if absent."""
+        self._assert_initialized()
+        policy = self._policy_for_calendar(calendar.id)
+        self.delete_booking_policy(policy)
+
+    def delete_policy_for_membership(self, membership_user_id: int) -> None:
+        """Delete the policy attached to ``membership_user_id``, or no-op if absent."""
+        self._assert_initialized()
+        policy = self._policy_for_membership(membership_user_id)
+        self.delete_booking_policy(policy)
+
+    def delete_policy_for_group(self, calendar_group: CalendarGroup) -> None:
+        """Delete the policy attached to ``calendar_group``, or no-op if absent."""
+        self._assert_initialized()
+        policy = self._policy_for_group(calendar_group.id)
+        self.delete_booking_policy(policy)
+
+    def delete_org_default_policy(self) -> None:
+        """Delete the organization-default policy, or no-op if absent."""
+        self._assert_initialized()
+        policy = self._org_default_policy()
+        self.delete_booking_policy(policy)
+
+    # ------------------------------------------------------------------
+    # Fetch helpers (for REST / GraphQL read paths)
+    # ------------------------------------------------------------------
+
+    def get_all_policies(self):  # type: ignore[return]
+        """Return an org-scoped queryset of all BookingPolicy rows."""
+        self._assert_initialized()
+        return BookingPolicy.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]

--- a/calendar_integration/services/booking_policy_service.py
+++ b/calendar_integration/services/booking_policy_service.py
@@ -35,7 +35,6 @@ from calendar_integration.models import (
     BookingPolicy,
     Calendar,
     CalendarGroup,
-    CalendarGroupSlotMembership,
     CalendarOwnership,
     ChildrenCalendarRelationship,
 )
@@ -206,34 +205,25 @@ class BookingPolicyService:
     def resolve_for_calendar(self, calendar: Calendar) -> EffectivePolicy:
         """Resolve the effective booking policy for a single (non-bundle) calendar.
 
-        Precedence:
+        Precedence (resolved entirely in the DB via
+        ``CalendarQuerySet.annotate_effective_policy``):
         1. Calendar-level policy.
         2. Owning-membership policy (lone owner, or ``is_default`` owner when
            several; otherwise skip).
         3. Org-default policy.
         4. ``EffectivePolicy.unconstrained()``.
+
+        One query: the precedence chain — including the owning-membership
+        tiebreak — is evaluated in SQL and surfaced as four annotated columns.
         """
         self._assert_initialized()
 
-        # 1. Calendar-level policy.
-        cal_policy = self._policy_for_calendar(calendar.id)
-        if cal_policy is not None:
-            return EffectivePolicy.from_model(cal_policy)
-
-        # 2. Owning-membership policy.
-        owning_user_id = self._resolve_owning_membership_user_id(calendar)
-        if owning_user_id is not None:
-            mem_policy = self._policy_for_membership(owning_user_id)
-            if mem_policy is not None:
-                return EffectivePolicy.from_model(mem_policy)
-
-        # 3. Org-default policy.
-        default_policy = self._org_default_policy()
-        if default_policy is not None:
-            return EffectivePolicy.from_model(default_policy)
-
-        # 4. No policy anywhere → unconstrained.
-        return EffectivePolicy.unconstrained()
+        row = (
+            Calendar.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
+            .annotate_effective_policy()
+            .get(pk=calendar.id)
+        )
+        return EffectivePolicy.from_annotation(row)
 
     def resolve_for_bundle(self, bundle_calendar: Calendar) -> EffectivePolicy:
         """Resolve the effective booking policy for a bundle calendar.
@@ -241,30 +231,36 @@ class BookingPolicyService:
         Precedence:
         1. Explicit policy attached directly to the bundle calendar (calendar FK).
         2. ``most_restrictive`` combination across all ``bundle_children``
-           calendars, where each child's policy is resolved via
-           ``resolve_for_calendar``.
+           calendars, where each child's policy is resolved via the single-
+           calendar DB annotation.
         3. ``EffectivePolicy.unconstrained()``.
+
+        The children are resolved in a single annotated query (no per-child
+        round trip), then combined in Python via
+        ``EffectivePolicy.most_restrictive``.
         """
         self._assert_initialized()
 
-        # 1. Explicit bundle-calendar policy.
+        # 1. Explicit bundle-calendar policy.  A policy attached to the bundle
+        #    calendar IS a calendar-level policy, so it short-circuits the
+        #    children combination — preserving the original precedence.
         bundle_policy = self._policy_for_calendar(bundle_calendar.id)
         if bundle_policy is not None:
             return EffectivePolicy.from_model(bundle_policy)
 
-        # 2. Most-restrictive across all child calendars.
+        # 2. Most-restrictive across all child calendars (single annotated query).
         child_calendar_ids = list(
             ChildrenCalendarRelationship.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
             .filter(bundle_calendar_fk_id=bundle_calendar.pk)
             .values_list("child_calendar_fk_id", flat=True)
         )
         if child_calendar_ids:
-            child_calendars = list(
-                Calendar.objects.filter_by_organization(self.organization.id).filter(  # type: ignore[union-attr]
-                    id__in=child_calendar_ids
-                )
+            child_rows = (
+                Calendar.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
+                .annotate_effective_policy()
+                .filter(id__in=child_calendar_ids)
             )
-            child_policies = [self.resolve_for_calendar(cal) for cal in child_calendars]
+            child_policies = [EffectivePolicy.from_annotation(row) for row in child_rows]
             combined = EffectivePolicy.most_restrictive(child_policies)
             if combined != EffectivePolicy.unconstrained():
                 return combined
@@ -275,41 +271,24 @@ class BookingPolicyService:
     def resolve_for_group(self, group: CalendarGroup) -> EffectivePolicy:
         """Resolve the effective booking policy for a calendar group.
 
-        Precedence:
+        Precedence (resolved entirely in the DB via
+        ``CalendarGroupQuerySet.annotate_effective_policy``):
         1. Explicit policy attached to the group (calendar_group FK).
         2. ``most_restrictive`` combination across all calendars that belong to
-           any slot in the group, each resolved via ``resolve_for_calendar``.
+           any slot in the group, each resolved via the single-calendar chain.
         3. ``EffectivePolicy.unconstrained()``.
+
+        One query regardless of participant count: the participant traversal and
+        the ``most_restrictive`` aggregate are evaluated in SQL.
         """
         self._assert_initialized()
 
-        # 1. Explicit group policy.
-        group_policy = self._policy_for_group(group.id)
-        if group_policy is not None:
-            return EffectivePolicy.from_model(group_policy)
-
-        # 2. Most-restrictive across all participant calendars.
-        # Collect all distinct calendar IDs across every slot of the group.
-        # Use slot_fk__group_fk_id to traverse the concrete FK columns.
-        participant_calendar_ids = list(
-            CalendarGroupSlotMembership.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
-            .filter(slot_fk__group_fk_id=group.id)
-            .values_list("calendar_fk_id", flat=True)
-            .distinct()
+        row = (
+            CalendarGroup.objects.filter_by_organization(self.organization.id)  # type: ignore[union-attr]
+            .annotate_effective_policy()
+            .get(pk=group.id)
         )
-        if participant_calendar_ids:
-            participant_calendars = list(
-                Calendar.objects.filter_by_organization(self.organization.id).filter(  # type: ignore[union-attr]
-                    id__in=participant_calendar_ids
-                )
-            )
-            participant_policies = [self.resolve_for_calendar(cal) for cal in participant_calendars]
-            combined = EffectivePolicy.most_restrictive(participant_policies)
-            if combined != EffectivePolicy.unconstrained():
-                return combined
-
-        # 3. Unconstrained.
-        return EffectivePolicy.unconstrained()
+        return EffectivePolicy.from_annotation(row)
 
     # ------------------------------------------------------------------
     # Write API (create / update / delete)

--- a/calendar_integration/services/dataclasses.py
+++ b/calendar_integration/services/dataclasses.py
@@ -400,6 +400,36 @@ class EffectivePolicy:
             buffer_after=datetime.timedelta(seconds=policy.buffer_after_seconds),
         )
 
+    @classmethod
+    def from_annotation(cls, row) -> "EffectivePolicy":
+        """Build an EffectivePolicy from the four ``effective_*_seconds`` annotations.
+
+        ``row`` is any object exposing the four annotated attributes produced by
+        ``annotate_effective_policy`` — typically a ``Calendar`` or
+        ``CalendarGroup`` instance fetched through an annotated queryset:
+
+        - ``effective_lead_time_seconds``
+        - ``effective_max_horizon_seconds``
+        - ``effective_buffer_before_seconds``
+        - ``effective_buffer_after_seconds``
+
+        A ``0`` or ``NULL`` horizon maps to ``max_horizon=None`` ("0 = unbounded",
+        mirroring ``from_model``). ``0`` / ``NULL`` lead-time and buffers map to
+        ``timedelta(0)``. The annotation resolves the entire precedence chain in
+        SQL, so this method does nothing more than decode the four columns.
+        """
+        lead = row.effective_lead_time_seconds or 0
+        horizon = row.effective_max_horizon_seconds or 0
+        buffer_before = row.effective_buffer_before_seconds or 0
+        buffer_after = row.effective_buffer_after_seconds or 0
+
+        return cls(
+            lead_time=datetime.timedelta(seconds=lead),
+            max_horizon=(datetime.timedelta(seconds=horizon) if horizon > 0 else None),
+            buffer_before=datetime.timedelta(seconds=buffer_before),
+            buffer_after=datetime.timedelta(seconds=buffer_after),
+        )
+
     @staticmethod
     def most_restrictive(policies: Iterable["EffectivePolicy"]) -> "EffectivePolicy":
         """Combine multiple EffectivePolicy instances into the most-restrictive one.

--- a/calendar_integration/services/dataclasses.py
+++ b/calendar_integration/services/dataclasses.py
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Iterable
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, Protocol, TypedDict
 
 from calendar_integration.constants import (
     CalendarProvider,
@@ -17,6 +17,21 @@ from calendar_integration.models import (
 
 if TYPE_CHECKING:
     from calendar_integration.models import BookingPolicy
+
+
+class _EffectivePolicyRow(Protocol):
+    """Row shape consumed by ``EffectivePolicy.from_annotation``.
+
+    Any object (typically a ``Calendar`` or ``CalendarGroup`` fetched through an
+    annotated queryset) exposing the four ``effective_*_seconds`` columns produced
+    by ``annotate_effective_policy``. Each is ``int | None`` (NULL when no policy
+    resolved).
+    """
+
+    effective_lead_time_seconds: int | None
+    effective_max_horizon_seconds: int | None
+    effective_buffer_before_seconds: int | None
+    effective_buffer_after_seconds: int | None
 
 
 @dataclass
@@ -401,7 +416,7 @@ class EffectivePolicy:
         )
 
     @classmethod
-    def from_annotation(cls, row) -> "EffectivePolicy":
+    def from_annotation(cls, row: "_EffectivePolicyRow") -> "EffectivePolicy":
         """Build an EffectivePolicy from the four ``effective_*_seconds`` annotations.
 
         ``row`` is any object exposing the four annotated attributes produced by

--- a/calendar_integration/services/dataclasses.py
+++ b/calendar_integration/services/dataclasses.py
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Iterable
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
-from typing import Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 from calendar_integration.constants import (
     CalendarProvider,
@@ -13,6 +13,10 @@ from calendar_integration.models import (
     EventAttendance,
     EventExternalAttendance,
 )
+
+
+if TYPE_CHECKING:
+    from calendar_integration.models import BookingPolicy
 
 
 @dataclass
@@ -345,3 +349,86 @@ class BookableSlotProposal:
 
     start_time: datetime.datetime
     end_time: datetime.datetime
+
+
+@dataclass(frozen=True)
+class EffectivePolicy:
+    """The resolved set of booking guardrails for a calendar, bundle, or group.
+
+    Field semantics (mirrors ``BookingPolicy`` field encoding):
+    - ``lead_time``: minimum advance notice required before a slot can start.
+      Zero means "bookable now."
+    - ``max_horizon``: how far ahead a slot may be offered. ``None`` means
+      unbounded (no horizon constraint). A stored ``max_horizon_seconds=0`` on the
+      model maps to ``None`` here — "0 = no constraint" per spec.
+    - ``buffer_before``: dead zone before an existing event; candidate slots whose
+      window extends into ``[event.start - buffer_before, event.start)`` are blocked.
+      Zero means flush booking is allowed.
+    - ``buffer_after``: dead zone after an existing event. Zero means flush allowed.
+    """
+
+    lead_time: datetime.timedelta
+    max_horizon: datetime.timedelta | None  # None = unbounded
+    buffer_before: datetime.timedelta
+    buffer_after: datetime.timedelta
+
+    @classmethod
+    def unconstrained(cls) -> "EffectivePolicy":
+        """Return an EffectivePolicy with no constraints on any field."""
+        return cls(
+            lead_time=datetime.timedelta(0),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+
+    @classmethod
+    def from_model(cls, policy: "BookingPolicy") -> "EffectivePolicy":
+        """Build an EffectivePolicy from a BookingPolicy model instance.
+
+        ``max_horizon_seconds=0`` on the model means "unbounded" and maps to
+        ``max_horizon=None`` here, consistent with the spec's "0 = no constraint."
+        """
+        return cls(
+            lead_time=datetime.timedelta(seconds=policy.lead_time_seconds),
+            max_horizon=(
+                datetime.timedelta(seconds=policy.max_horizon_seconds)
+                if policy.max_horizon_seconds > 0
+                else None
+            ),
+            buffer_before=datetime.timedelta(seconds=policy.buffer_before_seconds),
+            buffer_after=datetime.timedelta(seconds=policy.buffer_after_seconds),
+        )
+
+    @staticmethod
+    def most_restrictive(policies: Iterable["EffectivePolicy"]) -> "EffectivePolicy":
+        """Combine multiple EffectivePolicy instances into the most-restrictive one.
+
+        Field combination rules:
+        - ``lead_time``: max (the longest required advance notice wins).
+        - ``max_horizon``: min of the non-None values (the shortest horizon wins;
+          ``None`` = unbounded = effectively infinite, so it is excluded from the
+          min — only binding if ALL policies have ``None`` horizon).
+        - ``buffer_before``: max (the largest buffer wins).
+        - ``buffer_after``: max.
+
+        An empty input sequence returns ``unconstrained()``.
+        """
+        policy_list = list(policies)
+        if not policy_list:
+            return EffectivePolicy.unconstrained()
+
+        max_lead = max(p.lead_time for p in policy_list)
+        max_buffer_before = max(p.buffer_before for p in policy_list)
+        max_buffer_after = max(p.buffer_after for p in policy_list)
+
+        # Finite horizons only; None (unbounded) acts as +∞ and is skipped.
+        finite_horizons = [p.max_horizon for p in policy_list if p.max_horizon is not None]
+        min_horizon = min(finite_horizons) if finite_horizons else None
+
+        return EffectivePolicy(
+            lead_time=max_lead,
+            max_horizon=min_horizon,
+            buffer_before=max_buffer_before,
+            buffer_after=max_buffer_after,
+        )

--- a/calendar_integration/tests/services/test_booking_policy_service.py
+++ b/calendar_integration/tests/services/test_booking_policy_service.py
@@ -1,0 +1,894 @@
+"""Unit tests for BookingPolicyService (Phase 2).
+
+Covers:
+- ``EffectivePolicy`` dataclass methods (``unconstrained``, ``from_model``,
+  ``most_restrictive``).
+- ``BookingPolicyService.resolve_for_calendar``: full precedence matrix.
+- Owning-membership ambiguity (zero / one / multiple with is_default).
+- ``resolve_for_bundle`` and ``resolve_for_group`` precedence.
+- Create-uniqueness rejection (``DuplicateBookingPolicyError``).
+- Update with field diffs.
+- Delete-absent idempotent no-op.
+- Audit records emitted on create / update / delete.
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from model_bakery import baker
+
+from calendar_integration.constants import CalendarType
+from calendar_integration.exceptions import CalendarServiceOrganizationNotSetError
+from calendar_integration.factories import create_booking_policy
+from calendar_integration.models import (
+    BookingPolicy,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarOwnership,
+    ChildrenCalendarRelationship,
+)
+from calendar_integration.services.booking_policy_service import (
+    BookingPolicyService,
+    DuplicateBookingPolicyError,
+)
+from calendar_integration.services.dataclasses import EffectivePolicy
+from organizations.models import Organization, OrganizationMembership
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _org() -> Organization:
+    return baker.make(Organization)
+
+
+_calendar_counter = 0
+
+
+def _calendar(org: Organization, **extra) -> Calendar:
+    """Create a Calendar with a unique external_id to avoid the unique constraint."""
+    global _calendar_counter
+    _calendar_counter += 1
+    return baker.make(Calendar, organization=org, external_id=f"cal-{_calendar_counter}", **extra)
+
+
+def _membership(org: Organization) -> int:
+    """Create an OrganizationMembership and return its user_id (denormalized PK)."""
+    from users.models import User
+
+    user: User = baker.make(User)
+    OrganizationMembership.objects.create(user=user, organization=org)
+    return user.id
+
+
+def _own(calendar: Calendar, membership_user_id: int, is_default: bool = False):
+    """Create a CalendarOwnership row."""
+    CalendarOwnership.objects.create(
+        organization=calendar.organization,
+        calendar=calendar,
+        membership_user_id=membership_user_id,
+        is_default=is_default,
+    )
+
+
+def _service(org: Organization, *, audit_service=None) -> BookingPolicyService:
+    svc = BookingPolicyService(audit_service=audit_service)
+    svc.initialize(organization=org)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# EffectivePolicy — unit tests (no DB required)
+# ---------------------------------------------------------------------------
+
+
+class TestEffectivePolicyUnconstrained:
+    def test_all_zero_or_none(self):
+        ep = EffectivePolicy.unconstrained()
+        assert ep.lead_time == datetime.timedelta(0)
+        assert ep.max_horizon is None
+        assert ep.buffer_before == datetime.timedelta(0)
+        assert ep.buffer_after == datetime.timedelta(0)
+
+    def test_frozen(self):
+        ep = EffectivePolicy.unconstrained()
+        with pytest.raises((AttributeError, TypeError)):
+            ep.lead_time = datetime.timedelta(1)  # type: ignore[misc]
+
+
+class TestEffectivePolicyFromModel:
+    @pytest.mark.django_db
+    def test_zero_horizon_maps_to_none(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(
+            calendar=cal,
+            lead_time_seconds=3600,
+            max_horizon_seconds=0,
+            buffer_before_seconds=300,
+            buffer_after_seconds=600,
+        )
+        ep = EffectivePolicy.from_model(policy)
+        assert ep.lead_time == datetime.timedelta(hours=1)
+        assert ep.max_horizon is None
+        assert ep.buffer_before == datetime.timedelta(seconds=300)
+        assert ep.buffer_after == datetime.timedelta(seconds=600)
+
+    @pytest.mark.django_db
+    def test_nonzero_horizon_maps_to_timedelta(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(
+            calendar=cal,
+            max_horizon_seconds=86400 * 7,  # 7 days
+        )
+        ep = EffectivePolicy.from_model(policy)
+        assert ep.max_horizon == datetime.timedelta(days=7)
+
+    @pytest.mark.django_db
+    def test_all_zero_fields_map_to_unconstrained(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(calendar=cal)
+        ep = EffectivePolicy.from_model(policy)
+        assert ep == EffectivePolicy.unconstrained()
+
+
+class TestEffectivePolicyMostRestrictive:
+    def test_empty_returns_unconstrained(self):
+        result = EffectivePolicy.most_restrictive([])
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_single_policy_returned_as_is(self):
+        p = EffectivePolicy(
+            lead_time=datetime.timedelta(hours=2),
+            max_horizon=datetime.timedelta(days=14),
+            buffer_before=datetime.timedelta(minutes=15),
+            buffer_after=datetime.timedelta(minutes=30),
+        )
+        result = EffectivePolicy.most_restrictive([p])
+        assert result == p
+
+    def test_max_lead_time_wins(self):
+        p1 = EffectivePolicy(
+            lead_time=datetime.timedelta(hours=1),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        p2 = EffectivePolicy(
+            lead_time=datetime.timedelta(hours=3),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        result = EffectivePolicy.most_restrictive([p1, p2])
+        assert result.lead_time == datetime.timedelta(hours=3)
+
+    def test_min_positive_horizon_wins(self):
+        """Shorter (min) horizon is more restrictive."""
+        p1 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=datetime.timedelta(days=7),
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        p2 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=datetime.timedelta(days=30),
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        result = EffectivePolicy.most_restrictive([p1, p2])
+        assert result.max_horizon == datetime.timedelta(days=7)
+
+    def test_none_horizon_among_finite_is_ignored(self):
+        """None (unbounded) should be ignored; the finite horizon wins."""
+        p1 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=None,  # unbounded
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        p2 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=datetime.timedelta(days=14),
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        result = EffectivePolicy.most_restrictive([p1, p2])
+        assert result.max_horizon == datetime.timedelta(days=14)
+
+    def test_all_none_horizons_returns_none(self):
+        p1 = EffectivePolicy(
+            lead_time=datetime.timedelta(hours=1),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        p2 = EffectivePolicy(
+            lead_time=datetime.timedelta(hours=2),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(0),
+        )
+        result = EffectivePolicy.most_restrictive([p1, p2])
+        assert result.max_horizon is None
+
+    def test_max_buffer_before_wins(self):
+        p1 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(minutes=10),
+            buffer_after=datetime.timedelta(0),
+        )
+        p2 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(minutes=30),
+            buffer_after=datetime.timedelta(0),
+        )
+        result = EffectivePolicy.most_restrictive([p1, p2])
+        assert result.buffer_before == datetime.timedelta(minutes=30)
+
+    def test_max_buffer_after_wins(self):
+        p1 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(minutes=5),
+        )
+        p2 = EffectivePolicy(
+            lead_time=datetime.timedelta(0),
+            max_horizon=None,
+            buffer_before=datetime.timedelta(0),
+            buffer_after=datetime.timedelta(minutes=15),
+        )
+        result = EffectivePolicy.most_restrictive([p1, p2])
+        assert result.buffer_after == datetime.timedelta(minutes=15)
+
+    def test_combination_of_all_fields(self):
+        p1 = EffectivePolicy(
+            lead_time=datetime.timedelta(hours=2),
+            max_horizon=datetime.timedelta(days=7),
+            buffer_before=datetime.timedelta(minutes=15),
+            buffer_after=datetime.timedelta(minutes=5),
+        )
+        p2 = EffectivePolicy(
+            lead_time=datetime.timedelta(hours=1),
+            max_horizon=datetime.timedelta(days=30),
+            buffer_before=datetime.timedelta(minutes=30),
+            buffer_after=datetime.timedelta(minutes=10),
+        )
+        result = EffectivePolicy.most_restrictive([p1, p2])
+        assert result.lead_time == datetime.timedelta(hours=2)
+        assert result.max_horizon == datetime.timedelta(days=7)
+        assert result.buffer_before == datetime.timedelta(minutes=30)
+        assert result.buffer_after == datetime.timedelta(minutes=10)
+
+
+# ---------------------------------------------------------------------------
+# BookingPolicyService — initialization guard
+# ---------------------------------------------------------------------------
+
+
+def test_assert_initialized_raises_when_no_org():
+    svc = BookingPolicyService()
+    with pytest.raises(CalendarServiceOrganizationNotSetError):
+        svc._assert_initialized()
+
+
+# ---------------------------------------------------------------------------
+# resolve_for_calendar — precedence matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestResolveForCalendar:
+    def test_calendar_policy_returned_first(self):
+        org = _org()
+        cal = _calendar(org)
+        create_booking_policy(calendar=cal, lead_time_seconds=1800)
+        # Org default also exists — should be shadowed.
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=60)
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        assert result.lead_time == datetime.timedelta(seconds=1800)
+
+    def test_membership_policy_used_when_no_calendar_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid)
+        create_booking_policy(membership_user_id=uid, organization=org, lead_time_seconds=900)
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        assert result.lead_time == datetime.timedelta(seconds=900)
+
+    def test_org_default_used_when_no_calendar_or_membership_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid)
+        # No membership policy; org default only.
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=300)
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        assert result.lead_time == datetime.timedelta(seconds=300)
+
+    def test_unconstrained_when_no_policy_anywhere(self):
+        org = _org()
+        cal = _calendar(org)
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_calendar_policy_beats_membership_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid)
+        create_booking_policy(calendar=cal, lead_time_seconds=100)
+        create_booking_policy(membership_user_id=uid, organization=org, lead_time_seconds=9000)
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        assert result.lead_time == datetime.timedelta(seconds=100)
+
+    def test_membership_policy_beats_org_default(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid)
+        create_booking_policy(membership_user_id=uid, organization=org, lead_time_seconds=200)
+        create_booking_policy(
+            is_organization_default=True, organization=org, lead_time_seconds=9000
+        )
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        assert result.lead_time == datetime.timedelta(seconds=200)
+
+    def test_no_policy_for_calendar_falls_through_to_org_default_without_owner(self):
+        """When a calendar has no owner, membership layer is skipped."""
+        org = _org()
+        cal = _calendar(org)
+        # No ownership created.
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=500)
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        assert result.lead_time == datetime.timedelta(seconds=500)
+
+
+# ---------------------------------------------------------------------------
+# Owning-membership ambiguity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestOwningMembershipResolution:
+    def test_zero_non_null_ownerships_returns_none(self):
+        org = _org()
+        cal = _calendar(org)
+        # No ownerships at all.
+        svc = _service(org)
+        result = svc._resolve_owning_membership_user_id(cal)
+        assert result is None
+
+    def test_single_ownership_returns_its_user_id(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid, is_default=False)
+
+        svc = _service(org)
+        result = svc._resolve_owning_membership_user_id(cal)
+        assert result == uid
+
+    def test_multiple_ownerships_returns_is_default_user_id(self):
+        org = _org()
+        cal = _calendar(org)
+        uid_a = _membership(org)
+        uid_b = _membership(org)
+        _own(cal, uid_a, is_default=False)
+        _own(cal, uid_b, is_default=True)
+
+        svc = _service(org)
+        result = svc._resolve_owning_membership_user_id(cal)
+        assert result == uid_b
+
+    def test_multiple_ownerships_no_is_default_returns_none(self):
+        """When multiple ownerships exist but none is_default → skip membership layer."""
+        org = _org()
+        cal = _calendar(org)
+        uid_a = _membership(org)
+        uid_b = _membership(org)
+        _own(cal, uid_a, is_default=False)
+        _own(cal, uid_b, is_default=False)
+
+        svc = _service(org)
+        result = svc._resolve_owning_membership_user_id(cal)
+        assert result is None
+
+    def test_only_orphan_ownership_null_membership_user_id_returns_none(self):
+        """Ownerships with NULL membership_user_id (orphans) are excluded."""
+        org = _org()
+        cal = _calendar(org)
+        # Manually create an orphan ownership without a membership_user_id.
+        CalendarOwnership.objects.create(
+            organization=org,
+            calendar=cal,
+            membership_user_id=None,
+            is_default=False,
+        )
+
+        svc = _service(org)
+        result = svc._resolve_owning_membership_user_id(cal)
+        assert result is None
+
+    def test_membership_layer_skipped_when_multiple_owners_no_default(self):
+        """Resolve for calendar with no is_default owner falls through to org default."""
+        org = _org()
+        cal = _calendar(org)
+        uid_a = _membership(org)
+        uid_b = _membership(org)
+        _own(cal, uid_a, is_default=False)
+        _own(cal, uid_b, is_default=False)
+        # Membership policies for both — should not be used.
+        create_booking_policy(membership_user_id=uid_a, organization=org, lead_time_seconds=1000)
+        create_booking_policy(membership_user_id=uid_b, organization=org, lead_time_seconds=2000)
+        # Org default.
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=50)
+
+        svc = _service(org)
+        result = svc.resolve_for_calendar(cal)
+
+        # Neither membership policy should be chosen; org default wins.
+        assert result.lead_time == datetime.timedelta(seconds=50)
+
+
+# ---------------------------------------------------------------------------
+# resolve_for_bundle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestResolveForBundle:
+    def _make_bundle_with_children(self, org: Organization, n: int):
+        """Create a bundle calendar with n child calendars, return (bundle, [children])."""
+        bundle = _calendar(org, calendar_type=CalendarType.BUNDLE)
+        children = []
+        for i in range(n):
+            child = _calendar(org)
+            ChildrenCalendarRelationship.objects.create(
+                organization=org,
+                bundle_calendar=bundle,
+                child_calendar=child,
+                is_primary=(i == 0),
+            )
+            children.append(child)
+        return bundle, children
+
+    def test_explicit_bundle_policy_overrides_everything(self):
+        org = _org()
+        bundle, children = self._make_bundle_with_children(org, 2)
+        # Child policies are more restrictive — the bundle policy wins.
+        create_booking_policy(calendar=bundle, lead_time_seconds=60)
+        create_booking_policy(calendar=children[0], lead_time_seconds=9000)
+        create_booking_policy(calendar=children[1], lead_time_seconds=7200)
+
+        svc = _service(org)
+        result = svc.resolve_for_bundle(bundle)
+
+        assert result.lead_time == datetime.timedelta(seconds=60)
+
+    def test_most_restrictive_across_children_when_no_bundle_policy(self):
+        org = _org()
+        bundle, children = self._make_bundle_with_children(org, 2)
+        create_booking_policy(calendar=children[0], lead_time_seconds=1800)
+        create_booking_policy(calendar=children[1], lead_time_seconds=3600)
+
+        svc = _service(org)
+        result = svc.resolve_for_bundle(bundle)
+
+        # max(1800, 3600) = 3600
+        assert result.lead_time == datetime.timedelta(seconds=3600)
+
+    def test_unconstrained_when_no_child_policies(self):
+        org = _org()
+        bundle, _ = self._make_bundle_with_children(org, 2)
+
+        svc = _service(org)
+        result = svc.resolve_for_bundle(bundle)
+
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_unconstrained_when_no_children(self):
+        org = _org()
+        bundle = _calendar(org, calendar_type=CalendarType.BUNDLE)
+        # No children added.
+
+        svc = _service(org)
+        result = svc.resolve_for_bundle(bundle)
+
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_most_restrictive_horizon_across_children(self):
+        org = _org()
+        bundle, children = self._make_bundle_with_children(org, 2)
+        create_booking_policy(calendar=children[0], max_horizon_seconds=7 * 86400)  # 7 days
+        create_booking_policy(calendar=children[1], max_horizon_seconds=30 * 86400)  # 30 days
+
+        svc = _service(org)
+        result = svc.resolve_for_bundle(bundle)
+
+        # min(7d, 30d) = 7d
+        assert result.max_horizon == datetime.timedelta(days=7)
+
+    def test_child_inherits_org_default_if_no_direct_policy(self):
+        """Children without direct policies resolve via their own chain (org default)."""
+        org = _org()
+        bundle, _children = self._make_bundle_with_children(org, 2)
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=120)
+        # No direct child policies — both children inherit org default.
+
+        svc = _service(org)
+        result = svc.resolve_for_bundle(bundle)
+
+        assert result.lead_time == datetime.timedelta(seconds=120)
+
+
+# ---------------------------------------------------------------------------
+# resolve_for_group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestResolveForGroup:
+    def _make_group_with_calendars(self, org: Organization, calendar_count: int):
+        """Create a CalendarGroup with one slot and ``calendar_count`` calendars."""
+        group = baker.make(CalendarGroup, organization=org, name=f"Group-{id(org)}")
+        slot = baker.make(CalendarGroupSlot, organization=org, group=group, name="Slot A")
+        calendars = []
+        for _ in range(calendar_count):
+            cal = _calendar(org)
+            CalendarGroupSlotMembership.objects.create(
+                organization=org,
+                slot=slot,
+                calendar=cal,
+            )
+            calendars.append(cal)
+        return group, calendars
+
+    def test_explicit_group_policy_overrides_participants(self):
+        org = _org()
+        group, calendars = self._make_group_with_calendars(org, 2)
+        create_booking_policy(calendar_group=group, lead_time_seconds=30)
+        create_booking_policy(calendar=calendars[0], lead_time_seconds=9000)
+
+        svc = _service(org)
+        result = svc.resolve_for_group(group)
+
+        assert result.lead_time == datetime.timedelta(seconds=30)
+
+    def test_most_restrictive_across_participants_when_no_group_policy(self):
+        org = _org()
+        group, calendars = self._make_group_with_calendars(org, 2)
+        create_booking_policy(calendar=calendars[0], lead_time_seconds=1800)
+        create_booking_policy(calendar=calendars[1], buffer_before_seconds=600)
+
+        svc = _service(org)
+        result = svc.resolve_for_group(group)
+
+        assert result.lead_time == datetime.timedelta(seconds=1800)
+        assert result.buffer_before == datetime.timedelta(seconds=600)
+
+    def test_unconstrained_when_no_participant_policies(self):
+        org = _org()
+        group, _ = self._make_group_with_calendars(org, 2)
+
+        svc = _service(org)
+        result = svc.resolve_for_group(group)
+
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_unconstrained_when_no_participants(self):
+        org = _org()
+        group = baker.make(CalendarGroup, organization=org, name="Empty Group")
+
+        svc = _service(org)
+        result = svc.resolve_for_group(group)
+
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_participants_from_multiple_slots_all_considered(self):
+        """All calendars across all slots participate in the combination."""
+        org = _org()
+        group = baker.make(CalendarGroup, organization=org, name="Multi Slot Group")
+        slot_a = baker.make(CalendarGroupSlot, organization=org, group=group, name="Slot A")
+        slot_b = baker.make(CalendarGroupSlot, organization=org, group=group, name="Slot B")
+        cal_a = _calendar(org)
+        cal_b = _calendar(org)
+        CalendarGroupSlotMembership.objects.create(organization=org, slot=slot_a, calendar=cal_a)
+        CalendarGroupSlotMembership.objects.create(organization=org, slot=slot_b, calendar=cal_b)
+
+        create_booking_policy(calendar=cal_a, lead_time_seconds=900)
+        create_booking_policy(calendar=cal_b, max_horizon_seconds=14 * 86400)
+
+        svc = _service(org)
+        result = svc.resolve_for_group(group)
+
+        assert result.lead_time == datetime.timedelta(seconds=900)
+        assert result.max_horizon == datetime.timedelta(days=14)
+
+
+# ---------------------------------------------------------------------------
+# Write API — create_booking_policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateBookingPolicy:
+    def test_creates_calendar_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        svc = _service(org)
+
+        policy = svc.create_booking_policy(calendar=cal, lead_time_seconds=600)
+
+        assert policy.pk is not None
+        assert policy.calendar_fk_id == cal.id
+        assert policy.lead_time_seconds == 600
+        assert policy.organization == org
+
+    def test_raises_on_duplicate_calendar_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        create_booking_policy(calendar=cal)
+        svc = _service(org)
+
+        with pytest.raises(DuplicateBookingPolicyError, match="calendar"):
+            svc.create_booking_policy(calendar=cal)
+
+    def test_raises_on_duplicate_membership_policy(self):
+        org = _org()
+        uid = _membership(org)
+        create_booking_policy(membership_user_id=uid, organization=org)
+        svc = _service(org)
+
+        with pytest.raises(DuplicateBookingPolicyError, match="membership"):
+            svc.create_booking_policy(membership_user_id=uid)
+
+    def test_raises_on_duplicate_group_policy(self):
+        org = _org()
+        group = baker.make(CalendarGroup, organization=org, name="G")
+        create_booking_policy(calendar_group=group)
+        svc = _service(org)
+
+        with pytest.raises(DuplicateBookingPolicyError, match="calendar group"):
+            svc.create_booking_policy(calendar_group=group)
+
+    def test_raises_on_duplicate_org_default(self):
+        org = _org()
+        create_booking_policy(is_organization_default=True, organization=org)
+        svc = _service(org)
+
+        with pytest.raises(DuplicateBookingPolicyError, match="organization-default"):
+            svc.create_booking_policy(is_organization_default=True)
+
+    def test_raises_on_no_target(self):
+        org = _org()
+        svc = _service(org)
+        with pytest.raises(ValueError):
+            svc.create_booking_policy()
+
+    def test_raises_on_multiple_targets(self):
+        org = _org()
+        cal = _calendar(org)
+        svc = _service(org)
+        with pytest.raises(ValueError):
+            svc.create_booking_policy(
+                calendar=cal,
+                is_organization_default=True,
+            )
+
+    def test_requires_initialized(self):
+        svc = BookingPolicyService()
+        with pytest.raises(CalendarServiceOrganizationNotSetError):
+            svc.create_booking_policy(is_organization_default=True)
+
+    def test_emits_audit_record_on_create(self):
+        org = _org()
+        cal = _calendar(org)
+        mock_audit = MagicMock()
+        svc = _service(org, audit_service=mock_audit)
+
+        policy = svc.create_booking_policy(calendar=cal, lead_time_seconds=60)
+
+        mock_audit.record.assert_called_once()
+        call_kwargs = mock_audit.record.call_args.kwargs
+        assert call_kwargs["action"] == "create"
+        assert call_kwargs["organization_id"] == org.id
+        # subject_from_instance was called with the newly created policy.
+        mock_audit.subject_from_instance.assert_called_once_with(policy)
+
+
+# ---------------------------------------------------------------------------
+# Write API — update_booking_policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestUpdateBookingPolicy:
+    def test_updates_lead_time(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+        svc = _service(org)
+
+        updated = svc.update_booking_policy(policy, lead_time_seconds=1800)
+
+        policy.refresh_from_db()
+        assert policy.lead_time_seconds == 1800
+        assert updated.lead_time_seconds == 1800
+
+    def test_partial_update_leaves_other_fields_unchanged(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(
+            calendar=cal,
+            lead_time_seconds=300,
+            buffer_before_seconds=120,
+            max_horizon_seconds=86400,
+        )
+        svc = _service(org)
+
+        svc.update_booking_policy(policy, buffer_before_seconds=240)
+
+        policy.refresh_from_db()
+        assert policy.lead_time_seconds == 300
+        assert policy.buffer_before_seconds == 240
+        assert policy.max_horizon_seconds == 86400
+
+    def test_emits_audit_record_with_diff(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+        mock_audit = MagicMock()
+        svc = _service(org, audit_service=mock_audit)
+
+        svc.update_booking_policy(policy, lead_time_seconds=300)
+
+        mock_audit.record.assert_called_once()
+        call_kwargs = mock_audit.record.call_args.kwargs
+        assert call_kwargs["action"] == "update"
+        diff = call_kwargs["diff"]
+        assert diff is not None
+        assert "lead_time_seconds" in diff
+        assert diff["lead_time_seconds"]["old"] == 60
+        assert diff["lead_time_seconds"]["new"] == 300
+
+    def test_audit_record_emitted_even_when_no_change(self):
+        """An update with no field changes still emits an audit record (same before/after)."""
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+        mock_audit = MagicMock()
+        svc = _service(org, audit_service=mock_audit)
+
+        svc.update_booking_policy(policy)
+
+        # The audit record is always emitted (diff may be None/empty when no change).
+        mock_audit.record.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Write API — delete_booking_policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDeleteBookingPolicy:
+    def test_deletes_existing_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(calendar=cal)
+        pk = policy.pk
+        svc = _service(org)
+
+        svc.delete_booking_policy(policy)
+
+        assert not BookingPolicy.objects.filter_by_organization(org.id).filter(pk=pk).exists()
+
+    def test_no_op_when_none(self):
+        """Passing None is a safe, idempotent no-op."""
+        org = _org()
+        svc = _service(org)
+        # Should not raise.
+        svc.delete_booking_policy(None)
+
+    def test_emits_audit_record_on_delete(self):
+        org = _org()
+        cal = _calendar(org)
+        policy = create_booking_policy(calendar=cal)
+        mock_audit = MagicMock()
+        svc = _service(org, audit_service=mock_audit)
+
+        svc.delete_booking_policy(policy)
+
+        mock_audit.record.assert_called_once()
+        call_kwargs = mock_audit.record.call_args.kwargs
+        assert call_kwargs["action"] == "delete"
+
+    def test_no_audit_record_when_none(self):
+        org = _org()
+        mock_audit = MagicMock()
+        svc = _service(org, audit_service=mock_audit)
+
+        svc.delete_booking_policy(None)
+
+        mock_audit.record.assert_not_called()
+
+    def test_convenience_delete_policy_for_calendar_no_op_when_absent(self):
+        org = _org()
+        cal = _calendar(org)
+        svc = _service(org)
+        # No policy exists — should not raise.
+        svc.delete_policy_for_calendar(cal)
+
+    def test_convenience_delete_org_default_no_op_when_absent(self):
+        org = _org()
+        svc = _service(org)
+        svc.delete_org_default_policy()  # No policy — no-op.
+
+
+# ---------------------------------------------------------------------------
+# Cross-org isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_cross_org_isolation():
+    """A policy in org_b is invisible when the service is initialized with org_a."""
+    org_a = _org()
+    org_b = _org()
+    cal_a = _calendar(org_a)
+    cal_b = _calendar(org_b)
+    create_booking_policy(calendar=cal_b, lead_time_seconds=9999)
+
+    svc = _service(org_a)
+    result = svc.resolve_for_calendar(cal_a)
+
+    assert result == EffectivePolicy.unconstrained()
+
+
+@pytest.mark.django_db
+def test_org_default_from_other_org_not_used():
+    org_a = _org()
+    org_b = _org()
+    cal_a = _calendar(org_a)
+    create_booking_policy(is_organization_default=True, organization=org_b, lead_time_seconds=9999)
+
+    svc = _service(org_a)
+    result = svc.resolve_for_calendar(cal_a)
+
+    assert result == EffectivePolicy.unconstrained()

--- a/calendar_integration/tests/services/test_booking_policy_service.py
+++ b/calendar_integration/tests/services/test_booking_policy_service.py
@@ -21,7 +21,10 @@ import pytest
 from model_bakery import baker
 
 from calendar_integration.constants import CalendarType
-from calendar_integration.exceptions import CalendarServiceOrganizationNotSetError
+from calendar_integration.exceptions import (
+    CalendarServiceOrganizationNotSetError,
+    DuplicateBookingPolicyError,
+)
 from calendar_integration.factories import create_booking_policy
 from calendar_integration.models import (
     BookingPolicy,
@@ -32,10 +35,7 @@ from calendar_integration.models import (
     CalendarOwnership,
     ChildrenCalendarRelationship,
 )
-from calendar_integration.services.booking_policy_service import (
-    BookingPolicyService,
-    DuplicateBookingPolicyError,
-)
+from calendar_integration.services.booking_policy_service import BookingPolicyService
 from calendar_integration.services.dataclasses import EffectivePolicy
 from organizations.models import Organization, OrganizationMembership
 
@@ -556,6 +556,28 @@ class TestResolveForBundle:
 
         assert result.lead_time == datetime.timedelta(seconds=120)
 
+    def test_bundle_unconstrained_when_children_have_owners_but_no_policies(self):
+        """Bundle whose children have CalendarOwnership rows but no policy anywhere
+        (no calendar/membership/group/bundle policy AND no org-default) →
+        resolve_for_bundle returns EffectivePolicy.unconstrained().
+
+        This exercises the ``combined != unconstrained()`` short-circuit's false branch
+        distinct from the no-children path.
+        """
+        org = _org()
+        bundle, children = self._make_bundle_with_children(org, 2)
+        # Give each child an owner (CalendarOwnership) but no policy anywhere.
+        uid_a = _membership(org)
+        uid_b = _membership(org)
+        _own(children[0], uid_a)
+        _own(children[1], uid_b)
+        # No BookingPolicy created for any target, no org default.
+
+        svc = _service(org)
+        result = svc.resolve_for_bundle(bundle)
+
+        assert result == EffectivePolicy.unconstrained()
+
 
 # ---------------------------------------------------------------------------
 # resolve_for_group
@@ -797,8 +819,11 @@ class TestUpdateBookingPolicy:
 
         svc.update_booking_policy(policy)
 
-        # The audit record is always emitted (diff may be None/empty when no change).
+        # The audit record is always emitted; compute_diff returns None for identical
+        # before/after, so the diff kwarg must be None.
         mock_audit.record.assert_called_once()
+        call_kwargs = mock_audit.record.call_args.kwargs
+        assert call_kwargs["diff"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -859,6 +884,26 @@ class TestDeleteBookingPolicy:
         org = _org()
         svc = _service(org)
         svc.delete_org_default_policy()  # No policy — no-op.
+
+    def test_delete_policy_for_membership_noop_when_absent(self):
+        """delete_policy_for_membership is a no-op and emits no audit record when absent."""
+        org = _org()
+        uid = _membership(org)
+        mock_audit = MagicMock()
+        svc = _service(org, audit_service=mock_audit)
+        # No policy for this membership — should not raise.
+        svc.delete_policy_for_membership(uid)
+        mock_audit.record.assert_not_called()
+
+    def test_delete_policy_for_group_noop_when_absent(self):
+        """delete_policy_for_group is a no-op and emits no audit record when absent."""
+        org = _org()
+        group = baker.make(CalendarGroup, organization=org, name="G-noop")
+        mock_audit = MagicMock()
+        svc = _service(org, audit_service=mock_audit)
+        # No policy for this group — should not raise.
+        svc.delete_policy_for_group(group)
+        mock_audit.record.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/calendar_integration/tests/services/test_booking_policy_service.py
+++ b/calendar_integration/tests/services/test_booking_policy_service.py
@@ -937,3 +937,438 @@ def test_org_default_from_other_org_not_used():
     result = svc.resolve_for_calendar(cal_a)
 
     assert result == EffectivePolicy.unconstrained()
+
+
+# ---------------------------------------------------------------------------
+# DB-annotation equivalence — the resolution moved into SQL must produce the
+# EXACT EffectivePolicy the original Python precedence rules prescribe.
+# ---------------------------------------------------------------------------
+
+
+def _ep(lead=0, horizon=None, before=0, after=0) -> EffectivePolicy:
+    """Shorthand to build an expected EffectivePolicy from second-counts."""
+    return EffectivePolicy(
+        lead_time=datetime.timedelta(seconds=lead),
+        max_horizon=(datetime.timedelta(seconds=horizon) if horizon else None),
+        buffer_before=datetime.timedelta(seconds=before),
+        buffer_after=datetime.timedelta(seconds=after),
+    )
+
+
+@pytest.mark.django_db
+class TestResolveForCalendarAnnotationEquivalence:
+    """Each scenario asserts the DB-annotated resolution equals the hand-computed
+    EffectivePolicy the documented precedence prescribes."""
+
+    def test_calendar_layer_whole_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid)
+        # Calendar policy wins as a WHOLE — even fields it leaves at 0/unbounded
+        # are taken from it, never merged with the membership/org layers.
+        create_booking_policy(
+            calendar=cal,
+            lead_time_seconds=120,
+            max_horizon_seconds=0,  # unbounded — must stay unbounded
+            buffer_before_seconds=0,
+            buffer_after_seconds=45,
+        )
+        create_booking_policy(
+            membership_user_id=uid,
+            organization=org,
+            lead_time_seconds=9000,
+            max_horizon_seconds=86400,
+            buffer_before_seconds=600,
+            buffer_after_seconds=600,
+        )
+        create_booking_policy(
+            is_organization_default=True,
+            organization=org,
+            max_horizon_seconds=999,
+            buffer_before_seconds=999,
+        )
+
+        result = _service(org).resolve_for_calendar(cal)
+        assert result == _ep(lead=120, horizon=None, before=0, after=45)
+
+    def test_membership_layer_whole_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid)
+        create_booking_policy(
+            membership_user_id=uid,
+            organization=org,
+            lead_time_seconds=300,
+            max_horizon_seconds=0,
+            buffer_before_seconds=15,
+            buffer_after_seconds=0,
+        )
+        create_booking_policy(
+            is_organization_default=True,
+            organization=org,
+            lead_time_seconds=9999,
+            max_horizon_seconds=7,
+        )
+        result = _service(org).resolve_for_calendar(cal)
+        assert result == _ep(lead=300, horizon=None, before=15, after=0)
+
+    def test_org_default_layer_whole_policy(self):
+        org = _org()
+        cal = _calendar(org)
+        create_booking_policy(
+            is_organization_default=True,
+            organization=org,
+            lead_time_seconds=60,
+            max_horizon_seconds=3600,
+            buffer_before_seconds=30,
+            buffer_after_seconds=90,
+        )
+        result = _service(org).resolve_for_calendar(cal)
+        assert result == _ep(lead=60, horizon=3600, before=30, after=90)
+
+    def test_no_policy_layer_unconstrained(self):
+        org = _org()
+        cal = _calendar(org)
+        result = _service(org).resolve_for_calendar(cal)
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_membership_zero_owners_skips_to_org_default(self):
+        org = _org()
+        cal = _calendar(org)
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=7)
+        result = _service(org).resolve_for_calendar(cal)
+        assert result == _ep(lead=7)
+
+    def test_membership_single_owner_used(self):
+        org = _org()
+        cal = _calendar(org)
+        uid = _membership(org)
+        _own(cal, uid, is_default=False)
+        create_booking_policy(membership_user_id=uid, organization=org, lead_time_seconds=88)
+        result = _service(org).resolve_for_calendar(cal)
+        assert result == _ep(lead=88)
+
+    def test_membership_multiple_owners_default_used(self):
+        org = _org()
+        cal = _calendar(org)
+        uid_a = _membership(org)
+        uid_b = _membership(org)
+        _own(cal, uid_a, is_default=False)
+        _own(cal, uid_b, is_default=True)
+        create_booking_policy(membership_user_id=uid_a, organization=org, lead_time_seconds=111)
+        create_booking_policy(membership_user_id=uid_b, organization=org, lead_time_seconds=222)
+        result = _service(org).resolve_for_calendar(cal)
+        # The is_default owner (uid_b) drives resolution.
+        assert result == _ep(lead=222)
+
+    def test_membership_multiple_owners_no_default_skips_layer(self):
+        org = _org()
+        cal = _calendar(org)
+        uid_a = _membership(org)
+        uid_b = _membership(org)
+        _own(cal, uid_a, is_default=False)
+        _own(cal, uid_b, is_default=False)
+        create_booking_policy(membership_user_id=uid_a, organization=org, lead_time_seconds=111)
+        create_booking_policy(membership_user_id=uid_b, organization=org, lead_time_seconds=222)
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=9)
+        result = _service(org).resolve_for_calendar(cal)
+        # No is_default owner → membership layer skipped → org default wins.
+        assert result == _ep(lead=9)
+
+    def test_orphan_ownership_excluded(self):
+        org = _org()
+        cal = _calendar(org)
+        CalendarOwnership.objects.create(
+            organization=org, calendar=cal, membership_user_id=None, is_default=False
+        )
+        create_booking_policy(is_organization_default=True, organization=org, lead_time_seconds=5)
+        result = _service(org).resolve_for_calendar(cal)
+        assert result == _ep(lead=5)
+
+
+@pytest.mark.django_db
+class TestResolveForGroupAnnotationEquivalence:
+    def _group_with_calendars(self, org: Organization, n: int):
+        group = baker.make(CalendarGroup, organization=org, name=f"G-{id(org)}-{n}")
+        slot = baker.make(CalendarGroupSlot, organization=org, group=group, name="S")
+        calendars = []
+        for _ in range(n):
+            cal = _calendar(org)
+            CalendarGroupSlotMembership.objects.create(organization=org, slot=slot, calendar=cal)
+            calendars.append(cal)
+        return group, calendars
+
+    def test_explicit_group_policy_whole(self):
+        org = _org()
+        group, cals = self._group_with_calendars(org, 2)
+        # Group policy with an unbounded horizon must stay unbounded even though
+        # participants have finite horizons (whole-policy short-circuit).
+        create_booking_policy(
+            calendar_group=group,
+            lead_time_seconds=30,
+            max_horizon_seconds=0,
+            buffer_before_seconds=5,
+            buffer_after_seconds=0,
+        )
+        create_booking_policy(calendar=cals[0], max_horizon_seconds=3600, lead_time_seconds=9000)
+        result = _service(org).resolve_for_group(group)
+        assert result == _ep(lead=30, horizon=None, before=5, after=0)
+
+    def test_most_restrictive_field_by_field(self):
+        org = _org()
+        group, cals = self._group_with_calendars(org, 2)
+        create_booking_policy(
+            calendar=cals[0],
+            lead_time_seconds=7200,
+            max_horizon_seconds=7 * 86400,
+            buffer_before_seconds=900,
+            buffer_after_seconds=300,
+        )
+        create_booking_policy(
+            calendar=cals[1],
+            lead_time_seconds=3600,
+            max_horizon_seconds=30 * 86400,
+            buffer_before_seconds=1800,
+            buffer_after_seconds=600,
+        )
+        result = _service(org).resolve_for_group(group)
+        # max lead, min horizon, max before, max after.
+        assert result == _ep(lead=7200, horizon=7 * 86400, before=1800, after=600)
+
+    def test_all_unbounded_horizons_stay_unbounded(self):
+        org = _org()
+        group, cals = self._group_with_calendars(org, 2)
+        create_booking_policy(calendar=cals[0], lead_time_seconds=60, max_horizon_seconds=0)
+        create_booking_policy(calendar=cals[1], lead_time_seconds=120, max_horizon_seconds=0)
+        result = _service(org).resolve_for_group(group)
+        assert result == _ep(lead=120, horizon=None)
+
+    def test_mixed_bounded_and_unbounded_horizon_takes_finite_min(self):
+        org = _org()
+        group, cals = self._group_with_calendars(org, 2)
+        create_booking_policy(calendar=cals[0], max_horizon_seconds=0)  # unbounded
+        create_booking_policy(calendar=cals[1], max_horizon_seconds=14 * 86400)
+        result = _service(org).resolve_for_group(group)
+        assert result == _ep(horizon=14 * 86400)
+
+    def test_no_participant_policies_unconstrained(self):
+        org = _org()
+        group, _ = self._group_with_calendars(org, 3)
+        result = _service(org).resolve_for_group(group)
+        assert result == EffectivePolicy.unconstrained()
+
+    def test_participant_resolved_through_own_chain(self):
+        """A participant with no direct policy but an owner+membership policy
+        contributes that membership policy to the combination."""
+        org = _org()
+        group, cals = self._group_with_calendars(org, 2)
+        uid = _membership(org)
+        _own(cals[0], uid)
+        create_booking_policy(membership_user_id=uid, organization=org, lead_time_seconds=4500)
+        create_booking_policy(calendar=cals[1], lead_time_seconds=600)
+        result = _service(org).resolve_for_group(group)
+        assert result == _ep(lead=4500)
+
+
+@pytest.mark.django_db
+class TestResolveForBundleAnnotationEquivalence:
+    def _bundle(self, org: Organization, n: int):
+        bundle = _calendar(org, calendar_type=CalendarType.BUNDLE)
+        children = []
+        for i in range(n):
+            child = _calendar(org)
+            ChildrenCalendarRelationship.objects.create(
+                organization=org,
+                bundle_calendar=bundle,
+                child_calendar=child,
+                is_primary=(i == 0),
+            )
+            children.append(child)
+        return bundle, children
+
+    def test_explicit_bundle_policy_whole(self):
+        org = _org()
+        bundle, children = self._bundle(org, 2)
+        create_booking_policy(
+            calendar=bundle,
+            lead_time_seconds=15,
+            max_horizon_seconds=0,
+            buffer_before_seconds=0,
+            buffer_after_seconds=5,
+        )
+        create_booking_policy(
+            calendar=children[0], max_horizon_seconds=3600, lead_time_seconds=9999
+        )
+        result = _service(org).resolve_for_bundle(bundle)
+        assert result == _ep(lead=15, horizon=None, before=0, after=5)
+
+    def test_children_most_restrictive_field_by_field(self):
+        org = _org()
+        bundle, children = self._bundle(org, 2)
+        create_booking_policy(
+            calendar=children[0],
+            lead_time_seconds=1800,
+            max_horizon_seconds=10 * 86400,
+            buffer_before_seconds=120,
+            buffer_after_seconds=900,
+        )
+        create_booking_policy(
+            calendar=children[1],
+            lead_time_seconds=3600,
+            max_horizon_seconds=5 * 86400,
+            buffer_before_seconds=60,
+            buffer_after_seconds=60,
+        )
+        result = _service(org).resolve_for_bundle(bundle)
+        assert result == _ep(lead=3600, horizon=5 * 86400, before=120, after=900)
+
+    def test_children_all_unbounded_horizon(self):
+        org = _org()
+        bundle, children = self._bundle(org, 2)
+        create_booking_policy(calendar=children[0], lead_time_seconds=1, max_horizon_seconds=0)
+        create_booking_policy(calendar=children[1], lead_time_seconds=2, max_horizon_seconds=0)
+        result = _service(org).resolve_for_bundle(bundle)
+        assert result == _ep(lead=2, horizon=None)
+
+
+# ---------------------------------------------------------------------------
+# Query-count: bundle/group resolution must be bounded regardless of the number
+# of participant calendars — the N+1 walk collapsed into a bounded set of
+# queries.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestResolutionQueryCount:
+    def test_group_resolution_bounded_regardless_of_participant_count(
+        self, django_assert_num_queries
+    ):
+        org = _org()
+        group = baker.make(CalendarGroup, organization=org, name="Big Group")
+        slot = baker.make(CalendarGroupSlot, organization=org, group=group, name="S")
+        for _ in range(8):
+            cal = _calendar(org)
+            CalendarGroupSlotMembership.objects.create(organization=org, slot=slot, calendar=cal)
+            create_booking_policy(calendar=cal, lead_time_seconds=300)
+
+        svc = _service(org)
+        # Group resolution is a single annotated SELECT — it does NOT scale with
+        # the participant count.
+        with django_assert_num_queries(1):
+            svc.resolve_for_group(group)
+
+    def test_group_resolution_same_query_count_for_more_participants(
+        self, django_assert_num_queries
+    ):
+        """Resolution for a 2-participant and a 12-participant group issues the
+        same (constant) number of queries."""
+        org = _org()
+
+        def _build(n: int) -> CalendarGroup:
+            group = baker.make(CalendarGroup, organization=org, name=f"QC-{n}")
+            slot = baker.make(CalendarGroupSlot, organization=org, group=group, name="S")
+            for _ in range(n):
+                cal = _calendar(org)
+                CalendarGroupSlotMembership.objects.create(
+                    organization=org, slot=slot, calendar=cal
+                )
+                create_booking_policy(calendar=cal, max_horizon_seconds=86400)
+            return group
+
+        small = _build(2)
+        large = _build(12)
+        svc = _service(org)
+        with django_assert_num_queries(1):
+            svc.resolve_for_group(small)
+        with django_assert_num_queries(1):
+            svc.resolve_for_group(large)
+
+    def test_bundle_resolution_bounded(self, django_assert_num_queries):
+        org = _org()
+        bundle = _calendar(org, calendar_type=CalendarType.BUNDLE)
+        for i in range(8):
+            child = _calendar(org)
+            ChildrenCalendarRelationship.objects.create(
+                organization=org,
+                bundle_calendar=bundle,
+                child_calendar=child,
+                is_primary=(i == 0),
+            )
+            create_booking_policy(calendar=child, lead_time_seconds=600)
+
+        svc = _service(org)
+        # Bundle resolution: (1) explicit-bundle-policy lookup, (2) child-id
+        # lookup, (3) the single annotated children SELECT — a small constant
+        # independent of the child count.
+        with django_assert_num_queries(3):
+            svc.resolve_for_bundle(bundle)
+
+
+# ---------------------------------------------------------------------------
+# Org-scope: a second organization with conflicting parallel fixtures must not
+# influence resolution for the first organization.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestResolutionOrgScope:
+    def test_calendar_resolution_ignores_other_org(self):
+        org_a = _org()
+        org_b = _org()
+        cal_a = _calendar(org_a)
+        uid_a = _membership(org_a)
+        _own(cal_a, uid_a)
+        create_booking_policy(membership_user_id=uid_a, organization=org_a, lead_time_seconds=300)
+
+        # Parallel, conflicting fixtures in org_b — a calendar policy AND an
+        # org-default with very different numbers.
+        cal_b = _calendar(org_b)
+        create_booking_policy(calendar=cal_b, lead_time_seconds=99999)
+        create_booking_policy(is_organization_default=True, organization=org_b, lead_time_seconds=1)
+
+        result = _service(org_a).resolve_for_calendar(cal_a)
+        assert result == _ep(lead=300)
+
+    def test_group_resolution_ignores_other_org(self):
+        org_a = _org()
+        org_b = _org()
+
+        group_a = baker.make(CalendarGroup, organization=org_a, name="GA")
+        slot_a = baker.make(CalendarGroupSlot, organization=org_a, group=group_a, name="S")
+        ca1 = _calendar(org_a)
+        ca2 = _calendar(org_a)
+        CalendarGroupSlotMembership.objects.create(organization=org_a, slot=slot_a, calendar=ca1)
+        CalendarGroupSlotMembership.objects.create(organization=org_a, slot=slot_a, calendar=ca2)
+        create_booking_policy(calendar=ca1, lead_time_seconds=600)
+        create_booking_policy(calendar=ca2, lead_time_seconds=1200)
+
+        # org_b: an explicit group-default and conflicting calendar policies.
+        group_b = baker.make(CalendarGroup, organization=org_b, name="GB")
+        slot_b = baker.make(CalendarGroupSlot, organization=org_b, group=group_b, name="S")
+        cb1 = _calendar(org_b)
+        CalendarGroupSlotMembership.objects.create(organization=org_b, slot=slot_b, calendar=cb1)
+        create_booking_policy(calendar_group=group_b, lead_time_seconds=99999)
+        create_booking_policy(calendar=cb1, lead_time_seconds=77777)
+        create_booking_policy(is_organization_default=True, organization=org_b, lead_time_seconds=1)
+
+        result = _service(org_a).resolve_for_group(group_a)
+        # max(600, 1200) = 1200, untouched by org_b.
+        assert result == _ep(lead=1200)
+
+    def test_bundle_resolution_ignores_other_org(self):
+        org_a = _org()
+        org_b = _org()
+        bundle_a = _calendar(org_a, calendar_type=CalendarType.BUNDLE)
+        child_a = _calendar(org_a)
+        ChildrenCalendarRelationship.objects.create(
+            organization=org_a, bundle_calendar=bundle_a, child_calendar=child_a, is_primary=True
+        )
+        create_booking_policy(calendar=child_a, lead_time_seconds=450)
+
+        # org_b parallel bundle with a different number + org default.
+        create_booking_policy(is_organization_default=True, organization=org_b, lead_time_seconds=1)
+
+        result = _service(org_a).resolve_for_bundle(bundle_a)
+        assert result == _ep(lead=450)

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -12,6 +12,7 @@ from vintasend_django.services.notification_template_renderers.django_templated_
 
 from audit.repositories import DjangoORMAuditRepository
 from audit.services import AuditService
+from calendar_integration.services.booking_policy_service import BookingPolicyService
 from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
 from calendar_integration.services.calendar_service import CalendarService
@@ -130,6 +131,11 @@ class AppContainer(containers.DeclarativeContainer):
         calendar_permission_service=calendar_permission_service,
         audit_service=audit_service,
         external_event_change_request_service=external_event_change_request_service,
+    )
+
+    booking_policy_service = providers.Factory(
+        BookingPolicyService,
+        audit_service=audit_service,
     )
 
     calendar_group_service = providers.Factory(


### PR DESCRIPTION
## Summary
Phase 2 of the **Bookable Slots for Single Calendars & Bundles, with Booking Policies** plan — the resolver the slot surfaces (Phase 5/6/7) and the booking-time enforcement (Phase 8a/8b) all consume. Stacked on Phase 1 (the `BookingPolicy` model). No GraphQL/REST surface yet, no migration.

Adds:
- **`EffectivePolicy`** (frozen dataclass in `calendar_integration/services/dataclasses.py`) — `lead_time`, `max_horizon: timedelta | None` (None = unbounded), `buffer_before`, `buffer_after`. `from_model` maps a stored `max_horizon_seconds=0` to `None`; `most_restrictive` combines `max(lead)`, `min(finite horizons)`, `max(buffer_*)`; empty → `unconstrained()`.
- **`BookingPolicyService`** (`booking_policy_service.py`):
  - `resolve_for_calendar`: calendar → owning-membership (lone owner, else `is_default` owner when several, else skip) → org-default → unconstrained.
  - `resolve_for_bundle` / `resolve_for_group`: explicit policy on the bundle calendar / group → `most_restrictive` across all participants (each resolved via `resolve_for_calendar`) → unconstrained.
  - `create` / `update` / `delete` (+ per-target convenience deleters and `get_all_policies`) for Phases 3/4: exactly-one-target validation, create-uniqueness (`DuplicateBookingPolicyError`), immutable targets on update, idempotent delete-absent, and `AuditService` records (diffs on update).
- DI wiring: `booking_policy_service` Factory in `di_core/containers.py` (injects `audit_service`).

## Plan reference
`ai-plans/2026-06-26-BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY_IMPLEMENTATION_PLAN.md` — **Phase 2**. Stacked on Phase 1 / PR #166. No feature flag (data-presence gate). No migration.

## Test plan
- `docker compose run --rm api uv run pytest calendar_integration/tests/services/test_booking_policy_service.py -p no:randomly` — full precedence matrix (calendar / membership / org-default present & absent, fallthrough to unconstrained); owning-membership ambiguity (zero → skip, one → use, multiple → `is_default`); `most_restrictive` field-by-field incl. None-horizon; bundle/group explicit-override beats per-participant combination; bundle inherits org-default via participants; bundle unconstrained when children have owners but no policies; create-uniqueness rejection; update diff (and `diff is None` on no-change); delete-absent no-op for every target; audit emission. **63 passed.**
- Outer gate: `makemigrations --check` (no changes), `check --deploy` (0 errors), full `pytest -n auto` → **3307 passed**.