### PR TITLE
feat(legal): add read-only policy document REST API

### DIFF
--- a/legal/filtersets.py
+++ b/legal/filtersets.py
@@ -1,0 +1,17 @@
+import django_filters
+
+from legal.models import PolicyDocument, PolicyDocumentType
+
+
+class PolicyDocumentFilterSet(django_filters.FilterSet):
+    """Optional ``document_type`` filter for the policy-document history endpoint."""
+
+    document_type = django_filters.ChoiceFilter(
+        field_name="document_type",
+        choices=PolicyDocumentType.choices,
+        label="Filter by document type",
+    )
+
+    class Meta:
+        model = PolicyDocument
+        fields = ("document_type",)

--- a/legal/routes.py
+++ b/legal/routes.py
@@ -1,0 +1,12 @@
+from common.types import RouteDict
+
+from .views import PolicyDocumentViewSet
+
+
+routes: list[RouteDict] = [
+    {
+        "regex": r"policy-documents",
+        "viewset": PolicyDocumentViewSet,
+        "basename": "PolicyDocuments",
+    },
+]

--- a/legal/serializers.py
+++ b/legal/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from legal.models import PolicyDocument
+
+
+class PolicyDocumentSerializer(serializers.ModelSerializer):
+    """Read-only representation of a published :class:`PolicyDocument` version.
+
+    Every field is read-only — this app exposes no write surface for policy
+    documents over the REST API; documents are authored in Django admin.
+    """
+
+    class Meta:
+        model = PolicyDocument
+        fields = ("id", "document_type", "version", "title", "body_markdown", "published_at")
+        read_only_fields = fields

--- a/legal/tests/test_policy_document_api.py
+++ b/legal/tests/test_policy_document_api.py
@@ -1,0 +1,161 @@
+"""Integration tests for the read-only PolicyDocument REST API (Phase 2).
+
+Covers:
+- ``latest`` (list): one row per document_type, at its highest version. Public.
+- ``latest_by_type`` (retrieve-by-type): highest version of a single type. Public.
+  404 on an unknown / empty type.
+- ``retrieve`` (by id): exact version by primary key. Authenticated.
+- ``list`` (history): full version history, newest-first per type, optional
+  ``?document_type=`` filter. Authenticated.
+- Auth split: public ``latest``/``latest_by_type`` reachable unauthenticated;
+  ``list``/``retrieve`` refuse unauthenticated callers with 401.
+"""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+
+from legal.factories import PolicyDocumentFactory
+from legal.models import PolicyDocumentType
+
+
+pytestmark = pytest.mark.django_db
+
+LATEST_LIST_URL = "api:PolicyDocuments-latest"
+LATEST_BY_TYPE_URL = "api:PolicyDocuments-latest-by-type"
+LIST_URL = "api:PolicyDocuments-list"
+DETAIL_URL = "api:PolicyDocuments-detail"
+
+
+def _latest_list_url() -> str:
+    return reverse(LATEST_LIST_URL)
+
+
+def _latest_by_type_url(document_type: str) -> str:
+    return reverse(LATEST_BY_TYPE_URL, kwargs={"document_type": document_type})
+
+
+def _list_url() -> str:
+    return reverse(LIST_URL)
+
+
+def _detail_url(pk: int) -> str:
+    return reverse(DETAIL_URL, args=[pk])
+
+
+class TestLatestList:
+    """GET /policy-documents/latest/ — one row per type, at its highest version."""
+
+    def test_returns_one_row_per_type_at_highest_version(self, anonymous_client):
+        factory = PolicyDocumentFactory()
+        factory.create(document_type=PolicyDocumentType.PRIVACY_POLICY, version=1)
+        latest_privacy = factory.create(document_type=PolicyDocumentType.PRIVACY_POLICY, version=2)
+        latest_terms = factory.create(document_type=PolicyDocumentType.TERMS_OF_USE, version=1)
+        factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+        latest_sms = factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=2)
+
+        response = anonymous_client.get(_latest_list_url())
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()
+        assert isinstance(results, list)
+        ids = {row["id"] for row in results}
+        assert ids == {latest_privacy.id, latest_terms.id, latest_sms.id}
+
+    def test_reachable_unauthenticated(self, anonymous_client):
+        response = anonymous_client.get(_latest_list_url())
+        assert response.status_code == status.HTTP_200_OK
+
+
+class TestLatestByType:
+    """GET /policy-documents/latest/{document_type}/ — highest version of one type."""
+
+    def test_returns_highest_version(self, anonymous_client):
+        factory = PolicyDocumentFactory()
+        factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+        latest_sms = factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=2)
+        factory.create(document_type=PolicyDocumentType.PRIVACY_POLICY, version=1)
+
+        response = anonymous_client.get(_latest_by_type_url(PolicyDocumentType.SMS_CONSENT))
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["id"] == latest_sms.id
+        assert data["version"] == 2
+        assert data["document_type"] == PolicyDocumentType.SMS_CONSENT
+
+    def test_unknown_type_returns_404(self, anonymous_client):
+        response = anonymous_client.get(_latest_by_type_url("not_a_real_type"))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_empty_type_returns_404(self, anonymous_client):
+        """A known enum value with zero published rows also 404s."""
+        response = anonymous_client.get(_latest_by_type_url(PolicyDocumentType.TERMS_OF_USE))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_reachable_unauthenticated(self, anonymous_client):
+        PolicyDocumentFactory().create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+        response = anonymous_client.get(_latest_by_type_url(PolicyDocumentType.SMS_CONSENT))
+        assert response.status_code == status.HTTP_200_OK
+
+
+class TestRetrieveById:
+    """GET /policy-documents/{id}/ — exact version by primary key. Authenticated."""
+
+    def test_returns_exact_version(self, auth_client):
+        factory = PolicyDocumentFactory()
+        factory.create(document_type=PolicyDocumentType.PRIVACY_POLICY, version=1)
+        v2 = factory.create(document_type=PolicyDocumentType.PRIVACY_POLICY, version=2)
+
+        response = auth_client.get(_detail_url(v2.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["id"] == v2.id
+        assert data["version"] == 2
+        assert data["title"] == v2.title
+        assert data["body_markdown"] == v2.body_markdown
+
+    def test_unauthenticated_returns_401(self, anonymous_client):
+        document = PolicyDocumentFactory().create(
+            document_type=PolicyDocumentType.PRIVACY_POLICY, version=1
+        )
+        response = anonymous_client.get(_detail_url(document.id))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestHistoryList:
+    """GET /policy-documents/ — full version history, newest first; optional filter."""
+
+    def test_returns_all_versions_newest_first(self, auth_client):
+        factory = PolicyDocumentFactory()
+        v1 = factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+        v2 = factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=2)
+        v3 = factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=3)
+
+        response = auth_client.get(_list_url())
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        results = data.get("results", data)
+        versions = [row["version"] for row in results]
+        assert versions == [3, 2, 1]
+        assert {row["id"] for row in results} == {v1.id, v2.id, v3.id}
+
+    def test_document_type_filter(self, auth_client):
+        factory = PolicyDocumentFactory()
+        sms = factory.create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+        factory.create(document_type=PolicyDocumentType.PRIVACY_POLICY, version=1)
+
+        response = auth_client.get(_list_url(), {"document_type": PolicyDocumentType.SMS_CONSENT})
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        results = data.get("results", data)
+        assert len(results) == 1
+        assert results[0]["id"] == sms.id
+
+    def test_unauthenticated_returns_401(self, anonymous_client):
+        response = anonymous_client.get(_list_url())
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/legal/tests/test_policy_document_api.py
+++ b/legal/tests/test_policy_document_api.py
@@ -159,3 +159,7 @@ class TestHistoryList:
     def test_unauthenticated_returns_401(self, anonymous_client):
         response = anonymous_client.get(_list_url())
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_invalid_document_type_filter_returns_400(self, auth_client):
+        response = auth_client.get(_list_url(), {"document_type": "not_a_real_type"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/legal/views.py
+++ b/legal/views.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
@@ -8,6 +10,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from legal.filtersets import PolicyDocumentFilterSet
 from legal.models import PolicyDocument, PolicyDocumentType
+from legal.querysets import PolicyDocumentQuerySet
 from legal.serializers import PolicyDocumentSerializer
 
 
@@ -56,7 +59,7 @@ class PolicyDocumentViewSet(ReadOnlyModelViewSet):
 
         Public — no authentication required.
         """
-        queryset = PolicyDocument.objects.latest_per_type()
+        queryset = self.get_queryset().latest_per_type()
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -86,7 +89,8 @@ class PolicyDocumentViewSet(ReadOnlyModelViewSet):
         if document_type not in valid_types:
             raise NotFound(detail=f"Unknown document_type '{document_type}'.")
 
-        document = PolicyDocument.objects.latest_for(document_type)
+        queryset = cast(PolicyDocumentQuerySet, self.get_queryset())
+        document = queryset.of_type(document_type).order_by("-version").first()
         if document is None:
             raise NotFound(detail=f"No published document of type '{document_type}'.")
 

--- a/legal/views.py
+++ b/legal/views.py
@@ -1,0 +1,94 @@
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from legal.filtersets import PolicyDocumentFilterSet
+from legal.models import PolicyDocument, PolicyDocumentType
+from legal.serializers import PolicyDocumentSerializer
+
+
+@extend_schema(tags=["Legal"])
+class PolicyDocumentViewSet(ReadOnlyModelViewSet):
+    """Read-only REST surface for policy documents.
+
+    ``PolicyDocument`` is a global, non-tenant-scoped model (privacy policy,
+    terms of use, SMS-messaging consent). This viewset intentionally does not
+    build on the ``*VintaScheduleModelViewSet`` family: those bases mix in
+    ``TenantScopedViewMixin`` (irrelevant — no organization here) and
+    ``GenericVirtualModelViewMixin`` (requires a ``VirtualModelSerializer``
+    with a ``virtual_model``, which this flat, no-N+1 serializer doesn't need).
+    A plain DRF ``ReadOnlyModelViewSet`` mirrors the existing precedent in
+    ``organizations.views.ServiceAccountViewSet`` for this shape.
+
+    Auth split (per the plan's Open Questions):
+    - ``latest`` / ``latest_by_type`` are **public** (``AllowAny``) — the
+      frontend must be able to render policy text before a session exists
+      (mid-signup, pre-OAuth-completion).
+    - ``list`` (full history) / ``retrieve`` (by id) require authentication —
+      these expose the full version history rather than just the
+      currently-relevant text, so they stay behind the default auth gate.
+
+    No write surface is exposed anywhere on this viewset.
+    """
+
+    queryset = PolicyDocument.objects.all()
+    serializer_class = PolicyDocumentSerializer
+    permission_classes = (IsAuthenticated,)
+    filterset_class = PolicyDocumentFilterSet
+    http_method_names = ("get", "head", "options")
+
+    def get_permissions(self):
+        if self.action in ("latest", "latest_by_type"):
+            return [AllowAny()]
+        return super().get_permissions()
+
+    @extend_schema(
+        summary="List the latest published version of each policy document type",
+        responses={200: PolicyDocumentSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"], url_path="latest", pagination_class=None)
+    def latest(self, request):
+        """GET /policy-documents/latest/ — one row per document_type (highest version).
+
+        Public — no authentication required.
+        """
+        queryset = PolicyDocument.objects.latest_per_type()
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Retrieve the latest published version of a single document type",
+        parameters=[
+            OpenApiParameter(
+                name="document_type",
+                location=OpenApiParameter.PATH,
+                type=str,
+                description="One of PolicyDocumentType's values (e.g. sms_consent).",
+            ),
+        ],
+        responses={
+            200: PolicyDocumentSerializer,
+            404: OpenApiResponse(description="Unknown document_type, or no published version yet"),
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="latest/<str:document_type>")
+    def latest_by_type(self, request, document_type: str | None = None):
+        """GET /policy-documents/latest/{document_type}/ — highest version of one type.
+
+        Public — no authentication required. 404s on an unknown enum value or a
+        type with no published rows yet.
+        """
+        valid_types = set(PolicyDocumentType.values)
+        if document_type not in valid_types:
+            raise NotFound(detail=f"Unknown document_type '{document_type}'.")
+
+        document = PolicyDocument.objects.latest_for(document_type)
+        if document is None:
+            raise NotFound(detail=f"No published document of type '{document_type}'.")
+
+        serializer = self.get_serializer(document)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/schema.yml
+++ b/schema.yml
@@ -9591,6 +9591,382 @@ paths:
               schema:
                 description: Subscription payment update received.
           description: ''
+  /policy-documents/:
+    get:
+      operationId: policy_documents_list
+      description: |-
+        Read-only REST surface for policy documents.
+
+        ``PolicyDocument`` is a global, non-tenant-scoped model (privacy policy,
+        terms of use, SMS-messaging consent). This viewset intentionally does not
+        build on the ``*VintaScheduleModelViewSet`` family: those bases mix in
+        ``TenantScopedViewMixin`` (irrelevant — no organization here) and
+        ``GenericVirtualModelViewMixin`` (requires a ``VirtualModelSerializer``
+        with a ``virtual_model``, which this flat, no-N+1 serializer doesn't need).
+        A plain DRF ``ReadOnlyModelViewSet`` mirrors the existing precedent in
+        ``organizations.views.ServiceAccountViewSet`` for this shape.
+
+        Auth split (per the plan's Open Questions):
+        - ``latest`` / ``latest_by_type`` are **public** (``AllowAny``) — the
+          frontend must be able to render policy text before a session exists
+          (mid-signup, pre-OAuth-completion).
+        - ``list`` (full history) / ``retrieve`` (by id) require authentication —
+          these expose the full version history rather than just the
+          currently-relevant text, so they stay behind the default auth gate.
+
+        No write surface is exposed anywhere on this viewset.
+      parameters:
+      - in: query
+        name: document_type
+        schema:
+          type: string
+          enum:
+          - privacy_policy
+          - sms_consent
+          - terms_of_use
+        description: |-
+          Filter by document type
+
+          * `privacy_policy` - Privacy Policy
+          * `terms_of_use` - Terms of Use
+          * `sms_consent` - SMS Messaging Consent
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPolicyDocumentList'
+          description: ''
+  /policy-documents{format}:
+    get:
+      operationId: policy_documents_formatted_list
+      description: |-
+        Read-only REST surface for policy documents.
+
+        ``PolicyDocument`` is a global, non-tenant-scoped model (privacy policy,
+        terms of use, SMS-messaging consent). This viewset intentionally does not
+        build on the ``*VintaScheduleModelViewSet`` family: those bases mix in
+        ``TenantScopedViewMixin`` (irrelevant — no organization here) and
+        ``GenericVirtualModelViewMixin`` (requires a ``VirtualModelSerializer``
+        with a ``virtual_model``, which this flat, no-N+1 serializer doesn't need).
+        A plain DRF ``ReadOnlyModelViewSet`` mirrors the existing precedent in
+        ``organizations.views.ServiceAccountViewSet`` for this shape.
+
+        Auth split (per the plan's Open Questions):
+        - ``latest`` / ``latest_by_type`` are **public** (``AllowAny``) — the
+          frontend must be able to render policy text before a session exists
+          (mid-signup, pre-OAuth-completion).
+        - ``list`` (full history) / ``retrieve`` (by id) require authentication —
+          these expose the full version history rather than just the
+          currently-relevant text, so they stay behind the default auth gate.
+
+        No write surface is exposed anywhere on this viewset.
+      parameters:
+      - in: query
+        name: document_type
+        schema:
+          type: string
+          enum:
+          - privacy_policy
+          - sms_consent
+          - terms_of_use
+        description: |-
+          Filter by document type
+
+          * `privacy_policy` - Privacy Policy
+          * `terms_of_use` - Terms of Use
+          * `sms_consent` - SMS Messaging Consent
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPolicyDocumentList'
+          description: ''
+  /policy-documents/{id}/:
+    get:
+      operationId: policy_documents_retrieve
+      description: |-
+        Read-only REST surface for policy documents.
+
+        ``PolicyDocument`` is a global, non-tenant-scoped model (privacy policy,
+        terms of use, SMS-messaging consent). This viewset intentionally does not
+        build on the ``*VintaScheduleModelViewSet`` family: those bases mix in
+        ``TenantScopedViewMixin`` (irrelevant — no organization here) and
+        ``GenericVirtualModelViewMixin`` (requires a ``VirtualModelSerializer``
+        with a ``virtual_model``, which this flat, no-N+1 serializer doesn't need).
+        A plain DRF ``ReadOnlyModelViewSet`` mirrors the existing precedent in
+        ``organizations.views.ServiceAccountViewSet`` for this shape.
+
+        Auth split (per the plan's Open Questions):
+        - ``latest`` / ``latest_by_type`` are **public** (``AllowAny``) — the
+          frontend must be able to render policy text before a session exists
+          (mid-signup, pre-OAuth-completion).
+        - ``list`` (full history) / ``retrieve`` (by id) require authentication —
+          these expose the full version history rather than just the
+          currently-relevant text, so they stay behind the default auth gate.
+
+        No write surface is exposed anywhere on this viewset.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDocument'
+          description: ''
+  /policy-documents/{id}{format}:
+    get:
+      operationId: policy_documents_formatted_retrieve
+      description: |-
+        Read-only REST surface for policy documents.
+
+        ``PolicyDocument`` is a global, non-tenant-scoped model (privacy policy,
+        terms of use, SMS-messaging consent). This viewset intentionally does not
+        build on the ``*VintaScheduleModelViewSet`` family: those bases mix in
+        ``TenantScopedViewMixin`` (irrelevant — no organization here) and
+        ``GenericVirtualModelViewMixin`` (requires a ``VirtualModelSerializer``
+        with a ``virtual_model``, which this flat, no-N+1 serializer doesn't need).
+        A plain DRF ``ReadOnlyModelViewSet`` mirrors the existing precedent in
+        ``organizations.views.ServiceAccountViewSet`` for this shape.
+
+        Auth split (per the plan's Open Questions):
+        - ``latest`` / ``latest_by_type`` are **public** (``AllowAny``) — the
+          frontend must be able to render policy text before a session exists
+          (mid-signup, pre-OAuth-completion).
+        - ``list`` (full history) / ``retrieve`` (by id) require authentication —
+          these expose the full version history rather than just the
+          currently-relevant text, so they stay behind the default auth gate.
+
+        No write surface is exposed anywhere on this viewset.
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDocument'
+          description: ''
+  /policy-documents/latest/:
+    get:
+      operationId: policy_documents_latest_list
+      description: |-
+        GET /policy-documents/latest/ — one row per document_type (highest version).
+
+        Public — no authentication required.
+      summary: List the latest published version of each policy document type
+      parameters:
+      - in: query
+        name: document_type
+        schema:
+          type: string
+          enum:
+          - privacy_policy
+          - sms_consent
+          - terms_of_use
+        description: |-
+          Filter by document type
+
+          * `privacy_policy` - Privacy Policy
+          * `terms_of_use` - Terms of Use
+          * `sms_consent` - SMS Messaging Consent
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyDocument'
+          description: ''
+  /policy-documents/latest{format}:
+    get:
+      operationId: policy_documents_latest_formatted_list
+      description: |-
+        GET /policy-documents/latest/ — one row per document_type (highest version).
+
+        Public — no authentication required.
+      summary: List the latest published version of each policy document type
+      parameters:
+      - in: query
+        name: document_type
+        schema:
+          type: string
+          enum:
+          - privacy_policy
+          - sms_consent
+          - terms_of_use
+        description: |-
+          Filter by document type
+
+          * `privacy_policy` - Privacy Policy
+          * `terms_of_use` - Terms of Use
+          * `sms_consent` - SMS Messaging Consent
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyDocument'
+          description: ''
+  /policy-documents/latest/{document_type}/:
+    get:
+      operationId: policy_documents_latest_retrieve
+      description: |-
+        GET /policy-documents/latest/{document_type}/ — highest version of one type.
+
+        Public — no authentication required. 404s on an unknown enum value or a
+        type with no published rows yet.
+      summary: Retrieve the latest published version of a single document type
+      parameters:
+      - in: path
+        name: document_type
+        schema:
+          type: string
+        description: One of PolicyDocumentType's values (e.g. sms_consent).
+        required: true
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDocument'
+          description: ''
+        '404':
+          description: Unknown document_type, or no published version yet
+  /policy-documents/latest/{document_type}{format}:
+    get:
+      operationId: policy_documents_latest_formatted_retrieve
+      description: |-
+        GET /policy-documents/latest/{document_type}/ — highest version of one type.
+
+        Public — no authentication required. 404s on an unknown enum value or a
+        type with no published rows yet.
+      summary: Retrieve the latest published version of a single document type
+      parameters:
+      - in: path
+        name: document_type
+        schema:
+          type: string
+        description: One of PolicyDocumentType's values (e.g. sms_consent).
+        required: true
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - Legal
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDocument'
+          description: ''
+        '404':
+          description: Unknown document_type, or no published version yet
   /profile/{user}/:
     get:
       operationId: profile_retrieve
@@ -12916,6 +13292,16 @@ components:
       required:
       - organization
       - role
+    DocumentTypeEnum:
+      enum:
+      - privacy_policy
+      - terms_of_use
+      - sms_consent
+      type: string
+      description: |-
+        * `privacy_policy` - Privacy Policy
+        * `terms_of_use` - Terms of Use
+        * `sms_consent` - SMS Messaging Consent
     EventAttendance:
       type: object
       properties:
@@ -13767,6 +14153,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OrganizationMembership'
+    PaginatedPolicyDocumentList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyDocument'
     PaginatedServiceAccountReadList:
       type: object
       required:
@@ -14443,6 +14852,43 @@ components:
           format: uri
           maxLength: 2000
         headers: {}
+    PolicyDocument:
+      type: object
+      description: |-
+        Read-only representation of a published :class:`PolicyDocument` version.
+
+        Every field is read-only — this app exposes no write surface for policy
+        documents over the REST API; documents are authored in Django admin.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        document_type:
+          allOf:
+          - $ref: '#/components/schemas/DocumentTypeEnum'
+          readOnly: true
+        version:
+          type: integer
+          readOnly: true
+          description: Monotonically increasing per document_type.
+        title:
+          type: string
+          readOnly: true
+        body_markdown:
+          type: string
+          readOnly: true
+          description: Raw markdown body, rendered client-side.
+        published_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - body_markdown
+      - document_type
+      - id
+      - published_at
+      - title
+      - version
     Profile:
       type: object
       properties:

--- a/vinta_schedule_api/urls.py
+++ b/vinta_schedule_api/urls.py
@@ -13,6 +13,7 @@ from rest_framework.routers import DefaultRouter
 from strawberry.django.views import GraphQLView
 
 from calendar_integration.routes import routes as calendar_integration_routes
+from legal.routes import routes as legal_routes
 from notifications.routes import routes as notifications_routes
 from organizations.routes import extra_patterns as organizations_extra_patterns
 from organizations.routes import routes as organizations_routes
@@ -28,6 +29,7 @@ router = DefaultRouter(use_regex_path=False)
 
 routes = (
     *calendar_integration_routes,
+    *legal_routes,
     *notifications_routes,
     *organizations_routes,
     *payments_routes,


### PR DESCRIPTION
## Summary
Phase 2 of the **SMS MFA Consent** plan (stacked on Phase 1 / PR #177). Exposes the `PolicyDocument` versions from Phase 1 over four read-only GET endpoints so the frontend can render policy text at the consent step:

- `GET /policy-documents/latest/` — **public**, one latest published version per `document_type`.
- `GET /policy-documents/latest/{document_type}/` — **public**, latest version of one type; 404 on unknown enum value or a type with no published rows.
- `GET /policy-documents/{id}/` — **authenticated**, exact version by pk.
- `GET /policy-documents/` — **authenticated**, full version history (newest-first per type) with optional `?document_type=` filter.

The two `latest` endpoints are public because the frontend must render policy text before a session exists (mid-signup / pre-OAuth-completion, resolving the plan's **Open Questions** on doc-read auth); the full-history + by-id endpoints stay behind auth. No write surface is exposed anywhere (`http_method_names = ("get","head","options")`, fully read-only serializer).

Built on a plain DRF `ReadOnlyModelViewSet` rather than the `*VintaScheduleModelViewSet` base — that family mixes in tenant scoping (irrelevant; `PolicyDocument` is global) and a virtual-model requirement this flat 5-field serializer doesn't need. Mirrors the existing `organizations.views.ServiceAccountViewSet` precedent.

## Plan reference
`ai-plans/2026-07-03-SMS_MFA_CONSENT_IMPLEMENTATION_PLAN.md` — **Phase 2** (stacked on Phase 1). No feature flag. No migrations. `schema.yml` regenerated (drf-spectacular).

## Test plan
- `docker compose run --rm api uv run pytest legal/tests/test_policy_document_api.py -n auto` — latest-list one-per-type, latest-by-type highest version, by-id exact, history newest-first + `?document_type=` filter, unknown type → 404, invalid filter value → 400, and the auth split (401 on history/by-id unauth, 200 on public `latest`).
- Outer gate: `check --deploy` clean; `makemigrations --check` clean; schema byte-identical to a fresh `spectacular` run; full `pytest -n auto` → **3549 passed**.

Note (follow-up, not in this PR): the two public endpoints have no rate-limit — deliberately, since the repo has no `throttle_classes` precedent to follow; content is non-secret and static-ish. Worth revisiting if we add a project-wide anon-throttle policy.