### PR TITLE
feat(public-api): enforce owner scope on booking-policy management

### DIFF
--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -2,52 +2,11 @@ from dependency_injector.wiring import Provide, inject
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from calendar_integration.models import CalendarOwnership
+from calendar_integration.services.booking_policy_permission_service import (
+    BookingPolicyPermissionService,
+)
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
 from organizations.models import get_active_organization_membership
-
-
-def _member_can_manage_booking_policy_target(
-    *,
-    user,
-    membership,
-    organization_id: int,
-    calendar_id=None,
-    membership_user_id=None,
-    calendar_group_id=None,
-    is_organization_default: bool = False,
-) -> bool:
-    """Decide whether ``user`` may create/update/delete a policy for a target.
-
-    Single source of truth for the self-service rule, shared by the create-time
-    ``has_permission`` (target read from the request body) and the object-level
-    ``has_object_permission`` (target read from the existing policy row):
-
-    - **Org admins** may manage a policy for **any** target.
-    - A **non-admin member** may manage only their *own* personal policies:
-      - a ``calendar`` policy for a calendar they **own** (an active
-        ``CalendarOwnership`` links their membership to it), or
-      - a ``membership`` policy for **their own** membership
-        (``membership_user_id == user.id``).
-    - ``calendar_group`` and ``is_organization_default`` policies are **admin
-      only** — a non-admin never reaches a grant branch for them.
-    """
-    if membership is None:
-        return False
-    if membership.is_admin:
-        return True
-
-    # Non-admin: only self-owned calendar or own-membership targets.
-    if calendar_id is not None:
-        return (
-            CalendarOwnership.objects.filter_by_organization(organization_id)
-            .filter(membership_user_id=user.id, calendar_fk_id=calendar_id)
-            .exists()
-        )
-    if membership_user_id is not None:
-        return int(membership_user_id) == user.id
-
-    # calendar_group / is_organization_default (or no recognizable target) → admin only.
-    return False
 
 
 class BookingPolicyPermission(BasePermission):
@@ -64,14 +23,24 @@ class BookingPolicyPermission(BasePermission):
       policy targeting a calendar they own, or their own membership. Policies for
       calendar groups and the organization default stay **admin only**.
 
-    The per-target decision lives in ``_member_can_manage_booking_policy_target``.
-    Create reads the target from the request body here; update/delete read it from
-    the existing policy row in ``has_object_permission``.
+    The per-target decision is centralized in ``BookingPolicyPermissionService``
+    (shared with the public GraphQL surface). Create reads the target from the
+    request body here; update/delete read it from the existing policy row in
+    ``has_object_permission``.
 
     Membership-less (gated) users are allowed through on safe methods: the
     queryset returns [] rather than 403, which is the consistent pattern used by
     ``CalendarEventViewSet`` and ``BlockedTimeViewSet``.
     """
+
+    @inject
+    def __init__(
+        self,
+        booking_policy_permission_service: "BookingPolicyPermissionService | None" = Provide[
+            "booking_policy_permission_service"
+        ],
+    ):
+        self.booking_policy_permission_service = booking_policy_permission_service
 
     def has_permission(self, request, view) -> bool:
         """Safe methods: any authenticated user. Unsafe methods: self or admin."""
@@ -92,7 +61,7 @@ class BookingPolicyPermission(BasePermission):
             return True
 
         # Create: the target lives in the request body.
-        return _member_can_manage_booking_policy_target(
+        return self.booking_policy_permission_service.can_member_manage_target(
             user=request.user,
             membership=membership,
             organization_id=membership.organization_id,
@@ -107,16 +76,10 @@ class BookingPolicyPermission(BasePermission):
         if request.method in SAFE_METHODS:
             return True
         membership = get_active_organization_membership(request.user)
-        if membership is None or obj.organization_id != membership.organization_id:
-            return False
-        return _member_can_manage_booking_policy_target(
+        return self.booking_policy_permission_service.can_member_manage_policy(
             user=request.user,
             membership=membership,
-            organization_id=obj.organization_id,
-            calendar_id=obj.calendar_fk_id,
-            membership_user_id=obj.membership_user_id,
-            calendar_group_id=obj.calendar_group_fk_id,
-            is_organization_default=obj.is_organization_default,
+            policy=obj,
         )
 
 

--- a/calendar_integration/services/booking_policy_permission_service.py
+++ b/calendar_integration/services/booking_policy_permission_service.py
@@ -1,0 +1,223 @@
+"""Centralized authorization for managing ``BookingPolicy`` rows.
+
+Both API surfaces funnel their "may this actor manage a policy for target T?"
+decision through this one service, so the rule lives in a single place instead of
+being duplicated across the REST permission class and the GraphQL resolvers:
+
+- **Private REST** (``BookingPolicyPermission``): the actor is an internal
+  ``User`` + their ``OrganizationMembership``. Privileged == ``membership.is_admin``.
+- **Public GraphQL** (booking-policy mutations / query): the actor is a
+  ``SystemUser`` token. Privileged == the token is **organization-wide**
+  (``scoped_to_membership_user_id is None``); a token scoped to a membership is
+  treated exactly like that member.
+
+Both reduce to the same primitive — an *acting membership user id* plus an
+*is-privileged* flag — evaluated against the policy target by
+``_can_manage_target``:
+
+- **Privileged** actors (org admins / org-wide tokens) may manage **any** target.
+- Everyone else may manage only their **own** personal policies: a ``calendar``
+  they own (an active ``CalendarOwnership`` links their membership to it) or their
+  **own** membership. ``calendar_group`` and ``is_organization_default`` targets
+  are privileged-only.
+"""
+
+from typing import TYPE_CHECKING
+
+from django.db.models import Q
+
+from calendar_integration.models import BookingPolicy, CalendarOwnership
+
+
+if TYPE_CHECKING:
+    from calendar_integration.querysets import BookingPolicyQuerySet
+    from organizations.models import OrganizationMembership
+    from public_api.models import SystemUser
+    from users.models import User
+
+
+class BookingPolicyPermissionService:
+    """Single source of truth for booking-policy management authorization."""
+
+    # ------------------------------------------------------------------
+    # Core decision
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _can_manage_target(
+        *,
+        organization_id: int,
+        acting_membership_user_id: int | None,
+        is_privileged: bool,
+        calendar_id=None,
+        membership_user_id=None,
+        calendar_group_id=None,
+        is_organization_default: bool = False,
+    ) -> bool:
+        """Evaluate the rule for a resolved ``(actor, target)`` pair.
+
+        ``acting_membership_user_id`` is the ``membership_user_id`` the actor acts
+        as (``user.id`` for a member, ``scoped_to_membership_user_id`` for a scoped
+        token). ``is_privileged`` short-circuits to allow-all (org admin / org-wide
+        token). Non-privileged actors reach a grant only for a calendar they own or
+        their own membership; group / org-default targets fall through to ``False``.
+        """
+        if is_privileged:
+            return True
+        if acting_membership_user_id is None:
+            # Non-privileged actor with no membership identity manages nothing.
+            return False
+
+        if calendar_id is not None:
+            return (
+                CalendarOwnership.objects.filter_by_organization(organization_id)
+                .filter(membership_user_id=acting_membership_user_id, calendar_fk_id=calendar_id)
+                .exists()
+            )
+        if membership_user_id is not None:
+            return int(membership_user_id) == acting_membership_user_id
+
+        # calendar_group / is_organization_default (or no target) → privileged-only.
+        return False
+
+    @staticmethod
+    def _policy_membership_user_id(policy: BookingPolicy) -> int | None:
+        # Denormalized column contributed by OrganizationMembershipForeignKey;
+        # real at runtime but invisible to django-stubs.
+        return policy.membership_user_id  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _token_scoped_user_id(system_user: "SystemUser") -> int | None:
+        # Denormalized column contributed by OrganizationMembershipForeignKey.
+        return system_user.scoped_to_membership_user_id  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------------
+    # Member (private REST) adapters
+    # ------------------------------------------------------------------
+
+    def can_member_manage_target(
+        self,
+        *,
+        user: "User",
+        membership: "OrganizationMembership | None",
+        organization_id: int,
+        calendar_id=None,
+        membership_user_id=None,
+        calendar_group_id=None,
+        is_organization_default: bool = False,
+    ) -> bool:
+        """Whether an internal member may manage a policy for the given target."""
+        if membership is None:
+            return False
+        return self._can_manage_target(
+            organization_id=organization_id,
+            acting_membership_user_id=user.id,
+            is_privileged=membership.is_admin,
+            calendar_id=calendar_id,
+            membership_user_id=membership_user_id,
+            calendar_group_id=calendar_group_id,
+            is_organization_default=is_organization_default,
+        )
+
+    def can_member_manage_policy(
+        self,
+        *,
+        user: "User",
+        membership: "OrganizationMembership | None",
+        policy: BookingPolicy,
+    ) -> bool:
+        """Object-level variant: read the target from an existing policy row."""
+        if membership is None or policy.organization_id != membership.organization_id:
+            return False
+        return self.can_member_manage_target(
+            user=user,
+            membership=membership,
+            organization_id=policy.organization_id,
+            calendar_id=policy.calendar_fk_id,
+            membership_user_id=self._policy_membership_user_id(policy),
+            calendar_group_id=policy.calendar_group_fk_id,
+            is_organization_default=policy.is_organization_default,
+        )
+
+    # ------------------------------------------------------------------
+    # SystemUser (public GraphQL) adapters
+    # ------------------------------------------------------------------
+
+    def can_system_user_manage_target(
+        self,
+        *,
+        system_user: "SystemUser | None",
+        organization_id: int,
+        calendar_id=None,
+        membership_user_id=None,
+        calendar_group_id=None,
+        is_organization_default: bool = False,
+    ) -> bool:
+        """Whether a token may manage a policy for the given target.
+
+        An organization-wide token (``scoped_to_membership_user_id is None``) is
+        privileged and may manage any target — preserving the pre-existing
+        behavior. A membership-scoped token acts exactly as that member. A missing
+        token (no authenticated principal) manages nothing.
+        """
+        if system_user is None:
+            return False
+        scoped_uid = self._token_scoped_user_id(system_user)
+        return self._can_manage_target(
+            organization_id=organization_id,
+            acting_membership_user_id=scoped_uid,
+            is_privileged=scoped_uid is None,
+            calendar_id=calendar_id,
+            membership_user_id=membership_user_id,
+            calendar_group_id=calendar_group_id,
+            is_organization_default=is_organization_default,
+        )
+
+    def can_system_user_manage_policy(
+        self,
+        *,
+        system_user: "SystemUser | None",
+        policy: BookingPolicy,
+    ) -> bool:
+        """Object-level variant: read the target from an existing policy row."""
+        return self.can_system_user_manage_target(
+            system_user=system_user,
+            organization_id=policy.organization_id,
+            calendar_id=policy.calendar_fk_id,
+            membership_user_id=self._policy_membership_user_id(policy),
+            calendar_group_id=policy.calendar_group_fk_id,
+            is_organization_default=policy.is_organization_default,
+        )
+
+    # ------------------------------------------------------------------
+    # Read scoping (public GraphQL list query)
+    # ------------------------------------------------------------------
+
+    def scope_policies_for_system_user(
+        self,
+        queryset: "BookingPolicyQuerySet",
+        *,
+        system_user: "SystemUser | None",
+        organization_id: int,
+    ) -> "BookingPolicyQuerySet":
+        """Restrict a policy queryset to what ``system_user`` may see.
+
+        Org-wide tokens see everything (queryset returned unchanged). A
+        membership-scoped token sees only the policies it may manage — those for
+        calendars it owns and its own membership; group and org-default policies
+        are excluded. A missing token sees nothing.
+        """
+        if system_user is None:
+            return queryset.none()
+        scoped_uid = self._token_scoped_user_id(system_user)
+        if scoped_uid is None:
+            return queryset
+
+        owned_calendar_ids = (
+            CalendarOwnership.objects.filter_by_organization(organization_id)
+            .filter(membership_user_id=scoped_uid)
+            .values_list("calendar_fk_id", flat=True)
+        )
+        return queryset.filter(
+            Q(calendar_fk_id__in=owned_calendar_ids) | Q(membership_user_id=scoped_uid)
+        )

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -13,6 +13,9 @@ from vintasend_django.services.notification_template_renderers.django_templated_
 from audit.repositories import DjangoORMAuditRepository
 from audit.services import AuditService
 from calendar_integration.services.bookable_slots_service import BookableSlotsService
+from calendar_integration.services.booking_policy_permission_service import (
+    BookingPolicyPermissionService,
+)
 from calendar_integration.services.booking_policy_service import BookingPolicyService
 from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
@@ -129,6 +132,10 @@ class AppContainer(containers.DeclarativeContainer):
     booking_policy_service = providers.Factory(
         BookingPolicyService,
         audit_service=audit_service,
+    )
+
+    booking_policy_permission_service = providers.Factory(
+        BookingPolicyPermissionService,
     )
 
     calendar_service = providers.Factory(

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -81,6 +81,9 @@ if TYPE_CHECKING:
 
 
 if TYPE_CHECKING:
+    from calendar_integration.services.booking_policy_permission_service import (
+        BookingPolicyPermissionService,
+    )
     from calendar_integration.services.booking_policy_service import BookingPolicyService
     from calendar_integration.services.calendar_group_service import CalendarGroupService
     from calendar_integration.services.calendar_service import CalendarService
@@ -161,6 +164,19 @@ def get_booking_policy_mutation_dependencies(
     if booking_policy_service is None:
         raise GraphQLError("Missing required dependency: booking_policy_service")
     return booking_policy_service
+
+
+@inject
+def get_booking_policy_permission_service(
+    booking_policy_permission_service: Annotated[
+        "BookingPolicyPermissionService | None",
+        Provide["booking_policy_permission_service"],
+    ] = None,
+) -> "BookingPolicyPermissionService":
+    """Resolve the BookingPolicyPermissionService from the DI container."""
+    if booking_policy_permission_service is None:
+        raise GraphQLError("Missing required dependency: booking_policy_permission_service")
+    return booking_policy_permission_service
 
 
 def _get_org_and_init_calendar_service(
@@ -2658,6 +2674,21 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         actor = AuditService.actor_from_system_user(request.public_api_system_user)
         service.set_actor(actor)
 
+        # Owner-scope enforcement: a membership-scoped token may only manage its
+        # own calendar / membership policies; org-wide tokens are unrestricted.
+        permission_service = get_booking_policy_permission_service()
+        if not permission_service.can_system_user_manage_target(
+            system_user=request.public_api_system_user,
+            organization_id=org.id,
+            calendar_id=input.calendar_id,
+            membership_user_id=input.membership_user_id,
+            calendar_group_id=input.calendar_group_id,
+            is_organization_default=input.is_organization_default,
+        ):
+            raise GraphQLError(
+                "You do not have permission to manage a booking policy for this target."
+            )
+
         # Resolve optional FK targets.
         calendar: Calendar | None = None
         if input.calendar_id is not None:
@@ -2725,6 +2756,14 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         except BookingPolicy.DoesNotExist as exc:
             raise GraphQLError("Booking policy not found.") from exc
 
+        # Owner-scope enforcement — a scoped token may not touch a policy outside
+        # its scope. Reuse the not-found message so it cannot probe for existence.
+        permission_service = get_booking_policy_permission_service()
+        if not permission_service.can_system_user_manage_policy(
+            system_user=request.public_api_system_user, policy=policy
+        ):
+            raise GraphQLError("Booking policy not found.")
+
         policy = service.update_booking_policy(
             policy,
             lead_time_seconds=input.lead_time_seconds,
@@ -2768,6 +2807,16 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
             )
         except BookingPolicy.DoesNotExist:
             policy = None
+
+        # Owner-scope enforcement — a policy the token may not manage is treated
+        # exactly like an absent one: no delete, success returned. This keeps the
+        # idempotent contract and prevents a scoped token from probing existence.
+        if policy is not None:
+            permission_service = get_booking_policy_permission_service()
+            if not permission_service.can_system_user_manage_policy(
+                system_user=request.public_api_system_user, policy=policy
+            ):
+                policy = None
 
         service.delete_booking_policy(policy)
         return DeleteBookingPolicyResult(success=True)

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -69,6 +69,9 @@ from webhooks.models import WebhookConfiguration, WebhookEvent
 
 if TYPE_CHECKING:
     from calendar_integration.services.bookable_slots_service import BookableSlotsService
+    from calendar_integration.services.booking_policy_permission_service import (
+        BookingPolicyPermissionService,
+    )
     from calendar_integration.services.booking_policy_service import BookingPolicyService
     from calendar_integration.services.calendar_group_service import CalendarGroupService
     from calendar_integration.services.calendar_permission_service import CalendarPermissionService
@@ -123,6 +126,19 @@ def get_booking_policy_query_dependencies(
     if booking_policy_service is None:
         raise GraphQLError("Missing required dependency: booking_policy_service")
     return booking_policy_service
+
+
+@inject
+def get_booking_policy_permission_service(
+    booking_policy_permission_service: Annotated[
+        "BookingPolicyPermissionService | None",
+        Provide["booking_policy_permission_service"],
+    ] = None,
+) -> "BookingPolicyPermissionService":
+    """Resolve the BookingPolicyPermissionService from the DI container."""
+    if booking_policy_permission_service is None:
+        raise GraphQLError("Missing required dependency: booking_policy_permission_service")
+    return booking_policy_permission_service
 
 
 @inject
@@ -1160,6 +1176,15 @@ class Query:
         service.initialize(org)
 
         qs = service.get_all_policies()
+
+        # Owner-scope: a membership-scoped token sees only the policies it may
+        # manage (its own calendars + own membership); org-wide tokens see all.
+        permission_service = get_booking_policy_permission_service()
+        qs = permission_service.scope_policies_for_system_user(
+            qs,
+            system_user=info.context.request.public_api_system_user,
+            organization_id=org.id,
+        )
 
         if calendar_id is not None:
             qs = qs.filter(calendar_fk_id=calendar_id)

--- a/public_api/tests/test_booking_policy_graphql.py
+++ b/public_api/tests/test_booking_policy_graphql.py
@@ -19,8 +19,13 @@ from model_bakery import baker
 from rest_framework.test import APIClient
 
 from calendar_integration.factories import create_booking_policy
-from calendar_integration.models import BookingPolicy, Calendar, CalendarGroup
-from organizations.models import Organization, OrganizationMembership
+from calendar_integration.models import (
+    BookingPolicy,
+    Calendar,
+    CalendarGroup,
+    CalendarOwnership,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
 from public_api.constants import PublicAPIResources
 from public_api.models import ResourceAccess
 from public_api.services import PublicAPIAuthService
@@ -915,3 +920,248 @@ class TestDeleteBookingPolicyMutation:
 
         # No audit task should have been dispatched.
         assert not mock_task.delay.called
+
+
+# ---------------------------------------------------------------------------
+# Owner-scoped token authorization (scoped_to_membership)
+# ---------------------------------------------------------------------------
+
+
+def _scoped_setup(integration_name: str = "scoped_bp"):
+    """Return (org, membership, system_user, token, auth_service) for a token
+    scoped to a member's own calendars/membership, with the BOOKING_POLICY grant."""
+    org = baker.make(Organization, name="Scoped BP Org")
+    user = UserFactory().create_user()
+    membership = OrganizationMembership.objects.create(
+        user=user, organization=org, role=OrganizationRole.MEMBER, is_active=True
+    )
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name=integration_name, organization=org, scoped_to_membership=membership
+    )
+    baker.make(
+        ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.BOOKING_POLICY
+    )
+    return org, membership, system_user, token, auth_service
+
+
+def _own_cal(org: Organization, membership: OrganizationMembership, external_id: str) -> Calendar:
+    cal = baker.make(Calendar, organization=org, external_id=external_id)
+    CalendarOwnership.objects.create(
+        organization=org, calendar=cal, membership_user_id=membership.user_id, is_default=True
+    )
+    return cal
+
+
+@pytest.mark.django_db
+class TestBookingPolicyOwnerScoping:
+    """A membership-scoped SystemUser token may manage only its own calendar /
+    membership booking policies; calendar-group and org-default policies stay
+    org-wide-token only. Org-wide tokens are unaffected."""
+
+    # -- create ------------------------------------------------------------
+
+    def test_scoped_token_can_create_policy_for_owned_calendar(self):
+        org, membership, su, token, auth = _scoped_setup()
+        cal = _own_cal(org, membership, "scoped-owned-1")
+
+        resp = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"calendarId": cal.id, "leadTimeSeconds": 60}},
+        )
+        data = resp.json()
+        assert "errors" not in data, data.get("errors")
+        assert data["data"]["createBookingPolicy"]["success"] is True
+
+    def test_scoped_token_cannot_create_policy_for_unowned_calendar(self):
+        org, _membership, su, token, auth = _scoped_setup()
+        cal = baker.make(Calendar, organization=org, external_id="scoped-unowned-1")
+
+        resp = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"calendarId": cal.id, "leadTimeSeconds": 60}},
+        )
+        assert resp.json().get("errors")
+        assert not (
+            BookingPolicy.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=cal.id)
+            .exists()
+        )
+
+    def test_scoped_token_can_create_policy_for_own_membership(self):
+        _org, membership, su, token, auth = _scoped_setup()
+
+        resp = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"membershipUserId": membership.user_id, "leadTimeSeconds": 60}},
+        )
+        data = resp.json()
+        assert "errors" not in data, data.get("errors")
+        assert data["data"]["createBookingPolicy"]["success"] is True
+
+    def test_scoped_token_cannot_create_group_policy(self):
+        org, _membership, su, token, auth = _scoped_setup()
+        group = baker.make(CalendarGroup, organization=org, name="Scoped G")
+
+        resp = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"calendarGroupId": group.id, "leadTimeSeconds": 60}},
+        )
+        assert resp.json().get("errors")
+        assert not (
+            BookingPolicy.objects.filter_by_organization(org.id)
+            .filter(calendar_group_fk_id=group.id)
+            .exists()
+        )
+
+    def test_scoped_token_cannot_create_org_default_policy(self):
+        org, _membership, su, token, auth = _scoped_setup()
+
+        resp = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"isOrganizationDefault": True, "leadTimeSeconds": 60}},
+        )
+        assert resp.json().get("errors")
+        assert not (
+            BookingPolicy.objects.filter_by_organization(org.id)
+            .filter(is_organization_default=True)
+            .exists()
+        )
+
+    def test_org_wide_token_can_still_create_group_policy(self):
+        org, su, token, auth = _setup_org_and_token(integration_name="orgwide_bp")
+        group = baker.make(CalendarGroup, organization=org, name="Orgwide G")
+
+        resp = _post_graphql(
+            CREATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"calendarGroupId": group.id, "leadTimeSeconds": 60}},
+        )
+        data = resp.json()
+        assert "errors" not in data, data.get("errors")
+        assert data["data"]["createBookingPolicy"]["success"] is True
+
+    # -- update ------------------------------------------------------------
+
+    def test_scoped_token_can_update_own_calendar_policy(self):
+        org, membership, su, token, auth = _scoped_setup()
+        cal = _own_cal(org, membership, "scoped-upd-own")
+        policy = create_booking_policy(calendar=cal, lead_time_seconds=60)
+
+        resp = _post_graphql(
+            UPDATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"policyId": policy.id, "leadTimeSeconds": 999}},
+        )
+        data = resp.json()
+        assert "errors" not in data, data.get("errors")
+        assert data["data"]["updateBookingPolicy"]["policy"]["leadTimeSeconds"] == 999
+
+    def test_scoped_token_cannot_update_group_policy(self):
+        org, _membership, su, token, auth = _scoped_setup()
+        group = baker.make(CalendarGroup, organization=org, name="Scoped Upd G")
+        policy = create_booking_policy(calendar_group=group, lead_time_seconds=60)
+
+        resp = _post_graphql(
+            UPDATE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"policyId": policy.id, "leadTimeSeconds": 999}},
+        )
+        assert resp.json().get("errors")
+        policy.refresh_from_db()
+        assert policy.lead_time_seconds == 60
+
+    # -- delete ------------------------------------------------------------
+
+    def test_scoped_token_delete_group_policy_is_noop(self):
+        org, _membership, su, token, auth = _scoped_setup()
+        group = baker.make(CalendarGroup, organization=org, name="Scoped Del G")
+        policy = create_booking_policy(calendar_group=group, lead_time_seconds=60)
+
+        resp = _post_graphql(
+            DELETE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"policyId": policy.id}},
+        )
+        data = resp.json()
+        # Idempotent: success returned, but the policy is NOT deleted.
+        assert data["data"]["deleteBookingPolicy"]["success"] is True
+        assert BookingPolicy.objects.filter_by_organization(org.id).filter(pk=policy.pk).exists()
+
+    def test_scoped_token_can_delete_own_calendar_policy(self):
+        org, membership, su, token, auth = _scoped_setup()
+        cal = _own_cal(org, membership, "scoped-del-own")
+        policy = create_booking_policy(calendar=cal)
+
+        resp = _post_graphql(
+            DELETE_BOOKING_POLICY_MUTATION,
+            su,
+            token,
+            auth,
+            {"input": {"policyId": policy.id}},
+        )
+        assert resp.json()["data"]["deleteBookingPolicy"]["success"] is True
+        assert (
+            not BookingPolicy.objects.filter_by_organization(org.id).filter(pk=policy.pk).exists()
+        )
+
+    # -- read scoping ------------------------------------------------------
+
+    def test_scoped_token_query_sees_only_own_policies(self):
+        org, membership, su, token, auth = _scoped_setup()
+        own_cal = _own_cal(org, membership, "scoped-q-own")
+        create_booking_policy(calendar=own_cal, lead_time_seconds=60)
+        create_booking_policy(
+            membership_user_id=membership.user_id, organization=org, lead_time_seconds=120
+        )
+        # Noise the scoped token must NOT see: group, org-default, another member's calendar.
+        group = baker.make(CalendarGroup, organization=org, name="Scoped Q G")
+        create_booking_policy(calendar_group=group, lead_time_seconds=30)
+        create_booking_policy(organization=org, is_organization_default=True, lead_time_seconds=15)
+        other_user = UserFactory().create_user()
+        other_membership = OrganizationMembership.objects.create(
+            user=other_user, organization=org, role=OrganizationRole.MEMBER, is_active=True
+        )
+        other_cal = _own_cal(org, other_membership, "scoped-q-other")
+        create_booking_policy(calendar=other_cal, lead_time_seconds=45)
+
+        resp = _post_graphql(BOOKING_POLICIES_QUERY, su, token, auth, {})
+        data = resp.json()
+        assert "errors" not in data, data.get("errors")
+        policies = data["data"]["bookingPolicies"]
+        assert len(policies) == 2
+        assert {p["leadTimeSeconds"] for p in policies} == {60, 120}
+
+    def test_org_wide_token_query_sees_all(self):
+        org, su, token, auth = _setup_org_and_token(integration_name="orgwide_q_bp")
+        cal = baker.make(Calendar, organization=org, external_id="orgwide-q")
+        create_booking_policy(calendar=cal, lead_time_seconds=60)
+        create_booking_policy(organization=org, is_organization_default=True, lead_time_seconds=15)
+
+        resp = _post_graphql(BOOKING_POLICIES_QUERY, su, token, auth, {})
+        data = resp.json()
+        assert "errors" not in data, data.get("errors")
+        assert len(data["data"]["bookingPolicies"]) == 2


### PR DESCRIPTION
Centralize booking-policy management authorization in a new BookingPolicyPermissionService. Both API surfaces delegate to one core decision — an acting membership_user_id + an is-privileged flag against the policy target:
- REST BookingPolicyPermission (member): privileged = membership.is_admin.
- public GraphQL (SystemUser token): privileged = org-wide token (scoped_to_membership_user_id is None); a membership-scoped token acts as that member.

Wire the service into the GraphQL create/update/delete mutations and scope the bookingPolicies query, closing the gap where a membership-scoped token could manage/read any org policy. Update/delete denials reuse the not-found message and delete treats an unmanageable policy as a no-op, so a scoped token cannot probe existence. Org-wide tokens are unchanged.

The REST permission is refactored to delegate to the same service (no behavior change).