### PR TITLE
feat(accounts,legal): capture policy consent in email + OAuth signup

### DIFF
--- a/accounts/base_forms.py
+++ b/accounts/base_forms.py
@@ -1,17 +1,46 @@
+import logging
+
 from django import forms
 from django.utils import timezone
 
+from legal.exceptions import NoPolicyDocumentError
+from legal.models import ConsentSource, PolicyDocumentType
+from legal.services import ConsentService
 from organizations.models import OrganizationInvitation
 from users.models import Profile
+
+
+logger = logging.getLogger(__name__)
+
+
+def _client_ip_from_request(request: object) -> str | None:
+    """Extract the client IP address from a Django request for audit logging.
+
+    Prefers the first entry of ``X-Forwarded-For`` (set by load balancers /
+    proxies); falls back to ``REMOTE_ADDR``. Robust to a missing/``None``
+    request (allauth's ``signup()`` hook is invoked with ``request=None`` in
+    some tests) — returns ``None`` rather than raising.
+    """
+    meta = getattr(request, "META", {})
+    forwarded_for = meta.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return meta.get("REMOTE_ADDR") or None
+
+
+def _user_agent_from_request(request: object) -> str:
+    """Extract the client User-Agent header. Robust to a missing/``None`` request."""
+    return getattr(request, "META", {}).get("HTTP_USER_AGENT", "")
 
 
 class BaseVintaScheduleSignupForm(forms.Form):
     """
     Base form for user signup.
 
-    Captures first_name, last_name, and an optional organization_name. At
-    signup time, the intended org name is persisted on Profile.pending_organization_name
-    so it can be consumed during email-confirmation provisioning (Phase 3).
+    Captures first_name, last_name, an optional organization_name, and a
+    required policy-acceptance acknowledgement. At signup time, the intended
+    org name is persisted on Profile.pending_organization_name so it can be
+    consumed during email-confirmation provisioning (Phase 3).
 
     When a non-expired, unaccepted OrganizationInvitation exists for the
     signup email, the org name is left blank — the user will auto-join the
@@ -25,6 +54,16 @@ class BaseVintaScheduleSignupForm(forms.Form):
         required=False,
         label="Organization Name",
     )
+    accepted_policies = forms.BooleanField(
+        required=True,
+        label="I agree to the Privacy Policy, Terms of Use, and SMS messaging consent.",
+        error_messages={
+            "required": (
+                "You must accept the Privacy Policy, Terms of Use, and SMS messaging "
+                "consent to create an account."
+            ),
+        },
+    )
 
     def _has_pending_invitation(self, email: str) -> bool:
         """Return True if a non-expired, unaccepted invitation exists for *email*."""
@@ -35,16 +74,53 @@ class BaseVintaScheduleSignupForm(forms.Form):
             membership__isnull=True,
         ).exists()
 
+    def _record_signup_consents(self, request, user) -> None:
+        """Record acceptance of every published policy document type.
+
+        Consent is captured for all three ``PolicyDocumentType`` values at
+        signup (privacy policy, terms of use, SMS consent) — only
+        ``SMS_CONSENT`` gates SMS sending (Phase 5), but recording the other
+        two is captured for completeness per the plan's Open Questions.
+
+        A document type with no published version yet raises
+        ``NoPolicyDocumentError``; that is logged and swallowed per document
+        type so signup still succeeds — the SMS gate independently fails
+        closed if no ``SMS_CONSENT`` record exists.
+        """
+        consent_service = ConsentService()
+        client_ip = _client_ip_from_request(request)
+        user_agent = _user_agent_from_request(request)
+
+        for document_type in PolicyDocumentType.values:
+            try:
+                consent_service.record_consent(
+                    user,
+                    document_type,
+                    source=ConsentSource.SIGNUP_FORM,
+                    ip=client_ip,
+                    user_agent=user_agent,
+                )
+            except NoPolicyDocumentError:
+                logger.warning(
+                    "Skipping signup consent capture for document_type=%s, user=%s: "
+                    "no published PolicyDocument exists yet.",
+                    document_type,
+                    user.pk,
+                )
+
     def signup(self, request, user):
         """
         Persist first_name, last_name, and (conditionally) organization_name on
-        the user's Profile.
+        the user's Profile, and record acceptance of the published policy
+        documents (privacy policy, terms of use, SMS consent).
 
         organization_name is stored only when no pending invitation matches the
         signup email.  Invited users will auto-join an existing org at
         email-confirmation time; they must not accidentally trigger org creation.
         """
         user.save()
+
+        self._record_signup_consents(request, user)
 
         first_name = self.cleaned_data.get("first_name", "")
         last_name = self.cleaned_data.get("last_name", "")

--- a/accounts/base_forms.py
+++ b/accounts/base_forms.py
@@ -1,8 +1,12 @@
 import logging
+from typing import Annotated
 
 from django import forms
 from django.utils import timezone
 
+from dependency_injector.wiring import Provide, inject
+
+from common.utils.request_utils import client_ip_from_request, user_agent_from_request
 from legal.exceptions import NoPolicyDocumentError
 from legal.models import ConsentSource, PolicyDocumentType
 from legal.services import ConsentService
@@ -11,26 +15,6 @@ from users.models import Profile
 
 
 logger = logging.getLogger(__name__)
-
-
-def _client_ip_from_request(request: object) -> str | None:
-    """Extract the client IP address from a Django request for audit logging.
-
-    Prefers the first entry of ``X-Forwarded-For`` (set by load balancers /
-    proxies); falls back to ``REMOTE_ADDR``. Robust to a missing/``None``
-    request (allauth's ``signup()`` hook is invoked with ``request=None`` in
-    some tests) — returns ``None`` rather than raising.
-    """
-    meta = getattr(request, "META", {})
-    forwarded_for = meta.get("HTTP_X_FORWARDED_FOR", "")
-    if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
-    return meta.get("REMOTE_ADDR") or None
-
-
-def _user_agent_from_request(request: object) -> str:
-    """Extract the client User-Agent header. Robust to a missing/``None`` request."""
-    return getattr(request, "META", {}).get("HTTP_USER_AGENT", "")
 
 
 class BaseVintaScheduleSignupForm(forms.Form):
@@ -74,7 +58,7 @@ class BaseVintaScheduleSignupForm(forms.Form):
             membership__isnull=True,
         ).exists()
 
-    def _record_signup_consents(self, request, user) -> None:
+    def _record_signup_consents(self, request, user, consent_service: ConsentService) -> None:
         """Record acceptance of every published policy document type.
 
         Consent is captured for all three ``PolicyDocumentType`` values at
@@ -87,9 +71,8 @@ class BaseVintaScheduleSignupForm(forms.Form):
         type so signup still succeeds — the SMS gate independently fails
         closed if no ``SMS_CONSENT`` record exists.
         """
-        consent_service = ConsentService()
-        client_ip = _client_ip_from_request(request)
-        user_agent = _user_agent_from_request(request)
+        client_ip = client_ip_from_request(request)
+        user_agent = user_agent_from_request(request)
 
         for document_type in PolicyDocumentType.values:
             try:
@@ -108,7 +91,13 @@ class BaseVintaScheduleSignupForm(forms.Form):
                     user.pk,
                 )
 
-    def signup(self, request, user):
+    @inject
+    def signup(
+        self,
+        request,
+        user,
+        consent_service: Annotated[ConsentService, Provide["consent_service"]] = None,  # type: ignore[assignment]
+    ):
         """
         Persist first_name, last_name, and (conditionally) organization_name on
         the user's Profile, and record acceptance of the published policy
@@ -117,10 +106,16 @@ class BaseVintaScheduleSignupForm(forms.Form):
         organization_name is stored only when no pending invitation matches the
         signup email.  Invited users will auto-join an existing org at
         email-confirmation time; they must not accidentally trigger org creation.
+
+        ``consent_service`` is DI-injected (mirrors ``AccountAdapter`` /
+        ``CalendarViewSet``'s per-method ``@inject``). It carries a
+        ``Provide`` default rather than being required so allauth's
+        positional call ``self.signup(request, user)`` (see
+        ``allauth.account.forms``) keeps working unchanged.
         """
         user.save()
 
-        self._record_signup_consents(request, user)
+        self._record_signup_consents(request, user, consent_service)
 
         first_name = self.cleaned_data.get("first_name", "")
         last_name = self.cleaned_data.get("last_name", "")

--- a/accounts/tests/test_base_forms.py
+++ b/accounts/tests/test_base_forms.py
@@ -31,6 +31,7 @@ def _make_form(
         "first_name": first_name,
         "last_name": last_name,
         "organization_name": organization_name,
+        "accepted_policies": True,
     }
     form = BaseVintaScheduleSignupForm(data=data)
     assert form.is_valid(), form.errors

--- a/accounts/tests/test_email_invite_autojoin.py
+++ b/accounts/tests/test_email_invite_autojoin.py
@@ -117,6 +117,7 @@ class TestInvitedEmailAutoJoin:
             "first_name": "New",
             "last_name": "User",
             "organization_name": "",  # invited user wouldn't submit a name
+            "accepted_policies": True,
         }
         form = BaseVintaScheduleSignupForm(data=form_data)
         assert form.is_valid(), form.errors

--- a/accounts/tests/test_signup_consent.py
+++ b/accounts/tests/test_signup_consent.py
@@ -1,0 +1,133 @@
+"""
+Tests for consent capture in the email/password signup form (Phase 4).
+
+Covers:
+- Completing the signup form with `accepted_policies=True` records a
+  version-pinned SMS_CONSENT UserConsent with source=SIGNUP_FORM, capturing
+  the request's client IP + User-Agent.
+- Consent is recorded for all three PolicyDocumentType values when published.
+- Missing / false `accepted_policies` -> form invalid, signup never runs.
+- A document type with no published version yet is guarded (logged, not
+  raised) -- signup still succeeds.
+"""
+
+import pytest
+
+from accounts.base_forms import BaseVintaScheduleSignupForm
+from legal.factories import PolicyDocumentFactory
+from legal.models import ConsentSource, PolicyDocumentType, UserConsent
+from users.factories import UserFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _signup_form_data(**overrides):
+    data = {
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "organization_name": "ACME Corp",
+        "accepted_policies": True,
+    }
+    data.update(overrides)
+    return data
+
+
+class TestEmailSignupRecordsConsent:
+    """Integration: BaseVintaScheduleSignupForm.signup() records consent."""
+
+    def test_records_version_pinned_sms_consent_with_ip_and_user_agent(self, rf):
+        PolicyDocumentFactory().create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+        latest_sms = PolicyDocumentFactory().create(
+            document_type=PolicyDocumentType.SMS_CONSENT, version=2
+        )
+        user = UserFactory().create_user(email="consent-sms@example.com")
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data())
+        assert form.is_valid(), form.errors
+        request = rf.post("/", REMOTE_ADDR="203.0.113.9", HTTP_USER_AGENT="pytest-agent/1.0")
+
+        form.signup(request=request, user=user)
+
+        consent = UserConsent.objects.get(
+            user=user, policy_document__document_type=PolicyDocumentType.SMS_CONSENT
+        )
+        assert consent.policy_document == latest_sms
+        assert consent.policy_document.version == 2
+        assert consent.source == ConsentSource.SIGNUP_FORM
+        assert consent.ip_address == "203.0.113.9"
+        assert consent.user_agent == "pytest-agent/1.0"
+
+    def test_records_consent_for_all_three_document_types_when_published(self):
+        for document_type in PolicyDocumentType.values:
+            PolicyDocumentFactory().create(document_type=document_type, version=1)
+        user = UserFactory().create_user(email="consent-all@example.com")
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data())
+        assert form.is_valid(), form.errors
+
+        form.signup(request=None, user=user)
+
+        recorded_types = set(
+            UserConsent.objects.filter(user=user).values_list(
+                "policy_document__document_type", flat=True
+            )
+        )
+        assert recorded_types == set(PolicyDocumentType.values)
+        assert all(
+            consent.source == ConsentSource.SIGNUP_FORM
+            for consent in UserConsent.objects.filter(user=user)
+        )
+
+    def test_signup_succeeds_when_non_sms_document_type_unpublished(self):
+        """Only SMS_CONSENT is published; PRIVACY_POLICY / TERMS_OF_USE are not.
+
+        Signup must still succeed -- the missing-document guard swallows
+        NoPolicyDocumentError for the unpublished types, logging instead of
+        raising.
+        """
+        PolicyDocumentFactory().create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+        user = UserFactory().create_user(email="consent-partial@example.com")
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data())
+        assert form.is_valid(), form.errors
+
+        returned_user = form.signup(request=None, user=user)
+
+        assert returned_user == user
+        assert UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.SMS_CONSENT
+        ).exists()
+        assert not UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.PRIVACY_POLICY
+        ).exists()
+        assert not UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.TERMS_OF_USE
+        ).exists()
+
+    def test_signup_succeeds_when_no_policy_documents_published_at_all(self):
+        """No PolicyDocument exists anywhere -- every record_consent call is guarded."""
+        user = UserFactory().create_user(email="consent-none@example.com")
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data())
+        assert form.is_valid(), form.errors
+
+        returned_user = form.signup(request=None, user=user)
+
+        assert returned_user == user
+        assert not UserConsent.objects.filter(user=user).exists()
+
+
+class TestAcceptedPoliciesRequired:
+    """`accepted_policies` is a required, must-be-True acknowledgement field."""
+
+    def test_missing_acceptance_makes_form_invalid(self):
+        data = _signup_form_data()
+        del data["accepted_policies"]
+
+        form = BaseVintaScheduleSignupForm(data=data)
+
+        assert not form.is_valid()
+        assert "accepted_policies" in form.errors
+
+    def test_false_acceptance_makes_form_invalid(self):
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data(accepted_policies=False))
+
+        assert not form.is_valid()
+        assert "accepted_policies" in form.errors

--- a/accounts/tests/test_signup_consent_headless.py
+++ b/accounts/tests/test_signup_consent_headless.py
@@ -1,0 +1,82 @@
+"""
+Phase 4 — HTTP-level test: consent capture through the real headless signup
+endpoint (`POST /auth/{client}/v1/auth/signup`).
+
+``HEADLESS_ONLY = True`` (see ``vinta_schedule_api/settings/base.py``), so the
+headless endpoint -- not a direct call to
+``BaseVintaScheduleSignupForm.signup()`` -- is the only production
+email/password signup surface. The form-level tests in
+``test_signup_consent.py`` cover the consent-capture behavior in detail; this
+file proves the same behavior fires end-to-end through the real HTTP request
+allauth-headless routes to ``form.signup(request, user)``.
+"""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from legal.factories import PolicyDocumentFactory
+from legal.models import ConsentSource, PolicyDocumentType, UserConsent
+from users.models import User
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _signup_payload(**overrides):
+    data = {
+        "email": "headless-signup@example.com",
+        "phone": "+123456789",
+        "password1": "Sup3r-Secret-Passw0rd!",
+        "password2": "Sup3r-Secret-Passw0rd!",
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "accepted_policies": True,
+    }
+    data.update(overrides)
+    return data
+
+
+class TestHeadlessSignupRecordsConsent:
+    """POST /auth/app/v1/auth/signup with accepted_policies=True records consent."""
+
+    def test_accepted_policies_true_creates_user_and_sms_consent(self):
+        for document_type in PolicyDocumentType.values:
+            PolicyDocumentFactory().create(document_type=document_type, version=1)
+
+        client = APIClient()
+        url = reverse("headless:app:account:signup")
+
+        response = client.post(url, _signup_payload(), format="json")
+
+        # Email verification is mandatory, so a fresh signup responds 401
+        # (pending email verification) rather than 200 -- the account itself
+        # is created regardless.
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
+
+        user = User.objects.get(email="headless-signup@example.com")
+        consent = UserConsent.objects.get(
+            user=user, policy_document__document_type=PolicyDocumentType.SMS_CONSENT
+        )
+        assert consent.source == ConsentSource.SIGNUP_FORM
+
+    def test_missing_accepted_policies_rejects_signup(self):
+        for document_type in PolicyDocumentType.values:
+            PolicyDocumentFactory().create(document_type=document_type, version=1)
+
+        client = APIClient()
+        url = reverse("headless:app:account:signup")
+
+        response = client.post(
+            url,
+            _signup_payload(email="headless-no-consent@example.com", accepted_policies=False),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert not User.objects.filter(email="headless-no-consent@example.com").exists()
+        assert not UserConsent.objects.filter(
+            user__email="headless-no-consent@example.com"
+        ).exists()

--- a/common/utils/request_utils.py
+++ b/common/utils/request_utils.py
@@ -1,0 +1,19 @@
+def client_ip_from_request(request: object) -> str | None:
+    """Extract the client IP address from a Django/DRF request for audit logging.
+
+    Prefers the first entry of ``X-Forwarded-For`` (set by load balancers /
+    proxies); falls back to ``REMOTE_ADDR``. Robust to a missing/``None``
+    request (e.g. allauth's ``signup()`` hook can be invoked with
+    ``request=None`` in some tests) -- returns ``None`` rather than raising,
+    since fields such as ``UserConsent.ip_address`` are nullable.
+    """
+    meta = getattr(request, "META", {})
+    forwarded_for = meta.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return meta.get("REMOTE_ADDR") or None
+
+
+def user_agent_from_request(request: object) -> str:
+    """Extract the client User-Agent header. Robust to a missing/``None`` request."""
+    return getattr(request, "META", {}).get("HTTP_USER_AGENT", "")

--- a/legal/routes.py
+++ b/legal/routes.py
@@ -1,6 +1,6 @@
 from common.types import RouteDict
 
-from .views import PolicyDocumentViewSet
+from .views import ConsentViewSet, PolicyDocumentViewSet
 
 
 routes: list[RouteDict] = [
@@ -8,5 +8,10 @@ routes: list[RouteDict] = [
         "regex": r"policy-documents",
         "viewset": PolicyDocumentViewSet,
         "basename": "PolicyDocuments",
+    },
+    {
+        "regex": r"consents",
+        "viewset": ConsentViewSet,
+        "basename": "Consents",
     },
 ]

--- a/legal/serializers.py
+++ b/legal/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from legal.models import PolicyDocument
+from legal.models import PolicyDocument, PolicyDocumentType, UserConsent
 
 
 class PolicyDocumentSerializer(serializers.ModelSerializer):
@@ -14,3 +14,41 @@ class PolicyDocumentSerializer(serializers.ModelSerializer):
         model = PolicyDocument
         fields = ("id", "document_type", "version", "title", "body_markdown", "published_at")
         read_only_fields = fields
+
+
+class UserConsentSerializer(serializers.ModelSerializer):
+    """Read-only representation of a recorded :class:`UserConsent`.
+
+    Returned by ``ConsentViewSet.create`` after ``ConsentService.record_consent``
+    persists the acceptance; every field is read-only here too.
+    """
+
+    document_type = serializers.CharField(source="policy_document.document_type", read_only=True)
+    policy_document_version = serializers.IntegerField(
+        source="policy_document.version", read_only=True
+    )
+
+    class Meta:
+        model = UserConsent
+        fields = (
+            "id",
+            "document_type",
+            "policy_document",
+            "policy_document_version",
+            "source",
+            "accepted_at",
+            "ip_address",
+            "user_agent",
+        )
+        read_only_fields = fields
+
+
+class ConsentCreateSerializer(serializers.Serializer):
+    """Validates the input for the authenticated consent-record endpoint (OAuth step).
+
+    Only ``document_type`` is accepted from the client — the consenting user
+    comes from the authenticated request, and audit metadata (IP, user-agent,
+    source) is captured server-side in the view.
+    """
+
+    document_type = serializers.ChoiceField(choices=PolicyDocumentType.choices)

--- a/legal/tests/test_consent_endpoint.py
+++ b/legal/tests/test_consent_endpoint.py
@@ -1,0 +1,80 @@
+"""
+Integration tests for the authenticated consent-record endpoint (Phase 4).
+
+`POST /consents/` is the OAuth post-signup step: OAuth signups collect no
+phone/consent at signup, so the frontend calls this endpoint (authenticated,
+after social login completes) to record acceptance of a policy document
+type with `source=ConsentSource.OAUTH_STEP`, capturing IP + User-Agent.
+
+Covers:
+- Authenticated POST records a UserConsent with source=OAUTH_STEP + IP/UA.
+- Unauthenticated POST -> 401.
+- Unknown document_type -> 400.
+- No published document of a known type -> 400 (NoPolicyDocumentError).
+"""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+
+from legal.factories import PolicyDocumentFactory
+from legal.models import ConsentSource, PolicyDocumentType, UserConsent
+
+
+pytestmark = pytest.mark.django_db
+
+CONSENTS_URL = "api:Consents-list"
+
+
+def _consents_url() -> str:
+    return reverse(CONSENTS_URL)
+
+
+class TestRecordConsentEndpoint:
+    def test_authenticated_post_records_consent_with_oauth_step_source(self, auth_client, user):
+        latest = PolicyDocumentFactory().create(
+            document_type=PolicyDocumentType.SMS_CONSENT, version=1
+        )
+
+        response = auth_client.post(
+            _consents_url(),
+            {"document_type": PolicyDocumentType.SMS_CONSENT},
+            HTTP_USER_AGENT="oauth-frontend/1.0",
+            REMOTE_ADDR="198.51.100.7",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        consent = UserConsent.objects.get(user=user, policy_document=latest)
+        assert consent.source == ConsentSource.OAUTH_STEP
+        assert consent.ip_address == "198.51.100.7"
+        assert consent.user_agent == "oauth-frontend/1.0"
+
+        data = response.json()
+        assert data["document_type"] == PolicyDocumentType.SMS_CONSENT
+        assert data["source"] == ConsentSource.OAUTH_STEP
+
+    def test_unauthenticated_returns_401(self, anonymous_client):
+        PolicyDocumentFactory().create(document_type=PolicyDocumentType.SMS_CONSENT, version=1)
+
+        response = anonymous_client.post(
+            _consents_url(), {"document_type": PolicyDocumentType.SMS_CONSENT}
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert not UserConsent.objects.exists()
+
+    def test_unknown_document_type_returns_400(self, auth_client):
+        response = auth_client.post(_consents_url(), {"document_type": "not_a_real_type"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not UserConsent.objects.exists()
+
+    def test_unpublished_document_type_returns_400(self, auth_client):
+        """A known enum value with zero published PolicyDocument rows -> 400."""
+        response = auth_client.post(
+            _consents_url(), {"document_type": PolicyDocumentType.TERMS_OF_USE}
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not UserConsent.objects.exists()

--- a/legal/views.py
+++ b/legal/views.py
@@ -1,5 +1,6 @@
-from typing import cast
+from typing import Annotated, cast
 
+from dependency_injector.wiring import Provide, inject
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
@@ -8,6 +9,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
 
+from common.utils.request_utils import client_ip_from_request, user_agent_from_request
 from legal.filtersets import PolicyDocumentFilterSet
 from legal.models import ConsentSource, PolicyDocument, PolicyDocumentType, UserConsent
 from legal.querysets import PolicyDocumentQuerySet
@@ -103,22 +105,6 @@ class PolicyDocumentViewSet(ReadOnlyModelViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-def _client_ip_from_request(request) -> str | None:
-    """Extract the client IP address from a Django request for audit logging.
-
-    Mirrors ``calendar_integration.mutations._client_ip_from_request``: prefers
-    the first entry of ``X-Forwarded-For`` (set by load balancers / proxies);
-    falls back to ``REMOTE_ADDR``. Returns ``None`` (rather than ``""``) when
-    unavailable, since ``UserConsent.ip_address`` is a nullable
-    ``GenericIPAddressField``.
-    """
-    meta = getattr(request, "META", {})
-    forwarded_for = meta.get("HTTP_X_FORWARDED_FOR", "")
-    if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
-    return meta.get("REMOTE_ADDR") or None
-
-
 @extend_schema(tags=["Legal"])
 class ConsentViewSet(GenericViewSet):
     """Write-only REST surface for recording a :class:`UserConsent` (OAuth step).
@@ -149,7 +135,14 @@ class ConsentViewSet(GenericViewSet):
             ),
         },
     )
-    def create(self, request, *args, **kwargs):
+    @inject
+    def create(
+        self,
+        request,
+        *args,
+        consent_service: Annotated[ConsentService, Provide["consent_service"]] = None,  # type: ignore[assignment]
+        **kwargs,
+    ):
         """POST /consents/ — record acceptance of `document_type` for the current user.
 
         Authenticated only. Captures client IP + User-Agent for audit-grade
@@ -158,13 +151,12 @@ class ConsentViewSet(GenericViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        consent_service = ConsentService()
         consent = consent_service.record_consent(
             request.user,
             serializer.validated_data["document_type"],
             source=ConsentSource.OAUTH_STEP,
-            ip=_client_ip_from_request(request),
-            user_agent=request.headers.get("user-agent", ""),
+            ip=client_ip_from_request(request),
+            user_agent=user_agent_from_request(request),
         )
 
         output_serializer = UserConsentSerializer(consent)

--- a/legal/views.py
+++ b/legal/views.py
@@ -6,12 +6,17 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
 
 from legal.filtersets import PolicyDocumentFilterSet
-from legal.models import PolicyDocument, PolicyDocumentType
+from legal.models import ConsentSource, PolicyDocument, PolicyDocumentType, UserConsent
 from legal.querysets import PolicyDocumentQuerySet
-from legal.serializers import PolicyDocumentSerializer
+from legal.serializers import (
+    ConsentCreateSerializer,
+    PolicyDocumentSerializer,
+    UserConsentSerializer,
+)
+from legal.services import ConsentService
 
 
 @extend_schema(tags=["Legal"])
@@ -96,3 +101,71 @@ class PolicyDocumentViewSet(ReadOnlyModelViewSet):
 
         serializer = self.get_serializer(document)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+def _client_ip_from_request(request) -> str | None:
+    """Extract the client IP address from a Django request for audit logging.
+
+    Mirrors ``calendar_integration.mutations._client_ip_from_request``: prefers
+    the first entry of ``X-Forwarded-For`` (set by load balancers / proxies);
+    falls back to ``REMOTE_ADDR``. Returns ``None`` (rather than ``""``) when
+    unavailable, since ``UserConsent.ip_address`` is a nullable
+    ``GenericIPAddressField``.
+    """
+    meta = getattr(request, "META", {})
+    forwarded_for = meta.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return meta.get("REMOTE_ADDR") or None
+
+
+@extend_schema(tags=["Legal"])
+class ConsentViewSet(GenericViewSet):
+    """Write-only REST surface for recording a :class:`UserConsent` (OAuth step).
+
+    OAuth signups use ``SOCIALACCOUNT_AUTO_SIGNUP`` and collect no phone number
+    or consent acknowledgement at signup time. The frontend calls this
+    endpoint (authenticated, post-social-login) to record acceptance of a
+    published policy document with ``source=ConsentSource.OAUTH_STEP``,
+    before requesting phone verification. Mirrors the email-signup capture
+    path (``accounts.base_forms.BaseVintaScheduleSignupForm.signup``) for a
+    session that already exists.
+
+    No read surface is exposed here — consent history is not a public listing.
+    """
+
+    queryset = UserConsent.objects.none()
+    serializer_class = ConsentCreateSerializer
+    permission_classes = (IsAuthenticated,)
+    http_method_names = ("post", "options")
+
+    @extend_schema(
+        summary="Record the authenticated user's consent to a policy document type",
+        request=ConsentCreateSerializer,
+        responses={
+            201: UserConsentSerializer,
+            400: OpenApiResponse(
+                description="Invalid document_type, or no published document of that type yet"
+            ),
+        },
+    )
+    def create(self, request, *args, **kwargs):
+        """POST /consents/ — record acceptance of `document_type` for the current user.
+
+        Authenticated only. Captures client IP + User-Agent for audit-grade
+        proof; delegates version resolution + persistence to `ConsentService`.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        consent_service = ConsentService()
+        consent = consent_service.record_consent(
+            request.user,
+            serializer.validated_data["document_type"],
+            source=ConsentSource.OAUTH_STEP,
+            ip=_client_ip_from_request(request),
+            user_agent=request.headers.get("user-agent", ""),
+        )
+
+        output_serializer = UserConsentSerializer(consent)
+        return Response(output_serializer.data, status=status.HTTP_201_CREATED)

--- a/schema-auth.yml
+++ b/schema-auth.yml
@@ -1389,6 +1389,8 @@ components:
       type: object
     BaseSignup:
       properties:
+        accepted_policies:
+          type: boolean
         email:
           $ref: '#/components/schemas/Email'
         first_name:
@@ -1407,6 +1409,7 @@ components:
       - phone
       - first_name
       - last_name
+      - accepted_policies
       type: object
     ClientID:
       description: 'The client ID (in case of OAuth2 or OpenID Connect based providers)

--- a/schema.yml
+++ b/schema.yml
@@ -7251,6 +7251,86 @@ paths:
           description: Caller is not eligible to resolve this request.
         '409':
           description: Request is no longer PENDING.
+  /consents/:
+    post:
+      operationId: consents_create
+      description: |-
+        POST /consents/ — record acceptance of `document_type` for the current user.
+
+        Authenticated only. Captures client IP + User-Agent for audit-grade
+        proof; delegates version resolution + persistence to `ConsentService`.
+      summary: Record the authenticated user's consent to a policy document type
+      tags:
+      - Legal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsentCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ConsentCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ConsentCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserConsent'
+          description: ''
+        '400':
+          description: Invalid document_type, or no published document of that type
+            yet
+  /consents{format}:
+    post:
+      operationId: consents_formatted_create
+      description: |-
+        POST /consents/ — record acceptance of `document_type` for the current user.
+
+        Authenticated only. Captures client IP + User-Agent for audit-grade
+        proof; delegates version resolution + persistence to `ConsentService`.
+      summary: Record the authenticated user's consent to a policy document type
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - Legal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsentCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ConsentCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ConsentCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserConsent'
+          description: ''
+        '400':
+          description: Invalid document_type, or no published document of that type
+            yet
   /invitations/:
     get:
       operationId: invitations_list
@@ -13267,6 +13347,19 @@ components:
         * `resource` - Resource Calendar
         * `virtual` - Virtual Calendar
         * `bundle` - Bundle Calendar
+    ConsentCreate:
+      type: object
+      description: |-
+        Validates the input for the authenticated consent-record endpoint (OAuth step).
+
+        Only ``document_type`` is accepted from the client — the consenting user
+        comes from the authenticated request, and audit metadata (IP, user-agent,
+        source) is captured server-side in the view.
+      properties:
+        document_type:
+          $ref: '#/components/schemas/DocumentTypeEnum'
+      required:
+      - document_type
     CurrentMembership:
       type: object
       description: |-
@@ -15200,6 +15293,16 @@ components:
       - email
       - private_key
       - private_key_id
+    SourceEnum:
+      enum:
+      - signup_form
+      - oauth_step
+      - api
+      type: string
+      description: |-
+        * `signup_form` - Signup Form
+        * `oauth_step` - OAuth Consent Step
+        * `api` - API
     SystemUserToken:
       type: object
       description: |-
@@ -15384,6 +15487,50 @@ components:
           $ref: '#/components/schemas/RoleEnum'
       required:
       - role
+    UserConsent:
+      type: object
+      description: |-
+        Read-only representation of a recorded :class:`UserConsent`.
+
+        Returned by ``ConsentViewSet.create`` after ``ConsentService.record_consent``
+        persists the acceptance; every field is read-only here too.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        document_type:
+          type: string
+          readOnly: true
+        policy_document:
+          type: integer
+          readOnly: true
+        policy_document_version:
+          type: integer
+          readOnly: true
+        source:
+          allOf:
+          - $ref: '#/components/schemas/SourceEnum'
+          readOnly: true
+        accepted_at:
+          type: string
+          format: date-time
+          readOnly: true
+        ip_address:
+          type: string
+          readOnly: true
+          nullable: true
+        user_agent:
+          type: string
+          readOnly: true
+      required:
+      - accepted_at
+      - document_type
+      - id
+      - ip_address
+      - policy_document
+      - policy_document_version
+      - source
+      - user_agent
     VisibilityEnum:
       enum:
       - active


### PR DESCRIPTION
## Summary
Phase 4 of the **SMS MFA Consent** plan (stacked on Phase 3 / PR #179). Collects policy consent during onboarding on both signup paths, persisting it through the Phase 3 `ConsentService`. Phone verification is still OFF (Phase 6), so this capture triggers no SMS yet — it just records the consent the Phase 5 gate will require.

**Email/password path** — `accounts/base_forms.py` `BaseVintaScheduleSignupForm`:
- New **required** `accepted_policies` boolean acknowledging the privacy policy, terms of use, and SMS-messaging consent. A missing/false value makes the headless signup invalid.
- `signup()` records `SIGNUP_FORM`-sourced consent for **every published** policy document type (all three per the plan's Open Questions; only `SMS_CONSENT` gates SMS). A type with no published version yet is logged and skipped so signup never breaks — the Phase 5 gate independently fails closed.

**OAuth2 path** — new authenticated `POST /consents/` (`ConsentViewSet`): OAuth signups use `SOCIALACCOUNT_AUTO_SIGNUP` and collect no consent at signup, so the frontend calls this post-signup (before requesting phone verification). Records `OAUTH_STEP` consent for `request.user` only (payload is just `document_type` — no user id, no IDOR), capturing client IP + user-agent. Unknown/unpublished type → 400, unauthenticated → 401.

Both service call sites are DI-injected (`@inject` + `Provide["consent_service"]`, per AGENTS.md), and the client-IP/user-agent extraction is shared via `common/utils/request_utils.py`. The OAuth/social signup adapter (`SocialAccountAdapter.save_user`) does **not** go through this form, so the new required field does not regress social login.

## Plan reference
`ai-plans/2026-07-03-SMS_MFA_CONSENT_IMPLEMENTATION_PLAN.md` — **Phase 4** (stacked on Phase 3). No feature flag. No migrations. `schema.yml` / `schema-auth.yml` regenerated (headless `BaseSignup` now requires `accepted_policies`).

## Test plan
- `docker compose run --rm api uv run pytest accounts/tests/test_signup_consent.py accounts/tests/test_signup_consent_headless.py legal/tests/test_consent_endpoint.py -n auto` — form-level: acknowledgement records a version-pinned `SMS_CONSENT` row (source SIGNUP_FORM), missing acknowledgement → invalid, signup survives an unpublished doc type; **HTTP-level**: real headless signup endpoint with `accepted_policies: true` creates the consent row, without it → 400 no user/consent; endpoint: OAUTH_STEP consent with IP/UA, 401 unauth, 400 invalid type.
- Two existing signup fixtures updated to send `accepted_policies: true`.
- Outer gate: `check --deploy` clean; `makemigrations --check` clean; schema matches a fresh `spectacular` run; full `pytest -n auto` → **3576 passed**.