### PR TITLE
feat(accounts): gate verification SMS on recorded SMS consent

### DIFF
--- a/accounts/account_adapters.py
+++ b/accounts/account_adapters.py
@@ -18,6 +18,8 @@ from vintasend.constants import NotificationTypes
 from vintasend.services.dataclasses import NotificationContextDict
 from vintasend.services.notification_service import NotificationService
 
+from accounts.exceptions import ConsentRequiredError
+from legal.services import ConsentService
 from organizations.exceptions import UserAlreadyHasMembershipError
 from organizations.models import get_active_organization_membership
 from organizations.services import OrganizationService
@@ -258,10 +260,12 @@ class AccountAdapter(DefaultAccountAdapter):
         *args,
         notification_service: Annotated[NotificationService, Provide["notification_service"]],
         organization_service: Annotated[OrganizationService, Provide["organization_service"]],
+        consent_service: Annotated[ConsentService, Provide["consent_service"]],
         **kwargs,
     ):
         self.notification_service = notification_service
         self.organization_service = organization_service
+        self.consent_service = consent_service
         super().__init__(*args, **kwargs)
 
     def send_password_reset_mail(self, user, email, context):
@@ -429,6 +433,12 @@ class AccountAdapter(DefaultAccountAdapter):
     def send_verification_code_sms(self, user, phone: str, code: str, **kwargs):
         """
         Sends a verification code.
+
+        Security-critical gate: no verification SMS is ever dispatched for a
+        user without a recorded SMS_CONSENT ``UserConsent`` row (fail closed).
+        This is the authoritative, server-side guarantee behind the consent
+        capture UX — see ``legal.services.ConsentService.has_sms_consent`` and
+        ``accounts.exceptions.ConsentRequiredError``.
         """
         if not user:
             logger.warning("No user provided for sending verification code SMS.")
@@ -437,6 +447,13 @@ class AccountAdapter(DefaultAccountAdapter):
         if not phone:
             logger.warning("No phone number provided for sending verification code SMS.")
             return
+
+        if not self.consent_service.has_sms_consent(user):
+            logger.warning(
+                "Refusing to send verification code SMS to user %s: no SMS_CONSENT on file.",
+                user.id,
+            )
+            raise ConsentRequiredError()
 
         # Here you would implement the logic to send the SMS.
         # This is a placeholder for the actual SMS sending logic.

--- a/accounts/exceptions.py
+++ b/accounts/exceptions.py
@@ -1,3 +1,10 @@
+from http import HTTPStatus
+
+from django.http import JsonResponse
+
+from allauth.core.exceptions import ImmediateHttpResponse
+
+
 class AccountError(Exception):
     """Base exception for account related errors"""
 
@@ -7,3 +14,46 @@ class AccountError(Exception):
 class UserNotAuthenticatedError(AccountError):
     def __init__(self, message="User must be authenticated to generate an access token."):
         super().__init__(message)
+
+
+class ConsentRequiredError(AccountError, ImmediateHttpResponse):
+    """Refuses an SMS send because the user has no recorded SMS-messaging consent.
+
+    This is the server-side backstop behind the SMS consent gate (see
+    ``AccountAdapter.send_verification_code_sms``): no valid ``SMS_CONSENT``
+    ``UserConsent`` row ⇒ the verification SMS is refused.
+
+    Deliberately a **dual** exception: it is both an ``AccountError`` (so callers
+    and tests can identify/catch it as a normal, domain-level account error) and an
+    ``allauth.core.exceptions.ImmediateHttpResponse`` (allauth's documented hook for
+    aborting a flow mid-adapter-call with a specific ``HttpResponse``). Raising it from
+    inside an ``AccountAdapter`` hook is caught by allauth's
+    ``allauth.account.middleware.AccountMiddleware.process_exception`` and turned into
+    the well-formed 4xx response below — instead of propagating as an unhandled 500 —
+    regardless of which headless view/stage triggered the SMS send (signup phone-verify
+    stage, resend, or authenticated change-phone all funnel through the same adapter
+    call). The response body carries ``code="consent_required"`` so the frontend can
+    distinguish this error and route the user to the consent step.
+
+    The response is built as a plain ``JsonResponse`` (not allauth's headless
+    ``APIResponse``) so this error can be raised and inspected outside of an active
+    request context too (e.g. directly against the adapter in unit tests) without
+    depending on request-scoped state such as session/token metadata.
+    """
+
+    code = "consent_required"
+    default_message = "SMS consent is required before a verification code can be sent."
+
+    def __init__(self, message: str | None = None) -> None:
+        self.message = message or self.default_message
+        Exception.__init__(self, self.message)
+        ImmediateHttpResponse.__init__(self, response=self._build_response())
+
+    def _build_response(self) -> JsonResponse:
+        return JsonResponse(
+            {
+                "status": int(HTTPStatus.FORBIDDEN),
+                "errors": [{"code": self.code, "message": self.message}],
+            },
+            status=HTTPStatus.FORBIDDEN,
+        )

--- a/accounts/exceptions.py
+++ b/accounts/exceptions.py
@@ -2,7 +2,9 @@ from http import HTTPStatus
 
 from django.http import JsonResponse
 
+from allauth.core import context
 from allauth.core.exceptions import ImmediateHttpResponse
+from allauth.headless.internal.restkit.response import APIResponse
 
 
 class AccountError(Exception):
@@ -17,28 +19,19 @@ class UserNotAuthenticatedError(AccountError):
 
 
 class ConsentRequiredError(AccountError, ImmediateHttpResponse):
-    """Refuses an SMS send because the user has no recorded SMS-messaging consent.
+    """Raised by ``AccountAdapter.send_verification_code_sms`` to refuse an SMS
+    send when the user has no recorded ``SMS_CONSENT``.
 
-    This is the server-side backstop behind the SMS consent gate (see
-    ``AccountAdapter.send_verification_code_sms``): no valid ``SMS_CONSENT``
-    ``UserConsent`` row ⇒ the verification SMS is refused.
+    Dual-inherited: it's an ``AccountError`` (catchable in tests/callers) and an
+    ``ImmediateHttpResponse``, so allauth's
+    ``account.middleware.AccountMiddleware.process_exception`` turns it into a
+    clean 403 ``consent_required`` response instead of an unhandled 500.
 
-    Deliberately a **dual** exception: it is both an ``AccountError`` (so callers
-    and tests can identify/catch it as a normal, domain-level account error) and an
-    ``allauth.core.exceptions.ImmediateHttpResponse`` (allauth's documented hook for
-    aborting a flow mid-adapter-call with a specific ``HttpResponse``). Raising it from
-    inside an ``AccountAdapter`` hook is caught by allauth's
-    ``allauth.account.middleware.AccountMiddleware.process_exception`` and turned into
-    the well-formed 4xx response below — instead of propagating as an unhandled 500 —
-    regardless of which headless view/stage triggered the SMS send (signup phone-verify
-    stage, resend, or authenticated change-phone all funnel through the same adapter
-    call). The response body carries ``code="consent_required"`` so the frontend can
-    distinguish this error and route the user to the consent step.
-
-    The response is built as a plain ``JsonResponse`` (not allauth's headless
-    ``APIResponse``) so this error can be raised and inspected outside of an active
-    request context too (e.g. directly against the adapter in unit tests) without
-    depending on request-scoped state such as session/token metadata.
+    The response body matches allauth headless's own envelope
+    (``status``/``errors``/``meta``) when there's a live request to build it
+    from. It falls back to a plain envelope with the same ``status``/``errors``
+    keys when there isn't, since this error can also be raised and inspected
+    outside of a request (e.g. directly against the adapter in unit tests).
     """
 
     code = "consent_required"
@@ -50,10 +43,16 @@ class ConsentRequiredError(AccountError, ImmediateHttpResponse):
         ImmediateHttpResponse.__init__(self, response=self._build_response())
 
     def _build_response(self) -> JsonResponse:
+        errors = [{"code": self.code, "message": self.message}]
+        request = context.request
+        if request is not None:
+            try:
+                return APIResponse(request, errors=errors, status=HTTPStatus.FORBIDDEN)
+            except AttributeError:
+                # request isn't a fully-formed headless request (e.g. missing
+                # request.allauth.headless) - fall through to the plain envelope.
+                pass
         return JsonResponse(
-            {
-                "status": int(HTTPStatus.FORBIDDEN),
-                "errors": [{"code": self.code, "message": self.message}],
-            },
+            {"status": int(HTTPStatus.FORBIDDEN), "errors": errors},
             status=HTTPStatus.FORBIDDEN,
         )

--- a/accounts/tests/test_account_adapters.py
+++ b/accounts/tests/test_account_adapters.py
@@ -11,6 +11,7 @@ from accounts.account_adapters import (
     HeadlessAdapter,
     SocialAccountAdapter,
 )
+from legal.factories import UserConsentFactory
 from users.models import Profile, User
 
 
@@ -308,6 +309,11 @@ class TestAccountAdapter:
         assert found is None
 
     def test_send_verification_code_sms_success(self, adapter, user):
+        # The SMS consent gate (Phase 5) requires a recorded SMS_CONSENT
+        # UserConsent before any verification SMS is dispatched; see
+        # accounts/tests/test_sms_consent_gate.py for the gate's own tests.
+        UserConsentFactory().create(user=user)
+
         with patch("accounts.account_adapters.logger.info") as log_info:
             adapter.send_verification_code_sms(user, "+123456789", "1234")
             log_info.assert_called()

--- a/accounts/tests/test_sms_consent_gate.py
+++ b/accounts/tests/test_sms_consent_gate.py
@@ -1,0 +1,114 @@
+"""Phase 5 — SMS consent enforcement gate.
+
+Covers both layers of the gate:
+
+- Unit: ``AccountAdapter.send_verification_code_sms`` refuses to dispatch a
+  verification SMS (zero calls to ``notification_service.create_notification``)
+  when ``ConsentService.has_sms_consent`` is False, and signals the refusal via
+  ``ConsentRequiredError``.
+- Integration: the real headless phone-verification entry point
+  (``POST /auth/browser/v1/account/phone``) returns a deterministic, well-formed
+  4xx (not a 500) for a consent-less user and dispatches zero notifications; a
+  consented user still receives the OTP. ``ACCOUNT_PHONE_VERIFICATION_ENABLED``
+  is off in production settings until Phase 6 — it is overridden here, in-test
+  only, to exercise the gate through the real view/flow.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+import pytest
+
+from accounts.account_adapters import AccountAdapter
+from accounts.exceptions import ConsentRequiredError
+from legal.factories import UserConsentFactory
+from legal.models import PolicyDocumentType
+
+
+@pytest.mark.django_db
+class TestSendVerificationCodeSmsConsentGate:
+    """Unit-level: adapter dependencies fully controlled (consent_service mocked)."""
+
+    @pytest.fixture
+    def notification_service(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def consent_service(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def adapter(self, notification_service, consent_service):
+        return AccountAdapter(
+            notification_service=notification_service,
+            consent_service=consent_service,
+        )
+
+    def test_sends_when_consent_recorded(self, adapter, user):
+        adapter.consent_service.has_sms_consent.return_value = True
+
+        adapter.send_verification_code_sms(user, "+15555550100", "1234")
+
+        adapter.consent_service.has_sms_consent.assert_called_once_with(user)
+        adapter.notification_service.create_notification.assert_called_once()
+
+    def test_refuses_when_consent_missing(self, adapter, user):
+        adapter.consent_service.has_sms_consent.return_value = False
+
+        with pytest.raises(ConsentRequiredError):
+            adapter.send_verification_code_sms(user, "+15555550100", "1234")
+
+        adapter.consent_service.has_sms_consent.assert_called_once_with(user)
+        adapter.notification_service.create_notification.assert_not_called()
+
+    def test_refusal_error_carries_a_well_formed_client_response(self, adapter, user):
+        adapter.consent_service.has_sms_consent.return_value = False
+
+        with pytest.raises(ConsentRequiredError) as exc_info:
+            adapter.send_verification_code_sms(user, "+15555550100", "1234")
+
+        error = exc_info.value
+        assert error.response.status_code == 403
+        body = json.loads(error.response.content)
+        assert body["errors"][0]["code"] == "consent_required"
+
+    def test_logs_a_warning_on_refusal(self, adapter, user):
+        adapter.consent_service.has_sms_consent.return_value = False
+
+        with patch("accounts.account_adapters.logger.warning") as log_warn:
+            with pytest.raises(ConsentRequiredError):
+                adapter.send_verification_code_sms(user, "+15555550100", "1234")
+
+        log_warn.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestPhoneVerifyConsentGateIntegration:
+    """Drives the real headless phone-verification entry point end-to-end."""
+
+    url = "/auth/browser/v1/account/phone"
+
+    @override_settings(ACCOUNT_PHONE_VERIFICATION_ENABLED=True)
+    def test_consent_less_user_is_refused_with_zero_notifications(self, auth_client):
+        with patch(
+            "vintasend.services.notification_service.NotificationService.create_notification"
+        ) as mock_create:
+            response = auth_client.post(self.url, {"phone": "+15555550100"}, format="json")
+
+        assert response.status_code == 403
+        assert response.json()["errors"][0]["code"] == "consent_required"
+        mock_create.assert_not_called()
+
+    @override_settings(ACCOUNT_PHONE_VERIFICATION_ENABLED=True)
+    def test_consented_user_receives_otp(self, auth_client, user):
+        UserConsentFactory().create(user=user, document_type=PolicyDocumentType.SMS_CONSENT)
+
+        with patch(
+            "vintasend.services.notification_service.NotificationService.create_notification"
+        ) as mock_create:
+            response = auth_client.post(self.url, {"phone": "+15555550101"}, format="json")
+
+        assert response.status_code == 202
+        mock_create.assert_called_once()

--- a/accounts/tests/test_sms_consent_gate.py
+++ b/accounts/tests/test_sms_consent_gate.py
@@ -5,7 +5,8 @@ Covers both layers of the gate:
 - Unit: ``AccountAdapter.send_verification_code_sms`` refuses to dispatch a
   verification SMS (zero calls to ``notification_service.create_notification``)
   when ``ConsentService.has_sms_consent`` is False, and signals the refusal via
-  ``ConsentRequiredError``.
+  ``ConsentRequiredError``. Also fails closed (zero dispatch) when the consent
+  check itself raises.
 - Integration: the real headless phone-verification entry point
   (``POST /auth/browser/v1/account/phone``) returns a deterministic, well-formed
   4xx (not a 500) for a consent-less user and dispatches zero notifications; a
@@ -82,6 +83,14 @@ class TestSendVerificationCodeSmsConsentGate:
                 adapter.send_verification_code_sms(user, "+15555550100", "1234")
 
         log_warn.assert_called_once()
+
+    def test_fails_closed_when_consent_check_raises(self, adapter, user):
+        adapter.consent_service.has_sms_consent.side_effect = RuntimeError("db unavailable")
+
+        with pytest.raises(RuntimeError):
+            adapter.send_verification_code_sms(user, "+15555550100", "1234")
+
+        adapter.notification_service.create_notification.assert_not_called()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
Phase 5 of the **SMS MFA Consent** plan (stacked on Phase 4 / PR #180). The authoritative, server-side guarantee: no verification SMS is ever dispatched to a user without a recorded `SMS_CONSENT` consent. The Phase 4 capture UX is convenience; **this gate is the enforcement**, and it fails closed.

- `AccountAdapter.send_verification_code_sms` now checks `consent_service.has_sms_consent(user)` (DI-injected) before dispatching. No consent → log + raise `ConsentRequiredError`, **zero** notification/Twilio calls. A consented user's OTP path is unchanged.
- This adapter method is the single choke point every headless phone-verification path funnels through (signup stage, resend, authenticated change-phone), so one guard covers them all.
- `ConsentRequiredError` (`accounts/exceptions.py`) multi-inherits `AccountError` + allauth's `ImmediateHttpResponse`, so allauth's already-installed `AccountMiddleware.process_exception` turns it into a clean **403** carrying `code="consent_required"` (allauth headless `APIResponse` envelope when a request context exists; plain `JsonResponse` fallback for direct/unit calls) — never an unhandled 500. The frontend routes to the consent step on that code.

## ⚠️ Compliance gap surfaced (blocks Phase 6, not fixed here)
Phase 5 gates **verification-code** SMS only. Two other adapter methods — `send_unknown_account_sms` and `send_account_already_exists_sms` (anti-enumeration messages) — still send SMS with **no consent check** and fire when there's no `user` to check against (a phone merely typed into a form). They go live the moment `ACCOUNT_PHONE_VERIFICATION_ENABLED` flips (Phase 6). That is the exact Twilio/TCPA concern this feature exists for, and it conflicts with Goal 4. Gating/removing them is a **product decision** (it changes enumeration-prevention UX), so it's recorded as a hard **Phase 6 prerequisite** + **Open Question** in the plan rather than silently shipped. **Do not flip the setting until it's resolved.**

## Plan reference
`ai-plans/2026-07-03-SMS_MFA_CONSENT_IMPLEMENTATION_PLAN.md` — **Phase 5** (stacked on Phase 4). No feature flag. No migrations. `MFA_SUPPORTED_TYPES` unchanged (not an MFA factor).

## Test plan
- `docker compose run --rm api uv run pytest accounts/tests/test_sms_consent_gate.py accounts/tests/test_account_adapters.py -n auto` — unit: sends when consent present, refuses (asserts `create_notification` never called) when absent, **fails closed when `has_sms_consent` raises** (still zero dispatch); integration: real headless `POST .../account/phone` for a consent-less user → 403 `consent_required` + zero notifications, consented user → OTP dispatched once. `ACCOUNT_PHONE_VERIFICATION_ENABLED=True` is applied via `@override_settings` **in-test only** (production stays False until Phase 6).
- Outer gate: `check --deploy` clean; `makemigrations --check` clean; full `pytest -n auto` → **3583 passed**.