### PR TITLE
feat(accounts): split signup consent into separate terms + SMS checkboxes

### DIFF
--- a/accounts/base_forms.py
+++ b/accounts/base_forms.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated
+from typing import Annotated, ClassVar
 
 from django import forms
 from django.utils import timezone
@@ -21,14 +21,18 @@ class BaseVintaScheduleSignupForm(forms.Form):
     """
     Base form for user signup.
 
-    Captures first_name, last_name, an optional organization_name, and a
-    required policy-acceptance acknowledgement. At signup time, the intended
+    Captures first_name, last_name, an optional organization_name, and two
+    required policy-acceptance acknowledgements. At signup time, the intended
     org name is persisted on Profile.pending_organization_name so it can be
     consumed during email-confirmation provisioning (Phase 3).
 
     When a non-expired, unaccepted OrganizationInvitation exists for the
     signup email, the org name is left blank — the user will auto-join the
     inviting org instead of creating a new one.
+
+    Consent acceptance is split into two separate fields (Phase 9) rather
+    than one combined checkbox: Twilio / TCPA require SMS consent to be its
+    own explicit, distinct opt-in, not bundled with Terms/Privacy acceptance.
     """
 
     first_name = forms.CharField(max_length=255, required=True, label="First Name")
@@ -38,16 +42,38 @@ class BaseVintaScheduleSignupForm(forms.Form):
         required=False,
         label="Organization Name",
     )
-    accepted_policies = forms.BooleanField(
+    accepted_terms = forms.BooleanField(
         required=True,
-        label="I agree to the Privacy Policy, Terms of Use, and SMS messaging consent.",
+        label="I agree to the Privacy Policy and Terms of Use.",
+        error_messages={
+            "required": "You must accept the Privacy Policy and Terms of Use to create an account.",
+        },
+    )
+    accepted_sms_consent = forms.BooleanField(
+        required=True,
+        label=(
+            "I agree to receive SMS text messages (e.g. verification codes) at the "
+            "phone number I provide. Msg & data rates may apply."
+        ),
         error_messages={
             "required": (
-                "You must accept the Privacy Policy, Terms of Use, and SMS messaging "
-                "consent to create an account."
+                "You must agree to receive SMS text messages at the phone number you "
+                "provide to create an account."
             ),
         },
     )
+
+    # Maps each consent checkbox field to the PolicyDocumentType values it
+    # covers. Keeping this as an explicit mapping (rather than iterating
+    # PolicyDocumentType.values directly) means SMS consent could later
+    # become optional without touching how terms/privacy are recorded.
+    _CONSENT_FIELD_DOCUMENT_TYPES: ClassVar[dict[str, list[str]]] = {
+        "accepted_terms": [
+            PolicyDocumentType.PRIVACY_POLICY,
+            PolicyDocumentType.TERMS_OF_USE,
+        ],
+        "accepted_sms_consent": [PolicyDocumentType.SMS_CONSENT],
+    }
 
     def _has_pending_invitation(self, email: str) -> bool:
         """Return True if a non-expired, unaccepted invitation exists for *email*."""
@@ -66,6 +92,17 @@ class BaseVintaScheduleSignupForm(forms.Form):
         ``SMS_CONSENT`` gates SMS sending (Phase 5), but recording the other
         two is captured for completeness per the plan's Open Questions.
 
+        Each document type is driven by the checkbox that covers it (Phase 9
+        — separate SMS consent checkbox): ``PRIVACY_POLICY`` /
+        ``TERMS_OF_USE`` are recorded because ``accepted_terms`` is required
+        and checked, and ``SMS_CONSENT`` is recorded because
+        ``accepted_sms_consent`` is required and checked, independently. Both
+        fields are required today so all three document types are always
+        recorded on a successful signup, but the SMS row is driven
+        specifically by ``accepted_sms_consent`` — if that field ever became
+        optional, only the SMS_CONSENT recording would stop, leaving terms
+        recording untouched.
+
         Each row is recorded with ``phone_number=user.phone_number`` (Phase 8
         — phone-keyed consent). The email/password signup form collects no
         phone number, so this is ``""`` at this point in that path; the
@@ -81,23 +118,26 @@ class BaseVintaScheduleSignupForm(forms.Form):
         client_ip = client_ip_from_request(request)
         user_agent = user_agent_from_request(request)
 
-        for document_type in PolicyDocumentType.values:
-            try:
-                consent_service.record_consent(
-                    user,
-                    document_type,
-                    source=ConsentSource.SIGNUP_FORM,
-                    ip=client_ip,
-                    user_agent=user_agent,
-                    phone_number=user.phone_number,
-                )
-            except NoPolicyDocumentError:
-                logger.warning(
-                    "Skipping signup consent capture for document_type=%s, user=%s: "
-                    "no published PolicyDocument exists yet.",
-                    document_type,
-                    user.pk,
-                )
+        for field_name, document_types in self._CONSENT_FIELD_DOCUMENT_TYPES.items():
+            if not self.cleaned_data.get(field_name):
+                continue
+            for document_type in document_types:
+                try:
+                    consent_service.record_consent(
+                        user,
+                        document_type,
+                        source=ConsentSource.SIGNUP_FORM,
+                        ip=client_ip,
+                        user_agent=user_agent,
+                        phone_number=user.phone_number,
+                    )
+                except NoPolicyDocumentError:
+                    logger.warning(
+                        "Skipping signup consent capture for document_type=%s, user=%s: "
+                        "no published PolicyDocument exists yet.",
+                        document_type,
+                        user.pk,
+                    )
 
     @inject
     def signup(

--- a/accounts/tests/test_base_forms.py
+++ b/accounts/tests/test_base_forms.py
@@ -31,7 +31,8 @@ def _make_form(
         "first_name": first_name,
         "last_name": last_name,
         "organization_name": organization_name,
-        "accepted_policies": True,
+        "accepted_terms": True,
+        "accepted_sms_consent": True,
     }
     form = BaseVintaScheduleSignupForm(data=data)
     assert form.is_valid(), form.errors

--- a/accounts/tests/test_email_invite_autojoin.py
+++ b/accounts/tests/test_email_invite_autojoin.py
@@ -117,7 +117,8 @@ class TestInvitedEmailAutoJoin:
             "first_name": "New",
             "last_name": "User",
             "organization_name": "",  # invited user wouldn't submit a name
-            "accepted_policies": True,
+            "accepted_terms": True,
+            "accepted_sms_consent": True,
         }
         form = BaseVintaScheduleSignupForm(data=form_data)
         assert form.is_valid(), form.errors

--- a/accounts/tests/test_signup_consent.py
+++ b/accounts/tests/test_signup_consent.py
@@ -1,12 +1,17 @@
 """
-Tests for consent capture in the email/password signup form (Phase 4 / Phase 8).
+Tests for consent capture in the email/password signup form (Phase 4 / Phase 8 /
+Phase 9).
 
 Covers:
-- Completing the signup form with `accepted_policies=True` records a
-  version-pinned SMS_CONSENT UserConsent with source=SIGNUP_FORM, capturing
-  the request's client IP + User-Agent.
+- Completing the signup form with `accepted_terms=True` and
+  `accepted_sms_consent=True` records a version-pinned SMS_CONSENT UserConsent
+  with source=SIGNUP_FORM, capturing the request's client IP + User-Agent.
 - Consent is recorded for all three PolicyDocumentType values when published.
-- Missing / false `accepted_policies` -> form invalid, signup never runs.
+- Missing / false `accepted_terms` -> form invalid, signup never runs.
+- Missing / false `accepted_sms_consent` -> form invalid, signup never runs.
+- SMS_CONSENT recording is driven specifically by `accepted_sms_consent`,
+  independently of `accepted_terms` (Phase 9 — separate SMS consent
+  checkbox, Twilio/TCPA compliance).
 - A document type with no published version yet is guarded (logged, not
   raised) -- signup still succeeds.
 - Phase 8: every recorded consent row carries `phone_number=user.phone_number`
@@ -30,7 +35,8 @@ def _signup_form_data(**overrides):
         "first_name": "Ada",
         "last_name": "Lovelace",
         "organization_name": "ACME Corp",
-        "accepted_policies": True,
+        "accepted_terms": True,
+        "accepted_sms_consent": True,
     }
     data.update(overrides)
     return data
@@ -143,20 +149,116 @@ class TestEmailSignupRecordsConsent:
         assert not UserConsent.objects.filter(user=user).exists()
 
 
-class TestAcceptedPoliciesRequired:
-    """`accepted_policies` is a required, must-be-True acknowledgement field."""
+class TestAcceptedTermsRequired:
+    """`accepted_terms` is a required, must-be-True acknowledgement field."""
 
     def test_missing_acceptance_makes_form_invalid(self):
         data = _signup_form_data()
-        del data["accepted_policies"]
+        del data["accepted_terms"]
 
         form = BaseVintaScheduleSignupForm(data=data)
 
         assert not form.is_valid()
-        assert "accepted_policies" in form.errors
+        assert "accepted_terms" in form.errors
 
     def test_false_acceptance_makes_form_invalid(self):
-        form = BaseVintaScheduleSignupForm(data=_signup_form_data(accepted_policies=False))
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data(accepted_terms=False))
 
         assert not form.is_valid()
-        assert "accepted_policies" in form.errors
+        assert "accepted_terms" in form.errors
+
+
+class TestAcceptedSmsConsentRequired:
+    """`accepted_sms_consent` is its own required, must-be-True acknowledgement
+    field -- Twilio / TCPA compliance requires SMS consent to be a distinct,
+    explicit opt-in, not bundled with Terms/Privacy acceptance (Phase 9)."""
+
+    def test_missing_acceptance_makes_form_invalid(self):
+        data = _signup_form_data()
+        del data["accepted_sms_consent"]
+
+        form = BaseVintaScheduleSignupForm(data=data)
+
+        assert not form.is_valid()
+        assert "accepted_sms_consent" in form.errors
+
+    def test_false_acceptance_makes_form_invalid(self):
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data(accepted_sms_consent=False))
+
+        assert not form.is_valid()
+        assert "accepted_sms_consent" in form.errors
+
+    def test_accepted_terms_alone_does_not_satisfy_sms_consent(self):
+        """Checking only the terms checkbox must not also satisfy the SMS
+        checkbox -- the two are independent required fields."""
+        form = BaseVintaScheduleSignupForm(
+            data=_signup_form_data(accepted_terms=True, accepted_sms_consent=False)
+        )
+
+        assert not form.is_valid()
+        assert "accepted_sms_consent" in form.errors
+        assert "accepted_terms" not in form.errors
+
+    def test_sms_consent_recording_driven_by_sms_field_not_terms_field(self, di_container):
+        """SMS_CONSENT recording is driven specifically by `accepted_sms_consent`,
+        independently of `accepted_terms`.
+
+        Both fields are required for a *valid* form submission, so this
+        exercises the recording helper directly with `accepted_terms=True` /
+        `accepted_sms_consent=False` in `cleaned_data` -- a state a valid
+        submission can never reach, but the one an implementation bug (e.g.
+        recording all three document types whenever *any* consent field is
+        truthy) would mishandle. This test would fail if SMS_CONSENT recording
+        were driven by `accepted_terms` instead of `accepted_sms_consent`.
+        """
+        for document_type in PolicyDocumentType.values:
+            PolicyDocumentFactory().create(document_type=document_type, version=1)
+
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data())
+        assert form.is_valid(), form.errors
+        # Simulate "terms accepted, SMS consent not accepted" -- impossible via
+        # a real submission (both required), but proves the mapping's wiring.
+        form.cleaned_data["accepted_terms"] = True
+        form.cleaned_data["accepted_sms_consent"] = False
+
+        user = UserFactory().create_user(email="consent-terms-only@example.com")
+        consent_service = di_container.consent_service()
+
+        form._record_signup_consents(request=None, user=user, consent_service=consent_service)
+
+        assert not UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.SMS_CONSENT
+        ).exists()
+        assert UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.PRIVACY_POLICY
+        ).exists()
+        assert UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.TERMS_OF_USE
+        ).exists()
+
+    def test_sms_consent_recorded_when_sms_field_checked_even_if_terms_not(self, di_container):
+        """Mirror case: `accepted_sms_consent=True` records SMS_CONSENT even
+        with `accepted_terms=False` -- proving the SMS row is gated solely by
+        its own field, not by terms acceptance."""
+        for document_type in PolicyDocumentType.values:
+            PolicyDocumentFactory().create(document_type=document_type, version=1)
+
+        form = BaseVintaScheduleSignupForm(data=_signup_form_data())
+        assert form.is_valid(), form.errors
+        form.cleaned_data["accepted_terms"] = False
+        form.cleaned_data["accepted_sms_consent"] = True
+
+        user = UserFactory().create_user(email="consent-sms-only@example.com")
+        consent_service = di_container.consent_service()
+
+        form._record_signup_consents(request=None, user=user, consent_service=consent_service)
+
+        assert UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.SMS_CONSENT
+        ).exists()
+        assert not UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.PRIVACY_POLICY
+        ).exists()
+        assert not UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.TERMS_OF_USE
+        ).exists()

--- a/accounts/tests/test_signup_consent_headless.py
+++ b/accounts/tests/test_signup_consent_headless.py
@@ -1,6 +1,6 @@
 """
-Phase 4 — HTTP-level test: consent capture through the real headless signup
-endpoint (`POST /auth/{client}/v1/auth/signup`).
+Phase 4 / Phase 9 — HTTP-level test: consent capture through the real headless
+signup endpoint (`POST /auth/{client}/v1/auth/signup`).
 
 ``HEADLESS_ONLY = True`` (see ``vinta_schedule_api/settings/base.py``), so the
 headless endpoint -- not a direct call to
@@ -9,6 +9,10 @@ email/password signup surface. The form-level tests in
 ``test_signup_consent.py`` cover the consent-capture behavior in detail; this
 file proves the same behavior fires end-to-end through the real HTTP request
 allauth-headless routes to ``form.signup(request, user)``.
+
+Phase 9 split the single ``accepted_policies`` checkbox into two required,
+independent fields (`accepted_terms`, `accepted_sms_consent`) — Twilio / TCPA
+require SMS consent to be its own explicit, separate opt-in.
 """
 
 from django.urls import reverse
@@ -33,16 +37,17 @@ def _signup_payload(**overrides):
         "password2": "Sup3r-Secret-Passw0rd!",
         "first_name": "Ada",
         "last_name": "Lovelace",
-        "accepted_policies": True,
+        "accepted_terms": True,
+        "accepted_sms_consent": True,
     }
     data.update(overrides)
     return data
 
 
 class TestHeadlessSignupRecordsConsent:
-    """POST /auth/app/v1/auth/signup with accepted_policies=True records consent."""
+    """POST /auth/app/v1/auth/signup with both consent checkboxes records consent."""
 
-    def test_accepted_policies_true_creates_user_and_sms_consent(self):
+    def test_both_checkboxes_true_creates_user_and_sms_consent(self):
         for document_type in PolicyDocumentType.values:
             PolicyDocumentFactory().create(document_type=document_type, version=1)
 
@@ -66,8 +71,15 @@ class TestHeadlessSignupRecordsConsent:
         # form's signup() runs, so the phone lands on the recorded consent.
         assert user.phone_number == "+123456789"
         assert consent.phone_number == "+123456789"
+        # Terms/privacy are also recorded when both boxes are checked.
+        assert UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.PRIVACY_POLICY
+        ).exists()
+        assert UserConsent.objects.filter(
+            user=user, policy_document__document_type=PolicyDocumentType.TERMS_OF_USE
+        ).exists()
 
-    def test_missing_accepted_policies_rejects_signup(self):
+    def test_missing_accepted_terms_rejects_signup(self):
         for document_type in PolicyDocumentType.values:
             PolicyDocumentFactory().create(document_type=document_type, version=1)
 
@@ -76,12 +88,36 @@ class TestHeadlessSignupRecordsConsent:
 
         response = client.post(
             url,
-            _signup_payload(email="headless-no-consent@example.com", accepted_policies=False),
+            _signup_payload(email="headless-no-terms@example.com", accepted_terms=False),
             format="json",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-        assert not User.objects.filter(email="headless-no-consent@example.com").exists()
+        assert not User.objects.filter(email="headless-no-terms@example.com").exists()
+        assert not UserConsent.objects.filter(user__email="headless-no-terms@example.com").exists()
+
+    def test_missing_accepted_sms_consent_rejects_signup(self):
+        """SMS consent is its own required, separate checkbox (Twilio / TCPA
+        compliance) -- omitting it (even with terms accepted) must reject
+        signup, and must record no consent at all."""
+        for document_type in PolicyDocumentType.values:
+            PolicyDocumentFactory().create(document_type=document_type, version=1)
+
+        client = APIClient()
+        url = reverse("headless:app:account:signup")
+
+        response = client.post(
+            url,
+            _signup_payload(
+                email="headless-no-sms-consent@example.com",
+                accepted_terms=True,
+                accepted_sms_consent=False,
+            ),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert not User.objects.filter(email="headless-no-sms-consent@example.com").exists()
         assert not UserConsent.objects.filter(
-            user__email="headless-no-consent@example.com"
+            user__email="headless-no-sms-consent@example.com"
         ).exists()

--- a/ai-plans/2026-07-04-SMS_MFA_CONSENT_FRONTEND_HANDOFF.md
+++ b/ai-plans/2026-07-04-SMS_MFA_CONSENT_FRONTEND_HANDOFF.md
@@ -70,10 +70,12 @@ Before rendering the consent UI, fetch the policy text to link/show (endpoints i
 
 ### 3a. Email / password signup
 
-The headless signup form now has a **new required field `accepted_policies`** (boolean). It represents acceptance of the Privacy Policy, Terms of Use, and SMS messaging consent together.
+The headless signup form has **two separate required boolean fields** — `accepted_terms` and `accepted_sms_consent`. They replace the old combined `accepted_policies` field (renamed/split in Phase 9): Twilio / TCPA require SMS consent to be its own explicit, distinct opt-in, not bundled with Terms/Privacy acceptance, so each must be its **own unchecked checkbox** with its own copy — do not pre-check either, and do not merge them into one control.
 
-- Add a **required** checkbox to the signup form, e.g. "I agree to the Privacy Policy, Terms of Use, and to receive SMS messages." Link the first two to the pages in §1/§2.
-- Include `accepted_policies: true` in the existing headless signup POST body (alongside `email`, `password`, `phone`, `first_name`, `last_name`, and optional `organization_name`).
+- Add **two required** checkboxes to the signup form:
+  - `accepted_terms` — copy: **"I agree to the Privacy Policy and Terms of Use."** Link to the pages in §1/§2.
+  - `accepted_sms_consent` — copy: **"I agree to receive SMS text messages (e.g. verification codes) at the phone number I provide. Msg & data rates may apply."** This is the SMS-specific opt-in; keep it visually and functionally distinct from the terms checkbox.
+- Include both `accepted_terms: true` and `accepted_sms_consent: true` in the existing headless signup POST body (alongside `email`, `password`, `phone`, `first_name`, `last_name`, and optional `organization_name`).
 
 ```
 POST /auth/browser/v1/auth/signup     (or /auth/app/v1/auth/signup for the app client)
@@ -85,12 +87,13 @@ Content-Type: application/json
   "phone": "+15551234567",
   "first_name": "…",
   "last_name": "…",
-  "accepted_policies": true
+  "accepted_terms": true,
+  "accepted_sms_consent": true
 }
 ```
 
-- If `accepted_policies` is missing or `false`, signup is rejected with a validation error on that field — surface it inline on the checkbox.
-- On success, the backend records `sms_consent` (plus `privacy_policy` / `terms_of_use` if those are published) automatically — the frontend does **not** need a separate consent call on this path.
+- If either `accepted_terms` or `accepted_sms_consent` is missing or `false`, signup is rejected with a validation error on that specific field — surface each inline on its own checkbox.
+- On success, the backend records `sms_consent` (driven by `accepted_sms_consent`) and `privacy_policy` / `terms_of_use` (driven by `accepted_terms`, if those are published) automatically — the frontend does **not** need a separate consent call on this path.
 
 ### 3b. OAuth2 / social signup (Google, Apple)
 
@@ -170,7 +173,7 @@ Detect `errors[].code === "consent_required"` on phone-verification requests and
 | Terms page | GET | `/policy-documents/latest/terms_of_use/` | public | `404` = not published |
 | All latest | GET | `/policy-documents/latest/` | public | array, one per type |
 | History | GET | `/policy-documents/?document_type=…` | auth | paginated, newest first |
-| Email signup consent | POST | `/auth/browser/v1/auth/signup` | public | add required `accepted_policies: true` |
+| Email signup consent | POST | `/auth/browser/v1/auth/signup` | public | add required `accepted_terms: true` + `accepted_sms_consent: true` (two separate checkboxes) |
 | OAuth consent step | POST | `/consents/` | auth | `{ "document_type": "sms_consent", "phone_number": "…" }` |
 | New/changed phone consent | POST | `/consents/` | auth | same as above — record **before** requesting a code for that phone |
 | Gate refusal (has a user) | — | (verification-code requests) | — | `403` `code: consent_required` → route to consent step |

--- a/schema-auth.yml
+++ b/schema-auth.yml
@@ -1389,7 +1389,9 @@ components:
       type: object
     BaseSignup:
       properties:
-        accepted_policies:
+        accepted_sms_consent:
+          type: boolean
+        accepted_terms:
           type: boolean
         email:
           $ref: '#/components/schemas/Email'
@@ -1409,7 +1411,8 @@ components:
       - phone
       - first_name
       - last_name
-      - accepted_policies
+      - accepted_terms
+      - accepted_sms_consent
       type: object
     ClientID:
       description: 'The client ID (in case of OAuth2 or OpenID Connect based providers)


### PR DESCRIPTION
## Summary
Phase 9 of the **SMS MFA Consent** plan (stacked on Phase 6 / PR #184). Twilio (and TCPA) require SMS consent to be its **own explicit, separate, unchecked** opt-in — not bundled with Terms/Privacy acceptance. Phase 4 shipped a single combined `accepted_policies` checkbox; this splits it into two **required** signup checkboxes:

- `accepted_terms` — "I agree to the Privacy Policy and Terms of Use." → records `PRIVACY_POLICY` + `TERMS_OF_USE`.
- `accepted_sms_consent` — "I agree to receive SMS text messages (e.g. verification codes) at the phone number I provide. Msg & data rates may apply." → records `SMS_CONSENT`.

Both are required today (phone MFA is mandatory), but the SMS recording is driven **specifically** by `accepted_sms_consent` (via an explicit `_CONSENT_FIELD_DOCUMENT_TYPES` field→doc-type map), so SMS could later become optional without touching terms recording. `schema-auth.yml` regenerated (headless `BaseSignup`: `accepted_policies` → `accepted_terms` + `accepted_sms_consent`, both required); handoff §3a updated with the two-checkbox copy.

**Frontend contract change:** the signup POST body now sends `accepted_terms: true` and `accepted_sms_consent: true` (was `accepted_policies: true`). Documented in the handoff.

## Plan reference
`ai-plans/2026-07-03-SMS_MFA_CONSENT_IMPLEMENTATION_PLAN.md` — **Phase 9** (stacked on Phase 6). No migrations. No behavior change to the consent gate — only how consent is collected at signup.

## Test plan
- `docker compose run --rm api uv run pytest accounts/tests/test_signup_consent.py accounts/tests/test_signup_consent_headless.py -n auto` — both checkboxes required (missing either → invalid/400, no user/consent created); both checked → all three doc types recorded; **directed tests prove SMS recording is driven by `accepted_sms_consent`, not `accepted_terms`** (would fail under an "any consent → record all" bug). Headless HTTP-level covered. All prior signup fixtures updated to the two fields.
- Outer gate: `check --deploy` clean; `makemigrations --check` clean; schema regenerated; full `pytest -n auto` → **3632 passed**.