### PR TITLE
feat(calendar): add BookingPolicy REST CRUD endpoint

### DIFF
--- a/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
+++ b/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
@@ -18,6 +18,7 @@
 ## Branch stack
 - Phase 1: `plan/bookable-slots-single-calendar-and-booking-policy/phase-1` (base `main`)
 - Phase 2: `plan/bookable-slots-single-calendar-and-booking-policy/phase-2` (base phase-1)
+- Phase 3: `plan/bookable-slots-single-calendar-and-booking-policy/phase-3` (base phase-2)
 
 ## Completed phases
 
@@ -44,11 +45,21 @@
 - **Gates**: ruff clean; mypy baseline unchanged; `makemigrations --check` clean (no migration); `check --deploy` 0 errors; full `pytest -n auto` → 3307 passed.
 - **Acceptance**: ✅ `resolve_for_*` returns spec-correct `EffectivePolicy` across the full matrix; unconstrained when nothing applies.
 
+### Phase 3 — Policy CRUD private REST ✅
+- **Status**: DONE (reviewed, fixed, pushed, PR open)
+- **Model used**: sonnet (plan tier T2 → stepped up per >3-files rule) — implementer + sonnet fixer
+- **Branch**: `plan/bookable-slots-single-calendar-and-booking-policy/phase-3` (base phase-2)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/168
+- **Commits**: `1abddaf` (impl) + `6e5efeb` (review fixes)
+- **Summary**: `BookingPolicySerializer` (exactly-one-target, immutable targets on update, org-scoped FK querysets, `validate_membership_user_id`, `min_value=0`, `DuplicateBookingPolicyError`→400), `BookingPolicyViewSet(VintaScheduleModelViewSet)` (org-scoped get_queryset; create/update/destroy delegate to DI `booking_policy_service` w/ `set_actor`; idempotent destroy→204), `BookingPolicyPermission` (reads=member, **writes=org admin**), `booking-policies` route, regenerated `schema.yml`. 35 API tests.
+- **Review findings fixed**: BLOCKER — permission allowed any member to write org-wide config; gated writes to `IsOrganizationAdmin` (`membership.is_admin`), reads stay member-visible (spec use-case 3). SHOULD-FIX — added `validate_membership_user_id` (bogus id 500→400); deleted dead `get_serializer_context` override; clean `context=` serializer wiring; added member-forbidden(403)/bogus-id(400)/all-four-negative-field tests. Plain ModelSerializer reviewed + cleared.
+- **Gates**: ruff clean; mypy no new errors; `makemigrations --check` clean (no migration); `check --deploy` 0 errors; `schema.yml` drift-free; full `pytest -n auto` → 3342 passed.
+- **Acceptance**: ✅ REST CRUD org-scoped; duplicate/invalid→400; delete-absent→204; writes audited; member writes forbidden.
+
 ## Current phase
-Phase 3 — Policy CRUD private REST (next).
+Phase 4 — Policy CRUD public GraphQL (next).
 
 ## Remaining phases
-- Phase 3 — Policy CRUD private REST (T2 / haiku)
 - Phase 4 — Policy CRUD public GraphQL (T3 / sonnet)
 - Phase 5 — calendar_bookable_slots single+bundle (T4 / opus)
 - Phase 6 — calendar_bookable_slots_with_code (T2 / haiku)

--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -6,6 +6,29 @@ from calendar_integration.services.calendar_permission_service import CalendarPe
 from organizations.models import get_active_organization_membership
 
 
+class BookingPolicyPermission(BasePermission):
+    """Permission for ``BookingPolicyViewSet``.
+
+    Requires an authenticated user.  Membership-less (gated) users are allowed
+    through: ``get_queryset()`` returns an empty queryset for them so the list
+    action returns 200+[] rather than 403, which is the consistent pattern used
+    by ``CalendarEventViewSet`` and ``BlockedTimeViewSet``.
+
+    Write operations (create, update, destroy) that reach a membership-less user
+    will fail gracefully because ``_build_service()`` gets ``None`` from
+    ``get_active_organization_membership`` and will not initialize the service
+    with a tenant — but in practice the ``TenantScopedViewMixin`` will have
+    already returned 400/403 if the user has no org context.
+
+    Org-admin gating is intentionally **not** applied here — the plan does not
+    restrict policy management to admins only.
+    """
+
+    def has_permission(self, request, view) -> bool:
+        """Allow any authenticated user through (membership check happens in get_queryset)."""
+        return bool(request.user.is_authenticated)
+
+
 class ExternalEventChangeRequestPermission(BasePermission):
     """Permission for ``ExternalEventChangeRequestViewSet``.
 

--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -1,5 +1,5 @@
 from dependency_injector.wiring import Provide, inject
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from calendar_integration.models import CalendarOwnership
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
@@ -9,24 +9,26 @@ from organizations.models import get_active_organization_membership
 class BookingPolicyPermission(BasePermission):
     """Permission for ``BookingPolicyViewSet``.
 
-    Requires an authenticated user.  Membership-less (gated) users are allowed
-    through: ``get_queryset()`` returns an empty queryset for them so the list
-    action returns 200+[] rather than 403, which is the consistent pattern used
-    by ``CalendarEventViewSet`` and ``BlockedTimeViewSet``.
+    Reads (GET/HEAD/OPTIONS — list/retrieve) are open to any authenticated user;
+    ``get_queryset()`` already restricts visibility to the caller's org.
 
-    Write operations (create, update, destroy) that reach a membership-less user
-    will fail gracefully because ``_build_service()`` gets ``None`` from
-    ``get_active_organization_membership`` and will not initialize the service
-    with a tenant — but in practice the ``TenantScopedViewMixin`` will have
-    already returned 400/403 if the user has no org context.
+    Writes (POST/PUT/PATCH/DELETE — create/update/destroy) require the caller to
+    be an **organization admin** (per SPEC use-case 3, consistent with sibling
+    org-wide config writes gated by ``IsOrganizationAdmin``).
 
-    Org-admin gating is intentionally **not** applied here — the plan does not
-    restrict policy management to admins only.
+    Membership-less (gated) users are allowed through on safe methods: the
+    queryset returns [] rather than 403, which is the consistent pattern used by
+    ``CalendarEventViewSet`` and ``BlockedTimeViewSet``.
     """
 
     def has_permission(self, request, view) -> bool:
-        """Allow any authenticated user through (membership check happens in get_queryset)."""
-        return bool(request.user.is_authenticated)
+        """Safe methods: any authenticated user. Unsafe methods: org admin only."""
+        if not request.user or not request.user.is_authenticated:
+            return False
+        if request.method in SAFE_METHODS:
+            return True
+        membership = get_active_organization_membership(request.user)
+        return membership is not None and membership.is_admin
 
 
 class ExternalEventChangeRequestPermission(BasePermission):

--- a/calendar_integration/routes.py
+++ b/calendar_integration/routes.py
@@ -3,6 +3,7 @@ from common.types import RouteDict
 from .views import (
     AvailableTimeViewSet,
     BlockedTimeViewSet,
+    BookingPolicyViewSet,
     CalendarEventViewSet,
     CalendarGroupViewSet,
     CalendarViewSet,
@@ -40,5 +41,10 @@ routes: list[RouteDict] = [
         "regex": r"change-requests",
         "viewset": ExternalEventChangeRequestViewSet,
         "basename": "ChangeRequests",
+    },
+    {
+        "regex": r"booking-policies",
+        "viewset": BookingPolicyViewSet,
+        "basename": "BookingPolicies",
     },
 ]

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -72,7 +72,11 @@ from calendar_integration.virtual_models import (
     ResourceAllocationVirtualModel,
 )
 from common.utils.serializer_utils import VirtualModelSerializer
-from organizations.models import Organization, get_active_organization_membership
+from organizations.models import (
+    Organization,
+    OrganizationMembership,
+    get_active_organization_membership,
+)
 from users.models import User
 
 
@@ -2787,19 +2791,20 @@ class BookingPolicySerializer(serializers.ModelSerializer):
 
     Validation:
     - ``validate()`` enforces the exactly-one-target invariant on create.
+    - ``validate_membership_user_id()`` checks that the supplied user id belongs
+      to the caller's organization (on create only; targets are immutable on update).
     - ``DuplicateBookingPolicyError`` from the service is caught and surfaced as
       a 400 validation error so the client gets a named conflict message.
-    - ``PositiveIntegerField`` on the model rejects negatives at the DB level
-      (Django also enforces this in full-clean), but DRF's ``IntegerField``
-      wrapping is permissive by default, so we add ``min_value=0`` below.
+    - The four rule fields use ``min_value=0`` so DRF rejects negatives with a
+      clear field-level 400 before the value reaches the model's
+      ``PositiveIntegerField`` constraint.
 
     Write paths (create / update) delegate to ``BookingPolicyService`` stored on
     the serializer context as ``"booking_policy_service"`` (the viewset sets it).
     """
 
-    # Rule fields — PositiveIntegerField enforces >= 0 at the DB layer; we also
-    # add min_value=0 here so the serializer rejects negatives before even
-    # reaching model validation, giving a clear field-level error message.
+    # Rule fields — the effective guard is DRF's min_value=0; the model's
+    # PositiveIntegerField is a secondary DB-level constraint.
     lead_time_seconds = serializers.IntegerField(min_value=0, default=0)
     max_horizon_seconds = serializers.IntegerField(min_value=0, default=0)
     buffer_before_seconds = serializers.IntegerField(min_value=0, default=0)
@@ -2862,6 +2867,37 @@ class BookingPolicySerializer(serializers.ModelSerializer):
             required=False,
             allow_null=True,
         )
+
+    def validate_membership_user_id(self, value):
+        """Reject a ``membership_user_id`` that is not a member of the caller's org.
+
+        Skipped on update (targets are immutable and already stripped in ``validate``).
+        A bogus or cross-org id would otherwise reach the Phase-1 composite PROTECT FK
+        at commit time and raise an ``IntegrityError`` (HTTP 500); surfacing it here
+        gives a clean 400 instead.
+        """
+        if value is None:
+            return value
+        if self.instance is not None:
+            # Update path — target fields are immutable; skip the check.
+            return value
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        membership = (
+            get_active_organization_membership(user)
+            if user and getattr(user, "is_authenticated", False)
+            else None
+        )
+        if membership is None:
+            # No org context — permission layer will deny the request.
+            return value
+        if not OrganizationMembership.objects.filter(
+            organization_id=membership.organization_id, user_id=value
+        ).exists():
+            raise serializers.ValidationError(
+                "No membership with this user id in your organization."
+            )
+        return value
 
     def validate(self, attrs: dict) -> dict:
         """Enforce the exactly-one-target invariant on creates only.

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -15,10 +15,12 @@ from calendar_integration.exceptions import (
     CalendarGroupError,
     CalendarIntegrationError,
     CalendarServiceNotInjectedError,
+    DuplicateBookingPolicyError,
 )
 from calendar_integration.models import (
     AvailableTime,
     BlockedTime,
+    BookingPolicy,
     Calendar,
     CalendarEvent,
     CalendarEventGroupSelection,
@@ -2774,6 +2776,175 @@ class CalendarGroupAvailabilityQuerySerializer(serializers.Serializer):
 class BookableSlotProposalSerializer(serializers.Serializer):
     start_time = serializers.DateTimeField()
     end_time = serializers.DateTimeField()
+
+
+class BookingPolicySerializer(serializers.ModelSerializer):
+    """Serializer for ``BookingPolicy`` CRUD.
+
+    Exactly one of ``calendar``, ``membership_user_id``, ``calendar_group``, or
+    ``is_organization_default`` must be set on create.  Targets are immutable
+    after creation — only the four rule-field seconds are writable on update.
+
+    Validation:
+    - ``validate()`` enforces the exactly-one-target invariant on create.
+    - ``DuplicateBookingPolicyError`` from the service is caught and surfaced as
+      a 400 validation error so the client gets a named conflict message.
+    - ``PositiveIntegerField`` on the model rejects negatives at the DB level
+      (Django also enforces this in full-clean), but DRF's ``IntegerField``
+      wrapping is permissive by default, so we add ``min_value=0`` below.
+
+    Write paths (create / update) delegate to ``BookingPolicyService`` stored on
+    the serializer context as ``"booking_policy_service"`` (the viewset sets it).
+    """
+
+    # Rule fields — PositiveIntegerField enforces >= 0 at the DB layer; we also
+    # add min_value=0 here so the serializer rejects negatives before even
+    # reaching model validation, giving a clear field-level error message.
+    lead_time_seconds = serializers.IntegerField(min_value=0, default=0)
+    max_horizon_seconds = serializers.IntegerField(min_value=0, default=0)
+    buffer_before_seconds = serializers.IntegerField(min_value=0, default=0)
+    buffer_after_seconds = serializers.IntegerField(min_value=0, default=0)
+
+    # membership_user_id is a denormalized integer FK (not a model FK field) —
+    # expose it directly.  Nullable so the client can omit it when another target
+    # is set.
+    membership_user_id = serializers.IntegerField(required=False, allow_null=True, default=None)
+
+    # is_organization_default default False so the client can omit it.
+    is_organization_default = serializers.BooleanField(default=False)
+
+    class Meta:
+        model = BookingPolicy
+        fields = (
+            "id",
+            "calendar",
+            "calendar_group",
+            "membership_user_id",
+            "is_organization_default",
+            "lead_time_seconds",
+            "max_horizon_seconds",
+            "buffer_before_seconds",
+            "buffer_after_seconds",
+            "created",
+            "modified",
+        )
+        read_only_fields = ("id", "created", "modified")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Build org-scoped querysets for FK fields; fall back to empty querysets
+        # when there is no authenticated user with a membership (anonymous or
+        # membership-less callers are rejected at the permission layer anyway).
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        membership = (
+            get_active_organization_membership(user)
+            if user and getattr(user, "is_authenticated", False)
+            else None
+        )
+        org_id = membership.organization_id if membership else None
+
+        self.fields["calendar"] = serializers.PrimaryKeyRelatedField(
+            queryset=(
+                Calendar.objects.filter_by_organization(org_id)
+                if org_id is not None
+                else Calendar.original_manager.none()
+            ),
+            required=False,
+            allow_null=True,
+        )
+        self.fields["calendar_group"] = serializers.PrimaryKeyRelatedField(
+            queryset=(
+                CalendarGroup.objects.filter_by_organization(org_id)
+                if org_id is not None
+                else CalendarGroup.original_manager.none()
+            ),
+            required=False,
+            allow_null=True,
+        )
+
+    def validate(self, attrs: dict) -> dict:
+        """Enforce the exactly-one-target invariant on creates only.
+
+        Targets are immutable after creation: the service's ``update_booking_policy``
+        only accepts rule-field changes, so we skip the target check on updates
+        (``self.instance is not None``).
+        """
+        if self.instance is not None:
+            # Update path — targets cannot change; strip them from attrs so the
+            # service update method only sees rule-field changes.
+            attrs.pop("calendar", None)
+            attrs.pop("calendar_group", None)
+            attrs.pop("membership_user_id", None)
+            attrs.pop("is_organization_default", None)
+            return attrs
+
+        # Create path — exactly one target must be set.
+        calendar = attrs.get("calendar")
+        membership_user_id = attrs.get("membership_user_id")
+        calendar_group = attrs.get("calendar_group")
+        is_org_default = attrs.get("is_organization_default", False)
+
+        target_count = sum(
+            [
+                calendar is not None,
+                membership_user_id is not None,
+                calendar_group is not None,
+                bool(is_org_default),
+            ]
+        )
+
+        if target_count != 1:
+            raise serializers.ValidationError(
+                {
+                    "non_field_errors": [
+                        "Exactly one of 'calendar', 'membership_user_id', 'calendar_group', "
+                        "or 'is_organization_default' must be set."
+                    ]
+                }
+            )
+
+        return attrs
+
+    def create(self, validated_data: dict) -> BookingPolicy:
+        """Delegate to ``BookingPolicyService.create_booking_policy``."""
+        service = self.context.get("booking_policy_service")
+        if service is None:
+            raise CalendarServiceNotInjectedError(
+                "booking_policy_service is not in serializer context. "
+                "The viewset must set it before calling serializer.save()."
+            )
+
+        try:
+            return service.create_booking_policy(
+                calendar=validated_data.get("calendar"),
+                membership_user_id=validated_data.get("membership_user_id"),
+                calendar_group=validated_data.get("calendar_group"),
+                is_organization_default=validated_data.get("is_organization_default", False),
+                lead_time_seconds=validated_data.get("lead_time_seconds", 0),
+                max_horizon_seconds=validated_data.get("max_horizon_seconds", 0),
+                buffer_before_seconds=validated_data.get("buffer_before_seconds", 0),
+                buffer_after_seconds=validated_data.get("buffer_after_seconds", 0),
+            )
+        except DuplicateBookingPolicyError as exc:
+            raise serializers.ValidationError({"non_field_errors": [str(exc)]}) from exc
+
+    def update(self, instance: BookingPolicy, validated_data: dict) -> BookingPolicy:
+        """Delegate to ``BookingPolicyService.update_booking_policy`` (rule fields only)."""
+        service = self.context.get("booking_policy_service")
+        if service is None:
+            raise CalendarServiceNotInjectedError(
+                "booking_policy_service is not in serializer context. "
+                "The viewset must set it before calling serializer.save()."
+            )
+
+        return service.update_booking_policy(
+            instance,
+            lead_time_seconds=validated_data.get("lead_time_seconds"),
+            max_horizon_seconds=validated_data.get("max_horizon_seconds"),
+            buffer_before_seconds=validated_data.get("buffer_before_seconds"),
+            buffer_after_seconds=validated_data.get("buffer_after_seconds"),
+        )
 
 
 class ExternalEventChangeRequestSerializer(VirtualModelSerializer):

--- a/calendar_integration/tests/test_booking_policy_api.py
+++ b/calendar_integration/tests/test_booking_policy_api.py
@@ -1,0 +1,517 @@
+"""Integration tests for the BookingPolicy REST API (Phase 3).
+
+Covers:
+- Authenticated CRUD happy paths (create, read, update, delete).
+- Unauthorized / forbidden paths (unauthenticated, wrong org via X-Organization-Id header).
+- Duplicate-target create → 400 naming the conflict.
+- Negative buffer field → 400 naming the field.
+- Delete-absent → 204 no-op (idempotent destroy).
+- Audit record emitted on create / update / delete.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.urls import reverse
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from calendar_integration.factories import create_booking_policy
+from calendar_integration.models import BookingPolicy, Calendar, CalendarGroup
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.factories import UserFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_org_with_member(*, is_admin: bool = False) -> tuple[Organization, OrganizationMembership]:
+    """Return a fresh org + membership."""
+    user = UserFactory().create_user()
+    org = baker.make(Organization, name="Test Org")
+    membership = OrganizationMembership.objects.create(
+        user=user,
+        organization=org,
+        role=OrganizationRole.ADMIN if is_admin else OrganizationRole.MEMBER,
+        is_active=True,
+    )
+    return org, membership
+
+
+def _auth_client(membership: OrganizationMembership) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=membership.user)
+    return client
+
+
+def _make_calendar(org: Organization) -> Calendar:
+    return baker.make(Calendar, organization=org, external_id=f"cal-{org.id}")
+
+
+def _make_group(org: Organization) -> CalendarGroup:
+    return baker.make(CalendarGroup, organization=org, name="Group")
+
+
+LIST_URL = "api:BookingPolicies-list"
+DETAIL_URL = "api:BookingPolicies-detail"
+
+
+def _list_url() -> str:
+    return reverse(LIST_URL)
+
+
+def _detail_url(pk: int) -> str:
+    return reverse(DETAIL_URL, args=[pk])
+
+
+# ---------------------------------------------------------------------------
+# List / Retrieve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBookingPolicyList:
+    """GET /booking-policies/ — list and cross-org isolation."""
+
+    def test_unauthenticated_returns_401(self):
+        client = APIClient()
+        response = client.get(_list_url())
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_member_sees_own_org_policies_only(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        cal = _make_calendar(org)
+        create_booking_policy(calendar=cal, lead_time_seconds=300)
+
+        # Another org with its own policy
+        other_org, _ = _make_org_with_member()
+        other_cal = baker.make(Calendar, organization=other_org, external_id="other-cal")
+        create_booking_policy(calendar=other_cal, lead_time_seconds=600)
+
+        response = client.get(_list_url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        results = data.get("results", data)
+        assert len(results) == 1
+        assert results[0]["lead_time_seconds"] == 300
+
+    def test_returns_all_fields(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        cal = _make_calendar(org)
+        policy = create_booking_policy(
+            calendar=cal,
+            lead_time_seconds=60,
+            max_horizon_seconds=3600,
+            buffer_before_seconds=120,
+            buffer_after_seconds=180,
+        )
+
+        response = client.get(_detail_url(policy.pk))
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["id"] == policy.pk
+        assert data["lead_time_seconds"] == 60
+        assert data["max_horizon_seconds"] == 3600
+        assert data["buffer_before_seconds"] == 120
+        assert data["buffer_after_seconds"] == 180
+        assert data["is_organization_default"] is False
+
+    def test_membership_less_user_returns_empty_list(self):
+        """A user without any org membership sees an empty list, not a 403."""
+        user = UserFactory().create_user()
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(_list_url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        results = data.get("results", data)
+        assert results == []
+
+    def test_wrong_org_header_returns_403(self):
+        """X-Organization-Id that names a non-member org returns 403."""
+        _org, membership = _make_org_with_member()
+        other_org, _ = _make_org_with_member()  # The caller has NO membership here
+
+        client = _auth_client(membership)
+        response = client.get(_list_url(), HTTP_X_ORGANIZATION_ID=str(other_org.id))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBookingPolicyCreate:
+    """POST /booking-policies/ — happy paths, validation, duplicates, audit."""
+
+    def test_create_calendar_policy(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        response = client.post(
+            _list_url(),
+            {
+                "calendar": cal.pk,
+                "lead_time_seconds": 300,
+                "max_horizon_seconds": 0,
+                "buffer_before_seconds": 60,
+                "buffer_after_seconds": 0,
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        data = response.json()
+        assert data["lead_time_seconds"] == 300
+        assert data["buffer_before_seconds"] == 60
+
+        policy = BookingPolicy.objects.filter_by_organization(org.id).get(pk=data["id"])
+        assert policy.calendar_fk_id == cal.id
+
+    def test_create_org_default_policy(self):
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        response = client.post(
+            _list_url(),
+            {
+                "is_organization_default": True,
+                "lead_time_seconds": 0,
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["is_organization_default"] is True
+
+    def test_create_group_policy(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        group = _make_group(org)
+
+        response = client.post(
+            _list_url(),
+            {"calendar_group": group.pk, "lead_time_seconds": 1800},
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["lead_time_seconds"] == 1800
+
+    def test_create_membership_policy(self):
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        response = client.post(
+            _list_url(),
+            {
+                "membership_user_id": membership.user_id,
+                "max_horizon_seconds": 7200,
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["membership_user_id"] == membership.user_id
+
+    def test_create_without_target_returns_400(self):
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        response = client.post(_list_url(), {"lead_time_seconds": 60})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_with_two_targets_returns_400(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        response = client.post(
+            _list_url(),
+            {
+                "calendar": cal.pk,
+                "is_organization_default": True,
+                "lead_time_seconds": 60,
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_duplicate_calendar_target_returns_400(self):
+        """Creating a second policy for the same calendar returns 400."""
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+        create_booking_policy(calendar=cal)
+
+        response = client.post(
+            _list_url(),
+            {"calendar": cal.pk, "lead_time_seconds": 99},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        # Should surface the DuplicateBookingPolicyError message
+        error_text = str(body)
+        assert "BookingPolicy" in error_text or "already exists" in error_text
+
+    def test_duplicate_org_default_returns_400(self):
+        """Creating a second org-default policy returns 400."""
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        create_booking_policy(is_organization_default=True, organization=org)
+
+        response = client.post(
+            _list_url(),
+            {"is_organization_default": True, "lead_time_seconds": 100},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_negative_buffer_returns_400(self):
+        """Negative rule field values are rejected with a 400 naming the field."""
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        response = client.post(
+            _list_url(),
+            {
+                "calendar": cal.pk,
+                "buffer_before_seconds": -1,
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        # The error should mention the offending field name.
+        assert "buffer_before_seconds" in body
+
+    def test_negative_lead_time_returns_400_naming_field(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        response = client.post(
+            _list_url(),
+            {"calendar": cal.pk, "lead_time_seconds": -300},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert "lead_time_seconds" in body
+
+    def test_unauthenticated_create_returns_401(self):
+        client = APIClient()
+        response = client.post(_list_url(), {"is_organization_default": True})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_create_emits_audit_record(self, django_capture_on_commit_callbacks):
+        """create writes an audit CREATE record."""
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.post(
+                    _list_url(),
+                    {"calendar": cal.pk, "lead_time_seconds": 60},
+                )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert mock_task.delay.called
+        payload = mock_task.delay.call_args[0][0]
+        assert payload["action"] == "create"
+        assert payload["subject"]["subject_type"] == "calendar_integration.BookingPolicy"
+
+    def test_cross_org_calendar_not_accepted(self):
+        """Passing a calendar from a different org is rejected (FK queryset check)."""
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        other_org, _ = _make_org_with_member()
+        other_cal = baker.make(Calendar, organization=other_org, external_id="other-cal-2")
+
+        response = client.post(
+            _list_url(),
+            {"calendar": other_cal.pk, "lead_time_seconds": 60},
+        )
+        # The serializer's org-scoped queryset will reject the cross-org calendar PK.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBookingPolicyUpdate:
+    """PUT/PATCH /booking-policies/{id}/ — rule fields only, audit."""
+
+    def test_patch_updates_rule_fields(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+
+        response = client.patch(
+            _detail_url(policy.pk),
+            {"lead_time_seconds": 120, "buffer_after_seconds": 30},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        data = response.json()
+        assert data["lead_time_seconds"] == 120
+        assert data["buffer_after_seconds"] == 30
+
+    def test_target_fields_ignored_on_update(self):
+        """Passing 'is_organization_default' on update is silently ignored (target immutable)."""
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal)
+
+        response = client.patch(
+            _detail_url(policy.pk),
+            {"is_organization_default": True, "lead_time_seconds": 200},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        # Target should not have changed.
+        policy.refresh_from_db()
+        assert policy.is_organization_default is False
+        assert policy.lead_time_seconds == 200
+
+    def test_negative_buffer_on_update_returns_400(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal)
+
+        response = client.patch(
+            _detail_url(policy.pk),
+            {"buffer_before_seconds": -5},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert "buffer_before_seconds" in body
+
+    def test_update_cross_org_returns_404(self):
+        """Updating a policy from a different org returns 404 (not found in queryset)."""
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        other_org, _ = _make_org_with_member()
+        other_cal = baker.make(Calendar, organization=other_org, external_id="other-cal-u")
+        other_policy = create_booking_policy(calendar=other_cal)
+
+        response = client.patch(_detail_url(other_policy.pk), {"lead_time_seconds": 999})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_emits_audit_record(self, django_capture_on_commit_callbacks):
+        """update writes an audit UPDATE record with a diff."""
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.patch(
+                    _detail_url(policy.pk),
+                    {"lead_time_seconds": 300},
+                )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert mock_task.delay.called
+        payload = mock_task.delay.call_args[0][0]
+        assert payload["action"] == "update"
+        assert payload["diff"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Destroy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBookingPolicyDestroy:
+    """DELETE /booking-policies/{id}/ — idempotent no-op + audit."""
+
+    def test_delete_existing_policy(self):
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal)
+
+        response = client.delete(_detail_url(policy.pk))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert (
+            not BookingPolicy.objects.filter_by_organization(org.id).filter(pk=policy.pk).exists()
+        )
+
+    def test_delete_absent_returns_204_no_op(self):
+        """Deleting a non-existent policy pk returns 204 (idempotent no-op)."""
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        non_existent_pk = 9_999_999
+        response = client.delete(_detail_url(non_existent_pk))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_delete_cross_org_returns_204_no_op(self):
+        """Deleting a pk that belongs to a different org is an idempotent no-op, not a 403.
+
+        The plan's delete-absent semantics mean: if the policy isn't resolvable in
+        the caller's org, treat it the same as absent → 204 no-op.
+        """
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        other_org, _ = _make_org_with_member()
+        other_cal = baker.make(Calendar, organization=other_org, external_id="other-cal-d")
+        other_policy = create_booking_policy(calendar=other_cal)
+
+        response = client.delete(_detail_url(other_policy.pk))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        # The other org's policy must still exist.
+        assert (
+            BookingPolicy.objects.filter_by_organization(other_org.id)
+            .filter(pk=other_policy.pk)
+            .exists()
+        )
+
+    def test_delete_emits_audit_record(self, django_capture_on_commit_callbacks):
+        """delete writes an audit DELETE record."""
+        org, membership = _make_org_with_member()
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.delete(_detail_url(policy.pk))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert mock_task.delay.called
+        payload = mock_task.delay.call_args[0][0]
+        assert payload["action"] == "delete"
+
+    def test_delete_absent_does_not_emit_audit_record(self, django_capture_on_commit_callbacks):
+        """No audit record when the policy was already absent (truly idempotent)."""
+        _, membership = _make_org_with_member()
+        client = _auth_client(membership)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.delete(_detail_url(9_999_998))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        # The service's delete_booking_policy(None) should not call audit.
+        assert not mock_task.delay.called
+
+    def test_unauthenticated_delete_returns_401(self):
+        client = APIClient()
+        response = client.delete(_detail_url(1))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/calendar_integration/tests/test_booking_policy_api.py
+++ b/calendar_integration/tests/test_booking_policy_api.py
@@ -1,10 +1,11 @@
 """Integration tests for the BookingPolicy REST API (Phase 3).
 
 Covers:
-- Authenticated CRUD happy paths (create, read, update, delete).
-- Unauthorized / forbidden paths (unauthenticated, wrong org via X-Organization-Id header).
+- Authenticated CRUD happy paths (create, read, update, delete) — org admin only for writes.
+- Unauthorized / forbidden paths (unauthenticated, non-admin member, wrong org via X-Organization-Id header).
 - Duplicate-target create → 400 naming the conflict.
-- Negative buffer field → 400 naming the field.
+- Negative buffer field → 400 naming the field (all four rule fields).
+- bogus membership_user_id → 400 (not 500).
 - Delete-absent → 204 no-op (idempotent destroy).
 - Audit record emitted on create / update / delete.
 """
@@ -158,7 +159,7 @@ class TestBookingPolicyCreate:
     """POST /booking-policies/ — happy paths, validation, duplicates, audit."""
 
     def test_create_calendar_policy(self):
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
 
@@ -181,7 +182,7 @@ class TestBookingPolicyCreate:
         assert policy.calendar_fk_id == cal.id
 
     def test_create_org_default_policy(self):
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         response = client.post(
@@ -195,7 +196,7 @@ class TestBookingPolicyCreate:
         assert response.json()["is_organization_default"] is True
 
     def test_create_group_policy(self):
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         group = _make_group(org)
 
@@ -207,7 +208,7 @@ class TestBookingPolicyCreate:
         assert response.json()["lead_time_seconds"] == 1800
 
     def test_create_membership_policy(self):
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         response = client.post(
@@ -221,14 +222,14 @@ class TestBookingPolicyCreate:
         assert response.json()["membership_user_id"] == membership.user_id
 
     def test_create_without_target_returns_400(self):
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         response = client.post(_list_url(), {"lead_time_seconds": 60})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_create_with_two_targets_returns_400(self):
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
 
@@ -244,7 +245,7 @@ class TestBookingPolicyCreate:
 
     def test_duplicate_calendar_target_returns_400(self):
         """Creating a second policy for the same calendar returns 400."""
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
         create_booking_policy(calendar=cal)
@@ -261,7 +262,7 @@ class TestBookingPolicyCreate:
 
     def test_duplicate_org_default_returns_400(self):
         """Creating a second org-default policy returns 400."""
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         create_booking_policy(is_organization_default=True, organization=org)
 
@@ -273,7 +274,7 @@ class TestBookingPolicyCreate:
 
     def test_negative_buffer_returns_400(self):
         """Negative rule field values are rejected with a 400 naming the field."""
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
 
@@ -290,7 +291,7 @@ class TestBookingPolicyCreate:
         assert "buffer_before_seconds" in body
 
     def test_negative_lead_time_returns_400_naming_field(self):
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
 
@@ -302,14 +303,52 @@ class TestBookingPolicyCreate:
         body = response.json()
         assert "lead_time_seconds" in body
 
+    def test_negative_max_horizon_returns_400_naming_field(self):
+        org, membership = _make_org_with_member(is_admin=True)
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        response = client.post(
+            _list_url(),
+            {"calendar": cal.pk, "max_horizon_seconds": -1},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert "max_horizon_seconds" in body
+
+    def test_negative_buffer_after_returns_400_naming_field(self):
+        org, membership = _make_org_with_member(is_admin=True)
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        response = client.post(
+            _list_url(),
+            {"calendar": cal.pk, "buffer_after_seconds": -1},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert "buffer_after_seconds" in body
+
     def test_unauthenticated_create_returns_401(self):
         client = APIClient()
         response = client.post(_list_url(), {"is_organization_default": True})
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    def test_member_cannot_create_policy(self):
+        """A non-admin member POST → 403."""
+        org, membership = _make_org_with_member(is_admin=False)
+        client = _auth_client(membership)
+        cal = _make_calendar(org)
+
+        response = client.post(
+            _list_url(),
+            {"calendar": cal.pk, "lead_time_seconds": 60},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_create_emits_audit_record(self, django_capture_on_commit_callbacks):
         """create writes an audit CREATE record."""
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
 
@@ -328,7 +367,7 @@ class TestBookingPolicyCreate:
 
     def test_cross_org_calendar_not_accepted(self):
         """Passing a calendar from a different org is rejected (FK queryset check)."""
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         other_org, _ = _make_org_with_member()
@@ -341,6 +380,21 @@ class TestBookingPolicyCreate:
         # The serializer's org-scoped queryset will reject the cross-org calendar PK.
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_create_membership_policy_bogus_user_id_returns_400(self):
+        """membership_user_id that is not a member of the org → 400, not 500."""
+        _, membership = _make_org_with_member(is_admin=True)
+        client = _auth_client(membership)
+
+        bogus_user_id = 999_999_999
+
+        response = client.post(
+            _list_url(),
+            {"membership_user_id": bogus_user_id, "lead_time_seconds": 60},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert "membership_user_id" in body
+
 
 # ---------------------------------------------------------------------------
 # Update
@@ -352,7 +406,7 @@ class TestBookingPolicyUpdate:
     """PUT/PATCH /booking-policies/{id}/ — rule fields only, audit."""
 
     def test_patch_updates_rule_fields(self):
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
         policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
@@ -368,7 +422,7 @@ class TestBookingPolicyUpdate:
 
     def test_target_fields_ignored_on_update(self):
         """Passing 'is_organization_default' on update is silently ignored (target immutable)."""
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
         policy = create_booking_policy(calendar=cal)
@@ -384,7 +438,7 @@ class TestBookingPolicyUpdate:
         assert policy.lead_time_seconds == 200
 
     def test_negative_buffer_on_update_returns_400(self):
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
         policy = create_booking_policy(calendar=cal)
@@ -399,7 +453,7 @@ class TestBookingPolicyUpdate:
 
     def test_update_cross_org_returns_404(self):
         """Updating a policy from a different org returns 404 (not found in queryset)."""
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         other_org, _ = _make_org_with_member()
@@ -409,9 +463,28 @@ class TestBookingPolicyUpdate:
         response = client.patch(_detail_url(other_policy.pk), {"lead_time_seconds": 999})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_member_cannot_update_policy(self):
+        """A non-admin member PATCH → 403."""
+        org, _admin_membership = _make_org_with_member(is_admin=True)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+
+        # Create a non-admin member in the same org
+        non_admin_user = UserFactory().create_user()
+        non_admin_membership = OrganizationMembership.objects.create(
+            user=non_admin_user,
+            organization=org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        client = _auth_client(non_admin_membership)
+
+        response = client.patch(_detail_url(policy.pk), {"lead_time_seconds": 999})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_update_emits_audit_record(self, django_capture_on_commit_callbacks):
         """update writes an audit UPDATE record with a diff."""
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
         policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
@@ -440,7 +513,7 @@ class TestBookingPolicyDestroy:
     """DELETE /booking-policies/{id}/ — idempotent no-op + audit."""
 
     def test_delete_existing_policy(self):
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
         policy = create_booking_policy(calendar=cal)
@@ -453,7 +526,7 @@ class TestBookingPolicyDestroy:
 
     def test_delete_absent_returns_204_no_op(self):
         """Deleting a non-existent policy pk returns 204 (idempotent no-op)."""
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         non_existent_pk = 9_999_999
@@ -466,7 +539,7 @@ class TestBookingPolicyDestroy:
         The plan's delete-absent semantics mean: if the policy isn't resolvable in
         the caller's org, treat it the same as absent → 204 no-op.
         """
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         other_org, _ = _make_org_with_member()
@@ -482,9 +555,27 @@ class TestBookingPolicyDestroy:
             .exists()
         )
 
+    def test_member_cannot_delete_policy(self):
+        """A non-admin member DELETE → 403."""
+        org, _admin_membership = _make_org_with_member(is_admin=True)
+        cal = _make_calendar(org)
+        policy = create_booking_policy(calendar=cal)
+
+        non_admin_user = UserFactory().create_user()
+        non_admin_membership = OrganizationMembership.objects.create(
+            user=non_admin_user,
+            organization=org,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        client = _auth_client(non_admin_membership)
+
+        response = client.delete(_detail_url(policy.pk))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_delete_emits_audit_record(self, django_capture_on_commit_callbacks):
         """delete writes an audit DELETE record."""
-        org, membership = _make_org_with_member()
+        org, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
         cal = _make_calendar(org)
         policy = create_booking_policy(calendar=cal)
@@ -500,7 +591,7 @@ class TestBookingPolicyDestroy:
 
     def test_delete_absent_does_not_emit_audit_record(self, django_capture_on_commit_callbacks):
         """No audit record when the policy was already absent (truly idempotent)."""
-        _, membership = _make_org_with_member()
+        _, membership = _make_org_with_member(is_admin=True)
         client = _auth_client(membership)
 
         with patch("audit.services.persist_audit_record") as mock_task:

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -2057,14 +2057,6 @@ class BookingPolicyViewSet(VintaScheduleModelViewSet):
 
         return booking_policy_service
 
-    def get_serializer_context(self):
-        """Inject the initialized ``BookingPolicyService`` into the serializer context."""
-        context = super().get_serializer_context()
-        # We defer service construction to the @inject-decorated action methods
-        # (create / update / destroy) so DI is wired correctly per-request.
-        # The context key is set there, not here, to keep get_serializer_context pure.
-        return context
-
     @extend_schema(
         summary="Create a booking policy",
         description=(
@@ -2088,10 +2080,10 @@ class BookingPolicyViewSet(VintaScheduleModelViewSet):
         """POST /booking-policies/ — create a new policy."""
         service = self._build_service(booking_policy_service)
 
-        serializer = self.get_serializer(data=request.data)
-        # Pass the initialized service through context so BookingPolicySerializer
-        # can delegate to it without direct-importing the service.
-        cast(dict, serializer.context)["booking_policy_service"] = service
+        serializer = self.get_serializer(
+            data=request.data,
+            context={**self.get_serializer_context(), "booking_policy_service": service},
+        )
         serializer.is_valid(raise_exception=True)
         policy = serializer.save()
 
@@ -2125,8 +2117,12 @@ class BookingPolicyViewSet(VintaScheduleModelViewSet):
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
 
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
-        cast(dict, serializer.context)["booking_policy_service"] = service
+        serializer = self.get_serializer(
+            instance,
+            data=request.data,
+            partial=partial,
+            context={**self.get_serializer_context(), "booking_policy_service": service},
+        )
         serializer.is_valid(raise_exception=True)
         policy = serializer.save()
 

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -1,6 +1,6 @@
 import datetime
 from collections.abc import Callable
-from typing import Annotated
+from typing import Annotated, Any, cast
 
 from django.db.models import Case, IntegerField, Value, When
 from django.http import Http404, HttpResponse
@@ -19,6 +19,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.response import Response
 
+from audit.services import AuditService
 from calendar_integration.constants import (
     CalendarProvider,
     CalendarSyncTriggerSource,
@@ -43,6 +44,7 @@ from calendar_integration.filtersets import (
 from calendar_integration.models import (
     AvailableTime,
     BlockedTime,
+    BookingPolicy,
     Calendar,
     CalendarEvent,
     CalendarGroup,
@@ -50,6 +52,7 @@ from calendar_integration.models import (
     ExternalEventChangeRequest,
 )
 from calendar_integration.permissions import (
+    BookingPolicyPermission,
     CalendarAvailabilityPermission,
     CalendarEventPermission,
     CalendarGroupPermission,
@@ -65,6 +68,7 @@ from calendar_integration.serializers import (
     BlockedTimeRecurringExceptionSerializer,
     BlockedTimeSerializer,
     BookableSlotProposalSerializer,
+    BookingPolicySerializer,
     BulkBlockedTimeSerializer,
     CalendarBundleCreateSerializer,
     CalendarBundleUpdateSerializer,
@@ -83,6 +87,7 @@ from calendar_integration.serializers import (
     ResourceCalendarCreateSerializer,
     UnavailableTimeWindowSerializer,
 )
+from calendar_integration.services.booking_policy_service import BookingPolicyService
 from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_service import CalendarService
 from calendar_integration.services.external_event_change_request_service import (
@@ -1995,6 +2000,183 @@ class CalendarGroupViewSet(VintaScheduleModelViewSet):
 
         payload = [{"start_time": p.start_time, "end_time": p.end_time} for p in proposals]
         return Response(BookableSlotProposalSerializer(payload, many=True).data)
+
+
+@extend_schema(tags=["Booking Policies"])
+class BookingPolicyViewSet(VintaScheduleModelViewSet):
+    """ViewSet for managing ``BookingPolicy`` objects.
+
+    Provides full CRUD for booking policies scoped to the authenticated user's
+    organization.  Write operations (create, update, delete) delegate to
+    ``BookingPolicyService`` so validation, uniqueness checking, and audit
+    emission live in a single place.
+
+    **Exactly-one-target rule:** create requests must supply exactly one of
+    ``calendar``, ``membership_user_id``, ``calendar_group``, or
+    ``is_organization_default=true``.  Any other combination returns 400.
+
+    **Duplicate target → 400:** creating a second policy for the same target
+    is a validation error (not a 409) so the serializer can name the conflict.
+
+    **Idempotent destroy:** ``DELETE /booking-policies/{id}/`` returns 204 even
+    when the policy does not exist for the bound organization.
+    """
+
+    permission_classes = (BookingPolicyPermission,)
+    queryset = BookingPolicy.objects.all()
+    serializer_class = BookingPolicySerializer
+
+    def get_queryset(self):
+        """Return all policies for the authenticated user's organization."""
+        user = self.request.user
+        if not user.is_authenticated:
+            return BookingPolicy.original_manager.none()
+
+        membership = get_active_organization_membership(user)
+        if not membership:
+            return BookingPolicy.original_manager.none()
+
+        return BookingPolicy.objects.filter_by_organization(membership.organization_id)
+
+    def _build_service(
+        self,
+        booking_policy_service: "BookingPolicyService",
+    ) -> "BookingPolicyService":
+        """Initialize the service for this request's organization + actor."""
+        membership = get_active_organization_membership(cast("Any", self.request.user))
+        if membership is None:
+            # Callers without a membership are gated at the permission layer;
+            # this branch is a safeguard only.
+            return booking_policy_service
+
+        booking_policy_service.initialize(membership.organization)
+
+        # Resolve the acting principal for audit records.
+        actor = AuditService.actor_from_user(self.request.user, membership.organization_id)
+        booking_policy_service.set_actor(actor)
+
+        return booking_policy_service
+
+    def get_serializer_context(self):
+        """Inject the initialized ``BookingPolicyService`` into the serializer context."""
+        context = super().get_serializer_context()
+        # We defer service construction to the @inject-decorated action methods
+        # (create / update / destroy) so DI is wired correctly per-request.
+        # The context key is set there, not here, to keep get_serializer_context pure.
+        return context
+
+    @extend_schema(
+        summary="Create a booking policy",
+        description=(
+            "Create a new booking policy for the organization. "
+            "Exactly one of 'calendar', 'membership_user_id', 'calendar_group', "
+            "or 'is_organization_default' must be set. "
+            "Returns 400 when a policy for the target already exists."
+        ),
+        responses={201: BookingPolicySerializer},
+    )
+    @inject
+    def create(
+        self,
+        request,
+        *args,
+        booking_policy_service: Annotated[
+            BookingPolicyService, Provide["booking_policy_service"]
+        ] = None,  # type: ignore[assignment]
+        **kwargs,
+    ) -> Response:
+        """POST /booking-policies/ — create a new policy."""
+        service = self._build_service(booking_policy_service)
+
+        serializer = self.get_serializer(data=request.data)
+        # Pass the initialized service through context so BookingPolicySerializer
+        # can delegate to it without direct-importing the service.
+        cast(dict, serializer.context)["booking_policy_service"] = service
+        serializer.is_valid(raise_exception=True)
+        policy = serializer.save()
+
+        # Re-fetch through the queryset so annotations are applied uniformly.
+        policy = self.get_queryset().get(pk=policy.pk)
+        return Response(self.get_serializer(policy).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        summary="Update a booking policy",
+        description=(
+            "Update the rule fields (lead_time_seconds, max_horizon_seconds, "
+            "buffer_before_seconds, buffer_after_seconds) of an existing booking policy. "
+            "Target fields (calendar, membership_user_id, calendar_group, "
+            "is_organization_default) are immutable after creation."
+        ),
+        responses={200: BookingPolicySerializer},
+    )
+    @inject
+    def update(
+        self,
+        request,
+        *args,
+        booking_policy_service: Annotated[
+            BookingPolicyService, Provide["booking_policy_service"]
+        ] = None,  # type: ignore[assignment]
+        **kwargs,
+    ) -> Response:
+        """PUT/PATCH /booking-policies/{id}/ — update rule fields."""
+        service = self._build_service(booking_policy_service)
+
+        partial = kwargs.pop("partial", False)
+        instance = self.get_object()
+
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        cast(dict, serializer.context)["booking_policy_service"] = service
+        serializer.is_valid(raise_exception=True)
+        policy = serializer.save()
+
+        # Re-fetch through the queryset to ensure consistency with the list/retrieve paths.
+        policy = self.get_queryset().get(pk=policy.pk)
+        return Response(self.get_serializer(policy).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Delete a booking policy",
+        description=(
+            "Delete a booking policy by id. "
+            "Returns 204 even when the policy does not exist (idempotent no-op)."
+        ),
+        responses={204: None},
+    )
+    @inject
+    def destroy(
+        self,
+        request,
+        *args,
+        booking_policy_service: Annotated[
+            BookingPolicyService, Provide["booking_policy_service"]
+        ] = None,  # type: ignore[assignment]
+        **kwargs,
+    ) -> Response:
+        """DELETE /booking-policies/{id}/ — idempotent policy removal.
+
+        Returns 204 regardless of whether the policy existed.  The plan's
+        Guiding Decisions mandate delete-absent semantics: a missing row is not
+        an error on the caller's side.
+        """
+        service = self._build_service(booking_policy_service)
+
+        # Try to resolve the policy but do not 404 when absent — the contract
+        # is idempotent no-op.
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            # Gated — permission layer should catch this first.
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        pk = kwargs.get("pk") or self.kwargs.get("pk")
+        try:
+            policy: BookingPolicy | None = BookingPolicy.objects.filter_by_organization(
+                membership.organization_id
+            ).get(pk=pk)
+        except BookingPolicy.DoesNotExist:
+            policy = None
+
+        service.delete_booking_policy(policy)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @extend_schema(tags=["External Event Change Requests"])

--- a/schema.yml
+++ b/schema.yml
@@ -12374,11 +12374,13 @@ components:
 
         Validation:
         - ``validate()`` enforces the exactly-one-target invariant on create.
+        - ``validate_membership_user_id()`` checks that the supplied user id belongs
+          to the caller's organization (on create only; targets are immutable on update).
         - ``DuplicateBookingPolicyError`` from the service is caught and surfaced as
           a 400 validation error so the client gets a named conflict message.
-        - ``PositiveIntegerField`` on the model rejects negatives at the DB level
-          (Django also enforces this in full-clean), but DRF's ``IntegerField``
-          wrapping is permissive by default, so we add ``min_value=0`` below.
+        - The four rule fields use ``min_value=0`` so DRF rejects negatives with a
+          clear field-level 400 before the value reaches the model's
+          ``PositiveIntegerField`` constraint.
 
         Write paths (create / update) delegate to ``BookingPolicyService`` stored on
         the serializer context as ``"booking_policy_service"`` (the viewset sets it).
@@ -14046,11 +14048,13 @@ components:
 
         Validation:
         - ``validate()`` enforces the exactly-one-target invariant on create.
+        - ``validate_membership_user_id()`` checks that the supplied user id belongs
+          to the caller's organization (on create only; targets are immutable on update).
         - ``DuplicateBookingPolicyError`` from the service is caught and surfaced as
           a 400 validation error so the client gets a named conflict message.
-        - ``PositiveIntegerField`` on the model rejects negatives at the DB level
-          (Django also enforces this in full-clean), but DRF's ``IntegerField``
-          wrapping is permissive by default, so we add ``min_value=0`` below.
+        - The four rule fields use ``min_value=0`` so DRF rejects negatives with a
+          clear field-level 400 before the value reaches the model's
+          ``PositiveIntegerField`` constraint.
 
         Write paths (create / update) delegate to ``BookingPolicyService`` stored on
         the serializer context as ``"booking_policy_service"`` (the viewset sets it).

--- a/schema.yml
+++ b/schema.yml
@@ -2266,6 +2266,600 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedBlockedTimeList'
           description: ''
+  /booking-policies/:
+    get:
+      operationId: booking_policies_list
+      description: |-
+        ViewSet for managing ``BookingPolicy`` objects.
+
+        Provides full CRUD for booking policies scoped to the authenticated user's
+        organization.  Write operations (create, update, delete) delegate to
+        ``BookingPolicyService`` so validation, uniqueness checking, and audit
+        emission live in a single place.
+
+        **Exactly-one-target rule:** create requests must supply exactly one of
+        ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default=true``.  Any other combination returns 400.
+
+        **Duplicate target → 400:** creating a second policy for the same target
+        is a validation error (not a 409) so the serializer can name the conflict.
+
+        **Idempotent destroy:** ``DELETE /booking-policies/{id}/`` returns 204 even
+        when the policy does not exist for the bound organization.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - Booking Policies
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBookingPolicyList'
+          description: ''
+    post:
+      operationId: booking_policies_create
+      description: Create a new booking policy for the organization. Exactly one of
+        'calendar', 'membership_user_id', 'calendar_group', or 'is_organization_default'
+        must be set. Returns 400 when a policy for the target already exists.
+      summary: Create a booking policy
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      tags:
+      - Booking Policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+  /booking-policies{format}:
+    get:
+      operationId: booking_policies_formatted_list
+      description: |-
+        ViewSet for managing ``BookingPolicy`` objects.
+
+        Provides full CRUD for booking policies scoped to the authenticated user's
+        organization.  Write operations (create, update, delete) delegate to
+        ``BookingPolicyService`` so validation, uniqueness checking, and audit
+        emission live in a single place.
+
+        **Exactly-one-target rule:** create requests must supply exactly one of
+        ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default=true``.  Any other combination returns 400.
+
+        **Duplicate target → 400:** creating a second policy for the same target
+        is a validation error (not a 409) so the serializer can name the conflict.
+
+        **Idempotent destroy:** ``DELETE /booking-policies/{id}/`` returns 204 even
+        when the policy does not exist for the bound organization.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - Booking Policies
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBookingPolicyList'
+          description: ''
+    post:
+      operationId: booking_policies_formatted_create
+      description: Create a new booking policy for the organization. Exactly one of
+        'calendar', 'membership_user_id', 'calendar_group', or 'is_organization_default'
+        must be set. Returns 400 when a policy for the target already exists.
+      summary: Create a booking policy
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - Booking Policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+  /booking-policies/{id}/:
+    get:
+      operationId: booking_policies_retrieve
+      description: |-
+        ViewSet for managing ``BookingPolicy`` objects.
+
+        Provides full CRUD for booking policies scoped to the authenticated user's
+        organization.  Write operations (create, update, delete) delegate to
+        ``BookingPolicyService`` so validation, uniqueness checking, and audit
+        emission live in a single place.
+
+        **Exactly-one-target rule:** create requests must supply exactly one of
+        ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default=true``.  Any other combination returns 400.
+
+        **Duplicate target → 400:** creating a second policy for the same target
+        is a validation error (not a 409) so the serializer can name the conflict.
+
+        **Idempotent destroy:** ``DELETE /booking-policies/{id}/`` returns 204 even
+        when the policy does not exist for the bound organization.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+    put:
+      operationId: booking_policies_update
+      description: Update the rule fields (lead_time_seconds, max_horizon_seconds,
+        buffer_before_seconds, buffer_after_seconds) of an existing booking policy.
+        Target fields (calendar, membership_user_id, calendar_group, is_organization_default)
+        are immutable after creation.
+      summary: Update a booking policy
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+    patch:
+      operationId: booking_policies_partial_update
+      description: |-
+        ViewSet for managing ``BookingPolicy`` objects.
+
+        Provides full CRUD for booking policies scoped to the authenticated user's
+        organization.  Write operations (create, update, delete) delegate to
+        ``BookingPolicyService`` so validation, uniqueness checking, and audit
+        emission live in a single place.
+
+        **Exactly-one-target rule:** create requests must supply exactly one of
+        ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default=true``.  Any other combination returns 400.
+
+        **Duplicate target → 400:** creating a second policy for the same target
+        is a validation error (not a 409) so the serializer can name the conflict.
+
+        **Idempotent destroy:** ``DELETE /booking-policies/{id}/`` returns 204 even
+        when the policy does not exist for the bound organization.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedBookingPolicy'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedBookingPolicy'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedBookingPolicy'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+    delete:
+      operationId: booking_policies_destroy
+      description: Delete a booking policy by id. Returns 204 even when the policy
+        does not exist (idempotent no-op).
+      summary: Delete a booking policy
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /booking-policies/{id}{format}:
+    get:
+      operationId: booking_policies_formatted_retrieve
+      description: |-
+        ViewSet for managing ``BookingPolicy`` objects.
+
+        Provides full CRUD for booking policies scoped to the authenticated user's
+        organization.  Write operations (create, update, delete) delegate to
+        ``BookingPolicyService`` so validation, uniqueness checking, and audit
+        emission live in a single place.
+
+        **Exactly-one-target rule:** create requests must supply exactly one of
+        ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default=true``.  Any other combination returns 400.
+
+        **Duplicate target → 400:** creating a second policy for the same target
+        is a validation error (not a 409) so the serializer can name the conflict.
+
+        **Idempotent destroy:** ``DELETE /booking-policies/{id}/`` returns 204 even
+        when the policy does not exist for the bound organization.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+    put:
+      operationId: booking_policies_formatted_update
+      description: Update the rule fields (lead_time_seconds, max_horizon_seconds,
+        buffer_before_seconds, buffer_after_seconds) of an existing booking policy.
+        Target fields (calendar, membership_user_id, calendar_group, is_organization_default)
+        are immutable after creation.
+      summary: Update a booking policy
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BookingPolicy'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+    patch:
+      operationId: booking_policies_formatted_partial_update
+      description: |-
+        ViewSet for managing ``BookingPolicy`` objects.
+
+        Provides full CRUD for booking policies scoped to the authenticated user's
+        organization.  Write operations (create, update, delete) delegate to
+        ``BookingPolicyService`` so validation, uniqueness checking, and audit
+        emission live in a single place.
+
+        **Exactly-one-target rule:** create requests must supply exactly one of
+        ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default=true``.  Any other combination returns 400.
+
+        **Duplicate target → 400:** creating a second policy for the same target
+        is a validation error (not a 409) so the serializer can name the conflict.
+
+        **Idempotent destroy:** ``DELETE /booking-policies/{id}/`` returns 204 even
+        when the policy does not exist for the bound organization.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedBookingPolicy'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedBookingPolicy'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedBookingPolicy'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingPolicy'
+          description: ''
+    delete:
+      operationId: booking_policies_formatted_destroy
+      description: Delete a booking policy by id. Returns 204 even when the policy
+        does not exist (idempotent no-op).
+      summary: Delete a booking policy
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Booking Policies
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /branding/:
     get:
       operationId: branding_retrieve
@@ -11769,6 +12363,69 @@ components:
       required:
       - end_time
       - start_time
+    BookingPolicy:
+      type: object
+      description: |-
+        Serializer for ``BookingPolicy`` CRUD.
+
+        Exactly one of ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default`` must be set on create.  Targets are immutable
+        after creation — only the four rule-field seconds are writable on update.
+
+        Validation:
+        - ``validate()`` enforces the exactly-one-target invariant on create.
+        - ``DuplicateBookingPolicyError`` from the service is caught and surfaced as
+          a 400 validation error so the client gets a named conflict message.
+        - ``PositiveIntegerField`` on the model rejects negatives at the DB level
+          (Django also enforces this in full-clean), but DRF's ``IntegerField``
+          wrapping is permissive by default, so we add ``min_value=0`` below.
+
+        Write paths (create / update) delegate to ``BookingPolicyService`` stored on
+        the serializer context as ``"booking_policy_service"`` (the viewset sets it).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        calendar:
+          type: integer
+          nullable: true
+        calendar_group:
+          type: integer
+          nullable: true
+        membership_user_id:
+          type: integer
+          nullable: true
+        is_organization_default:
+          type: boolean
+          default: false
+        lead_time_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        max_horizon_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        buffer_before_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        buffer_after_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created
+      - id
+      - modified
     BulkBlockedTime:
       type: object
       description: Serializer for creating multiple blocked times.
@@ -12920,6 +13577,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BookableSlotProposal'
+    PaginatedBookingPolicyList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookingPolicy'
     PaginatedCalendarEventList:
       type: object
       required:
@@ -13355,6 +14035,65 @@ components:
         calendar:
           type: integer
           nullable: true
+    PatchedBookingPolicy:
+      type: object
+      description: |-
+        Serializer for ``BookingPolicy`` CRUD.
+
+        Exactly one of ``calendar``, ``membership_user_id``, ``calendar_group``, or
+        ``is_organization_default`` must be set on create.  Targets are immutable
+        after creation — only the four rule-field seconds are writable on update.
+
+        Validation:
+        - ``validate()`` enforces the exactly-one-target invariant on create.
+        - ``DuplicateBookingPolicyError`` from the service is caught and surfaced as
+          a 400 validation error so the client gets a named conflict message.
+        - ``PositiveIntegerField`` on the model rejects negatives at the DB level
+          (Django also enforces this in full-clean), but DRF's ``IntegerField``
+          wrapping is permissive by default, so we add ``min_value=0`` below.
+
+        Write paths (create / update) delegate to ``BookingPolicyService`` stored on
+        the serializer context as ``"booking_policy_service"`` (the viewset sets it).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        calendar:
+          type: integer
+          nullable: true
+        calendar_group:
+          type: integer
+          nullable: true
+        membership_user_id:
+          type: integer
+          nullable: true
+        is_organization_default:
+          type: boolean
+          default: false
+        lead_time_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        max_horizon_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        buffer_before_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        buffer_after_seconds:
+          type: integer
+          minimum: 0
+          default: 0
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
     PatchedCalendar:
       type: object
       properties:


### PR DESCRIPTION
## Summary
Phase 3 of the **Bookable Slots for Single Calendars & Bundles, with Booking Policies** plan — the private REST CRUD surface for `BookingPolicy` (spec use-case 3, REST half). Stacked on Phase 2 (the resolver/write service). No migration; `schema.yml` regenerated.

Adds:
- **`BookingPolicySerializer`** (`serializers.py`) — exactly-one-target validation on create, immutable targets on update (stripped), org-scoped `calendar`/`calendar_group` querysets, `validate_membership_user_id` (rejects bogus/cross-org ids with 400 instead of a DB 500), `min_value=0` on the four rule fields, and `DuplicateBookingPolicyError → 400`. Writes delegate to `BookingPolicyService`.
- **`BookingPolicyViewSet(VintaScheduleModelViewSet)`** (`views.py`) — org-scoped `get_queryset`; `create`/`update`/`destroy` resolve the DI `booking_policy_service`, `initialize(org)` + `set_actor(...)`, then delegate; idempotent `destroy` (204 even when absent).
- **`BookingPolicyPermission`** (`permissions.py`) — reads = any authenticated member; **writes = organization admin** (mirrors `IsOrganizationAdmin`), per spec use-case 3.
- Route `booking-policies` in `routes.py`; regenerated `schema.yml`.

## Plan reference
`ai-plans/2026-06-26-BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY_IMPLEMENTATION_PLAN.md` — **Phase 3**. Stacked on Phase 2 / PR #167. No feature flag (data-presence gate). No migration.

## Test plan
- `docker compose run --rm api uv run pytest calendar_integration/tests/test_booking_policy_api.py -p no:randomly` — list/retrieve; create for all four target types; duplicate-target → 400; exactly-one-target (zero/multiple) → 400; negative on all four rule fields → 400; cross-org isolation (retrieve/update 404, delete 204 no-op); delete-absent → 204; **member write → 403, admin write → 2xx**; bogus `membership_user_id` → 400; audit emission on create/update/delete. **35 tests.**
- Outer gate: `makemigrations --check` (no changes), `check --deploy` (0 errors), `schema.yml` drift-free, full `pytest -n auto` → **3342 passed**.