### PR TITLE
feat(accounts): make ACCOUNT_PHONE_VERIFICATION_ENABLED env-driven (default off)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -23,3 +23,6 @@ TWILIO_API_KEY_SECRET=
 TWILIO_AUTH_TOKEN=
 TWILIO_NUMBER=
 TWILIO_DEFAULT_BROADCAST_NUMBERS=
+# Per-environment rollout gate for SMS phone verification. Keep False until
+# Twilio approves the messaging profile for this environment.
+ACCOUNT_PHONE_VERIFICATION_ENABLED=False

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ TWILIO_API_KEY_SECRET=
 TWILIO_AUTH_TOKEN=
 TWILIO_NUMBER=
 TWILIO_DEFAULT_BROADCAST_NUMBERS=
+# Per-environment rollout gate for SMS phone verification. Keep False until
+# Twilio approves the messaging profile for this environment.
+ACCOUNT_PHONE_VERIFICATION_ENABLED=False

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,7 @@ jobs:
           TWILIO_API_KEY_SECRET: 'FAKE_API_KEY_SECRET'
           TWILIO_NUMBER: '+12345678901'
           TWILIO_DEFAULT_BROADCAST_NUMBERS: '+12345678901,+10987654321'
+          ACCOUNT_PHONE_VERIFICATION_ENABLED: 'false'
 
 
       - run: uv run pre-commit run --all-files
@@ -129,6 +130,7 @@ jobs:
           TWILIO_API_KEY_SECRET: 'FAKE_API_KEY_SECRET'
           TWILIO_NUMBER: '+12345678901'
           TWILIO_DEFAULT_BROADCAST_NUMBERS: '+12345678901,+10987654321'
+          ACCOUNT_PHONE_VERIFICATION_ENABLED: 'false'
       - run: uv run python manage.py makemigrations --check --dry-run
         env:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.production"
@@ -161,6 +163,7 @@ jobs:
           TWILIO_API_KEY_SECRET: 'FAKE_API_KEY_SECRET'
           TWILIO_NUMBER: '+12345678901'
           TWILIO_DEFAULT_BROADCAST_NUMBERS: '+12345678901,+10987654321'
+          ACCOUNT_PHONE_VERIFICATION_ENABLED: 'false'
       - run: uv run python manage.py check --deploy
         env:
           DJANGO_SETTINGS_MODULE: "vinta_schedule_api.settings.production"
@@ -193,6 +196,7 @@ jobs:
           TWILIO_API_KEY_SECRET: 'FAKE_API_KEY_SECRET'
           TWILIO_NUMBER: '+12345678901'
           TWILIO_DEFAULT_BROADCAST_NUMBERS: '+12345678901,+10987654321'
+          ACCOUNT_PHONE_VERIFICATION_ENABLED: 'false'
       - run: |
           uv run pytest $(ARG) -vs  -n auto --no-header --cov=. --cov-report=xml:junit/test-results.xml --junitxml=junit.xml -o junit_family=legacy
         env:
@@ -226,6 +230,7 @@ jobs:
           TWILIO_API_KEY_SECRET: 'FAKE_API_KEY_SECRET'
           TWILIO_NUMBER: '+12345678901'
           TWILIO_DEFAULT_BROADCAST_NUMBERS: '+12345678901,+10987654321'
+          ACCOUNT_PHONE_VERIFICATION_ENABLED: 'false'
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4

--- a/accounts/tests/test_account_phone_verification_env_var.py
+++ b/accounts/tests/test_account_phone_verification_env_var.py
@@ -1,0 +1,55 @@
+"""Phase 6 — ``ACCOUNT_PHONE_VERIFICATION_ENABLED`` is env-driven, default off.
+
+Unit-level: exercises the exact ``decouple.config(...)`` expression used in
+``vinta_schedule_api/settings/base.py`` directly, so it fails if the cast/
+default behavior ever regresses (e.g. someone swaps ``cast=bool`` for a plain
+string compare). Does not reload the settings module — that would have wider
+side effects (app registry, other required env vars) unrelated to this
+single setting's resolution.
+"""
+
+from django.conf import settings
+from django.test import override_settings
+
+import pytest
+from decouple import config
+
+
+class TestAccountPhoneVerificationEnabledEnvVarResolution:
+    def test_defaults_to_false_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ACCOUNT_PHONE_VERIFICATION_ENABLED", raising=False)
+
+        resolved = config("ACCOUNT_PHONE_VERIFICATION_ENABLED", cast=bool, default=False)
+
+        assert resolved is False
+
+    @pytest.mark.parametrize("truthy_value", ["true", "True", "1", "yes", "on"])
+    def test_resolves_true_for_truthy_env_values(
+        self, monkeypatch: pytest.MonkeyPatch, truthy_value: str
+    ) -> None:
+        monkeypatch.setenv("ACCOUNT_PHONE_VERIFICATION_ENABLED", truthy_value)
+
+        resolved = config("ACCOUNT_PHONE_VERIFICATION_ENABLED", cast=bool, default=False)
+
+        assert resolved is True
+
+    @pytest.mark.parametrize("falsy_value", ["false", "False", "0", "no", "off"])
+    def test_resolves_false_for_falsy_env_values(
+        self, monkeypatch: pytest.MonkeyPatch, falsy_value: str
+    ) -> None:
+        monkeypatch.setenv("ACCOUNT_PHONE_VERIFICATION_ENABLED", falsy_value)
+
+        resolved = config("ACCOUNT_PHONE_VERIFICATION_ENABLED", cast=bool, default=False)
+
+        assert resolved is False
+
+
+class TestAccountPhoneVerificationEnabledDefaultSetting:
+    """Behavioral: the setting object itself, as loaded for the test run."""
+
+    def test_default_is_false_with_no_override(self) -> None:
+        assert settings.ACCOUNT_PHONE_VERIFICATION_ENABLED is False
+
+    @override_settings(ACCOUNT_PHONE_VERIFICATION_ENABLED=True)
+    def test_can_be_overridden_true_per_environment(self) -> None:
+        assert settings.ACCOUNT_PHONE_VERIFICATION_ENABLED is True

--- a/accounts/tests/test_sms_consent_gate.py
+++ b/accounts/tests/test_sms_consent_gate.py
@@ -260,6 +260,35 @@ class TestPhoneVerifyConsentGateIntegration:
         assert response.status_code == 202
         mock_create.assert_called_once()
 
+    def test_default_disabled_flag_phone_verify_is_inert_for_a_consent_less_phone(
+        self, auth_client
+    ):
+        """Phase 6 acceptance: "with it disabled (default), the phone-verify
+        flow is inert." No ``@override_settings`` here — this exercises the
+        actual out-of-the-box default (``ACCOUNT_PHONE_VERIFICATION_ENABLED``
+        unset/False, as in production today).
+
+        Verified empirically: the vendored allauth ``ManagePhoneView`` /
+        ``ChangePhoneVerificationProcess`` call path used by this endpoint
+        does not itself branch on ``ACCOUNT_PHONE_VERIFICATION_ENABLED`` (that
+        setting is only consulted by allauth's signup/login
+        ``PhoneVerificationStage``, a different code path). So the endpoint
+        stays reachable either way; what actually keeps it inert by default is
+        the SMS-consent gate (Phase 5/8) refusing a consent-less phone. The
+        real, observed response for this exact request (no consent recorded,
+        default settings) is a 403 with the ``consent_required`` error code
+        and zero notification dispatches -- asserted below rather than
+        assumed.
+        """
+        with patch(
+            "vintasend.services.notification_service.NotificationService.create_notification"
+        ) as mock_create:
+            response = auth_client.post(self.url, {"phone": "+15555550199"}, format="json")
+
+        assert response.status_code == 403
+        assert response.json()["errors"][0]["code"] == "consent_required"
+        mock_create.assert_not_called()
+
 
 @pytest.mark.django_db
 class TestAntiEnumerationSmsRealFlowIntegration:

--- a/ai-tools/AGENTS.md
+++ b/ai-tools/AGENTS.md
@@ -207,7 +207,10 @@ TWILIO_API_KEY_SECRET
 TWILIO_AUTH_TOKEN
 TWILIO_NUMBER
 TWILIO_DEFAULT_BROADCAST_NUMBERS
+ACCOUNT_PHONE_VERIFICATION_ENABLED
 ```
+
+- `ACCOUNT_PHONE_VERIFICATION_ENABLED` (bool, default `False`) — per-environment rollout gate for SMS phone verification. Stays off until Twilio approves the messaging profile for that environment; an operator flips it in the environment (Render dashboard / `.env`) with no code change.
 
 Production-only vars (set via Render `envVarGroups`): `SECRET_KEY`, `SENTRY_DSN`, `SMTP_HOST`/`USERNAME`/`PASSWORD`, `ALLOWED_HOSTS`, `SITE_DOMAIN`, `API_DOMAIN`, `DEFAULT_BCC_EMAILS`, AWS bucket / CloudFront settings, `ENABLE_DJANGO_COLLECTSTATIC`, `AUTO_MIGRATE`. Adding a new env var requires updates to both example files and `render.yaml` envVarGroups — see the `add-env-var` skill.
 

--- a/render.yaml
+++ b/render.yaml
@@ -168,6 +168,11 @@ envVarGroups:
         sync: false
       - key: TWILIO_DEFAULT_BROADCAST_NUMBERS
         sync: false
+      # Per-environment rollout gate for SMS phone verification. Default off;
+      # flip to true in the Render dashboard once Twilio approves this
+      # environment's messaging profile.
+      - key: ACCOUNT_PHONE_VERIFICATION_ENABLED
+        value: false
 
   # AWS S3 + CloudFront storage. Values come from the Terragrunt/Scalr stack
   # under infrastructure/ — see `terragrunt output`. Secrets are sync:false so

--- a/vinta_schedule_api/settings/base.py
+++ b/vinta_schedule_api/settings/base.py
@@ -347,7 +347,12 @@ HEADLESS_TOKEN_STRATEGY = "accounts.token_strategies.AccessAndRefreshTokenStrate
 ACCESS_TOKEN_EXPIRY_MINUTES = config("ACCESS_TOKEN_EXPIRY_MINUTES", cast=int, default=15)
 REFRESH_TOKEN_EXPIRY_DAYS = config("REFRESH_TOKEN_EXPIRY_DAYS", cast=int, default=30)
 ACCOUNT_LOGIN_METHODS = {"phone", "email"}
-ACCOUNT_PHONE_VERIFICATION_ENABLED = False
+# Rollout gate: default off while Twilio validates our messaging profile per
+# environment. An operator flips this in the environment (Render dashboard /
+# .env) once approved there — no code change required.
+ACCOUNT_PHONE_VERIFICATION_ENABLED = config(
+    "ACCOUNT_PHONE_VERIFICATION_ENABLED", cast=bool, default=False
+)
 ACCOUNT_PHONE_VERIFICATION_MAX_ATTEMPTS = 3
 ACCOUNT_PHONE_VERIFICATION_SUPPORTS_RESEND = True
 ACCOUNT_SIGNUP_FORM_CLASS = "accounts.base_forms.BaseVintaScheduleSignupForm"


### PR DESCRIPTION
## Summary
Phase 6 of the **SMS MFA Consent** plan (stacked on Phase 8 / PR #183). Converts the hardcoded `ACCOUNT_PHONE_VERIFICATION_ENABLED = False` (set in commit `62a3968` while Twilio validated the messaging profile) into an **environment variable**: `config("ACCOUNT_PHONE_VERIFICATION_ENABLED", cast=bool, default=False)`.

This is the rollout control the reactivation needs: **default `False`, so a plain deploy changes nothing**, and each environment (staging, prod) enables SMS phone verification independently by setting the env var — **no code change to flip**. The Phase 5/8 consent gate protects all SMS sends, so enabling per-environment is safe once Twilio approves that environment.

Wired through every layer (per the `add-env-var` skill): `vinta_schedule_api/settings/base.py`, `.env.example`, `.env.docker.example`, `render.yaml` (`integrations-credentials` group, `value: false` — operators flip in the Render dashboard), the CI workflow `env:` blocks (`'false'`, keeps CI off), and `ai-tools/AGENTS.md`.

## Behavioral nuance (reviewers please note)
`ACCOUNT_PHONE_VERIFICATION_ENABLED` gates allauth's **signup/login phone-verification stage**. allauth's authenticated `ManagePhoneView` (add/change phone) does **not** consult this flag — it always attempts to send, gated only by the Phase 5/8 SMS-consent check. So with the flag OFF, a *consented, authenticated* user could still receive an OTP via change-phone. This is pre-existing allauth behavior (not introduced here), and unconsented sends are still blocked by the consent gate — but the flag is **not a total SMS kill-switch**. If a full kill-switch is wanted, gating `ManagePhoneView`/the adapter on the flag too is a small follow-up (deliberately not scoped into this phase).

## Plan reference
`ai-plans/2026-07-03-SMS_MFA_CONSENT_IMPLEMENTATION_PLAN.md` — **Phase 6** (stacked on Phase 8). No migrations. Remaining real-world gate to actually enable in an environment: Twilio approving that environment's messaging profile.

## Test plan
- `docker compose run --rm api uv run pytest accounts/tests/test_account_phone_verification_env_var.py accounts/tests/test_sms_consent_gate.py -n auto` — settings resolves the env var (unset → False; truthy strings → True; falsy → False); with the flag at its default False the phone endpoint stays consent-gated (consent-less → `403 consent_required`, zero dispatch); enabled-path integration (consented → OTP) already covered from Phase 5/8.
- Outer gate: `check --deploy` clean; `makemigrations --check` clean; full `pytest -n auto` → **3626 passed**.