### PR TITLE
feat(public_api): expose BookingPolicy CRUD on the public GraphQL API

### DIFF
--- a/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
+++ b/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
@@ -19,6 +19,7 @@
 - Phase 1: `plan/bookable-slots-single-calendar-and-booking-policy/phase-1` (base `main`)
 - Phase 2: `plan/bookable-slots-single-calendar-and-booking-policy/phase-2` (base phase-1)
 - Phase 3: `plan/bookable-slots-single-calendar-and-booking-policy/phase-3` (base phase-2)
+- Phase 4: `plan/bookable-slots-single-calendar-and-booking-policy/phase-4` (base phase-3)
 
 ## Completed phases
 
@@ -56,11 +57,21 @@
 - **Gates**: ruff clean; mypy no new errors; `makemigrations --check` clean (no migration); `check --deploy` 0 errors; `schema.yml` drift-free; full `pytest -n auto` → 3342 passed.
 - **Acceptance**: ✅ REST CRUD org-scoped; duplicate/invalid→400; delete-absent→204; writes audited; member writes forbidden.
 
+### Phase 4 — Policy CRUD public GraphQL ✅
+- **Status**: DONE (reviewed, fixed, pushed, PR open)
+- **Model used**: sonnet (plan tier T3) — implementer + sonnet fixer
+- **Branch**: `plan/bookable-slots-single-calendar-and-booking-policy/phase-4` (base phase-3)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/169
+- **Commits**: `5c14975` (impl) + `c0a08ed` (review fixes)
+- **Summary**: `BookingPolicyGraphQLType` + input/result types (`calendar_integration/graphql.py`); `booking_policies` query (org-scoped, target filters); `create/update/delete_booking_policy` mutations (`public_api/mutations.py`) delegating to shared `BookingPolicyService` w/ `actor_from_system_user`, org-scoped target resolution, `DuplicateBookingPolicyError`/`ValueError`→GraphQLError, idempotent delete; `PublicAPIResources.BOOKING_POLICY` + 4 `FIELD_TO_RESOURCE_MAPPING` entries. 35 GraphQL tests + 1 service test.
+- **Review findings fixed**: BLOCKER — GraphQL bypassed the REST serializer's membership validation → bogus `membership_user_id` 500. Moved membership-existence validation into the **shared service** `create_booking_policy` (raises ValueError; GraphQL maps it) → REST/GraphQL parity in one place. SHOULD-FIX — removed dead `error_message` from both result types (errors-as-exceptions, sibling-consistent); added multiple-targets + duplicate-membership/group GraphQL tests + bogus-membership GraphQL/service tests. NIT — corrected `type: ignore` category on the membership resolver.
+- **Gates**: ruff clean; mypy 299 (1 fewer than baseline, no new); `makemigrations --check` clean; `check --deploy` 0 errors; `schema.yml` drift-free; full `pytest -n auto` → 3377 passed.
+- **Acceptance**: ✅ GraphQL CRUD org+resource-scoped; behavior matches REST (incl. clean bogus-membership error); writes audited.
+
 ## Current phase
-Phase 4 — Policy CRUD public GraphQL (next).
+Phase 5 — calendar_bookable_slots single+bundle (next) — the slot-engine keystone.
 
 ## Remaining phases
-- Phase 4 — Policy CRUD public GraphQL (T3 / sonnet)
 - Phase 5 — calendar_bookable_slots single+bundle (T4 / opus)
 - Phase 6 — calendar_bookable_slots_with_code (T2 / haiku)
 - Phase 7 — group query policy-aware (T3 / sonnet)

--- a/calendar_integration/graphql.py
+++ b/calendar_integration/graphql.py
@@ -871,7 +871,7 @@ class BookingPolicyGraphQLType:
     @strawberry.field
     def membership_user_id(self) -> int | None:
         """Return the denormalized membership user id, or None."""
-        return self.membership_user_id  # type: ignore[attr-defined]
+        return self.membership_user_id  # type: ignore[return-value]
 
 
 @strawberry.input
@@ -922,7 +922,6 @@ class BookingPolicyResult:
 
     success: bool
     policy: BookingPolicyGraphQLType | None = None
-    error_message: str | None = None
 
 
 @strawberry.type
@@ -930,7 +929,6 @@ class DeleteBookingPolicyResult:
     """Result type for the deleteBookingPolicy mutation."""
 
     success: bool
-    error_message: str | None = None
 
 
 @strawberry.type

--- a/calendar_integration/graphql.py
+++ b/calendar_integration/graphql.py
@@ -9,6 +9,7 @@ from calendar_integration.models import (
     AvailableTimeRecurrenceException,
     BlockedTime,
     BlockedTimeRecurrenceException,
+    BookingPolicy,
     Calendar,
     CalendarEvent,
     CalendarEventGroupSelection,
@@ -830,6 +831,106 @@ class CodeEventResult:
 # ---------------------------------------------------------------------------
 # ExternalEventChangeRequest types
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# BookingPolicy types (Phase 4 — public GraphQL CRUD)
+# ---------------------------------------------------------------------------
+
+
+@strawberry_django.type(BookingPolicy)
+class BookingPolicyGraphQLType:
+    """GraphQL type for a BookingPolicy row.
+
+    Exposes the id, target fields (calendar_id, membership_user_id,
+    calendar_group_id, is_organization_default) and the four rule
+    second-counts. ``calendar_id`` / ``calendar_group_id`` are the FK
+    column values; ``membership_user_id`` is the denormalized column.
+    Zero on any rule field means "no constraint".
+    """
+
+    id: strawberry.auto  # noqa: A003
+    is_organization_default: strawberry.auto
+    lead_time_seconds: strawberry.auto
+    max_horizon_seconds: strawberry.auto
+    buffer_before_seconds: strawberry.auto
+    buffer_after_seconds: strawberry.auto
+    created: datetime.datetime
+    modified: datetime.datetime
+
+    @strawberry.field
+    def calendar_id(self) -> int | None:
+        """Return the FK id of the bound calendar, or None."""
+        return self.calendar_fk_id  # type: ignore[attr-defined]
+
+    @strawberry.field
+    def calendar_group_id(self) -> int | None:
+        """Return the FK id of the bound calendar group, or None."""
+        return self.calendar_group_fk_id  # type: ignore[attr-defined]
+
+    @strawberry.field
+    def membership_user_id(self) -> int | None:
+        """Return the denormalized membership user id, or None."""
+        return self.membership_user_id  # type: ignore[attr-defined]
+
+
+@strawberry.input
+class CreateBookingPolicyInput:
+    """Input for creating a new BookingPolicy.
+
+    Exactly one of ``calendar_id``, ``membership_user_id``, ``calendar_group_id``,
+    or ``is_organization_default=True`` must be set. All rule fields default to 0
+    (no constraint). ``PositiveIntegerField`` rejects negative values.
+    """
+
+    calendar_id: int | None = None
+    membership_user_id: int | None = None
+    calendar_group_id: int | None = None
+    is_organization_default: bool = False
+    lead_time_seconds: int = 0
+    max_horizon_seconds: int = 0
+    buffer_before_seconds: int = 0
+    buffer_after_seconds: int = 0
+
+
+@strawberry.input
+class UpdateBookingPolicyInput:
+    """Input for updating rule fields of an existing BookingPolicy.
+
+    Target fields (calendar, membership, calendar_group, is_organization_default)
+    are immutable. Only rule-second-count fields are updatable.
+    Any field left as None is not updated.
+    """
+
+    policy_id: int
+    lead_time_seconds: int | None = None
+    max_horizon_seconds: int | None = None
+    buffer_before_seconds: int | None = None
+    buffer_after_seconds: int | None = None
+
+
+@strawberry.input
+class DeleteBookingPolicyInput:
+    """Input for deleting a BookingPolicy (idempotent no-op when absent)."""
+
+    policy_id: int
+
+
+@strawberry.type
+class BookingPolicyResult:
+    """Result type for booking-policy write mutations."""
+
+    success: bool
+    policy: BookingPolicyGraphQLType | None = None
+    error_message: str | None = None
+
+
+@strawberry.type
+class DeleteBookingPolicyResult:
+    """Result type for the deleteBookingPolicy mutation."""
+
+    success: bool
+    error_message: str | None = None
 
 
 @strawberry.type

--- a/calendar_integration/services/booking_policy_service.py
+++ b/calendar_integration/services/booking_policy_service.py
@@ -39,7 +39,7 @@ from calendar_integration.models import (
     ChildrenCalendarRelationship,
 )
 from calendar_integration.services.dataclasses import EffectivePolicy
-from organizations.models import Organization
+from organizations.models import Organization, OrganizationMembership
 
 
 if TYPE_CHECKING:
@@ -329,6 +329,13 @@ class BookingPolicyService:
 
         org_id = self.organization.id  # type: ignore[union-attr]
         org = self.organization  # type: ignore[assignment]
+
+        # Validate that membership_user_id references a real membership in the bound org.
+        if membership_user_id is not None:
+            if not OrganizationMembership.objects.filter(
+                organization_id=org_id, user_id=membership_user_id
+            ).exists():
+                raise ValueError("No membership with this user id in your organization.")
 
         # Check uniqueness before hitting the DB constraint to provide a clear error.
         if calendar is not None and self._policy_for_calendar(calendar.id) is not None:

--- a/calendar_integration/tests/services/test_booking_policy_service.py
+++ b/calendar_integration/tests/services/test_booking_policy_service.py
@@ -738,6 +738,18 @@ class TestCreateBookingPolicy:
         with pytest.raises(CalendarServiceOrganizationNotSetError):
             svc.create_booking_policy(is_organization_default=True)
 
+    def test_raises_value_error_when_membership_user_id_not_in_org(self):
+        """create_booking_policy raises ValueError when membership_user_id is not a member of the bound org."""
+        org = _org()
+        other_org = _org()
+        uid = _membership(other_org)  # member of other_org, not org
+        svc = _service(org)
+
+        with pytest.raises(
+            ValueError, match=r"No membership with this user id in your organization\."
+        ):
+            svc.create_booking_policy(membership_user_id=uid)
+
     def test_emits_audit_record_on_create(self):
         org = _org()
         cal = _calendar(org)

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -60,6 +60,7 @@ class PublicAPIResources(TextChoices):
         "external_event_change_request",
         "External Event Change Request",
     )
+    BOOKING_POLICY = "booking_policy", "Booking Policy"
 
 
 PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -18,16 +18,22 @@ from graphql import GraphQLError
 from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import (
     CalendarIntegrationError,
+    DuplicateBookingPolicyError,
     NoAvailableTimeWindowsError,
 )
 from calendar_integration.graphql import (
     AvailableTimeGraphQLType,
     BlockedTimeGraphQLType,
+    BookingPolicyResult,
     CalendarBundleGraphQLType,
     CalendarEventGraphQLType,
     CalendarGraphQLType,
+    CreateBookingPolicyInput,
+    DeleteBookingPolicyInput,
+    DeleteBookingPolicyResult,
+    UpdateBookingPolicyInput,
 )
-from calendar_integration.models import Calendar, CalendarEvent
+from calendar_integration.models import BookingPolicy, Calendar, CalendarEvent, CalendarGroup
 from calendar_integration.mutations import (
     CalendarGroupMutations,
     ExternalEventChangeRequestMutations,
@@ -74,6 +80,7 @@ if TYPE_CHECKING:
 
 
 if TYPE_CHECKING:
+    from calendar_integration.services.booking_policy_service import BookingPolicyService
     from calendar_integration.services.calendar_group_service import CalendarGroupService
     from calendar_integration.services.calendar_service import CalendarService
 
@@ -141,6 +148,18 @@ def get_calendar_mutation_dependencies(
         calendar_service=cast("CalendarService", calendar_service),
         calendar_group_service=cast("CalendarGroupService", calendar_group_service),
     )
+
+
+@inject
+def get_booking_policy_mutation_dependencies(
+    booking_policy_service: Annotated[
+        "BookingPolicyService | None", Provide["booking_policy_service"]
+    ] = None,
+) -> "BookingPolicyService":
+    """Resolve the BookingPolicyService from the DI container."""
+    if booking_policy_service is None:
+        raise GraphQLError("Missing required dependency: booking_policy_service")
+    return booking_policy_service
 
 
 def _get_org_and_init_calendar_service(
@@ -2600,3 +2619,149 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
             raise GraphQLError(str(exc)) from exc
 
         return CancelEventResult(success=True)
+
+    # ------------------------------------------------------------------
+    # BookingPolicy mutations (Phase 4)
+    # ------------------------------------------------------------------
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def create_booking_policy(
+        self,
+        info: strawberry.Info,
+        input: CreateBookingPolicyInput,  # noqa: A002
+    ) -> BookingPolicyResult:
+        """Create a new BookingPolicy for the caller's organization.
+
+        Exactly one of ``calendar_id``, ``membership_user_id``,
+        ``calendar_group_id``, or ``is_organization_default=True`` must be set.
+        Returns an error when a policy already exists for the given target.
+        Write is audited via ``BookingPolicyService``.
+
+        The token's ``OrganizationResourceAccess`` must include the
+        ``BOOKING_POLICY`` resource.
+        """
+        from audit.services import AuditService
+
+        org = info.context.request.public_api_organization
+        if not org:
+            raise GraphQLError("Organization not found in request context")
+
+        request: PublicApiHttpRequest = info.context.request
+        service = get_booking_policy_mutation_dependencies()
+        service.initialize(org)
+        actor = AuditService.actor_from_system_user(request.public_api_system_user)
+        service.set_actor(actor)
+
+        # Resolve optional FK targets.
+        calendar: Calendar | None = None
+        if input.calendar_id is not None:
+            try:
+                calendar = Calendar.objects.filter_by_organization(org.id).get(id=input.calendar_id)
+            except Calendar.DoesNotExist as exc:
+                raise GraphQLError("Calendar not found.") from exc
+
+        calendar_group: CalendarGroup | None = None
+        if input.calendar_group_id is not None:
+            try:
+                calendar_group = CalendarGroup.objects.filter_by_organization(org.id).get(
+                    id=input.calendar_group_id
+                )
+            except CalendarGroup.DoesNotExist as exc:
+                raise GraphQLError("Calendar group not found.") from exc
+
+        try:
+            policy = service.create_booking_policy(
+                calendar=calendar,
+                membership_user_id=input.membership_user_id,
+                calendar_group=calendar_group,
+                is_organization_default=input.is_organization_default,
+                lead_time_seconds=input.lead_time_seconds,
+                max_horizon_seconds=input.max_horizon_seconds,
+                buffer_before_seconds=input.buffer_before_seconds,
+                buffer_after_seconds=input.buffer_after_seconds,
+            )
+        except DuplicateBookingPolicyError as exc:
+            raise GraphQLError(str(exc)) from exc
+        except ValueError as exc:
+            raise GraphQLError(str(exc)) from exc
+
+        return BookingPolicyResult(success=True, policy=policy)  # type: ignore[arg-type]
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def update_booking_policy(
+        self,
+        info: strawberry.Info,
+        input: UpdateBookingPolicyInput,  # noqa: A002
+    ) -> BookingPolicyResult:
+        """Update the rule fields of an existing BookingPolicy (org-scoped).
+
+        Target fields are immutable. Only the four rule second-count fields may
+        be changed; any field supplied as ``None`` is left unchanged.
+        Write is audited via ``BookingPolicyService``.
+
+        The token's ``OrganizationResourceAccess`` must include the
+        ``BOOKING_POLICY`` resource.
+        """
+        from audit.services import AuditService
+
+        org = info.context.request.public_api_organization
+        if not org:
+            raise GraphQLError("Organization not found in request context")
+
+        request: PublicApiHttpRequest = info.context.request
+        service = get_booking_policy_mutation_dependencies()
+        service.initialize(org)
+        actor = AuditService.actor_from_system_user(request.public_api_system_user)
+        service.set_actor(actor)
+
+        try:
+            policy = BookingPolicy.objects.filter_by_organization(org.id).get(id=input.policy_id)
+        except BookingPolicy.DoesNotExist as exc:
+            raise GraphQLError("Booking policy not found.") from exc
+
+        policy = service.update_booking_policy(
+            policy,
+            lead_time_seconds=input.lead_time_seconds,
+            max_horizon_seconds=input.max_horizon_seconds,
+            buffer_before_seconds=input.buffer_before_seconds,
+            buffer_after_seconds=input.buffer_after_seconds,
+        )
+
+        return BookingPolicyResult(success=True, policy=policy)  # type: ignore[arg-type]
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def delete_booking_policy(
+        self,
+        info: strawberry.Info,
+        input: DeleteBookingPolicyInput,  # noqa: A002
+    ) -> DeleteBookingPolicyResult:
+        """Delete a BookingPolicy (idempotent no-op when absent).
+
+        Returns ``success=True`` regardless of whether the policy existed.
+        Write is audited when an actual row is deleted.
+
+        The token's ``OrganizationResourceAccess`` must include the
+        ``BOOKING_POLICY`` resource.
+        """
+        from audit.services import AuditService
+
+        org = info.context.request.public_api_organization
+        if not org:
+            raise GraphQLError("Organization not found in request context")
+
+        request: PublicApiHttpRequest = info.context.request
+        service = get_booking_policy_mutation_dependencies()
+        service.initialize(org)
+        actor = AuditService.actor_from_system_user(request.public_api_system_user)
+        service.set_actor(actor)
+
+        # Idempotent: a missing policy is a no-op success (per Guiding Decisions).
+        try:
+            policy: BookingPolicy | None = BookingPolicy.objects.filter_by_organization(org.id).get(
+                id=input.policy_id
+            )
+        except BookingPolicy.DoesNotExist:
+            policy = None
+
+        service.delete_booking_policy(policy)
+        return DeleteBookingPolicyResult(success=True)

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -87,6 +87,10 @@ class OrganizationResourceAccess(BasePermission):
         "externalEventChangeRequests": PublicAPIResources.EXTERNAL_EVENT_CHANGE_REQUEST,
         "approveExternalEventChangeRequest": PublicAPIResources.EXTERNAL_EVENT_CHANGE_REQUEST,
         "rejectExternalEventChangeRequest": PublicAPIResources.EXTERNAL_EVENT_CHANGE_REQUEST,
+        "bookingPolicies": PublicAPIResources.BOOKING_POLICY,
+        "createBookingPolicy": PublicAPIResources.BOOKING_POLICY,
+        "updateBookingPolicy": PublicAPIResources.BOOKING_POLICY,
+        "deleteBookingPolicy": PublicAPIResources.BOOKING_POLICY,
     }
 
     def has_permission(self, source, info: Info, **kwargs) -> bool:  # type: ignore

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -25,6 +25,7 @@ from calendar_integration.graphql import (
     AvailableTimeWindowGraphQLType,
     BlockedTimeGraphQLType,
     BookableSlotProposalGraphQLType,
+    BookingPolicyGraphQLType,
     CalendarBundleGraphQLType,
     CalendarEventGraphQLType,
     CalendarGraphQLType,
@@ -67,6 +68,7 @@ from webhooks.models import WebhookConfiguration, WebhookEvent
 
 
 if TYPE_CHECKING:
+    from calendar_integration.services.booking_policy_service import BookingPolicyService
     from calendar_integration.services.calendar_group_service import CalendarGroupService
     from calendar_integration.services.calendar_permission_service import CalendarPermissionService
     from calendar_integration.services.calendar_service import CalendarService
@@ -108,6 +110,18 @@ def get_query_dependencies(
         calendar_group_service=cast("CalendarGroupService", calendar_group_service),
         calendar_permission_service=cast("CalendarPermissionService", calendar_permission_service),
     )
+
+
+@inject
+def get_booking_policy_query_dependencies(
+    booking_policy_service: Annotated[
+        "BookingPolicyService | None", Provide["booking_policy_service"]
+    ] = None,
+) -> "BookingPolicyService":
+    """Resolve the BookingPolicyService from the DI container."""
+    if booking_policy_service is None:
+        raise GraphQLError("Missing required dependency: booking_policy_service")
+    return booking_policy_service
 
 
 def _get_org(info: strawberry.Info):
@@ -1064,6 +1078,44 @@ class Query:
             list[ExternalEventChangeRequestGraphQLType],
             list(_slice_qs(qs, offset, limit)),
         )
+
+    # ------------------------------------------------------------------
+    # BookingPolicy queries (Phase 4)
+    # ------------------------------------------------------------------
+
+    @strawberry_django.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def booking_policies(
+        self,
+        info: strawberry.Info,
+        calendar_id: int | None = None,
+        membership_user_id: int | None = None,
+        calendar_group_id: int | None = None,
+        is_organization_default: bool | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[BookingPolicyGraphQLType]:
+        """List BookingPolicy rows for the caller's organization.
+
+        All four filter args are optional and combinable.  When none are
+        supplied, all policies for the org are returned (paginated).
+        """
+        org = _get_org(info)
+        service = get_booking_policy_query_dependencies()
+        service.initialize(org)
+
+        qs = service.get_all_policies()
+
+        if calendar_id is not None:
+            qs = qs.filter(calendar_fk_id=calendar_id)
+        if membership_user_id is not None:
+            qs = qs.filter(membership_user_id=membership_user_id)
+        if calendar_group_id is not None:
+            qs = qs.filter(calendar_group_fk_id=calendar_group_id)
+        if is_organization_default is not None:
+            qs = qs.filter(is_organization_default=is_organization_default)
+
+        qs = _slice_qs(qs.order_by("pk"), offset, limit)
+        return cast(list[BookingPolicyGraphQLType], list(qs))
 
     # ------------------------------------------------------------------
     # Code-gated read fields (unauthenticated — authorized by booking code)

--- a/public_api/tests/test_booking_policy_graphql.py
+++ b/public_api/tests/test_booking_policy_graphql.py
@@ -67,7 +67,6 @@ CREATE_BOOKING_POLICY_MUTATION = """
 mutation CreateBookingPolicy($input: CreateBookingPolicyInput!) {
     createBookingPolicy(input: $input) {
         success
-        errorMessage
         policy {
             id
             calendarId
@@ -87,7 +86,6 @@ UPDATE_BOOKING_POLICY_MUTATION = """
 mutation UpdateBookingPolicy($input: UpdateBookingPolicyInput!) {
     updateBookingPolicy(input: $input) {
         success
-        errorMessage
         policy {
             id
             leadTimeSeconds
@@ -103,7 +101,6 @@ DELETE_BOOKING_POLICY_MUTATION = """
 mutation DeleteBookingPolicy($input: DeleteBookingPolicyInput!) {
     deleteBookingPolicy(input: $input) {
         success
-        errorMessage
     }
 }
 """
@@ -387,7 +384,6 @@ class TestCreateBookingPolicyMutation:
         assert "errors" not in data, data.get("errors")
         result = data["data"]["createBookingPolicy"]
         assert result["success"] is True
-        assert result["errorMessage"] is None
         policy = result["policy"]
         assert policy["calendarId"] == cal.id
         assert policy["leadTimeSeconds"] == 300
@@ -577,6 +573,96 @@ class TestCreateBookingPolicyMutation:
 
         data = response.json()
         assert data.get("errors") or data["data"].get("createBookingPolicy") is None
+
+    def test_create_membership_user_not_in_org_rejected(self):
+        """Passing a membershipUserId for a user who is NOT in the caller's org returns a clean GraphQL error."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+        # Create a user that is a member of a different org, not the caller's org.
+        other_org = baker.make(Organization, name="Other Org Membership")
+        other_user = UserFactory().create_user()
+        baker.make(OrganizationMembership, user=other_user, organization=other_org)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"membershipUserId": other_user.id}},
+        )
+
+        data = response.json()
+        # Must surface a GraphQL error — no 500, errors array populated.
+        assert data.get("errors"), "Expected a GraphQL error for cross-org membership"
+        assert response.status_code == 200
+
+    def test_create_nonexistent_membership_user_rejected(self):
+        """Passing a membershipUserId that doesn't exist anywhere returns a clean GraphQL error."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"membershipUserId": 999999}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for nonexistent membership user"
+        assert response.status_code == 200
+
+    def test_create_multiple_targets_rejected(self):
+        """Passing two targets (calendarId + isOrganizationDefault=True) returns a clean GraphQL error."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"calendarId": cal.id, "isOrganizationDefault": True}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for multiple targets"
+
+    def test_create_duplicate_membership_policy_rejected(self):
+        """Creating a second policy for the same membershipUserId returns a GraphQL error."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        user = UserFactory().create_user()
+        baker.make(OrganizationMembership, user=user, organization=org)
+        create_booking_policy(membership_user_id=user.id, organization=org)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"membershipUserId": user.id}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for duplicate membership policy"
+        assert any("already exists" in e["message"] for e in data["errors"])
+
+    def test_create_duplicate_calendar_group_policy_rejected(self):
+        """Creating a second policy for the same calendarGroupId returns a GraphQL error."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        group = baker.make(CalendarGroup, organization=org)
+        create_booking_policy(calendar_group=group)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"calendarGroupId": group.id}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for duplicate calendar-group policy"
+        assert any("already exists" in e["message"] for e in data["errors"])
 
 
 # ---------------------------------------------------------------------------

--- a/public_api/tests/test_booking_policy_graphql.py
+++ b/public_api/tests/test_booking_policy_graphql.py
@@ -1,0 +1,831 @@
+"""Integration tests for the BookingPolicy GraphQL CRUD surface (Phase 4).
+
+Covers:
+- bookingPolicies query: happy path (all, filtered by target); cross-org
+  isolation; missing-resource permission error; pagination.
+- createBookingPolicy mutation: each target type; duplicate-target rejection;
+  exactly-one-target validation; cross-org lookup of calendar/group; audit.
+- updateBookingPolicy mutation: rule fields updated; policy not found;
+  cross-org isolation.
+- deleteBookingPolicy mutation: idempotent no-op (absent policy); actual
+  delete; audit on writes.
+- Auth: unauthenticated and wrong-resource token are rejected uniformly.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.factories import create_booking_policy
+from calendar_integration.models import BookingPolicy, Calendar, CalendarGroup
+from organizations.models import Organization, OrganizationMembership
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+from users.factories import UserFactory
+
+
+# ---------------------------------------------------------------------------
+# GraphQL operation strings
+# ---------------------------------------------------------------------------
+
+BOOKING_POLICIES_QUERY = """
+query BookingPolicies(
+    $calendarId: Int,
+    $membershipUserId: Int,
+    $calendarGroupId: Int,
+    $isOrganizationDefault: Boolean,
+    $offset: Int,
+    $limit: Int
+) {
+    bookingPolicies(
+        calendarId: $calendarId,
+        membershipUserId: $membershipUserId,
+        calendarGroupId: $calendarGroupId,
+        isOrganizationDefault: $isOrganizationDefault,
+        offset: $offset,
+        limit: $limit
+    ) {
+        id
+        calendarId
+        membershipUserId
+        calendarGroupId
+        isOrganizationDefault
+        leadTimeSeconds
+        maxHorizonSeconds
+        bufferBeforeSeconds
+        bufferAfterSeconds
+        created
+        modified
+    }
+}
+"""
+
+CREATE_BOOKING_POLICY_MUTATION = """
+mutation CreateBookingPolicy($input: CreateBookingPolicyInput!) {
+    createBookingPolicy(input: $input) {
+        success
+        errorMessage
+        policy {
+            id
+            calendarId
+            membershipUserId
+            calendarGroupId
+            isOrganizationDefault
+            leadTimeSeconds
+            maxHorizonSeconds
+            bufferBeforeSeconds
+            bufferAfterSeconds
+        }
+    }
+}
+"""
+
+UPDATE_BOOKING_POLICY_MUTATION = """
+mutation UpdateBookingPolicy($input: UpdateBookingPolicyInput!) {
+    updateBookingPolicy(input: $input) {
+        success
+        errorMessage
+        policy {
+            id
+            leadTimeSeconds
+            maxHorizonSeconds
+            bufferBeforeSeconds
+            bufferAfterSeconds
+        }
+    }
+}
+"""
+
+DELETE_BOOKING_POLICY_MUTATION = """
+mutation DeleteBookingPolicy($input: DeleteBookingPolicyInput!) {
+    deleteBookingPolicy(input: $input) {
+        success
+        errorMessage
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_org_and_token(
+    resources: list[str] | None = None,
+    integration_name: str = "test_bp_integration",
+) -> tuple[Organization, object, str, PublicAPIAuthService]:
+    """Return (org, system_user, token, auth_service) with the given resource grants."""
+    if resources is None:
+        resources = [PublicAPIResources.BOOKING_POLICY]
+    org = baker.make(Organization, name="BP Test Org")
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name=integration_name, organization=org
+    )
+    for resource in resources:
+        baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+    return org, system_user, token, auth_service
+
+
+def _post_graphql(
+    operation: str,
+    system_user,
+    token: str,
+    auth_service: PublicAPIAuthService,
+    variables: dict,
+):
+    """Post a GraphQL operation and return the response."""
+    from di_core.containers import container
+
+    assert container is not None  # noqa: S101
+    client = APIClient()
+    with container.public_api_auth_service.override(auth_service):
+        return client.post(
+            "/graphql/",
+            data={"query": operation, "variables": variables},
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+
+
+def _post_graphql_anon(operation: str, variables: dict):
+    """Post a GraphQL operation without authentication."""
+    client = APIClient()
+    return client.post(
+        "/graphql/",
+        data={"query": operation, "variables": variables},
+        format="json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# bookingPolicies query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBookingPoliciesQuery:
+    """Integration tests for the bookingPolicies query."""
+
+    def test_list_all_policies(self):
+        """All policies for the caller's org are returned."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        create_booking_policy(calendar=cal, lead_time_seconds=300)
+        create_booking_policy(
+            organization=org, is_organization_default=True, max_horizon_seconds=7200
+        )
+
+        response = _post_graphql(BOOKING_POLICIES_QUERY, system_user, token, auth_service, {})
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        policies = data["data"]["bookingPolicies"]
+        assert len(policies) == 2
+
+    def test_filter_by_calendar_id(self):
+        """Filtering by calendarId returns only the matching policy."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal1 = baker.make(Calendar, organization=org, external_id="cal-filter-1")
+        cal2 = baker.make(Calendar, organization=org, external_id="cal-filter-2")
+        create_booking_policy(calendar=cal1, lead_time_seconds=60)
+        create_booking_policy(calendar=cal2, lead_time_seconds=120)
+
+        response = _post_graphql(
+            BOOKING_POLICIES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"calendarId": cal1.id},
+        )
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        policies = data["data"]["bookingPolicies"]
+        assert len(policies) == 1
+        assert policies[0]["calendarId"] == cal1.id
+        assert policies[0]["leadTimeSeconds"] == 60
+
+    def test_filter_by_is_organization_default(self):
+        """Filtering by isOrganizationDefault=True returns only the default policy."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        create_booking_policy(calendar=cal)
+        create_booking_policy(organization=org, is_organization_default=True, lead_time_seconds=900)
+
+        response = _post_graphql(
+            BOOKING_POLICIES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"isOrganizationDefault": True},
+        )
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        policies = data["data"]["bookingPolicies"]
+        assert len(policies) == 1
+        assert policies[0]["isOrganizationDefault"] is True
+        assert policies[0]["leadTimeSeconds"] == 900
+
+    def test_filter_by_membership_user_id(self):
+        """Filtering by membershipUserId returns only the matching policy."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        user = UserFactory().create_user()
+        baker.make(OrganizationMembership, user=user, organization=org)
+        create_booking_policy(membership_user_id=user.id, organization=org, lead_time_seconds=180)
+        create_booking_policy(organization=org, is_organization_default=True)
+
+        response = _post_graphql(
+            BOOKING_POLICIES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"membershipUserId": user.id},
+        )
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        policies = data["data"]["bookingPolicies"]
+        assert len(policies) == 1
+        assert policies[0]["membershipUserId"] == user.id
+
+    def test_filter_by_calendar_group_id(self):
+        """Filtering by calendarGroupId returns only the matching policy."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        group = baker.make(CalendarGroup, organization=org)
+        create_booking_policy(calendar_group=group, buffer_before_seconds=600)
+        create_booking_policy(organization=org, is_organization_default=True)
+
+        response = _post_graphql(
+            BOOKING_POLICIES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"calendarGroupId": group.id},
+        )
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        policies = data["data"]["bookingPolicies"]
+        assert len(policies) == 1
+        assert policies[0]["calendarGroupId"] == group.id
+
+    def test_cross_org_isolation(self):
+        """Policies from another org are never returned."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+        other_org = baker.make(Organization, name="Other Org")
+        other_cal = baker.make(Calendar, organization=other_org)
+        create_booking_policy(calendar=other_cal)
+
+        # Caller's org has no policies.
+        response = _post_graphql(BOOKING_POLICIES_QUERY, system_user, token, auth_service, {})
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        assert data["data"]["bookingPolicies"] == []
+
+    def test_missing_resource_permission_denied(self):
+        """A token without BOOKING_POLICY resource is rejected."""
+        org = baker.make(Organization, name="No BP Org")
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="no_bp", organization=org
+        )
+        # Only give CALENDAR, not BOOKING_POLICY
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+
+        client = APIClient()
+        from di_core.containers import container
+
+        assert container is not None  # noqa: S101
+        with container.public_api_auth_service.override(auth_service):
+            response = client.post(
+                "/graphql/",
+                data={"query": BOOKING_POLICIES_QUERY, "variables": {}},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Should return errors (permission denied)
+        assert data.get("errors") or data["data"].get("bookingPolicies") is None
+
+    def test_unauthenticated_rejected(self):
+        """An unauthenticated request is rejected."""
+        response = _post_graphql_anon(BOOKING_POLICIES_QUERY, {})
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors") or data["data"].get("bookingPolicies") is None
+
+    def test_pagination(self):
+        """Offset and limit slice the result set."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cals = [
+            baker.make(Calendar, organization=org, external_id=f"pag-cal-{i}") for i in range(5)
+        ]
+        for cal in cals:
+            create_booking_policy(calendar=cal)
+
+        response = _post_graphql(
+            BOOKING_POLICIES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"offset": 0, "limit": 3},
+        )
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        assert len(data["data"]["bookingPolicies"]) == 3
+
+        response2 = _post_graphql(
+            BOOKING_POLICIES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"offset": 3, "limit": 3},
+        )
+        data2 = response2.json()
+        assert "errors" not in data2, data2.get("errors")
+        assert len(data2["data"]["bookingPolicies"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# createBookingPolicy mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateBookingPolicyMutation:
+    """Integration tests for the createBookingPolicy mutation."""
+
+    def test_create_with_calendar_target(self):
+        """Create a calendar-scoped policy and verify the response."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "calendarId": cal.id,
+                    "leadTimeSeconds": 300,
+                    "maxHorizonSeconds": 86400,
+                    "bufferBeforeSeconds": 600,
+                    "bufferAfterSeconds": 900,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["createBookingPolicy"]
+        assert result["success"] is True
+        assert result["errorMessage"] is None
+        policy = result["policy"]
+        assert policy["calendarId"] == cal.id
+        assert policy["leadTimeSeconds"] == 300
+        assert policy["maxHorizonSeconds"] == 86400
+        assert policy["bufferBeforeSeconds"] == 600
+        assert policy["bufferAfterSeconds"] == 900
+        assert policy["isOrganizationDefault"] is False
+
+        # Verify DB state
+        db_policy = BookingPolicy.objects.filter_by_organization(org.id).get(id=int(policy["id"]))
+        assert db_policy.calendar_fk_id == cal.id
+        assert db_policy.lead_time_seconds == 300
+
+    def test_create_with_organization_default(self):
+        """Create an org-default policy."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"isOrganizationDefault": True, "leadTimeSeconds": 600}},
+        )
+
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["createBookingPolicy"]
+        assert result["success"] is True
+        policy = result["policy"]
+        assert policy["isOrganizationDefault"] is True
+        assert policy["calendarId"] is None
+
+    def test_create_with_calendar_group_target(self):
+        """Create a calendar-group-scoped policy."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        group = baker.make(CalendarGroup, organization=org)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"calendarGroupId": group.id, "bufferBeforeSeconds": 300}},
+        )
+
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["createBookingPolicy"]
+        assert result["success"] is True
+        assert result["policy"]["calendarGroupId"] == group.id
+
+    def test_create_with_membership_user_id(self):
+        """Create a membership-scoped policy."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        user = UserFactory().create_user()
+        baker.make(OrganizationMembership, user=user, organization=org)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"membershipUserId": user.id, "leadTimeSeconds": 120}},
+        )
+
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["createBookingPolicy"]
+        assert result["success"] is True
+        assert result["policy"]["membershipUserId"] == user.id
+
+    def test_create_duplicate_calendar_policy_rejected(self):
+        """Creating a second policy for the same calendar returns a GraphQL error."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        create_booking_policy(calendar=cal)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"calendarId": cal.id}},
+        )
+
+        data = response.json()
+        # Must surface an error for the duplicate
+        assert data.get("errors"), "Expected a GraphQL error for duplicate policy"
+        assert any("already exists" in e["message"] for e in data["errors"])
+
+    def test_create_duplicate_org_default_rejected(self):
+        """Creating a second org-default policy returns a GraphQL error."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        create_booking_policy(organization=org, is_organization_default=True)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"isOrganizationDefault": True}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for duplicate org-default policy"
+
+    def test_create_zero_targets_rejected(self):
+        """Passing no target returns a GraphQL error (exactly-one-target validation)."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            # All targets absent — violates the exactly-one rule
+            {"input": {}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for zero targets"
+
+    def test_create_calendar_not_found_in_org(self):
+        """Passing a calendar_id that belongs to another org returns a GraphQL error."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+        other_org = baker.make(Organization, name="Other Org")
+        other_cal = baker.make(Calendar, organization=other_org)
+
+        response = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"calendarId": other_cal.id}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for cross-org calendar"
+
+    def test_create_audited(self, django_capture_on_commit_callbacks):
+        """A CREATE audit record is enqueued on successful creation."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                _post_graphql(
+                    CREATE_BOOKING_POLICY_MUTATION,
+                    system_user,
+                    token,
+                    auth_service,
+                    {"input": {"calendarId": cal.id, "leadTimeSeconds": 60}},
+                )
+
+        assert mock_task.delay.called
+        payload = mock_task.delay.call_args[0][0]
+        assert payload["action"] == "create"
+        assert "BookingPolicy" in payload["subject"]["subject_type"]
+
+    def test_create_missing_resource_denied(self):
+        """A token without BOOKING_POLICY resource cannot create a policy."""
+        org = baker.make(Organization, name="No BP Org")
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="no_bp_create", organization=org
+        )
+        baker.make(
+            ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR
+        )
+        cal = baker.make(Calendar, organization=org)
+
+        client = APIClient()
+        from di_core.containers import container
+
+        assert container is not None  # noqa: S101
+        with container.public_api_auth_service.override(auth_service):
+            response = client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_BOOKING_POLICY_MUTATION,
+                    "variables": {"input": {"calendarId": cal.id}},
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        data = response.json()
+        assert data.get("errors") or data["data"].get("createBookingPolicy") is None
+
+
+# ---------------------------------------------------------------------------
+# updateBookingPolicy mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestUpdateBookingPolicyMutation:
+    """Integration tests for the updateBookingPolicy mutation."""
+
+    def test_update_rule_fields(self):
+        """Rule fields are updated; target fields are unchanged."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        policy = create_booking_policy(
+            calendar=cal,
+            lead_time_seconds=60,
+            max_horizon_seconds=0,
+            buffer_before_seconds=0,
+            buffer_after_seconds=0,
+        )
+
+        response = _post_graphql(
+            UPDATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "policyId": policy.id,
+                    "leadTimeSeconds": 120,
+                    "maxHorizonSeconds": 3600,
+                    "bufferBeforeSeconds": 300,
+                    "bufferAfterSeconds": 600,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["updateBookingPolicy"]
+        assert result["success"] is True
+        p = result["policy"]
+        assert p["leadTimeSeconds"] == 120
+        assert p["maxHorizonSeconds"] == 3600
+        assert p["bufferBeforeSeconds"] == 300
+        assert p["bufferAfterSeconds"] == 600
+
+        policy.refresh_from_db()
+        assert policy.lead_time_seconds == 120
+
+    def test_update_partial_fields_only(self):
+        """Omitting a field leaves it unchanged (partial update semantics)."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        policy = create_booking_policy(
+            calendar=cal,
+            lead_time_seconds=300,
+            buffer_before_seconds=600,
+        )
+
+        response = _post_graphql(
+            UPDATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            # Only update buffer_before_seconds; lead_time_seconds omitted.
+            {"input": {"policyId": policy.id, "bufferBeforeSeconds": 900}},
+        )
+
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["updateBookingPolicy"]
+        assert result["success"] is True
+        p = result["policy"]
+        # bufferBefore updated
+        assert p["bufferBeforeSeconds"] == 900
+        # leadTime unchanged
+        assert p["leadTimeSeconds"] == 300
+
+    def test_update_not_found_returns_error(self):
+        """Updating a non-existent policy returns a GraphQL error."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+
+        response = _post_graphql(
+            UPDATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"policyId": 999999, "leadTimeSeconds": 60}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for missing policy"
+
+    def test_update_cross_org_isolation(self):
+        """Updating a policy from another org returns a GraphQL error (no existence leak)."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+        other_org = baker.make(Organization, name="Other Org")
+        other_cal = baker.make(Calendar, organization=other_org)
+        other_policy = create_booking_policy(calendar=other_cal)
+
+        response = _post_graphql(
+            UPDATE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"policyId": other_policy.id, "leadTimeSeconds": 60}},
+        )
+
+        data = response.json()
+        assert data.get("errors"), "Expected a GraphQL error for cross-org policy"
+
+    def test_update_audited(self, django_capture_on_commit_callbacks):
+        """An UPDATE audit record is enqueued on successful update."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=0)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                _post_graphql(
+                    UPDATE_BOOKING_POLICY_MUTATION,
+                    system_user,
+                    token,
+                    auth_service,
+                    {"input": {"policyId": policy.id, "leadTimeSeconds": 300}},
+                )
+
+        assert mock_task.delay.called
+        payload = mock_task.delay.call_args[0][0]
+        assert payload["action"] == "update"
+        assert "BookingPolicy" in payload["subject"]["subject_type"]
+
+
+# ---------------------------------------------------------------------------
+# deleteBookingPolicy mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDeleteBookingPolicyMutation:
+    """Integration tests for the deleteBookingPolicy mutation."""
+
+    def test_delete_existing_policy(self):
+        """Deleting an existing policy removes it from the DB."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        policy = create_booking_policy(calendar=cal)
+
+        response = _post_graphql(
+            DELETE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"policyId": policy.id}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["deleteBookingPolicy"]
+        assert result["success"] is True
+
+        assert (
+            not BookingPolicy.objects.filter_by_organization(org.id).filter(id=policy.id).exists()
+        )
+
+    def test_delete_absent_is_idempotent(self):
+        """Deleting a policy id that doesn't exist returns success (idempotent no-op)."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+
+        response = _post_graphql(
+            DELETE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"policyId": 999999}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["deleteBookingPolicy"]
+        assert result["success"] is True
+
+    def test_delete_cross_org_is_idempotent_no_op(self):
+        """Deleting a policy from another org is treated as absent (idempotent no-op)."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+        other_org = baker.make(Organization, name="Other Org")
+        other_cal = baker.make(Calendar, organization=other_org)
+        other_policy = create_booking_policy(calendar=other_cal)
+
+        # Pass the other org's policy id; the org-scoped lookup won't find it.
+        response = _post_graphql(
+            DELETE_BOOKING_POLICY_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {"input": {"policyId": other_policy.id}},
+        )
+
+        data = response.json()
+        assert "errors" not in data, data.get("errors")
+        result = data["data"]["deleteBookingPolicy"]
+        # Idempotent no-op — no error, other org's policy untouched.
+        assert result["success"] is True
+        assert (
+            BookingPolicy.objects.filter_by_organization(other_org.id)
+            .filter(id=other_policy.id)
+            .exists()
+        )
+
+    def test_delete_audited(self, django_capture_on_commit_callbacks):
+        """A DELETE audit record is enqueued on actual deletion."""
+        org, system_user, token, auth_service = _setup_org_and_token()
+        cal = baker.make(Calendar, organization=org)
+        policy = create_booking_policy(calendar=cal)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                _post_graphql(
+                    DELETE_BOOKING_POLICY_MUTATION,
+                    system_user,
+                    token,
+                    auth_service,
+                    {"input": {"policyId": policy.id}},
+                )
+
+        assert mock_task.delay.called
+        payload = mock_task.delay.call_args[0][0]
+        assert payload["action"] == "delete"
+        assert "BookingPolicy" in payload["subject"]["subject_type"]
+
+    def test_delete_absent_not_audited(self, django_capture_on_commit_callbacks):
+        """No audit record is enqueued when the policy was already absent (no-op)."""
+        _org, system_user, token, auth_service = _setup_org_and_token()
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                _post_graphql(
+                    DELETE_BOOKING_POLICY_MUTATION,
+                    system_user,
+                    token,
+                    auth_service,
+                    {"input": {"policyId": 999999}},
+                )
+
+        # No audit task should have been dispatched.
+        assert not mock_task.delay.called

--- a/schema.yml
+++ b/schema.yml
@@ -11928,6 +11928,7 @@ components:
       - disable_calendar_bundle
       - webhook_configuration
       - external_event_change_request
+      - booking_policy
       type: string
       description: |-
         * `calendar_event` - Calendar Event
@@ -11972,6 +11973,7 @@ components:
         * `disable_calendar_bundle` - Disable Calendar Bundle
         * `webhook_configuration` - Webhook Configuration
         * `external_event_change_request` - External Event Change Request
+        * `booking_policy` - Booking Policy
     AvailableTime:
       type: object
       description: Serializer for AvailableTime model with recurring support.


### PR DESCRIPTION
## Summary
Phase 4 of the **Bookable Slots for Single Calendars & Bundles, with Booking Policies** plan — the public GraphQL CRUD surface for `BookingPolicy` (spec use-case 3, GraphQL half). Stacked on Phase 3 (REST CRUD). No migration.

Adds:
- **`BookingPolicyGraphQLType`** + `CreateBookingPolicyInput` / `UpdateBookingPolicyInput` / `DeleteBookingPolicyInput` / `BookingPolicyResult` / `DeleteBookingPolicyResult` (`calendar_integration/graphql.py`).
- **`booking_policies`** query (`public_api/queries.py`) — org-scoped via `BookingPolicyService.get_all_policies()`, filterable by target.
- **`create_booking_policy` / `update_booking_policy` / `delete_booking_policy`** mutations (`public_api/mutations.py`) — delegate to the shared `BookingPolicyService` (`set_actor(actor_from_system_user)`), resolve targets org-scoped, map `DuplicateBookingPolicyError`/`ValueError` → `GraphQLError`, idempotent delete.
- **`PublicAPIResources.BOOKING_POLICY`** + the four `FIELD_TO_RESOURCE_MAPPING` entries (`public_api/constants.py`, `public_api/permissions.py`) — a SystemUser token must hold the `BOOKING_POLICY` resource.

Parity fix (review): membership-existence validation was moved into the **shared service** `create_booking_policy` (raising `ValueError`), so GraphQL and REST behave identically — a bogus/cross-org `membership_user_id` now returns a clean error on both surfaces instead of a DB 500 on GraphQL.

## Plan reference
`ai-plans/2026-06-26-BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY_IMPLEMENTATION_PLAN.md` — **Phase 4**. Stacked on Phase 3 / PR #168. No feature flag (data-presence gate). No migration.

## Test plan
- `docker compose run --rm api uv run pytest public_api/tests/test_booking_policy_graphql.py -p no:randomly` — authorized CRUD per target; missing-resource → permission error; cross-org isolation; duplicate-target (calendar / org-default / membership / group) rejection; exactly-one-target (zero / multiple) rejection; bogus & cross-org `membershipUserId` → clean error (not 500); idempotent delete; audit emission. Plus a service-level unit test for the membership `ValueError`.
- Outer gate: `makemigrations --check` (no changes), `check --deploy` (0 errors), `schema.yml` drift-free, full `pytest -n auto` → **3377 passed**.