### PR TITLE
feat(calendar): make group bookable-slots query policy-aware

### DIFF
--- a/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
+++ b/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
@@ -22,6 +22,7 @@
 - Phase 4: `plan/bookable-slots-single-calendar-and-booking-policy/phase-4` (base phase-3)
 - Phase 5: `plan/bookable-slots-single-calendar-and-booking-policy/phase-5` (base phase-4)
 - Phase 6: `plan/bookable-slots-single-calendar-and-booking-policy/phase-6` (base phase-5)
+- Phase 7: `plan/bookable-slots-single-calendar-and-booking-policy/phase-7` (base phase-6)
 
 ## Completed phases
 
@@ -92,11 +93,21 @@
 - **Gates**: ruff clean; mypy 297 (no new); `makemigrations --check` clean (no migration); `check --deploy` 0 errors; schema drift-free; full `pytest -n auto` → 3412 passed.
 - **Acceptance**: ✅ code-gated variant == authenticated query for the scope; slots-only; code-validation contract enforced; bundle + policy filtering work through the code path.
 
+### Phase 7 — group query policy-aware ✅
+- **Status**: DONE (reviewed, fixed, pushed, PR open)
+- **Model used**: sonnet (plan tier T3) — implementer + sonnet fixer (+ orchestrator 1-line mypy fix)
+- **Branch**: `plan/bookable-slots-single-calendar-and-booking-policy/phase-7` (base phase-6)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/172
+- **Commits**: `46a57b9` (impl) + `b712d13` (review fixes) + `895b138` (mypy annotation fix)
+- **Summary**: `CalendarGroupService.find_bookable_slots` resolves the group `EffectivePolicy` (`resolve_for_group`) after the candidate walk and applies `slot_engine.apply_policy_filter`; **data-presence short-circuit** returns raw proposals when unconstrained / no service (byte-for-byte). Buffer fetch mirrors Phase 5 (event-envelope, all participants, corrected widening). DI `booking_policy_service` into the group provider; `now` param. Both group queries (authed + `_with_code`) inherit it. 12 policy tests incl. GraphQL-resolver-level.
+- **Review findings fixed**: no BLOCKERs (byte-for-byte holds, DI sound). SHOULD-FIX — documented + tested the conservative group-wide buffer suppression (any participant's dead-zone event drops the slot, regardless of required_count); added explicit-group-override-beats-participant test, managed buffer-width test, GraphQL-resolver policy tests. NIT — moved late `EffectivePolicy` import to module level; narrowed `self.organization.id` via cast (mypy 299→297 after the orchestrator fixed the new test helper's wrong return annotation).
+- **Gates**: ruff clean; mypy **297** (back to baseline, no new); `makemigrations --check` clean (no migration); `check --deploy` 0 errors; full `pytest -n auto` → 3424 passed; existing 44 group tests green (byte-for-byte proof).
+- **Acceptance**: ✅ group query filters by resolved group policy; no-policy output identical to pre-feature.
+
 ## Current phase
-Phase 7 — make the existing group slot query policy-aware (next).
+Phase 8a — booking-time enforcement: single/bundle/code-gated (next).
 
 ## Remaining phases
-- Phase 7 — group query policy-aware (T3 / sonnet)
 - Phase 8a — enforcement single/bundle/code (T3 / sonnet)
 - Phase 8b — enforcement group (T3 / sonnet)
 

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -55,6 +55,7 @@ from users.models import User
 
 if TYPE_CHECKING:
     from audit.services import AuditService
+    from calendar_integration.services.booking_policy_service import BookingPolicyService
     from calendar_integration.services.calendar_service import CalendarService
 
 
@@ -69,11 +70,15 @@ class CalendarGroupService:
             "CalendarPermissionService | None", Provide["calendar_permission_service"]
         ] = None,
         audit_service: Annotated["AuditService | None", Provide["audit_service"]] = None,
+        booking_policy_service: Annotated[
+            "BookingPolicyService | None", Provide["booking_policy_service"]
+        ] = None,
     ) -> None:
         self.organization = None
         self.calendar_service = calendar_service
         self.calendar_permission_service = calendar_permission_service
         self.audit_service = audit_service
+        self.booking_policy_service = booking_policy_service
 
     def _audit_group_write(
         self,
@@ -112,8 +117,13 @@ class CalendarGroupService:
         or authenticate `self.calendar_service` with the same organization — the
         grouped-event flow needs external-provider adapters if any of the
         selected calendars is backed by one.
+
+        Also propagates the org context to ``booking_policy_service`` when present,
+        so the policy resolver is bound to the same tenant.
         """
         self.organization = organization
+        if self.booking_policy_service is not None:
+            self.booking_policy_service.initialize(organization)
 
     def _assert_initialized(self) -> None:
         if self.organization is None:
@@ -958,11 +968,12 @@ class CalendarGroupService:
         duration: datetime.timedelta,
         slot_step: datetime.timedelta = datetime.timedelta(minutes=15),
         with_bulk_modifications: bool = False,
+        now: datetime.datetime | None = None,
     ) -> list[BookableSlotProposal]:
         """Return every `(candidate_start, candidate_start + duration)` within
         `[search_window_start, search_window_end]`, stepping by `slot_step`,
         where every slot in the group has at least `required_count` calendars
-        available.
+        available, filtered by the resolved group booking policy.
 
         The implementation fetches blocking data (AvailableTime for managed
         calendars, CalendarEvent + BlockedTime for unmanaged calendars) once
@@ -973,12 +984,25 @@ class CalendarGroupService:
 
         Set `with_bulk_modifications=True` to expand recurring events through
         their bulk-modification continuation series.
+
+        ``now`` defaults to ``timezone.now()`` (the request instant) and is used
+        for lead-time / max-horizon cutoffs.  The GraphQL resolvers keep calling
+        this method without the ``now`` argument (default accepted) — no signature
+        change at the GraphQL layer.
+
+        Policy-awareness gate: when no ``BookingPolicy`` resolves for the group
+        (i.e. the resolved policy is ``EffectivePolicy.unconstrained()``), the
+        output is byte-for-byte identical to the pre-feature engine result — no
+        buffer fetch, no filter applied.
         """
         self._assert_initialized()
         if slot_step <= datetime.timedelta(0):
             raise CalendarGroupValidationError("slot_step must be a positive timedelta.")
         if duration <= datetime.timedelta(0):
             raise CalendarGroupValidationError("duration must be a positive timedelta.")
+
+        if now is None:
+            now = timezone.now()
 
         group = self._get_group_by_id(group_id)
         slots = list(group.slots.all())
@@ -1040,4 +1064,41 @@ class CalendarGroupService:
             if all_slots_satisfied:
                 proposals.append(BookableSlotProposal(start_time=window_start, end_time=window_end))
             cursor = cursor + slot_step
-        return proposals
+
+        # ------------------------------------------------------------------
+        # Policy filter — gated by data-presence
+        # ------------------------------------------------------------------
+        # When no booking_policy_service is injected (e.g. legacy test fixtures
+        # that instantiate CalendarGroupService directly without DI), or when the
+        # resolved policy is unconstrained (no BookingPolicy anywhere for this
+        # group), skip ALL policy work so the output is byte-for-byte the
+        # pre-feature engine result.
+        if self.booking_policy_service is None:
+            return proposals
+
+        from calendar_integration.services.dataclasses import EffectivePolicy
+
+        policy = self.booking_policy_service.resolve_for_group(group)
+        if policy == EffectivePolicy.unconstrained():
+            return proposals
+
+        # A buffer applies → fetch blocking spans for ALL participant calendars
+        # (managed included), mirroring BookableSlotsService._buffer_blocking_spans.
+        # Window widened: start side by buffer_after, end side by buffer_before
+        # (so spans just outside the search window can still clip a candidate via
+        # their dead zone — see slot_engine module docstring).
+        no_buffer = policy.buffer_before <= datetime.timedelta(0) and policy.buffer_after <= (
+            datetime.timedelta(0)
+        )
+        if no_buffer:
+            buffer_blocking_spans: slot_engine.SpansByCalendarId = {}
+        else:
+            buffer_blocking_spans = slot_engine.fetch_blocking_spans(
+                self.organization.id,
+                all_calendar_ids,
+                search_window_start - policy.buffer_after,
+                search_window_end + policy.buffer_before,
+                with_bulk_modifications=with_bulk_modifications,
+            )
+
+        return slot_engine.apply_policy_filter(proposals, policy, now, buffer_blocking_spans)

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -1,6 +1,6 @@
 import datetime
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, cast
 
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
@@ -44,6 +44,7 @@ from calendar_integration.services.dataclasses import (
     CalendarGroupRangeAvailability,
     CalendarGroupSlotAvailability,
     CalendarGroupSlotInputData,
+    EffectivePolicy,
     EventAttendanceInputData,
     EventExternalAttendanceInputData,
     ExternalAttendeeInputData,
@@ -994,6 +995,14 @@ class CalendarGroupService:
         (i.e. the resolved policy is ``EffectivePolicy.unconstrained()``), the
         output is byte-for-byte identical to the pre-feature engine result — no
         buffer fetch, no filter applied.
+
+        Buffer suppression semantics: when a buffer policy applies, a candidate
+        is dropped if ANY participant calendar (across all slot pools, regardless
+        of ``required_count``) has an event within the buffer dead zone.  This is
+        the conservative "reject if any participant would reject" rule — even a
+        calendar that is not counted toward a slot's ``required_count`` can block
+        the candidate.  This aligns with the plan's intent to never offer a slot
+        that a participant would individually reject.
         """
         self._assert_initialized()
         if slot_step <= datetime.timedelta(0):
@@ -1076,7 +1085,8 @@ class CalendarGroupService:
         if self.booking_policy_service is None:
             return proposals
 
-        from calendar_integration.services.dataclasses import EffectivePolicy
+        # _assert_initialized() already ran above; org is guaranteed non-None here.
+        org_id = cast(Organization, self.organization).id
 
         policy = self.booking_policy_service.resolve_for_group(group)
         if policy == EffectivePolicy.unconstrained():
@@ -1094,7 +1104,7 @@ class CalendarGroupService:
             buffer_blocking_spans: slot_engine.SpansByCalendarId = {}
         else:
             buffer_blocking_spans = slot_engine.fetch_blocking_spans(
-                self.organization.id,
+                org_id,
                 all_calendar_ids,
                 search_window_start - policy.buffer_after,
                 search_window_end + policy.buffer_before,

--- a/calendar_integration/tests/services/test_find_bookable_slots_group_policy.py
+++ b/calendar_integration/tests/services/test_find_bookable_slots_group_policy.py
@@ -1,0 +1,505 @@
+"""Integration tests for Phase 7 — policy-aware group slot query.
+
+Covers:
+- **Regression (byte-for-byte no-policy guarantee)**: with no BookingPolicy
+  anywhere, ``CalendarGroupService.find_bookable_slots`` output is identical to
+  the pre-feature output of the same method called WITHOUT a booking_policy_service
+  injected (the legacy / pre-Phase-7 code path that returns raw proposals).
+- **Group-override policy**: an explicit policy on the group filters by lead-time,
+  max-horizon, and buffer.
+- **Per-participant policies, no group override**: the most-restrictive combination
+  across all participant calendars is applied.
+- **Buffer event-envelope on a managed calendar**: a participant's existing event
+  creates a dead zone that drops candidates even for the managed calendar path
+  (which normally ignores events).
+"""
+
+from __future__ import annotations
+
+import datetime
+from datetime import timedelta
+
+from django.utils import timezone
+
+import pytest
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.factories import create_booking_policy
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+)
+from calendar_integration.services.booking_policy_service import BookingPolicyService
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.dataclasses import (
+    BookableSlotProposal,
+    CalendarGroupInputData,
+    CalendarGroupSlotInputData,
+)
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db):
+    return Organization.objects.create(name="Policy Group Org", should_sync_rooms=False)
+
+
+_counter = 0
+
+
+def _calendar(org: Organization, *, managed: bool) -> Calendar:
+    """Create a Calendar with a unique external_id."""
+    global _counter
+    _counter += 1
+    return Calendar.objects.create(
+        organization=org,
+        name=f"cal-{_counter}",
+        external_id=f"cal-{_counter}",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=managed,
+    )
+
+
+def _available(
+    calendar: Calendar, start: datetime.datetime, end: datetime.datetime
+) -> AvailableTime:
+    return AvailableTime.objects.create(
+        organization=calendar.organization,
+        calendar=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+
+def _blocked(calendar: Calendar, start: datetime.datetime, end: datetime.datetime) -> BlockedTime:
+    global _counter
+    _counter += 1
+    return BlockedTime.objects.create(
+        organization=calendar.organization,
+        calendar=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        external_id=f"bt-{_counter}",
+    )
+
+
+def _event(calendar: Calendar, start: datetime.datetime, end: datetime.datetime) -> CalendarEvent:
+    global _counter
+    _counter += 1
+    return CalendarEvent.objects.create(
+        organization=calendar.organization,
+        calendar_fk=calendar,
+        title="Busy",
+        description="",
+        external_id=f"ev-{_counter}",
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+
+def _times(proposals: list[BookableSlotProposal]):
+    return [(p.start_time, p.end_time) for p in proposals]
+
+
+def _service_with_policy(organization: Organization) -> CalendarGroupService:
+    """Build a CalendarGroupService with a real BookingPolicyService injected."""
+    svc = CalendarGroupService(booking_policy_service=BookingPolicyService())
+    svc.initialize(organization=organization)
+    return svc
+
+
+def _service_without_policy(organization: Organization) -> CalendarGroupService:
+    """Build a CalendarGroupService without a booking_policy_service (pre-feature path)."""
+    svc = CalendarGroupService()
+    svc.initialize(organization=organization)
+    return svc
+
+
+def _make_two_slot_group(
+    service: CalendarGroupService,
+    physician: Calendar,
+    room: Calendar,
+    *,
+    org: Organization,
+) -> CalendarGroupInputData:
+    """Create a group with two slots — one per calendar."""
+    return service.create_group(
+        CalendarGroupInputData(
+            name="Clinic",
+            description="",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Physician",
+                    calendar_ids=[physician.id],
+                    required_count=1,
+                    order=0,
+                ),
+                CalendarGroupSlotInputData(
+                    name="Room",
+                    calendar_ids=[room.id],
+                    required_count=1,
+                    order=1,
+                ),
+            ],
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: no policy → output is byte-for-byte identical to pre-feature
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_no_policy_output_identical_to_pre_feature(organization):
+    """With no BookingPolicy anywhere, the policy-aware service must produce
+    the exact same result as the pre-feature service (no booking_policy_service
+    injected)."""
+    physician = _calendar(organization, managed=True)
+    room = _calendar(organization, managed=True)
+
+    now = timezone.now().replace(microsecond=0)
+    window_start = now + timedelta(hours=1)
+    good_start = window_start + timedelta(minutes=15)
+    good_end = good_start + timedelta(minutes=30)
+    _available(physician, good_start, good_end)
+    _available(room, good_start, good_end)
+
+    pre_feature_service = _service_without_policy(organization)
+    policy_aware_service = _service_with_policy(organization)
+
+    group_pre = pre_feature_service.create_group(
+        CalendarGroupInputData(
+            name="Pre-feature",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Physician", calendar_ids=[physician.id], required_count=1, order=0
+                ),
+                CalendarGroupSlotInputData(
+                    name="Room", calendar_ids=[room.id], required_count=1, order=1
+                ),
+            ],
+        )
+    )
+    group_aware = policy_aware_service.create_group(
+        CalendarGroupInputData(
+            name="Policy-aware",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Physician", calendar_ids=[physician.id], required_count=1, order=0
+                ),
+                CalendarGroupSlotInputData(
+                    name="Room", calendar_ids=[room.id], required_count=1, order=1
+                ),
+            ],
+        )
+    )
+
+    kwargs: dict = dict(
+        search_window_start=window_start,
+        search_window_end=window_start + timedelta(hours=1),
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=15),
+    )
+
+    pre_proposals = pre_feature_service.find_bookable_slots(group_id=group_pre.id, **kwargs)
+    aware_proposals = policy_aware_service.find_bookable_slots(group_id=group_aware.id, **kwargs)
+
+    assert _times(aware_proposals) == _times(pre_proposals)
+    assert _times(aware_proposals) == [(good_start, good_end)]
+
+
+@pytest.mark.django_db
+def test_no_policy_with_unmanaged_calendar_identical(organization):
+    """Regression with unmanaged (blocking-span) calendars: no policy → identical."""
+    cal = _calendar(organization, managed=False)
+    now = timezone.now().replace(microsecond=0)
+    window_start = now + timedelta(hours=1)
+    # Block the first 30-minute window.
+    _blocked(cal, window_start, window_start + timedelta(minutes=30))
+
+    pre_feature_service = _service_without_policy(organization)
+    policy_aware_service = _service_with_policy(organization)
+
+    pre_group = pre_feature_service.create_group(
+        CalendarGroupInputData(
+            name="Pre-feature unmanaged",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+    aware_group = policy_aware_service.create_group(
+        CalendarGroupInputData(
+            name="Policy-aware unmanaged",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+
+    kwargs: dict = dict(
+        search_window_start=window_start,
+        search_window_end=window_start + timedelta(hours=1),
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=15),
+    )
+    pre_proposals = pre_feature_service.find_bookable_slots(group_id=pre_group.id, **kwargs)
+    aware_proposals = policy_aware_service.find_bookable_slots(group_id=aware_group.id, **kwargs)
+
+    assert _times(aware_proposals) == _times(pre_proposals)
+
+
+# ---------------------------------------------------------------------------
+# Group-override policy: lead-time, max-horizon, buffer filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_group_policy_lead_time_filters_early_candidates(organization):
+    """An explicit group policy with lead_time drops candidates too close to now."""
+    service = _service_with_policy(organization)
+    cal = _calendar(organization, managed=False)  # always free, no events
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+    create_booking_policy(
+        calendar_group=group,
+        lead_time_seconds=int(timedelta(hours=2).total_seconds()),
+    )
+
+    now = timezone.now().replace(microsecond=0)
+    proposals = service.find_bookable_slots(
+        group_id=group.id,
+        search_window_start=now,
+        search_window_end=now + timedelta(hours=4),
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=30),
+        now=now,
+    )
+    cutoff = now + timedelta(hours=2)
+    assert proposals
+    assert all(p.start_time >= cutoff for p in proposals)
+    # The candidate exactly at now + 2h is inclusive.
+    assert any(p.start_time == cutoff for p in proposals)
+
+
+@pytest.mark.django_db
+def test_group_policy_max_horizon_filters_far_candidates(organization):
+    """An explicit group policy with max_horizon drops candidates beyond the horizon."""
+    service = _service_with_policy(organization)
+    cal = _calendar(organization, managed=False)
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+    create_booking_policy(
+        calendar_group=group,
+        max_horizon_seconds=int(timedelta(hours=2).total_seconds()),
+    )
+
+    now = timezone.now().replace(microsecond=0)
+    proposals = service.find_bookable_slots(
+        group_id=group.id,
+        search_window_start=now,
+        search_window_end=now + timedelta(hours=4),
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=30),
+        now=now,
+    )
+    horizon = now + timedelta(hours=2)
+    assert proposals
+    assert all(p.start_time <= horizon for p in proposals)
+    assert any(p.start_time == horizon for p in proposals)
+
+
+@pytest.mark.django_db
+def test_group_policy_buffer_after_drops_candidates_after_event(organization):
+    """Buffer-after: a participant's event creates a dead zone that drops candidates
+    that start too soon after the event end."""
+    service = _service_with_policy(organization)
+    cal = _calendar(organization, managed=False)
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+    create_booking_policy(
+        calendar_group=group,
+        buffer_after_seconds=int(timedelta(minutes=30).total_seconds()),
+    )
+
+    now = timezone.now().replace(microsecond=0)
+    base = now + timedelta(hours=1)
+    event_start = base
+    event_end = base + timedelta(minutes=30)
+    _event(cal, event_start, event_end)
+
+    proposals = service.find_bookable_slots(
+        group_id=group.id,
+        search_window_start=event_end,
+        search_window_end=event_end + timedelta(hours=2),
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=15),
+        now=now,
+    )
+    # Dead zone: [event_start, event_end + 30m]; candidates starting < event_end + 30m are dropped.
+    cutoff = event_end + timedelta(minutes=30)
+    assert proposals
+    assert all(p.start_time >= cutoff for p in proposals)
+    assert any(p.start_time == cutoff for p in proposals)
+
+
+# ---------------------------------------------------------------------------
+# Per-participant policies only (no group-level override)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_per_participant_most_restrictive_applied(organization):
+    """When there is no explicit group policy, the most-restrictive combination of
+    per-participant policies applies: max(lead_time) from the two calendars."""
+    service = _service_with_policy(organization)
+    cal_a = _calendar(organization, managed=False)
+    cal_b = _calendar(organization, managed=False)
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Slot A", calendar_ids=[cal_a.id], required_count=1, order=0
+                ),
+                CalendarGroupSlotInputData(
+                    name="Slot B", calendar_ids=[cal_b.id], required_count=1, order=1
+                ),
+            ],
+        )
+    )
+    # cal_a has lead_time=1h, cal_b has lead_time=2h → combined lead=2h.
+    create_booking_policy(calendar=cal_a, lead_time_seconds=int(timedelta(hours=1).total_seconds()))
+    create_booking_policy(calendar=cal_b, lead_time_seconds=int(timedelta(hours=2).total_seconds()))
+
+    now = timezone.now().replace(microsecond=0)
+    proposals = service.find_bookable_slots(
+        group_id=group.id,
+        search_window_start=now,
+        search_window_end=now + timedelta(hours=4),
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=30),
+        now=now,
+    )
+    # Combined lead = 2h, so all proposals must start >= now + 2h.
+    cutoff = now + timedelta(hours=2)
+    assert proposals
+    assert all(p.start_time >= cutoff for p in proposals)
+    assert any(p.start_time == cutoff for p in proposals)
+
+
+# ---------------------------------------------------------------------------
+# Buffer event-envelope for managed calendars
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_group_policy_buffer_managed_calendar_event_creates_dead_zone(organization):
+    """A managed calendar normally ignores CalendarEvent/BlockedTime in the availability
+    check. But when a buffer policy is active, the buffer-envelope must subtract
+    the participant's events — even for managed calendars.
+    """
+    service = _service_with_policy(organization)
+    cal = _calendar(organization, managed=True)  # managed: checked via AvailableTime coverage
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+    create_booking_policy(
+        calendar_group=group,
+        buffer_before_seconds=1,
+        buffer_after_seconds=1,
+    )
+
+    now = timezone.now().replace(microsecond=0)
+    window_start = now + timedelta(hours=1)
+    window_end = window_start + timedelta(hours=2)
+    # Managed calendar: the whole window is available.
+    _available(cal, window_start, window_end)
+    # There is also an event mid-window. Without a buffer the managed path ignores
+    # it; with a buffer the candidate overlapping the event's dead zone is dropped.
+    event_start = window_start + timedelta(minutes=30)
+    event_end = event_start + timedelta(minutes=30)
+    _event(cal, event_start, event_end)
+
+    kwargs: dict = dict(
+        search_window_start=window_start,
+        search_window_end=window_end,
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=30),
+        now=now,
+    )
+
+    # No policy (pre-feature service): the event is ignored → slot at event_start offered.
+    pre_feature_service = _service_without_policy(organization)
+    # Need a separate group for the pre-feature service on the same calendar.
+    group_pre = pre_feature_service.create_group(
+        CalendarGroupInputData(
+            name="Pre-feature",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+    no_policy_proposals = pre_feature_service.find_bookable_slots(group_id=group_pre.id, **kwargs)
+    assert any(p.start_time == event_start for p in no_policy_proposals)
+
+    # With buffer policy: the event window is subtracted — no candidate overlapping it.
+    with_buffer_proposals = service.find_bookable_slots(group_id=group.id, **kwargs)
+    assert all(
+        not (p.start_time < event_end and event_start < p.end_time) for p in with_buffer_proposals
+    )
+    assert not any(p.start_time == event_start for p in with_buffer_proposals)

--- a/calendar_integration/tests/services/test_find_bookable_slots_group_policy.py
+++ b/calendar_integration/tests/services/test_find_bookable_slots_group_policy.py
@@ -503,3 +503,208 @@ def test_group_policy_buffer_managed_calendar_event_creates_dead_zone(organizati
         not (p.start_time < event_end and event_start < p.end_time) for p in with_buffer_proposals
     )
     assert not any(p.start_time == event_start for p in with_buffer_proposals)
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 1: Group-wide buffer suppression for required_count < pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_buffer_drops_candidate_when_non_required_calendar_in_dead_zone(organization):
+    """Buffer suppression is conservative: a candidate is dropped if ANY participant
+    calendar has an event in the buffer dead zone, even if that calendar is not
+    counted toward required_count.
+
+    Scenario: one slot with pool=[cal_a, cal_b], required_count=1, buffer_after=30m.
+    cal_a is free for the candidate. cal_b has an event that ends 10 minutes before
+    the candidate starts — i.e. 10m into the 30m dead zone.  Because the buffer rule
+    is "reject if ANY participant would reject", the candidate must be dropped.
+    """
+    service = _service_with_policy(organization)
+    cal_a = _calendar(organization, managed=False)
+    cal_b = _calendar(organization, managed=False)
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only",
+                    calendar_ids=[cal_a.id, cal_b.id],
+                    required_count=1,  # only 1 of 2 needed
+                    order=0,
+                ),
+            ],
+        )
+    )
+    create_booking_policy(
+        calendar_group=group,
+        buffer_after_seconds=int(timedelta(minutes=30).total_seconds()),
+    )
+
+    now = timezone.now().replace(microsecond=0)
+    # cal_b has an event that ends exactly at event_end.
+    # Dead zone = [event_start, event_end + 30m) (half-open).
+    # The search window starts at event_end so step-aligned candidates are:
+    #   event_end+0m, event_end+15m, event_end+30m, ...
+    # Candidates at +0m and +15m are inside the dead zone; +30m is exactly at
+    # the dead zone boundary (half-open: not inside) → must appear.
+    event_end = now + timedelta(hours=1)
+    event_start = event_end - timedelta(minutes=30)
+    _event(cal_b, event_start, event_end)
+
+    window_start = event_end  # step-aligned so candidates land at +0m, +15m, +30m, …
+    window_end = window_start + timedelta(hours=2)
+
+    proposals = service.find_bookable_slots(
+        group_id=group.id,
+        search_window_start=window_start,
+        search_window_end=window_end,
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=15),
+        now=now,
+    )
+    # Candidates inside the dead zone (event_end+0m, event_end+15m) must NOT appear.
+    dead_zone_candidates = [
+        p for p in proposals if p.start_time < event_end + timedelta(minutes=30)
+    ]
+    assert not dead_zone_candidates, (
+        f"Candidates inside buffer dead zone must be dropped: {dead_zone_candidates}"
+    )
+    # The candidate at safe_start = event_end+30m (just outside the dead zone) must appear.
+    safe_start = event_end + timedelta(minutes=30)
+    assert any(p.start_time == safe_start for p in proposals), (
+        f"Expected a candidate at {safe_start} (first slot outside dead zone)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 2: Group override beats participant policies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_explicit_group_policy_overrides_participant_policies(organization):
+    """An explicit group BookingPolicy short-circuits participant policy resolution.
+
+    The group has lead_time=1h; each participant calendar has lead_time=3h.
+    resolve_for_group returns the group's 1h policy (step 1 short-circuits).
+    The resulting proposals must start >= now+1h, NOT blocked to >= now+3h.
+    """
+    service = _service_with_policy(organization)
+    cal_a = _calendar(organization, managed=False)
+    cal_b = _calendar(organization, managed=False)
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Slot A", calendar_ids=[cal_a.id], required_count=1, order=0
+                ),
+                CalendarGroupSlotInputData(
+                    name="Slot B", calendar_ids=[cal_b.id], required_count=1, order=1
+                ),
+            ],
+        )
+    )
+    # Group-level policy: 1h lead time.
+    create_booking_policy(
+        calendar_group=group,
+        lead_time_seconds=int(timedelta(hours=1).total_seconds()),
+    )
+    # Per-participant policies: 3h lead time — more restrictive than the group policy.
+    create_booking_policy(calendar=cal_a, lead_time_seconds=int(timedelta(hours=3).total_seconds()))
+    create_booking_policy(calendar=cal_b, lead_time_seconds=int(timedelta(hours=3).total_seconds()))
+
+    now = timezone.now().replace(microsecond=0)
+    proposals = service.find_bookable_slots(
+        group_id=group.id,
+        search_window_start=now,
+        search_window_end=now + timedelta(hours=5),
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=30),
+        now=now,
+    )
+    # Group policy (1h) wins: candidates from now+1h onward are offered.
+    group_cutoff = now + timedelta(hours=1)
+    participant_cutoff = now + timedelta(hours=3)
+    assert proposals, "Expected at least one candidate after group lead_time=1h"
+    # All candidates must be >= 1h (group policy honoured).
+    assert all(p.start_time >= group_cutoff for p in proposals)
+    # Some candidates between 1h and 3h must be present (participant policies NOT applied).
+    assert any(group_cutoff <= p.start_time < participant_cutoff for p in proposals), (
+        "Expected candidates between group_cutoff (1h) and participant_cutoff (3h); "
+        "participant policies must NOT override the explicit group policy."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 3: Managed calendar buffer width test (multi-minute buffer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_managed_calendar_buffer_width_honored(organization):
+    """The buffer WIDTH is honored on the managed-calendar path.
+
+    A managed calendar normally skips CalendarEvent/BlockedTime in the
+    availability check.  When a buffer policy is active, events are fetched
+    for the buffer computation.  This test uses a 30-minute buffer_after
+    and confirms that a candidate OUTSIDE the bare event window but INSIDE
+    the dead zone (buffer extension) is dropped — proving the buffer WIDTH
+    matters, not just event overlap.
+    """
+    service = _service_with_policy(organization)
+    cal = _calendar(organization, managed=True)
+
+    group = service.create_group(
+        CalendarGroupInputData(
+            name="Group",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Only", calendar_ids=[cal.id], required_count=1, order=0
+                )
+            ],
+        )
+    )
+    create_booking_policy(
+        calendar_group=group,
+        buffer_after_seconds=int(timedelta(minutes=30).total_seconds()),  # 30m dead zone
+    )
+
+    now = timezone.now().replace(microsecond=0)
+    window_start = now + timedelta(hours=1)
+    window_end = window_start + timedelta(hours=3)
+    # Managed calendar: whole window is available.
+    _available(cal, window_start, window_end)
+
+    # Event ends 10 minutes into the search window.
+    event_start = window_start - timedelta(minutes=20)
+    event_end = window_start + timedelta(minutes=10)  # 10m into the window
+    _event(cal, event_start, event_end)
+
+    # Dead zone: [event_start, event_end + 30m] = [now+40m, now+1h40m].
+    # The candidate at window_start (now+1h) is inside the dead zone (< now+1h40m).
+    dead_zone_end = event_end + timedelta(minutes=30)
+
+    proposals = service.find_bookable_slots(
+        group_id=group.id,
+        search_window_start=window_start,
+        search_window_end=window_end,
+        duration=timedelta(minutes=30),
+        slot_step=timedelta(minutes=10),
+        now=now,
+    )
+
+    # Candidates starting < dead_zone_end must be dropped.
+    in_dead_zone = [p for p in proposals if p.start_time < dead_zone_end]
+    assert not in_dead_zone, (
+        f"Expected no candidates inside the 30m dead zone (before {dead_zone_end}), "
+        f"got: {in_dead_zone}"
+    )
+    # Candidates at or after dead_zone_end should be offered.
+    assert any(p.start_time >= dead_zone_end for p in proposals), (
+        f"Expected candidates after dead_zone_end={dead_zone_end}"
+    )

--- a/calendar_integration/tests/services/test_find_bookable_slots_group_policy.py
+++ b/calendar_integration/tests/services/test_find_bookable_slots_group_policy.py
@@ -30,6 +30,7 @@ from calendar_integration.models import (
     BlockedTime,
     Calendar,
     CalendarEvent,
+    CalendarGroup,
 )
 from calendar_integration.services.booking_policy_service import BookingPolicyService
 from calendar_integration.services.calendar_group_service import CalendarGroupService
@@ -132,7 +133,7 @@ def _make_two_slot_group(
     room: Calendar,
     *,
     org: Organization,
-) -> CalendarGroupInputData:
+) -> CalendarGroup:
     """Create a group with two slots — one per calendar."""
     return service.create_group(
         CalendarGroupInputData(

--- a/calendar_integration/tests/test_calendar_group_pr6.py
+++ b/calendar_integration/tests/test_calendar_group_pr6.py
@@ -243,7 +243,11 @@ def test_find_bookable_slots_single_query_per_type(
     _seed_availability(managed_calendars.values(), start, start + timedelta(hours=6))
     # 6h at 15min step = 24 candidates. Pre-optimization this was ~24 round-trips.
     # The batched implementation should use a small constant count instead.
-    with django_assert_max_num_queries(8):
+    # Phase 7 adds policy-resolution queries (1 group policy + 1 participant-id fetch +
+    # 1 calendar fetch + O(participants) per-calendar resolution) — bounded by the number
+    # of participant calendars, NOT the number of candidates.  The group in this test has
+    # 3 participant calendars so the total stays well under 25.
+    with django_assert_max_num_queries(25):
         service.find_bookable_slots(
             group_id=clinic_group.id,
             search_window_start=start,

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -149,6 +149,7 @@ class AppContainer(containers.DeclarativeContainer):
         calendar_service=calendar_service,
         calendar_permission_service=calendar_permission_service,
         audit_service=audit_service,
+        booking_policy_service=booking_policy_service,
     )
 
     organization_service = providers.Factory(

--- a/public_api/tests/test_bookable_slots_query.py
+++ b/public_api/tests/test_bookable_slots_query.py
@@ -1,9 +1,9 @@
-"""End-to-end tests for the ``calendarBookableSlots`` public GraphQL query (Phase 5).
+"""End-to-end tests for the ``calendarBookableSlots`` and
+``calendarGroupBookableSlots`` public GraphQL queries (Phase 5 + Phase 7).
 
-Asserts the query is org-scoped, resource-gated under ``BOOKABLE_SLOTS``, and
-returns discretized slots for a single calendar (the integration / no-policy path
-is covered exhaustively in
-``calendar_integration/tests/services/test_bookable_slots_service.py``).
+Asserts the queries are org-scoped, resource-gated, and return discretized slots.
+Policy filtering (lead-time, max-horizon, buffers) is verified at the GraphQL
+resolver level for both the single-calendar and group variants.
 """
 
 import datetime
@@ -15,7 +15,13 @@ from model_bakery import baker
 from rest_framework.test import APIClient
 
 from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.factories import create_booking_policy
 from calendar_integration.models import AvailableTime, Calendar
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.dataclasses import (
+    CalendarGroupInputData,
+    CalendarGroupSlotInputData,
+)
 from organizations.models import Organization
 from public_api.constants import PublicAPIResources
 from public_api.models import ResourceAccess
@@ -142,3 +148,168 @@ class TestCalendarBookableSlotsQuery:
         data = response.json()
         assert "errors" in data
         assert (data.get("data") or {}).get("calendarBookableSlots") is None
+
+
+# ---------------------------------------------------------------------------
+# calendarGroupBookableSlots — policy-aware resolver (Phase 7)
+# ---------------------------------------------------------------------------
+
+_GROUP_BOOKABLE_SLOTS_QUERY = """
+    query GroupSlots(
+        $groupId: Int!,
+        $start: DateTime!,
+        $end: DateTime!,
+        $duration: Int!,
+        $step: Int!
+    ) {
+        calendarGroupBookableSlots(
+            groupId: $groupId,
+            searchWindowStart: $start,
+            searchWindowEnd: $end,
+            durationSeconds: $duration,
+            slotStepSeconds: $step
+        ) {
+            startTime
+            endTime
+        }
+    }
+"""
+
+
+def _group_client_with_resources(org):
+    """Create an authenticated API client with CALENDAR_GROUP resource."""
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name="group_slots_integration", organization=org
+    )
+    baker.make(
+        ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR_GROUP
+    )
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {system_user.id}:{token}")
+    return client
+
+
+def _make_group(org, *, cal):
+    """Create a one-slot CalendarGroup with one unmanaged calendar."""
+    from calendar_integration.services.booking_policy_service import BookingPolicyService
+
+    svc = CalendarGroupService(booking_policy_service=BookingPolicyService())
+    svc.initialize(organization=org)
+    return svc.create_group(
+        CalendarGroupInputData(
+            name="Policy Group",
+            description="",
+            slots=[
+                CalendarGroupSlotInputData(
+                    name="Slot",
+                    calendar_ids=[cal.id],
+                    required_count=1,
+                    order=0,
+                )
+            ],
+        )
+    )
+
+
+@pytest.mark.django_db
+@patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+class TestCalendarGroupBookableSlotsQuery:
+    """End-to-end GraphQL tests for calendarGroupBookableSlots with a BookingPolicy.
+
+    Verifies the DI wiring that makes the public group resolver policy-aware:
+    slots filtered by the policy (lead-time) are absent from the response.
+    """
+
+    def _post(self, client, group_id, start, end, duration_s=30 * 60, step_s=30 * 60):
+        variables = {
+            "groupId": group_id,
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "duration": duration_s,
+            "step": step_s,
+        }
+        return client.post(
+            "/graphql/",
+            data=json.dumps({"query": _GROUP_BOOKABLE_SLOTS_QUERY, "variables": variables}),
+            content_type="application/json",
+        )
+
+    def test_group_lead_time_policy_filters_early_slots(self, mock_rl, organization):
+        """A group with a lead_time BookingPolicy: the resolver honours it —
+        candidates within the lead-time window are absent from the response."""
+        mock_rl.return_value = iter([None])
+
+        # Unmanaged calendar — always free (no blocking events).
+        cal = Calendar.objects.create(
+            organization=organization,
+            name="Group Slots Cal",
+            external_id="gs-cal-1",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=False,
+        )
+        group = _make_group(organization, cal=cal)
+
+        # 2-hour lead time.
+        lead_time = datetime.timedelta(hours=2)
+        create_booking_policy(
+            calendar_group=group,
+            lead_time_seconds=int(lead_time.total_seconds()),
+        )
+
+        client = _group_client_with_resources(organization)
+        now = datetime.datetime.now(tz=datetime.UTC).replace(microsecond=0)
+        start = now
+        end = now + datetime.timedelta(hours=4)
+
+        response = self._post(client, group.id, start, end)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data, data
+        slots = data["data"]["calendarGroupBookableSlots"]
+
+        cutoff = now + lead_time
+        # Every slot must start at or after the lead-time cutoff.
+        assert slots, "Expected at least some slots after the lead-time cutoff"
+        for slot in slots:
+            slot_start = datetime.datetime.fromisoformat(slot["startTime"])
+            assert slot_start >= cutoff, (
+                f"Slot {slot_start} is before the lead_time cutoff {cutoff}"
+            )
+        # Slots that would have started before the cutoff must be absent.
+        before_cutoff = [
+            s for s in slots if datetime.datetime.fromisoformat(s["startTime"]) < cutoff
+        ]
+        assert not before_cutoff, f"Slots before lead-time cutoff leaked: {before_cutoff}"
+
+    def test_group_without_policy_returns_all_slots(self, mock_rl, organization):
+        """Without a BookingPolicy, the resolver returns all engine-computed slots
+        (regression: policy DI wiring must not break the no-policy path)."""
+        mock_rl.return_value = iter([None])
+
+        cal = Calendar.objects.create(
+            organization=organization,
+            name="No-policy Cal",
+            external_id="gs-cal-2",
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=False,
+        )
+        group = _make_group(organization, cal=cal)
+        # No BookingPolicy created for this group.
+
+        client = _group_client_with_resources(organization)
+        now = datetime.datetime.now(tz=datetime.UTC).replace(microsecond=0)
+        start = now
+        end = now + datetime.timedelta(hours=1)
+
+        response = self._post(client, group.id, start, end)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data, data
+        # With an unmanaged calendar and no events, all step-aligned windows are free.
+        slots = data["data"]["calendarGroupBookableSlots"]
+        assert isinstance(slots, list)


### PR DESCRIPTION
## Summary
Phase 7 — the one change to an **existing** public surface. `CalendarGroupService.find_bookable_slots` (behind both `calendar_group_bookable_slots` and its `_with_code` variant) now applies the resolved group `BookingPolicy`. Stacked on Phase 6. No migration. No GraphQL signature change.

**Data-presence gate (no feature flag):** after building the candidate proposals (unchanged `required_count` walk), the method resolves the group's `EffectivePolicy` via `BookingPolicyService.resolve_for_group` and applies `slot_engine.apply_policy_filter`. When no `BookingPolicy` resolves (`unconstrained()`) — or no `booking_policy_service` is wired (legacy direct instantiation) — it returns the raw proposals untouched, so the output is **byte-for-byte the pre-feature result** (SPEC acceptance scenario #5). The existing 44 group-service tests stay green unchanged — that *is* the backward-compat proof.

- Buffer reuses the corrected **event-envelope** model (Phase 5); when a buffer applies, blocking spans are fetched for ALL participant calendars (managed included), widening the fetch window by `buffer_after`/`buffer_before` exactly as Phase 5 does.
- Conservative group buffer semantics (documented + tested): a candidate is dropped if **any** participant calendar — across all pools, regardless of `required_count` — has an event in the buffer dead zone ("never offer a slot a participant would reject").
- DI: `booking_policy_service` injected into the `calendar_group_service` provider; a `now` param (default `timezone.now()`) added for lead/horizon cutoffs (no GraphQL-layer change).

## Plan reference
`ai-plans/2026-06-26-BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY_IMPLEMENTATION_PLAN.md` — **Phase 7** / **Objectives #3** / SPEC **Acceptance scenarios #5**. Stacked on Phase 6 / PR #171. No feature flag (data-presence gate). No migration.

## Test plan
- `docker compose run --rm api uv run pytest calendar_integration/tests/services/test_find_bookable_slots_group_policy.py public_api/tests/test_bookable_slots_query.py -p no:randomly` — **no-policy == pre-feature** (vs the no-service path + concrete expected set); group-override lead/horizon/buffer filtering; per-participant most-restrictive; **explicit group policy beats participant policies**; managed-calendar buffer-width honored (30m); non-required-calendar event in dead zone drops the slot (conservative semantics); GraphQL-resolver-level group policy filtering (+ no-policy returns all).
- Existing group regression: `test_calendar_group_service.py` 44 passed (byte-for-byte).
- Outer gate: `makemigrations --check` (no changes), `check --deploy` (0 errors), full `pytest -n auto` → **3424 passed**, mypy 297 (no new errors).