### PR TITLE
feat(calendar): enforce booking policy on single/bundle event creation

### DIFF
--- a/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
+++ b/ai-plans/TRACKING_BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY.md
@@ -23,6 +23,7 @@
 - Phase 5: `plan/bookable-slots-single-calendar-and-booking-policy/phase-5` (base phase-4)
 - Phase 6: `plan/bookable-slots-single-calendar-and-booking-policy/phase-6` (base phase-5)
 - Phase 7: `plan/bookable-slots-single-calendar-and-booking-policy/phase-7` (base phase-6)
+- Phase 8a: `plan/bookable-slots-single-calendar-and-booking-policy/phase-8a` (base phase-7)
 
 ## Completed phases
 
@@ -104,12 +105,25 @@
 - **Gates**: ruff clean; mypy **297** (back to baseline, no new); `makemigrations --check` clean (no migration); `check --deploy` 0 errors; full `pytest -n auto` → 3424 passed; existing 44 group tests green (byte-for-byte proof).
 - **Acceptance**: ✅ group query filters by resolved group policy; no-policy output identical to pre-feature.
 
+### Phase 8a — booking-time enforcement: single/bundle/code-gated ✅
+- **Status**: DONE (reviewed, fixed, pushed, PR open)
+- **Model used**: sonnet (plan tier T3) — implementer + sonnet fixer
+- **Branch**: `plan/bookable-slots-single-calendar-and-booking-policy/phase-8a` (base phase-7)
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/173
+- **Commits**: `8d02d73` (impl) + `bdd650e` (review fixes)
+- **Summary**: `BookingPolicyViolationError`; single enforcement gate `_check_booking_policy` in `CalendarService.create_event` (covers single + bundle + code-gated, all funnel through it). Reuses `slot_engine.apply_policy_filter([proposal], …)` so enforcement == discovery by construction. Data-presence skip on `unconstrained()`. Runs in the create transaction (rollback on violation). Error mapping: `schedule_event` → explanatory error, `create_calendar_event_with_code` → `SLOT_UNAVAILABLE`. DI `booking_policy_service` into CalendarService; `_calendar_cache` populated. 30 tests.
+- **Review findings fixed**: no BLOCKERs. SHOULD-FIX (correctness) — bundle fan-out re-checked each child's individual policy → divergence (a stricter child rejecting a booking the bundle policy/discovery allows). Fixed with `_enforce_policy=False` on bundle child creates → enforce once at top-level via `resolve_for_bundle`; added the divergence test. Also: cache fix (dup query); bundle no-rows-on-violation + compliant-success + agreement tests; mutation horizon/buffer/positive agreement tests. NIT — mypy +1 → back to 297.
+- **Gates**: ruff clean; mypy **297**; `makemigrations --check` clean (no migration); `check --deploy` 0 errors; full `pytest -n auto` → 3455 passed.
+- **Acceptance**: ✅ policy-violating single/bundle/code-gated bookings rejected with no rows persisted; compliant succeed; no-policy unchanged; discovery/enforcement agree.
+
 ## Current phase
-Phase 8a — booking-time enforcement: single/bundle/code-gated (next).
+Phase 8b — booking-time enforcement: group bookings (final executable phase).
 
 ## Remaining phases
-- Phase 8a — enforcement single/bundle/code (T3 / sonnet)
 - Phase 8b — enforcement group (T3 / sonnet)
 
 ## Deferred phases
 None (no cross-repo, no flag-removal — data-presence gate means no flag).
+
+## Follow-up notes (not in this plan's scope)
+- **Recurring-series enforcement** (flagged in Phase 8a review): the internal `create_recurring_event` shortcut bypasses the facade `_check_booking_policy`. The public `schedule_event` rrule path IS enforced on the first occurrence (via the facade), but per-occurrence enforcement of an entire recurring series is not covered by this plan. Candidate for a future ticket.

--- a/calendar_integration/exceptions.py
+++ b/calendar_integration/exceptions.py
@@ -351,3 +351,16 @@ class DuplicateBookingPolicyError(CalendarIntegrationError):
     """
 
     pass
+
+
+class BookingPolicyViolationError(CalendarIntegrationError):
+    """Raised when a booking request violates the resolved EffectivePolicy.
+
+    The violation may be due to lead-time (too soon), max-horizon (too far
+    ahead), or a buffer envelope (the requested window overlaps the dead zone
+    of an existing event).  Callers (GraphQL mutations) should map this to a
+    user-facing error explaining that the slot is not available under the
+    current policy.
+    """
+
+    default_message = "The requested time slot is not available under the current booking policy."

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -14,6 +14,7 @@ from graphql import GraphQLError
 
 from calendar_integration.constants import ExternalEventChangeRequestStatus
 from calendar_integration.exceptions import (
+    BookingPolicyViolationError,
     CalendarGroupError,
     CalendarGroupValidationError,
     ChangeRequestIneligibleError,
@@ -1255,6 +1256,15 @@ class CalendarGroupMutations:
                 success=False,
                 error_code=BookingCodeErrorCode.NOT_PERMITTED,
                 error_message="This code does not permit booking on this calendar.",
+            )
+        except BookingPolicyViolationError:
+            # Policy violated — code NOT consumed (txn rolled back), patient may retry.
+            return CodeEventResult(
+                success=False,
+                error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
+                error_message=(
+                    "The requested time slot is not available under the current booking policy."
+                ),
             )
         except (NoAvailableTimeWindowsError, EventManagementError):
             # Slot taken / invalid times — code NOT consumed (txn rolled back), patient may retry.

--- a/calendar_integration/services/calendar_bundle_service.py
+++ b/calendar_integration/services/calendar_bundle_service.py
@@ -110,7 +110,11 @@ class BundleServiceHost(Protocol):
     ) -> Iterable[AvailableTimeWindow]: ...
 
     def create_event(
-        self, calendar_id: int, event_data: CalendarEventInputData
+        self,
+        calendar_id: int,
+        event_data: CalendarEventInputData,
+        *,
+        _enforce_policy: bool = True,
     ) -> CalendarEvent: ...
 
     def update_event(
@@ -434,7 +438,14 @@ class CalendarBundleService:
             recurrence_rule=event_data.recurrence_rule,
         )
 
-        primary_event = self._host.create_event(primary_calendar.id, primary_event_data)
+        # Policy was already enforced once at the top-level CalendarService.create_event
+        # entry (using resolve_for_bundle). Skip re-enforcement for all child creates to
+        # avoid: (a) N redundant policy resolutions and buffer fetches, and (b) false
+        # rejections when a child has its own stricter individual policy that would block
+        # a booking the bundle policy (and Phase-5 discovery) correctly permits.
+        primary_event = self._host.create_event(
+            primary_calendar.id, primary_event_data, _enforce_policy=False
+        )
 
         # Mark primary event as part of bundle
         primary_event.bundle_calendar = bundle_calendar
@@ -459,7 +470,9 @@ class CalendarBundleService:
                     resource_allocations=[],
                 )
 
-                child_event = self._host.create_event(child_calendar.id, child_event_data)
+                child_event = self._host.create_event(
+                    child_calendar.id, child_event_data, _enforce_policy=False
+                )
 
                 # Link to primary event and bundle
                 child_event.bundle_calendar = bundle_calendar

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -169,7 +169,11 @@ class EventServiceHost(Protocol):
     def _grant_event_attendee_permissions(self, event: CalendarEvent) -> None: ...
 
     def create_event(
-        self, calendar_id: int, event_data: CalendarEventInputData
+        self,
+        calendar_id: int,
+        event_data: CalendarEventInputData,
+        *,
+        _enforce_policy: bool = True,
     ) -> CalendarEvent: ...
 
     def delete_event(

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -1298,14 +1298,25 @@ class CalendarService(BaseCalendarService):
         if not allowed:
             raise BookingPolicyViolationError()
 
-    def create_event(self, calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
+    def create_event(
+        self,
+        calendar_id: int,
+        event_data: CalendarEventInputData,
+        *,
+        _enforce_policy: bool = True,
+    ) -> CalendarEvent:
         """
         Create a new event in the calendar.
         :param calendar_id: Internal ID of the calendar
         :param event_data: Dictionary containing event details.
+        :param _enforce_policy: Internal flag; callers must NOT pass this. Set to
+            ``False`` by the bundle fan-out so policy is enforced exactly once at the
+            top-level entry point (using ``resolve_for_bundle``), not again for each
+            child create (which would use ``resolve_for_calendar`` on the child and
+            could falsely reject bookings the bundle policy permits).
         :return: Response from the calendar client.
         """
-        if self.organization is not None:
+        if _enforce_policy and self.organization is not None:
             # Enforcement runs inside the existing transaction (ATOMIC_REQUESTS) so any
             # violation rolls back the entire write — no event or blocked time is created.
             try:
@@ -1321,6 +1332,10 @@ class CalendarService(BaseCalendarService):
                 end_time=event_data.end_time,
                 now=_tz.now(),
             )
+            # Populate the calendar cache so the event service does not re-query the
+            # same row. The cache is keyed on (organization_id, calendar_id) — the same
+            # shape used by _get_calendar_by_id_util.
+            self._calendar_cache[(self.organization.id, calendar_id)] = calendar
         return self._get_event_service().create_event(calendar_id, event_data)
 
     def _update_bundle_event(

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Annotated
 from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest
+from django.utils import timezone as _tz
 
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from dependency_injector.wiring import Provide, inject
@@ -50,6 +51,7 @@ from calendar_integration.constants import (
     CalendarVisibility,
 )
 from calendar_integration.exceptions import (
+    BookingPolicyViolationError,
     InvalidCalendarTokenError,
 )
 from calendar_integration.models import (
@@ -62,13 +64,16 @@ from calendar_integration.models import (
     CalendarSync,
     CalendarWebhookEvent,
     CalendarWebhookSubscription,
+    ChildrenCalendarRelationship,
     EventAttendance,
     EventExternalAttendance,
     GoogleCalendarServiceAccount,
     RecurrenceRule,
 )
 from calendar_integration.querysets import CalendarEventQuerySet
+from calendar_integration.services import slot_engine
 from calendar_integration.services.availability_service import AvailabilityService
+from calendar_integration.services.booking_policy_service import BookingPolicyService
 from calendar_integration.services.calendar_bundle_service import CalendarBundleService
 from calendar_integration.services.calendar_event_service import CalendarEventService
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
@@ -112,10 +117,12 @@ from calendar_integration.services.calendar_webhook_service import (
 from calendar_integration.services.dataclasses import (
     ApplicationCalendarData,
     AvailableTimeWindow,
+    BookableSlotProposal,
     CalendarEventAdapterOutputData,
     CalendarEventData,
     CalendarEventInputData,
     CalendarResourceData,
+    EffectivePolicy,
     EventAttendanceInputData,
     EventExternalAttendanceInputData,
     EventExternalAttendeeData,
@@ -187,6 +194,9 @@ class CalendarService(BaseCalendarService):
             "ExternalEventChangeRequestService | None",
             Provide["external_event_change_request_service"],
         ] = None,
+        booking_policy_service: Annotated[
+            "BookingPolicyService | None", Provide["booking_policy_service"]
+        ] = None,
     ) -> None:
         """Initialize a CalendarService instance. Call authenticate() before using calendar operations."""
         self.organization = None
@@ -197,6 +207,7 @@ class CalendarService(BaseCalendarService):
         self.calendar_permission_service = calendar_permission_service
         self.audit_service = audit_service
         self.external_event_change_request_service = external_event_change_request_service
+        self.booking_policy_service = booking_policy_service
         # Per-instance calendar lookup cache: keyed on (organization_id, id_or_external_id).
         # This replaces the @lru_cache approach which was keyed only on id/external_id and
         # could return a cached Calendar from a different organization when the service
@@ -1214,6 +1225,79 @@ class CalendarService(BaseCalendarService):
     ) -> CalendarEventData:
         return _serialize_event_data_input_util(event, event_data, self.organization)
 
+    def _check_booking_policy(
+        self,
+        calendar: Calendar,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        now: datetime.datetime,
+    ) -> None:
+        """Enforce the resolved EffectivePolicy for a booking request.
+
+        This is the single enforcement gate for ALL ``create_event`` paths: single
+        calendar, bundle calendar (both fan-out to the same facade entry point), and
+        the code-gated single-calendar path (which also calls ``create_event``).
+
+        Steps:
+        1. Skip entirely when ``booking_policy_service`` is not injected or no
+           policy resolves for the target (``EffectivePolicy.unconstrained()``) —
+           preserving byte-for-byte pre-feature behavior (the data-presence gate).
+        2. Resolve the EffectivePolicy: ``resolve_for_bundle`` for bundle calendars,
+           ``resolve_for_calendar`` for all others.
+        3. Build a single ``BookableSlotProposal(start_time, end_time)`` and fetch
+           the buffer blocking spans the same way Phase 5 does (all target calendars,
+           window widened by the buffer magnitudes).
+        4. Call ``slot_engine.apply_policy_filter`` — if the result is empty, the
+           booking violates the policy and ``BookingPolicyViolationError`` is raised.
+
+        This re-reads current calendar state inside the existing ``create_event``
+        transaction, so a slot valid at discovery but invalidated by a concurrent
+        booking is correctly rejected (the concurrency guard).
+        """
+        if self.booking_policy_service is None or self.organization is None:
+            return
+
+        self.booking_policy_service.initialize(self.organization)
+
+        if calendar.calendar_type == CalendarType.BUNDLE:
+            policy = self.booking_policy_service.resolve_for_bundle(calendar)
+            target_calendar_ids: set[int] = set(
+                ChildrenCalendarRelationship.objects.filter_by_organization(self.organization.id)
+                .filter(bundle_calendar_fk_id=calendar.pk)
+                .values_list("child_calendar_fk_id", flat=True)
+            )
+            if not target_calendar_ids:
+                target_calendar_ids = {calendar.id}
+        else:
+            policy = self.booking_policy_service.resolve_for_calendar(calendar)
+            target_calendar_ids = {calendar.id}
+
+        if policy == EffectivePolicy.unconstrained():
+            # No policy → skip all enforcement (data-presence gate).
+            return
+
+        # Fetch buffer blocking spans across all target calendars (managed + unmanaged),
+        # widening the window by the buffer magnitudes — mirrors Phase 5's
+        # ``BookableSlotsService._buffer_blocking_spans``.
+        no_buffer = policy.buffer_before <= datetime.timedelta(
+            0
+        ) and policy.buffer_after <= datetime.timedelta(0)
+        if no_buffer:
+            buffer_blocking_spans: slot_engine.SpansByCalendarId = {}
+        else:
+            buffer_blocking_spans = slot_engine.fetch_blocking_spans(
+                self.organization.id,
+                target_calendar_ids,
+                start_time - policy.buffer_after,
+                end_time + policy.buffer_before,
+                with_bulk_modifications=False,
+            )
+
+        proposal = BookableSlotProposal(start_time=start_time, end_time=end_time)
+        allowed = slot_engine.apply_policy_filter([proposal], policy, now, buffer_blocking_spans)
+        if not allowed:
+            raise BookingPolicyViolationError()
+
     def create_event(self, calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
         """
         Create a new event in the calendar.
@@ -1221,6 +1305,22 @@ class CalendarService(BaseCalendarService):
         :param event_data: Dictionary containing event details.
         :return: Response from the calendar client.
         """
+        if self.organization is not None:
+            # Enforcement runs inside the existing transaction (ATOMIC_REQUESTS) so any
+            # violation rolls back the entire write — no event or blocked time is created.
+            try:
+                calendar = Calendar.objects.filter_by_organization(self.organization.id).get(
+                    id=calendar_id
+                )
+            except Calendar.DoesNotExist:
+                # Let the event service raise the not-found; do not hide the error.
+                return self._get_event_service().create_event(calendar_id, event_data)
+            self._check_booking_policy(
+                calendar,
+                start_time=event_data.start_time,
+                end_time=event_data.end_time,
+                now=_tz.now(),
+            )
         return self._get_event_service().create_event(calendar_id, event_data)
 
     def _update_bundle_event(

--- a/calendar_integration/tests/services/test_booking_policy_enforcement.py
+++ b/calendar_integration/tests/services/test_booking_policy_enforcement.py
@@ -361,26 +361,26 @@ class TestBookingPolicyEnforcementBundle:
         return bundle, child
 
     def test_bundle_no_policy_write_unchanged(self, org):
-        """No policy on bundle or children → create_event is not blocked."""
-        bundle, _child = self._make_bundle(org)
-        svc = _service(org)
-        # The bundle create_event path actually calls _create_bundle_event which
-        # does additional bundle-specific checks, but it should not raise
-        # BookingPolicyViolationError when no policy exists.
-        # Since we're in a non-managed bundle without a full adapter, the
-        # call may raise NoAvailableTimeWindowsError or similar for the child,
-        # but NOT BookingPolicyViolationError.
-        from calendar_integration.exceptions import BookingPolicyViolationError
+        """No policy on bundle → booking completes; primary event persisted.
 
-        try:
-            svc.create_event(bundle.id, _event_input_data())
-        except BookingPolicyViolationError:
-            pytest.fail("BookingPolicyViolationError raised with no policy in place")
-        except Exception:  # noqa: BLE001
-            pass  # other errors (NoAvailableTime, PermissionDenied) are acceptable
+        The ``_make_bundle`` helper has a single child designated as primary.
+        We assert that the booking succeeds (primary event created, marked as
+        bundle primary) and that the BookingPolicyViolationError is NOT raised —
+        the meaningful check for the off-state.
+        """
+        bundle, _primary_child = self._make_bundle(org)
+        svc = _service(org)
+        primary = svc.create_event(bundle.id, _event_input_data())
+        assert primary is not None
+        assert primary.is_bundle_primary
+        # Primary event exists in the DB.
+        assert CalendarEvent.objects.filter_by_organization(org.id).filter(id=primary.id).exists()
 
     def test_bundle_lead_time_violation_raises(self, org):
-        """Policy attached directly to the bundle calendar enforces lead time."""
+        """Policy attached directly to the bundle calendar enforces lead time.
+
+        Also asserts ZERO rows (CalendarEvent + BlockedTime) persist after rejection.
+        """
         bundle, _child = self._make_bundle(org)
         lead_seconds = int((_BOOKING_START - _NOW).total_seconds()) + 3600
         create_booking_policy(calendar=bundle, lead_time_seconds=lead_seconds)
@@ -393,8 +393,15 @@ class TestBookingPolicyEnforcementBundle:
                 mock_tz.now.return_value = _NOW
                 svc.create_event(bundle.id, _event_input_data())
 
+        # No orphan rows must remain after the rolled-back create.
+        assert CalendarEvent.objects.filter_by_organization(org.id).count() == 0
+        assert BlockedTime.objects.filter_by_organization(org.id).count() == 0
+
     def test_bundle_horizon_violation_raises(self, org):
-        """Policy attached to bundle calendar enforces max_horizon."""
+        """Policy attached to bundle calendar enforces max_horizon.
+
+        Also asserts ZERO rows (CalendarEvent + BlockedTime) persist after rejection.
+        """
         bundle, _child = self._make_bundle(org)
         short_horizon = int((_BOOKING_START - _NOW).total_seconds()) - 3600
         create_booking_policy(calendar=bundle, max_horizon_seconds=short_horizon)
@@ -406,6 +413,52 @@ class TestBookingPolicyEnforcementBundle:
             with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
                 mock_tz.now.return_value = _NOW
                 svc.create_event(bundle.id, _event_input_data())
+
+        # No orphan rows must remain after the rolled-back create.
+        assert CalendarEvent.objects.filter_by_organization(org.id).count() == 0
+        assert BlockedTime.objects.filter_by_organization(org.id).count() == 0
+
+    def test_bundle_explicit_policy_allows_when_child_individual_policy_is_stricter(self, org):
+        """Discovery/enforcement agreement for the key divergence case.
+
+        Setup: bundle has an explicit policy that allows the booking.  A child
+        calendar has its OWN stricter policy (shorter lead time) that would
+        forbid the booking if enforcement checked the child individually.
+
+        Expected: booking SUCCEEDS because enforcement uses ``resolve_for_bundle``
+        (precedence #1 = explicit bundle policy), not ``resolve_for_calendar`` on
+        the child.  This mirrors what Phase-5 discovery returns (it also uses
+        ``resolve_for_bundle``).  Regression guard for SHOULD-FIX 1.
+        """
+        from calendar_integration.services.bookable_slots_service import BookableSlotsService
+        from calendar_integration.services.booking_policy_service import BookingPolicyService
+
+        bundle, child = self._make_bundle(org)
+
+        # Bundle policy: lead_time = 0 (no constraint) → booking at _BOOKING_START is allowed.
+        create_booking_policy(calendar=bundle, lead_time_seconds=0)
+
+        # Child policy: lead_time = entire gap + 1h → would reject the booking if checked.
+        lead_seconds_strict = int((_BOOKING_START - _NOW).total_seconds()) + 3600
+        create_booking_policy(calendar=child, lead_time_seconds=lead_seconds_strict)
+
+        # 1. Discovery: Phase-5 slot engine uses resolve_for_bundle → should OFFER the slot.
+        slots_svc = BookableSlotsService(booking_policy_service=BookingPolicyService())
+        slots_svc.initialize(org)
+        slots = slots_svc.find_bookable_slots_for_calendar(
+            calendar_id=bundle.id,
+            search_window_start=_BOOKING_START - datetime.timedelta(minutes=5),
+            search_window_end=_BOOKING_END + datetime.timedelta(minutes=5),
+            duration=datetime.timedelta(hours=1),
+            now=_NOW,
+        )
+        assert len(slots) > 0, "Discovery should offer the slot (bundle policy is permissive)"
+
+        # 2. Enforcement: create_event must also ALLOW the booking (not re-check child policy).
+        svc = _service(org)
+        primary = svc.create_event(bundle.id, _event_input_data())
+        assert primary is not None
+        assert primary.is_bundle_primary
 
 
 @pytest.mark.django_db

--- a/calendar_integration/tests/services/test_booking_policy_enforcement.py
+++ b/calendar_integration/tests/services/test_booking_policy_enforcement.py
@@ -1,0 +1,427 @@
+"""Integration tests for Phase 8a — booking-time policy enforcement on ``create_event``.
+
+Coverage:
+- **Single calendar (auth path)**:
+  - Lead-time violation: booking too soon is rejected.
+  - Horizon violation: booking too far ahead is rejected.
+  - Buffer violation: booking inside an existing event's dead zone is rejected.
+  - Compliant booking (all rules satisfied): succeeds.
+  - No policy → unchanged write behavior (the data-presence off-state).
+
+- **Bundle calendar (auth path)**:
+  - Policy attached to bundle calendar: violation raises ``BookingPolicyViolationError``.
+  - No policy: write goes through unchanged.
+
+- **Concurrency guard**:
+  - A slot valid at discovery time but made invalid by a concurrent event (created
+    between discovery and booking) is correctly rejected at write time.
+
+- **Event-envelope semantics**:
+  - A booking inside the buffer dead zone of an existing event is rejected;
+    a booking touching the dead zone boundary (flush) is allowed.
+
+- **Error inheritance**:
+  - ``BookingPolicyViolationError`` is a ``CalendarIntegrationError`` subclass.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.exceptions import BookingPolicyViolationError
+from calendar_integration.factories import create_booking_policy
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+    ChildrenCalendarRelationship,
+)
+from calendar_integration.services.booking_policy_service import BookingPolicyService
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import CalendarEventInputData
+from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_counter = 0
+
+
+def _cal(org: Organization, *, managed: bool = True, cal_type=CalendarType.PERSONAL) -> Calendar:
+    global _counter
+    _counter += 1
+    return Calendar.objects.create(
+        organization=org,
+        name=f"enforce-cal-{_counter}",
+        external_id=f"enforce-cal-{_counter}",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=cal_type,
+        manage_available_windows=managed,
+        accepts_public_scheduling=True,
+    )
+
+
+def _available(
+    calendar: Calendar, start: datetime.datetime, end: datetime.datetime
+) -> AvailableTime:
+    return AvailableTime.objects.create(
+        organization=calendar.organization,
+        calendar=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+
+def _blocked(calendar: Calendar, start: datetime.datetime, end: datetime.datetime) -> BlockedTime:
+    global _counter
+    _counter += 1
+    return BlockedTime.objects.create(
+        organization=calendar.organization,
+        calendar=calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        external_id=f"bt-enforce-{_counter}",
+    )
+
+
+def _event_in_db(
+    calendar: Calendar, start: datetime.datetime, end: datetime.datetime
+) -> CalendarEvent:
+    global _counter
+    _counter += 1
+    return CalendarEvent.objects.create(
+        organization=calendar.organization,
+        calendar_fk=calendar,
+        title="Busy",
+        description="",
+        external_id=f"ev-enforce-{_counter}",
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+
+def _service(org: Organization) -> CalendarService:
+    """Build a CalendarService with a real BookingPolicyService injected.
+
+    No ``calendar_permission_service`` is passed so permission checks in
+    ``CalendarEventService.create_event`` fall through to the unconstrained path
+    (``can_perform_scheduling`` with no user/token and an INTERNAL
+    ``accepts_public_scheduling=True`` calendar).  This keeps the tests focused
+    on the booking-policy enforcement hook without needing real token plumbing.
+    """
+    svc = CalendarService(booking_policy_service=BookingPolicyService())
+    # Use user_or_token=None so the service does NOT try to initialize a token.
+    svc.initialize_without_provider(user_or_token=None, organization=org)
+    return svc
+
+
+# Booking dates well in the future so lead/horizon comparisons are stable.
+_NOW = datetime.datetime(2030, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+_BOOKING_START = datetime.datetime(2030, 6, 1, 10, 0, 0, tzinfo=datetime.UTC)
+_BOOKING_END = datetime.datetime(2030, 6, 1, 11, 0, 0, tzinfo=datetime.UTC)
+
+
+def _event_input_data(
+    start_time: datetime.datetime = _BOOKING_START,
+    end_time: datetime.datetime = _BOOKING_END,
+) -> CalendarEventInputData:
+    """Build a ``CalendarEventInputData`` for the standard test booking window.
+
+    ``group_authorized=True`` bypasses the permission-service check inside
+    ``CalendarEventService.create_event`` so the tests don't need real token
+    plumbing; the booking-policy enforcement (our concern) runs first.
+    """
+    return CalendarEventInputData(
+        title="Test Booking",
+        description="",
+        start_time=start_time,
+        end_time=end_time,
+        timezone="UTC",
+        attendances=[],
+        external_attendances=[],
+        resource_allocations=[],
+        group_authorized=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBookingPolicyEnforcementSingleCalendar:
+    """Policy enforcement on the single-calendar ``create_event`` path."""
+
+    @pytest.fixture
+    def org(self, db):
+        return Organization.objects.create(name="Enforcement Org Single", should_sync_rooms=False)
+
+    @pytest.fixture
+    def calendar(self, org):
+        cal = _cal(org, managed=True)
+        _available(
+            cal,
+            _BOOKING_START - datetime.timedelta(hours=2),
+            _BOOKING_END + datetime.timedelta(hours=2),
+        )
+        return cal
+
+    def _svc(self, org):
+        return _service(org)
+
+    # ------------------------------------------------------------------
+    # Off-state: no policy → no enforcement, write succeeds
+    # ------------------------------------------------------------------
+
+    def test_no_policy_write_unchanged(self, org, calendar):
+        """With no BookingPolicy anywhere, create_event behaves exactly as before."""
+        svc = self._svc(org)
+        # No policy created — booking should succeed without any violation check.
+        event = svc.create_event(calendar.id, _event_input_data())
+        assert event is not None
+        assert CalendarEvent.objects.filter_by_organization(org.id).filter(id=event.id).exists()
+
+    # ------------------------------------------------------------------
+    # Lead-time violation
+    # ------------------------------------------------------------------
+
+    def test_lead_time_violation_raises(self, org, calendar):
+        """A booking whose start < now + lead_time is rejected."""
+        lead_seconds = int((_BOOKING_START - _NOW).total_seconds()) + 3600  # 1 extra hour
+        create_booking_policy(calendar=calendar, lead_time_seconds=lead_seconds)
+        svc = self._svc(org)
+
+        with pytest.raises(BookingPolicyViolationError):
+            from unittest.mock import patch
+
+            with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+                mock_tz.now.return_value = _NOW
+                svc.create_event(calendar.id, _event_input_data())
+
+    def test_lead_time_compliant_succeeds(self, org, calendar):
+        """A booking exactly at now + lead_time (inclusive) is allowed."""
+        # lead_time of 0 seconds: any future booking is fine.
+        create_booking_policy(calendar=calendar, lead_time_seconds=0)
+        svc = self._svc(org)
+        event = svc.create_event(calendar.id, _event_input_data())
+        assert event is not None
+
+    # ------------------------------------------------------------------
+    # Horizon violation
+    # ------------------------------------------------------------------
+
+    def test_horizon_violation_raises(self, org, calendar):
+        """A booking whose start > now + max_horizon is rejected."""
+        # max_horizon shorter than the gap between now and BOOKING_START
+        short_horizon = int((_BOOKING_START - _NOW).total_seconds()) - 3600
+        create_booking_policy(calendar=calendar, max_horizon_seconds=short_horizon)
+        svc = self._svc(org)
+
+        with pytest.raises(BookingPolicyViolationError):
+            from unittest.mock import patch
+
+            with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+                mock_tz.now.return_value = _NOW
+                svc.create_event(calendar.id, _event_input_data())
+
+    def test_horizon_zero_means_unbounded(self, org, calendar):
+        """max_horizon_seconds=0 means unbounded; any future booking is allowed."""
+        create_booking_policy(calendar=calendar, max_horizon_seconds=0)
+        svc = self._svc(org)
+        event = svc.create_event(calendar.id, _event_input_data())
+        assert event is not None
+
+    # ------------------------------------------------------------------
+    # Buffer violation (event-envelope / dead-zone)
+    # ------------------------------------------------------------------
+
+    def test_buffer_after_violation_raises(self, org, calendar):
+        """A booking that falls inside an existing event's after-buffer dead zone is rejected."""
+        # Existing event ends at 09:00 (1h before booking start 10:00).
+        # buffer_after = 3600s (1h) → dead zone is [09:00, 09:00 + 1h) = [09:00, 10:00).
+        # Booking [10:00, 11:00) starts exactly at 10:00. Touching is NOT overlap, so this
+        # should PASS. Let's make buffer_after = 3601s to push the dead zone past 10:00.
+        existing_end = datetime.datetime(2030, 6, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        existing_start = datetime.datetime(2030, 6, 1, 8, 0, 0, tzinfo=datetime.UTC)
+        _event_in_db(calendar, existing_start, existing_end)
+        # buffer_after = 1h + 1s → dead zone ends at 10:00:01 > booking start 10:00.
+        create_booking_policy(calendar=calendar, buffer_after_seconds=3601)
+        svc = self._svc(org)
+
+        with pytest.raises(BookingPolicyViolationError):
+            from unittest.mock import patch
+
+            with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+                mock_tz.now.return_value = _NOW
+                svc.create_event(calendar.id, _event_input_data())
+
+    def test_buffer_after_flush_boundary_allowed(self, org, calendar):
+        """A booking touching exactly the end of the dead zone (flush) is allowed."""
+        # Existing event ends at 09:00, buffer_after = 3600s → dead zone [09:00, 10:00).
+        # Booking starts exactly at 10:00 — touching, not overlapping → allowed.
+        existing_end = datetime.datetime(2030, 6, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        existing_start = datetime.datetime(2030, 6, 1, 8, 0, 0, tzinfo=datetime.UTC)
+        _event_in_db(calendar, existing_start, existing_end)
+        create_booking_policy(calendar=calendar, buffer_after_seconds=3600)
+        svc = self._svc(org)
+        event = svc.create_event(calendar.id, _event_input_data())
+        assert event is not None
+
+    def test_buffer_before_violation_raises(self, org, calendar):
+        """A booking that falls inside an existing event's before-buffer dead zone is rejected."""
+        # Existing event starts at 11:30 (30 min after booking end 11:00).
+        # buffer_before = 1800s (30 min) → dead zone is [11:30 - 30m, 11:30) = [11:00, 11:30).
+        # Booking end 11:00 → dead zone starts at 11:00; touching, so this should PASS.
+        # Use buffer_before = 1801s → dead zone starts at 10:59:59 < booking end 11:00 → overlap.
+        existing_start = datetime.datetime(2030, 6, 1, 11, 30, 0, tzinfo=datetime.UTC)
+        existing_end = datetime.datetime(2030, 6, 1, 12, 30, 0, tzinfo=datetime.UTC)
+        _event_in_db(calendar, existing_start, existing_end)
+        create_booking_policy(calendar=calendar, buffer_before_seconds=1801)
+        svc = self._svc(org)
+
+        with pytest.raises(BookingPolicyViolationError):
+            from unittest.mock import patch
+
+            with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+                mock_tz.now.return_value = _NOW
+                svc.create_event(calendar.id, _event_input_data())
+
+    def test_no_buffer_no_adjacent_events_compliant(self, org, calendar):
+        """With no buffer policy, a booking adjacent to existing events is allowed."""
+        # Adjacent event ending exactly at booking start.
+        adjacent_end = _BOOKING_START
+        adjacent_start = _BOOKING_START - datetime.timedelta(hours=1)
+        _event_in_db(calendar, adjacent_start, adjacent_end)
+        create_booking_policy(calendar=calendar, lead_time_seconds=0)
+        svc = self._svc(org)
+        event = svc.create_event(calendar.id, _event_input_data())
+        assert event is not None
+
+    # ------------------------------------------------------------------
+    # Concurrency guard
+    # ------------------------------------------------------------------
+
+    def test_concurrency_guard_rejects_slot_invalidated_between_discovery_and_booking(
+        self, org, calendar
+    ):
+        """A slot valid at discovery is rejected if it is inside the buffer dead zone
+        of an event created concurrently (after discovery, before booking)."""
+        buffer_after_s = 3601
+        create_booking_policy(calendar=calendar, buffer_after_seconds=buffer_after_s)
+        svc = self._svc(org)
+
+        # Simulate: discovery ran, found the slot free. Concurrently an event is created.
+        _event_in_db(
+            calendar,
+            datetime.datetime(2030, 6, 1, 8, 0, 0, tzinfo=datetime.UTC),
+            datetime.datetime(2030, 6, 1, 9, 0, 0, tzinfo=datetime.UTC),
+        )
+
+        # Booking attempt now — slot is inside the dead zone, must be rejected.
+        with pytest.raises(BookingPolicyViolationError):
+            from unittest.mock import patch
+
+            with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+                mock_tz.now.return_value = _NOW
+                svc.create_event(calendar.id, _event_input_data())
+
+
+@pytest.mark.django_db
+class TestBookingPolicyEnforcementBundle:
+    """Policy enforcement on the bundle calendar ``create_event`` path."""
+
+    @pytest.fixture
+    def org(self, db):
+        return Organization.objects.create(name="Enforcement Org Bundle", should_sync_rooms=False)
+
+    def _make_bundle(self, org: Organization):
+        bundle = _cal(org, managed=False, cal_type=CalendarType.BUNDLE)
+        child = _cal(org, managed=True)
+        _available(
+            child,
+            _BOOKING_START - datetime.timedelta(hours=2),
+            _BOOKING_END + datetime.timedelta(hours=2),
+        )
+        ChildrenCalendarRelationship.objects.create(
+            organization=org,
+            bundle_calendar=bundle,
+            child_calendar=child,
+            is_primary=True,
+        )
+        return bundle, child
+
+    def test_bundle_no_policy_write_unchanged(self, org):
+        """No policy on bundle or children → create_event is not blocked."""
+        bundle, _child = self._make_bundle(org)
+        svc = _service(org)
+        # The bundle create_event path actually calls _create_bundle_event which
+        # does additional bundle-specific checks, but it should not raise
+        # BookingPolicyViolationError when no policy exists.
+        # Since we're in a non-managed bundle without a full adapter, the
+        # call may raise NoAvailableTimeWindowsError or similar for the child,
+        # but NOT BookingPolicyViolationError.
+        from calendar_integration.exceptions import BookingPolicyViolationError
+
+        try:
+            svc.create_event(bundle.id, _event_input_data())
+        except BookingPolicyViolationError:
+            pytest.fail("BookingPolicyViolationError raised with no policy in place")
+        except Exception:  # noqa: BLE001
+            pass  # other errors (NoAvailableTime, PermissionDenied) are acceptable
+
+    def test_bundle_lead_time_violation_raises(self, org):
+        """Policy attached directly to the bundle calendar enforces lead time."""
+        bundle, _child = self._make_bundle(org)
+        lead_seconds = int((_BOOKING_START - _NOW).total_seconds()) + 3600
+        create_booking_policy(calendar=bundle, lead_time_seconds=lead_seconds)
+        svc = _service(org)
+
+        with pytest.raises(BookingPolicyViolationError):
+            from unittest.mock import patch
+
+            with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+                mock_tz.now.return_value = _NOW
+                svc.create_event(bundle.id, _event_input_data())
+
+    def test_bundle_horizon_violation_raises(self, org):
+        """Policy attached to bundle calendar enforces max_horizon."""
+        bundle, _child = self._make_bundle(org)
+        short_horizon = int((_BOOKING_START - _NOW).total_seconds()) - 3600
+        create_booking_policy(calendar=bundle, max_horizon_seconds=short_horizon)
+        svc = _service(org)
+
+        with pytest.raises(BookingPolicyViolationError):
+            from unittest.mock import patch
+
+            with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+                mock_tz.now.return_value = _NOW
+                svc.create_event(bundle.id, _event_input_data())
+
+
+@pytest.mark.django_db
+class TestBookingPolicyErrorInheritance:
+    """Verify the exception class hierarchy is correct."""
+
+    def test_booking_policy_violation_is_calendar_integration_error(self):
+        from calendar_integration.exceptions import CalendarIntegrationError
+
+        err = BookingPolicyViolationError()
+        assert isinstance(err, CalendarIntegrationError)
+
+    def test_booking_policy_violation_default_message(self):
+        err = BookingPolicyViolationError()
+        assert "booking policy" in str(err).lower()
+
+    def test_booking_policy_violation_custom_message(self):
+        err = BookingPolicyViolationError("custom message")
+        assert str(err) == "custom message"

--- a/calendar_integration/tests/services/test_calendar_bundle_service.py
+++ b/calendar_integration/tests/services/test_calendar_bundle_service.py
@@ -464,7 +464,9 @@ def test_create_bundle_event_uses_designated_primary(
 
     created_calls: list[tuple[int, CalendarEventInputData]] = []
 
-    def fake_create_event(calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
+    def fake_create_event(
+        calendar_id: int, event_data: CalendarEventInputData, **kwargs
+    ) -> CalendarEvent:
         """Return a minimal CalendarEvent for the requested calendar."""
         cal = Calendar.objects.get(id=calendar_id, organization=organization)
         evt = CalendarEvent(
@@ -531,7 +533,9 @@ def test_create_bundle_event_creates_blocked_time_for_provider_children(
         )
     ]
 
-    def fake_create_event(calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
+    def fake_create_event(
+        calendar_id: int, event_data: CalendarEventInputData, **kwargs
+    ) -> CalendarEvent:
         cal = Calendar.objects.get(id=calendar_id, organization=organization)
         evt = CalendarEvent(
             title=event_data.title,

--- a/calendar_integration/tests/services/test_calendar_bundle_service_audit.py
+++ b/calendar_integration/tests/services/test_calendar_bundle_service_audit.py
@@ -231,7 +231,9 @@ def test_create_bundle_event_records_single_create(
 
     counter = {"n": 0}
 
-    def fake_create_event(calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
+    def fake_create_event(
+        calendar_id: int, event_data: CalendarEventInputData, **kwargs
+    ) -> CalendarEvent:
         counter["n"] += 1
         cal = Calendar.objects.get(id=calendar_id, organization=organization)
         evt = CalendarEvent(

--- a/calendar_integration/tests/services/test_calendar_service.py
+++ b/calendar_integration/tests/services/test_calendar_service.py
@@ -6490,7 +6490,7 @@ def test_create_bundle_event_creates_representations(
     # Mock the create_event method to track calls
     created_events = []
 
-    def mock_create_event(calendar_id, event_data):
+    def mock_create_event(calendar_id, event_data, **kwargs):
         # Get calendar from the bundle relationships
         relationships = bundle_calendar.bundle_relationships.all()
         calendar = None

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -126,17 +126,18 @@ class AppContainer(containers.DeclarativeContainer):
         notification_service=notification_service,
     )
 
+    booking_policy_service = providers.Factory(
+        BookingPolicyService,
+        audit_service=audit_service,
+    )
+
     calendar_service = providers.Factory(
         CalendarService,
         calendar_side_effects_service=calendar_side_effects_service,
         calendar_permission_service=calendar_permission_service,
         audit_service=audit_service,
         external_event_change_request_service=external_event_change_request_service,
-    )
-
-    booking_policy_service = providers.Factory(
-        BookingPolicyService,
-        audit_service=audit_service,
+        booking_policy_service=booking_policy_service,
     )
 
     bookable_slots_service = providers.Factory(

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -17,6 +17,7 @@ from graphql import GraphQLError
 
 from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import (
+    BookingPolicyViolationError,
     CalendarIntegrationError,
     DuplicateBookingPolicyError,
     NoAvailableTimeWindowsError,
@@ -2266,6 +2267,11 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
             raise GraphQLError("Calendar not found.") from exc
         except NoAvailableTimeWindowsError as exc:
             raise GraphQLError("No available time window covers the requested event time.") from exc
+        except BookingPolicyViolationError as exc:
+            raise GraphQLError(
+                str(exc)
+                or "The requested time slot is not available under the current booking policy."
+            ) from exc
         except PermissionDenied as exc:
             raise GraphQLError(
                 str(exc) or "You do not have permission to schedule this event."

--- a/public_api/tests/test_booking_policy_enforcement_mutations.py
+++ b/public_api/tests/test_booking_policy_enforcement_mutations.py
@@ -112,7 +112,7 @@ def _owner_calendar(org: Organization) -> tuple:
     return user, membership, cal
 
 
-def _scoped_system_user(org: Organization, membership: OrganizationMembership):
+def _scoped_system_user(org, membership):
     auth_service = PublicAPIAuthService()
     system_user, token = auth_service.create_system_user(
         integration_name=f"enforce_su_{uuid.uuid4().hex[:6]}",
@@ -500,3 +500,109 @@ class TestCreateCalendarEventWithCodePolicyEnforcement:
         result = data["data"]["createCalendarEventWithCode"]
         assert result["success"] is False
         assert result["errorCode"] == "SLOT_UNAVAILABLE"
+
+    def test_discovery_enforcement_agreement_horizon(self):
+        """A slot beyond the max-horizon is rejected by both discovery and enforcement."""
+        from calendar_integration.services.bookable_slots_service import BookableSlotsService
+        from calendar_integration.services.booking_policy_service import BookingPolicyService
+
+        org = _org()
+        cal = _code_calendar(org)
+
+        # Horizon shorter than the gap to _START → slot is beyond the window.
+        horizon_s = int((_START - _NOW).total_seconds()) - 3600
+        create_booking_policy(calendar=cal, max_horizon_seconds=horizon_s)
+
+        # Discovery rejects.
+        slots_svc = BookableSlotsService(booking_policy_service=BookingPolicyService())
+        slots_svc.initialize(org)
+        slots = slots_svc.find_bookable_slots_for_calendar(
+            calendar_id=cal.id,
+            search_window_start=_START - datetime.timedelta(minutes=5),
+            search_window_end=_END + datetime.timedelta(minutes=5),
+            duration=datetime.timedelta(hours=1),
+            now=_NOW,
+        )
+        assert len(slots) == 0, "Discovery should NOT offer the slot beyond horizon"
+
+        # Enforcement rejects.
+        _token_obj, code = _booking_code(org, cal)
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_code_gated(variables={"input": _code_input(code)})
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+
+    def test_discovery_enforcement_agreement_buffer(self):
+        """A slot inside an existing event's buffer dead zone is rejected by both."""
+        from calendar_integration.services.bookable_slots_service import BookableSlotsService
+        from calendar_integration.services.booking_policy_service import BookingPolicyService
+
+        org = _org()
+        cal = _code_calendar(org)
+
+        # Existing event ending at 09:00; buffer_after = 3601s → dead zone [09:00, 10:00:01).
+        CalendarEvent.objects.create(
+            organization=org,
+            calendar_fk=cal,
+            title="Busy",
+            description="",
+            external_id=f"busy-{uuid.uuid4().hex[:6]}",
+            start_time_tz_unaware=datetime.datetime(2030, 6, 1, 8, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+        create_booking_policy(calendar=cal, buffer_after_seconds=3601)
+
+        # Discovery rejects.
+        slots_svc = BookableSlotsService(booking_policy_service=BookingPolicyService())
+        slots_svc.initialize(org)
+        slots = slots_svc.find_bookable_slots_for_calendar(
+            calendar_id=cal.id,
+            search_window_start=_START - datetime.timedelta(minutes=5),
+            search_window_end=_END + datetime.timedelta(minutes=5),
+            duration=datetime.timedelta(hours=1),
+            now=_NOW,
+        )
+        assert len(slots) == 0, "Discovery should NOT offer the slot inside buffer dead zone"
+
+        # Enforcement rejects.
+        _token_obj, code = _booking_code(org, cal)
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_code_gated(variables={"input": _code_input(code)})
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+
+    def test_discovery_enforcement_agreement_positive(self):
+        """A slot the engine DOES offer is accepted by the mutation (positive agreement)."""
+        from calendar_integration.services.bookable_slots_service import BookableSlotsService
+        from calendar_integration.services.booking_policy_service import BookingPolicyService
+
+        org = _org()
+        cal = _code_calendar(org)
+
+        # Policy: no lead-time constraint → all future slots offered.
+        create_booking_policy(calendar=cal, lead_time_seconds=0)
+
+        # Discovery offers the slot.
+        slots_svc = BookableSlotsService(booking_policy_service=BookingPolicyService())
+        slots_svc.initialize(org)
+        slots = slots_svc.find_bookable_slots_for_calendar(
+            calendar_id=cal.id,
+            search_window_start=_START - datetime.timedelta(minutes=5),
+            search_window_end=_END + datetime.timedelta(minutes=5),
+            duration=datetime.timedelta(hours=1),
+            now=_NOW,
+        )
+        assert len(slots) > 0, "Discovery should offer the slot"
+
+        # Enforcement accepts.
+        _token_obj, code = _booking_code(org, cal)
+        data = _post_code_gated(variables={"input": _code_input(code)})
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True

--- a/public_api/tests/test_booking_policy_enforcement_mutations.py
+++ b/public_api/tests/test_booking_policy_enforcement_mutations.py
@@ -1,0 +1,502 @@
+"""Integration tests for Phase 8a — booking-time policy enforcement at the GraphQL layer.
+
+Coverage:
+- ``scheduleEvent`` (authenticated single-calendar):
+  - Lead-time / horizon / buffer violations → GraphQL error with explanatory message.
+  - Compliant booking → succeeds (no regression).
+  - No policy → write unchanged (off-state).
+
+- ``createCalendarEventWithCode`` (code-gated single-calendar):
+  - Policy violation → SLOT_UNAVAILABLE with an explanatory message and code NOT consumed.
+  - Compliant booking → succeeds.
+  - No policy → write unchanged (off-state).
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.factories import create_booking_policy
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarManagementToken,
+    CalendarOwnership,
+    EventManagementPermissions,
+)
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from organizations.models import Organization, OrganizationMembership
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+# ---------------------------------------------------------------------------
+# GraphQL strings
+# ---------------------------------------------------------------------------
+
+_SCHEDULE_EVENT = """
+mutation ScheduleEvent($input: ScheduleEventInput!) {
+    scheduleEvent(input: $input) {
+        id
+        title
+    }
+}
+"""
+
+_CREATE_WITH_CODE = """
+mutation CreateCalendarEventWithCode($input: CreateEventWithCodeInput!) {
+    createCalendarEventWithCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        event { id }
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Shared dates
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.datetime(2030, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+_START = datetime.datetime(2030, 6, 1, 10, 0, 0, tzinfo=datetime.UTC)
+_END = datetime.datetime(2030, 6, 1, 11, 0, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers (schedule_event path)
+# ---------------------------------------------------------------------------
+
+
+def _org() -> Organization:
+    unique = uuid.uuid4().hex[:6]
+    return Organization.objects.create(name=f"Enforce Org {unique}", should_sync_rooms=False)
+
+
+def _owner_calendar(org: Organization) -> tuple:
+    """Return (owner_user, membership, calendar) — personal managed calendar with ownership."""
+    from django.contrib.auth import get_user_model
+
+    user_model = get_user_model()
+    unique = uuid.uuid4().hex[:6]
+    user = user_model.objects.create_user(email=f"owner_{unique}@example.com", password="pw")
+    membership = OrganizationMembership.objects.create(user=user, organization=org, is_active=True)
+    cal = Calendar.objects.create(
+        organization=org,
+        name=f"enforce-cal-{unique}",
+        external_id=f"enforce-ext-{unique}",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=False,
+    )
+    CalendarOwnership.objects.create(organization=org, calendar=cal, membership_user_id=user.id)
+    # Seed an availability window covering the test slot.
+    AvailableTime.objects.create(
+        organization=org,
+        calendar=cal,
+        start_time_tz_unaware=_START - datetime.timedelta(hours=2),
+        end_time_tz_unaware=_END + datetime.timedelta(hours=2),
+        timezone="UTC",
+    )
+    return user, membership, cal
+
+
+def _scoped_system_user(org: Organization, membership: OrganizationMembership):
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name=f"enforce_su_{uuid.uuid4().hex[:6]}",
+        organization=org,
+        scoped_to_membership=membership,
+    )
+    baker.make(
+        ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR_EVENT
+    )
+    return system_user, token, auth_service
+
+
+def _schedule_input(org: Organization, cal: Calendar, **overrides) -> dict:
+    base = {
+        "organizationId": org.id,
+        "calendarId": cal.id,
+        "startTime": _START.isoformat(),
+        "endTime": _END.isoformat(),
+        "timezone": "UTC",
+        "title": "Test Booking",
+    }
+    base.update(overrides)
+    return base
+
+
+def _post_authenticated(system_user, token, auth_service, variables: dict) -> dict:
+    client = APIClient()
+    from di_core.containers import container
+
+    assert container is not None  # noqa: S101
+    with container.public_api_auth_service.override(auth_service):
+        response = client.post(
+            "/graphql/",
+            data={"query": _SCHEDULE_EVENT, "variables": variables},
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+    assert response.status_code == 200
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers (code-gated path)
+# ---------------------------------------------------------------------------
+
+
+def _code_calendar(org: Organization) -> Calendar:
+    unique = uuid.uuid4().hex[:6]
+    cal = Calendar.objects.create(
+        organization=org,
+        name=f"code-enforce-cal-{unique}",
+        external_id=f"code-enforce-{unique}",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=False,
+    )
+    # Seed availability.
+    AvailableTime.objects.create(
+        organization=org,
+        calendar=cal,
+        start_time_tz_unaware=_START - datetime.timedelta(hours=2),
+        end_time_tz_unaware=_END + datetime.timedelta(hours=2),
+        timezone="UTC",
+    )
+    return cal
+
+
+def _booking_code(org: Organization, cal: Calendar) -> tuple[CalendarManagementToken, str]:
+    svc = CalendarPermissionService()
+    token, code = svc.create_booking_token(
+        organization_id=org.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_id=cal.id,
+    )
+    return token, code
+
+
+def _code_input(code: str, **overrides) -> dict:
+    base = {
+        "code": code,
+        "title": "Code Booking",
+        "description": "",
+        "startTime": _START.isoformat(),
+        "endTime": _END.isoformat(),
+        "timezone": "UTC",
+        "externalAttendee": {"email": "patient@example.com", "name": "Pat"},
+    }
+    base.update(overrides)
+    return base
+
+
+@patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+def _post_code_gated(mock_rl, variables: dict) -> dict:
+    mock_rl.return_value = iter([None])
+    client = APIClient()
+    response = client.post(
+        "/graphql/",
+        data={"query": _CREATE_WITH_CODE, "variables": variables},
+        format="json",
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests — scheduleEvent (authenticated single-calendar path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestScheduleEventPolicyEnforcement:
+    """Policy enforcement via the authenticated ``scheduleEvent`` mutation."""
+
+    def test_no_policy_schedules_successfully(self):
+        """Off-state: no BookingPolicy → write behaves exactly as before."""
+        org = _org()
+        _user, membership, cal = _owner_calendar(org)
+        system_user, token, auth_service = _scoped_system_user(org, membership)
+
+        data = _post_authenticated(
+            system_user, token, auth_service, {"input": _schedule_input(org, cal)}
+        )
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["scheduleEvent"]
+        assert result is not None and result["title"] == "Test Booking"
+
+    def test_lead_time_violation_returns_graphql_error(self):
+        """Lead-time violation → GraphQL error with policy message, no event created."""
+        org = _org()
+        _user, membership, cal = _owner_calendar(org)
+        system_user, token, auth_service = _scoped_system_user(org, membership)
+
+        # Policy: lead = gap + 1h (so booking at _START is too soon relative to _NOW).
+        lead_s = int((_START - _NOW).total_seconds()) + 3600
+        create_booking_policy(calendar=cal, lead_time_seconds=lead_s)
+
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_authenticated(
+                system_user, token, auth_service, {"input": _schedule_input(org, cal)}
+            )
+
+        assert data.get("errors"), "Expected a GraphQL error for lead-time violation"
+        error_msg = data["errors"][0]["message"].lower()
+        assert "booking policy" in error_msg or "not available" in error_msg
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=cal.id)
+            .exists()
+        ), "No event should be persisted on violation"
+
+    def test_horizon_violation_returns_graphql_error(self):
+        """Max-horizon violation → GraphQL error, no event created."""
+        org = _org()
+        _user, membership, cal = _owner_calendar(org)
+        system_user, token, auth_service = _scoped_system_user(org, membership)
+
+        # Policy: horizon shorter than gap to _START.
+        horizon_s = int((_START - _NOW).total_seconds()) - 3600
+        create_booking_policy(calendar=cal, max_horizon_seconds=horizon_s)
+
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_authenticated(
+                system_user, token, auth_service, {"input": _schedule_input(org, cal)}
+            )
+
+        assert data.get("errors"), "Expected a GraphQL error for horizon violation"
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=cal.id)
+            .exists()
+        )
+
+    def test_buffer_violation_returns_graphql_error(self):
+        """Buffer-envelope violation → GraphQL error, no event created."""
+        org = _org()
+        _user, membership, cal = _owner_calendar(org)
+        system_user, token, auth_service = _scoped_system_user(org, membership)
+
+        # Existing event ending at 09:00; buffer_after = 3601s → dead zone [09:00, 10:00:01).
+        CalendarEvent.objects.create(
+            organization=org,
+            calendar_fk=cal,
+            title="Busy",
+            description="",
+            external_id=f"busy-{uuid.uuid4().hex[:6]}",
+            start_time_tz_unaware=datetime.datetime(2030, 6, 1, 8, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+        create_booking_policy(calendar=cal, buffer_after_seconds=3601)
+
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_authenticated(
+                system_user, token, auth_service, {"input": _schedule_input(org, cal)}
+            )
+
+        assert data.get("errors"), "Expected a GraphQL error for buffer violation"
+        # The existing busy event + the new event (if it were created) - only the pre-existing one.
+        events = list(
+            CalendarEvent.objects.filter_by_organization(org.id).filter(
+                calendar_fk_id=cal.id, title="Test Booking"
+            )
+        )
+        assert len(events) == 0, "New event must NOT be persisted on buffer violation"
+
+    def test_compliant_booking_succeeds(self):
+        """A booking that satisfies all policy rules (sufficient lead time) succeeds."""
+        org = _org()
+        _user, membership, cal = _owner_calendar(org)
+        system_user, token, auth_service = _scoped_system_user(org, membership)
+
+        # Policy: lead = 0 (no constraint), no horizon, no buffer.
+        create_booking_policy(calendar=cal, lead_time_seconds=0)
+
+        data = _post_authenticated(
+            system_user, token, auth_service, {"input": _schedule_input(org, cal)}
+        )
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["scheduleEvent"]
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests — createCalendarEventWithCode (code-gated single-calendar path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateCalendarEventWithCodePolicyEnforcement:
+    """Policy enforcement via the code-gated ``createCalendarEventWithCode`` mutation."""
+
+    def test_no_policy_booking_succeeds_off_state(self):
+        """Off-state: no BookingPolicy → code-gated write unchanged."""
+        org = _org()
+        cal = _code_calendar(org)
+        token_obj, code = _booking_code(org, cal)
+
+        data = _post_code_gated(variables={"input": _code_input(code)})
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True
+        assert result["errorCode"] is None
+        # Code consumed.
+        token_obj.refresh_from_db()
+        assert token_obj.used_at is not None
+
+    def test_lead_time_violation_returns_slot_unavailable_code_not_consumed(self):
+        """Policy lead-time violation → SLOT_UNAVAILABLE result, code NOT consumed."""
+        org = _org()
+        cal = _code_calendar(org)
+        token_obj, code = _booking_code(org, cal)
+
+        lead_s = int((_START - _NOW).total_seconds()) + 3600
+        create_booking_policy(calendar=cal, lead_time_seconds=lead_s)
+
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_code_gated(variables={"input": _code_input(code)})
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+        assert (
+            "booking policy" in result["errorMessage"].lower()
+            or "not available" in result["errorMessage"].lower()
+        )
+
+        # Code must NOT be consumed on violation.
+        token_obj.refresh_from_db()
+        assert token_obj.used_at is None
+
+        # No event must be created.
+        assert (
+            not CalendarEvent.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=cal.id)
+            .exists()
+        )
+
+    def test_horizon_violation_returns_slot_unavailable_code_not_consumed(self):
+        """Policy horizon violation → SLOT_UNAVAILABLE result, code NOT consumed."""
+        org = _org()
+        cal = _code_calendar(org)
+        token_obj, code = _booking_code(org, cal)
+
+        horizon_s = int((_START - _NOW).total_seconds()) - 3600
+        create_booking_policy(calendar=cal, max_horizon_seconds=horizon_s)
+
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_code_gated(variables={"input": _code_input(code)})
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+
+        token_obj.refresh_from_db()
+        assert token_obj.used_at is None
+
+    def test_buffer_violation_returns_slot_unavailable_code_not_consumed(self):
+        """Buffer dead-zone violation → SLOT_UNAVAILABLE, code NOT consumed."""
+        org = _org()
+        cal = _code_calendar(org)
+        token_obj, code = _booking_code(org, cal)
+
+        CalendarEvent.objects.create(
+            organization=org,
+            calendar_fk=cal,
+            title="Busy",
+            description="",
+            external_id=f"busy-{uuid.uuid4().hex[:6]}",
+            start_time_tz_unaware=datetime.datetime(2030, 6, 1, 8, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2030, 6, 1, 9, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+        create_booking_policy(calendar=cal, buffer_after_seconds=3601)
+
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_code_gated(variables={"input": _code_input(code)})
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"
+        assert (
+            "booking policy" in result["errorMessage"].lower()
+            or "not available" in result["errorMessage"].lower()
+        )
+
+        token_obj.refresh_from_db()
+        assert token_obj.used_at is None
+
+    def test_compliant_code_gated_booking_succeeds(self):
+        """A code-gated booking satisfying all policy rules succeeds."""
+        org = _org()
+        cal = _code_calendar(org)
+        token_obj, code = _booking_code(org, cal)
+
+        create_booking_policy(calendar=cal, lead_time_seconds=0)
+
+        data = _post_code_gated(variables={"input": _code_input(code)})
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True
+
+        token_obj.refresh_from_db()
+        assert token_obj.used_at is not None
+
+    def test_discovery_enforcement_agreement_lead_time(self):
+        """A slot NOT offered by the slot engine (lead-time) is also rejected at booking time.
+
+        This test asserts the discovery/enforcement agreement: a slot the Phase 5
+        ``BookableSlotsService`` would reject is also rejected by ``create_event``.
+        """
+        from calendar_integration.services.bookable_slots_service import BookableSlotsService
+        from calendar_integration.services.booking_policy_service import BookingPolicyService
+
+        org = _org()
+        cal = _code_calendar(org)
+        _booking_code(org, cal)
+
+        # Lead time: booking at _START from _NOW is too soon.
+        lead_s = int((_START - _NOW).total_seconds()) + 3600
+        create_booking_policy(calendar=cal, lead_time_seconds=lead_s)
+
+        # Discovery: slot engine should NOT offer the slot.
+        slots_svc = BookableSlotsService(booking_policy_service=BookingPolicyService())
+        slots_svc.initialize(org)
+        slots = slots_svc.find_bookable_slots_for_calendar(
+            calendar_id=cal.id,
+            search_window_start=_START - datetime.timedelta(minutes=5),
+            search_window_end=_END + datetime.timedelta(minutes=5),
+            duration=datetime.timedelta(hours=1),
+            now=_NOW,
+        )
+        assert len(slots) == 0, "Discovery should NOT offer the slot"
+
+        # Enforcement: create_event should also reject.
+        _token_obj, code = _booking_code(org, cal)
+        with patch("calendar_integration.services.calendar_service._tz") as mock_tz:
+            mock_tz.now.return_value = _NOW
+            data = _post_code_gated(variables={"input": _code_input(code)})
+
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is False
+        assert result["errorCode"] == "SLOT_UNAVAILABLE"


### PR DESCRIPTION
## Summary
Phase 8a — booking-time enforcement for the single-calendar, bundle, and code-gated-single write paths (spec use-case #5). Stacked on Phase 7. No migration. Discovery and the write path now AGREE: a time `calendar_bookable_slots` would not offer cannot be booked.

- New `BookingPolicyViolationError(CalendarIntegrationError)` (`calendar_integration/exceptions.py`).
- A single enforcement gate `_check_booking_policy` + call in `CalendarService.create_event` (the facade all three paths funnel through). It resolves the `EffectivePolicy` (`resolve_for_bundle` for a bundle, `resolve_for_calendar` otherwise), builds a `BookableSlotProposal(start, end)`, fetches buffer blocking spans the **same way Phase 5 does**, and calls `slot_engine.apply_policy_filter([proposal], …)` — empty result ⇒ violation. So enforcement is byte-identical to discovery (lead inclusive, horizon inclusive, event-envelope half-open buffer).
- **Data-presence gate**: `unconstrained()` ⇒ skip the check ⇒ pre-feature write behavior, byte-for-byte.
- **Enforce-once on bundles**: the bundle fan-out passes a private `_enforce_policy=False` for the per-child creates, so the policy is checked exactly once at the top-level entry using `resolve_for_bundle`. This prevents a child's *individual* policy from rejecting a booking the bundle policy (and discovery) allows — a discovery/enforcement divergence, now tested.
- The check runs inside the existing `create_event` transaction (`ATOMIC_REQUESTS` / the code path's `transaction.atomic()`), so a violation rolls back the whole write — no event or blocked time (incl. bundle children) is persisted.
- Error mapping: `schedule_event` → explanatory GraphQL error; `create_calendar_event_with_code` → `SLOT_UNAVAILABLE` (no policy internals leaked to anonymous bookers).
- DI: `booking_policy_service` injected into `CalendarService`. The facade fetch now populates `_calendar_cache` so the event service reuses it (no duplicate query).

## Plan reference
`ai-plans/2026-06-26-BOOKABLE_SLOTS_SINGLE_CALENDAR_AND_BOOKING_POLICY_IMPLEMENTATION_PLAN.md` — **Phase 8a** / **Use-cases #5** / SPEC **Acceptance #7**. Stacked on Phase 7 / PR #172. No feature flag (data-presence gate). No migration.

Follow-up note (out of scope here): the internal `create_recurring_event` shortcut delegates to the event service directly and bypasses the facade gate — the public `schedule_event` rrule path IS enforced (on the first occurrence via the facade). Recurring-series enforcement beyond the first occurrence is not part of this plan.

## Test plan
- `docker compose run --rm api uv run pytest calendar_integration/tests/services/test_booking_policy_enforcement.py public_api/tests/test_booking_policy_enforcement_mutations.py -p no:randomly` — lead / horizon / buffer rejection on single, bundle, and code-gated paths; compliant bookings succeed (incl. a real bundle success creating primary + child rows); **no-policy ⇒ unchanged**; **zero rows persisted on a rejected bundle booking** (no orphan children); event-envelope buffer; discovery/enforcement agreement (negative + positive, lead/horizon/buffer); **bundle explicit-policy-allows-when-child-stricter** (proves enforce-once matches discovery).
- Outer gate: `makemigrations --check` (no changes), `check --deploy` (0 errors), full `pytest -n auto` → **3455 passed**, mypy 297 (no new errors).