### PR TITLE
feat(calendar): self-service booking policies for members

### DIFF
--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -6,15 +6,67 @@ from calendar_integration.services.calendar_permission_service import CalendarPe
 from organizations.models import get_active_organization_membership
 
 
+def _member_can_manage_booking_policy_target(
+    *,
+    user,
+    membership,
+    organization_id: int,
+    calendar_id=None,
+    membership_user_id=None,
+    calendar_group_id=None,
+    is_organization_default: bool = False,
+) -> bool:
+    """Decide whether ``user`` may create/update/delete a policy for a target.
+
+    Single source of truth for the self-service rule, shared by the create-time
+    ``has_permission`` (target read from the request body) and the object-level
+    ``has_object_permission`` (target read from the existing policy row):
+
+    - **Org admins** may manage a policy for **any** target.
+    - A **non-admin member** may manage only their *own* personal policies:
+      - a ``calendar`` policy for a calendar they **own** (an active
+        ``CalendarOwnership`` links their membership to it), or
+      - a ``membership`` policy for **their own** membership
+        (``membership_user_id == user.id``).
+    - ``calendar_group`` and ``is_organization_default`` policies are **admin
+      only** — a non-admin never reaches a grant branch for them.
+    """
+    if membership is None:
+        return False
+    if membership.is_admin:
+        return True
+
+    # Non-admin: only self-owned calendar or own-membership targets.
+    if calendar_id is not None:
+        return (
+            CalendarOwnership.objects.filter_by_organization(organization_id)
+            .filter(membership_user_id=user.id, calendar_fk_id=calendar_id)
+            .exists()
+        )
+    if membership_user_id is not None:
+        return int(membership_user_id) == user.id
+
+    # calendar_group / is_organization_default (or no recognizable target) → admin only.
+    return False
+
+
 class BookingPolicyPermission(BasePermission):
     """Permission for ``BookingPolicyViewSet``.
 
     Reads (GET/HEAD/OPTIONS — list/retrieve) are open to any authenticated user;
     ``get_queryset()`` already restricts visibility to the caller's org.
 
-    Writes (POST/PUT/PATCH/DELETE — create/update/destroy) require the caller to
-    be an **organization admin** (per SPEC use-case 3, consistent with sibling
-    org-wide config writes gated by ``IsOrganizationAdmin``).
+    Writes (POST/PUT/PATCH/DELETE — create/update/destroy) are **self-service**:
+
+    - Org admins may manage policies for any target (calendar, membership,
+      calendar group, or the organization default).
+    - Non-admin members may manage only their **own** personal policies — a
+      policy targeting a calendar they own, or their own membership. Policies for
+      calendar groups and the organization default stay **admin only**.
+
+    The per-target decision lives in ``_member_can_manage_booking_policy_target``.
+    Create reads the target from the request body here; update/delete read it from
+    the existing policy row in ``has_object_permission``.
 
     Membership-less (gated) users are allowed through on safe methods: the
     queryset returns [] rather than 403, which is the consistent pattern used by
@@ -22,13 +74,50 @@ class BookingPolicyPermission(BasePermission):
     """
 
     def has_permission(self, request, view) -> bool:
-        """Safe methods: any authenticated user. Unsafe methods: org admin only."""
+        """Safe methods: any authenticated user. Unsafe methods: self or admin."""
         if not request.user or not request.user.is_authenticated:
             return False
         if request.method in SAFE_METHODS:
             return True
+
         membership = get_active_organization_membership(request.user)
-        return membership is not None and membership.is_admin
+        if membership is None:
+            return False
+        if membership.is_admin:
+            return True
+
+        # Detail writes (update/delete) are gated per-object in
+        # ``has_object_permission`` — allow a non-admin member to proceed to it.
+        if request.method not in ("POST",):
+            return True
+
+        # Create: the target lives in the request body.
+        return _member_can_manage_booking_policy_target(
+            user=request.user,
+            membership=membership,
+            organization_id=membership.organization_id,
+            calendar_id=request.data.get("calendar"),
+            membership_user_id=request.data.get("membership_user_id"),
+            calendar_group_id=request.data.get("calendar_group"),
+            is_organization_default=bool(request.data.get("is_organization_default", False)),
+        )
+
+    def has_object_permission(self, request, view, obj) -> bool:
+        """Detail writes: admins always; members only for their own target."""
+        if request.method in SAFE_METHODS:
+            return True
+        membership = get_active_organization_membership(request.user)
+        if membership is None or obj.organization_id != membership.organization_id:
+            return False
+        return _member_can_manage_booking_policy_target(
+            user=request.user,
+            membership=membership,
+            organization_id=obj.organization_id,
+            calendar_id=obj.calendar_fk_id,
+            membership_user_id=obj.membership_user_id,
+            calendar_group_id=obj.calendar_group_fk_id,
+            is_organization_default=obj.is_organization_default,
+        )
 
 
 class ExternalEventChangeRequestPermission(BasePermission):

--- a/calendar_integration/tests/test_booking_policy_api.py
+++ b/calendar_integration/tests/test_booking_policy_api.py
@@ -22,7 +22,12 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from calendar_integration.factories import create_booking_policy
-from calendar_integration.models import BookingPolicy, Calendar, CalendarGroup
+from calendar_integration.models import (
+    BookingPolicy,
+    Calendar,
+    CalendarGroup,
+    CalendarOwnership,
+)
 from organizations.models import Organization, OrganizationMembership, OrganizationRole
 from users.factories import UserFactory
 
@@ -606,3 +611,149 @@ class TestBookingPolicyDestroy:
         client = APIClient()
         response = client.delete(_detail_url(1))
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def _own(org: Organization, calendar: Calendar, membership: OrganizationMembership) -> None:
+    """Link ``membership`` to ``calendar`` as an owner."""
+    CalendarOwnership.objects.create(
+        organization=org,
+        calendar=calendar,
+        membership_user_id=membership.user_id,
+        is_default=True,
+    )
+
+
+@pytest.mark.django_db
+class TestBookingPolicySelfService:
+    """Non-admin members manage their OWN personal/calendar policies; group and
+    organization-default policies stay admin-only."""
+
+    # -- create ------------------------------------------------------------
+
+    def test_member_can_create_policy_for_owned_calendar(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        cal = _make_calendar(org)
+        _own(org, cal, membership)
+        client = _auth_client(membership)
+
+        response = client.post(_list_url(), {"calendar": cal.pk, "lead_time_seconds": 60})
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["lead_time_seconds"] == 60
+
+    def test_member_cannot_create_policy_for_unowned_calendar(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        cal = _make_calendar(org)  # not owned by this member
+        client = _auth_client(membership)
+
+        response = client.post(_list_url(), {"calendar": cal.pk, "lead_time_seconds": 60})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_member_can_create_policy_for_own_membership(self):
+        _, membership = _make_org_with_member(is_admin=False)
+        client = _auth_client(membership)
+
+        response = client.post(
+            _list_url(),
+            {"membership_user_id": membership.user_id, "lead_time_seconds": 120},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_member_cannot_create_policy_for_another_membership(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        other_user = UserFactory().create_user()
+        other_membership = OrganizationMembership.objects.create(
+            user=other_user, organization=org, role=OrganizationRole.MEMBER, is_active=True
+        )
+        client = _auth_client(membership)
+
+        response = client.post(
+            _list_url(),
+            {"membership_user_id": other_membership.user_id, "lead_time_seconds": 120},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_member_cannot_create_calendar_group_policy(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        group = _make_group(org)
+        client = _auth_client(membership)
+
+        response = client.post(_list_url(), {"calendar_group": group.pk, "lead_time_seconds": 60})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_member_cannot_create_org_default_policy(self):
+        _, membership = _make_org_with_member(is_admin=False)
+        client = _auth_client(membership)
+
+        response = client.post(
+            _list_url(), {"is_organization_default": True, "lead_time_seconds": 60}
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_admin_can_create_group_and_org_default(self):
+        org, membership = _make_org_with_member(is_admin=True)
+        group = _make_group(org)
+        client = _auth_client(membership)
+
+        group_resp = client.post(_list_url(), {"calendar_group": group.pk, "lead_time_seconds": 60})
+        org_resp = client.post(
+            _list_url(), {"is_organization_default": True, "lead_time_seconds": 60}
+        )
+
+        assert group_resp.status_code == status.HTTP_201_CREATED, group_resp.json()
+        assert org_resp.status_code == status.HTTP_201_CREATED, org_resp.json()
+
+    # -- update ------------------------------------------------------------
+
+    def test_member_can_update_own_calendar_policy(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        cal = _make_calendar(org)
+        _own(org, cal, membership)
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+        client = _auth_client(membership)
+
+        response = client.patch(_detail_url(policy.pk), {"lead_time_seconds": 999})
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["lead_time_seconds"] == 999
+
+    def test_member_cannot_update_group_policy(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        group = _make_group(org)
+        policy = create_booking_policy(calendar_group=group, lead_time_seconds=60)
+        client = _auth_client(membership)
+
+        response = client.patch(_detail_url(policy.pk), {"lead_time_seconds": 999})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # -- delete ------------------------------------------------------------
+
+    def test_member_can_delete_own_calendar_policy(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        cal = _make_calendar(org)
+        _own(org, cal, membership)
+        policy = create_booking_policy(calendar=cal)
+        client = _auth_client(membership)
+
+        response = client.delete(_detail_url(policy.pk))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert (
+            not BookingPolicy.objects.filter_by_organization(org.id).filter(pk=policy.pk).exists()
+        )
+
+    def test_member_cannot_delete_org_default_policy(self):
+        org, membership = _make_org_with_member(is_admin=False)
+        policy = create_booking_policy(is_organization_default=True, organization=org)
+        client = _auth_client(membership)
+
+        response = client.delete(_detail_url(policy.pk))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert BookingPolicy.objects.filter_by_organization(org.id).filter(pk=policy.pk).exists()

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -2171,6 +2171,11 @@ class BookingPolicyViewSet(VintaScheduleModelViewSet):
         except BookingPolicy.DoesNotExist:
             policy = None
 
+        # Absent policy → idempotent no-op (204). A present policy the caller may
+        # not manage → 403 (non-admin deleting a group/org/other-member policy).
+        if policy is not None:
+            self.check_object_permissions(request, policy)
+
         service.delete_booking_policy(policy)
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Members may now manage their OWN personal/calendar booking policies via the REST API: a policy targeting a calendar they own (CalendarOwnership) or their own membership. Calendar-group and organization-default policies remain admin-only.

BookingPolicyPermission gains a shared target-scoped rule applied at create time (target from request body) and at update/delete time (target from the existing row via has_object_permission). destroy() calls check_object_permissions for a present policy while keeping delete-absent idempotent. Reads unchanged (org-scoped visibility).

The public GraphQL surface is token/resource-based (system users, no user-role concept) and is intentionally unchanged.