### PR TITLE
test(public_api): lock in CORS origins and GraphQL introspection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 # Copy to .env. To run INSIDE the containers, use .env.docker.example -> .env.docker.
 DJANGO_SETTINGS_MODULE=vinta_schedule_api.settings.local
 CELERY_BROKER_URL=amqp://localhost:5672//
+# Local dev CORS origins. Production deploys add: https://schedule.vintasoftware.com (prod)
+# and https://schedule-staging.vintasoftware.com (staging) via Render environment config.
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
 REDIS_URL=redis://localhost:6379
 DATABASE_URL=postgres://vinta_schedule_api:password@localhost:5432/vinta_schedule_api

--- a/ai-plans/TRACKING_PUBLIC_API_DOCS_BACKEND.md
+++ b/ai-plans/TRACKING_PUBLIC_API_DOCS_BACKEND.md
@@ -1,0 +1,71 @@
+# Tracking — Public API Docs (Backend Support)
+
+- **Feature name**: Public API Docs — Backend Support
+- **Plan**: `ai-plans/2026-07-16-PUBLIC_API_DOCS_BACKEND_IMPLEMENTATION_PLAN.md`
+- **Started**: 2026-07-17
+- **Last updated**: 2026-07-17
+- **Feature flag**: none — all three phases are purely additive (new URL prefix, new dict, an env-var value change). See the plan's **Risk & Rollout Notes**.
+
+## Run options
+
+| Option | Value |
+| --- | --- |
+| `pause_between_phases` | false |
+| `generate_inline_comments` | false |
+| `full_test_suite` | false (scoped suites only) |
+| `commit_strategy_resolved` | stacked-branches |
+| `use_worktree` | true |
+| `worktree_path` | `.claude/worktrees/plan-public-api-docs-backend` |
+| `worktree_branch` | `plan-public-api-docs-backend` |
+| `worktree_summary` | `.vinta-ai-workflows/worktrees/plan-public-api-docs-backend.yaml` |
+| `sandbox_tier` | enforced (claude-hook pre-write guard; no OS-level layer) |
+
+Worktree notes: `node_modules` symlinked; `.env` / `.env.docker` copied with `COMPOSE_PROJECT_NAME=vinta_schedule_api_plan-public-api-docs-backend`; **no DB fork** (the plan introduces no migrations, so `test_db_strategy: fork-on-schema-change` did not trigger — the dev/test DB is shared with the main checkout).
+
+Model assignments: implementer per phase (plan-owned); reviewer tier 3 → `claude-sonnet-5`; fixer tier 2 → `claude-haiku-4-5`; worktree_prep + integrate tier 1 → `claude-haiku-4-5`.
+
+## Completed phases
+
+### Phase 1 — Lock in CORS and introspection for the docs origin ✅
+
+- Base: `plan-public-api-docs-backend`
+- Branch: `plan/public-api-docs-backend/phase-1`
+- Model: tier 2 → `claude-haiku-4-5` (implementer); reviewer `claude-sonnet-5`; fixer `claude-haiku-4-5`
+- Commits: `1510616` (tests + `.env.example`), `a1f6457` (reviewer fix)
+
+Summary:
+
+- Ships **tests only**, exactly as the plan requires. `vinta_schedule_api/settings/base.py` is untouched; the real production/staging origins remain a manual Render env edit (see **Manual follow-ups**).
+- New `public_api/tests/test_docs_cors_and_introspection.py` locks three properties: introspection answers on `POST /graphql/` with a non-empty `__schema.types`; a preflight from a configured origin echoes it and permits `authorization`; a preflight from an unconfigured origin gets **no** `Access-Control-Allow-Origin` header at all.
+- `.env.example` gained a comment naming the deployed origins; the localhost-only default value is unchanged.
+- Reviewer caught a **BLOCKER**: the unconfigured-origin test originally asserted only `allow_origin != evil_origin`. With `CORS_ALLOW_ALL_ORIGINS=True` + `CORS_ALLOW_CREDENTIALS=False`, corsheaders returns a literal `*`, and `"*" != evil` passes — so the test sailed past the exact wildcard misconfiguration it existed to catch. Fixed to `assert allow_origin is None`, which subsumes both "not echoed" and "not wildcard". The fixer proved the teeth: with the wildcard settings applied the test fails on `Got Allow-Origin: '*'`, and passes once reverted.
+- Verified independently by the conductor: `check --deploy` clean; `pytest public_api/tests/` 822 passed. mypy has a 322-error pre-existing repo baseline; the new file adds none.
+
+### Infrastructure incident during Phase 1 (resolved)
+
+The worktree was **not** isolated as provisioned. `docker-compose.yml` declares its volumes `external: true` with fixed names, which `COMPOSE_PROJECT_NAME` does not namespace, so the worktree's Postgres mounted the **same** PGDATA as the main checkout's. Two postmasters ran on one data directory (through the implementer's whole test run), and a `docker compose down` in the worktree removed the shared `postmaster.pid`, causing the main checkout's 2-day-old Postgres to self-terminate (`data directory lock file is invalid`). Main's DB was restarted, recovered cleanly (exit 0, no PANIC/corruption), and data was verified intact (77 tables, 21 orgs, 26 calendars).
+
+Resolved by an isolation override kept **outside the repo** at
+`<scratchpad>/docker-compose.worktree-noports.yml`, wired in via `COMPOSE_FILE` in the worktree's gitignored `.env`. It forks `dbdata` + `floci_data` to worktree-specific volumes and strips all host port publishing (the compose file hardcodes 5432/5672/6379/8000/1025/8025/4566, which collided with main's running stack). `virtualenv` stays shared on purpose — this plan adds no dependencies.
+
+Also reclaimed 17.1 GB of Docker build cache mid-phase after `No space left on device` (build cache only; volumes were never pruned).
+
+**This is a `prepare-worktree` bug affecting all ~18 worktrees in this repo, not something specific to this plan.** Any worktree that boots its DB stack while the main stack is up reproduces it. Worth fixing upstream in the skill.
+
+## Current phase
+
+_None — Phase 1 integrating._
+
+## Remaining phases
+
+- **Phase 2** — Serve concept docs over HTTP (tier 3 → `claude-sonnet-5`); base: `plan/public-api-docs-backend/phase-1`
+- **Phase 3** — Serve the webhook event catalog (tier 2 → `claude-haiku-4-5`); base: `plan/public-api-docs-backend/phase-2`
+
+## Deferred phases
+
+None in this repo — the plan declares no feature flag and no cross-repo phase.
+
+## Manual follow-ups (not executed by this run)
+
+1. **Phase 1 deploy step (human).** Append to `CORS_ALLOWED_ORIGINS` on Render — production: `https://schedule.vintasoftware.com`; staging: `https://schedule-staging.vintasoftware.com`. Verify the deployed value after editing: a typo fails open into a broken explorer, visible only in the browser console.
+2. **After Phase 3.** Run `amend-plan` against the frontend plan at `~/Workspaces/vinta-schedule-frontend-web/ai-plans/2026-07-16-PUBLIC_API_DOCS_IMPLEMENTATION_PLAN.md` to rewrite its Phase 4 to fetch `/public-api-docs/webhook-events/` instead of hand-authoring the event list.

--- a/public_api/tests/test_docs_cors_and_introspection.py
+++ b/public_api/tests/test_docs_cors_and_introspection.py
@@ -1,0 +1,159 @@
+"""Tests locking in CORS and GraphQL introspection for the docs origin.
+
+Phase 1 of the Public API Docs backend implementation plan.
+
+Guarantees:
+- Introspection is enabled on /graphql/ (so docs build-time schema fetch works).
+- CORS allows the configured docs origins to make cross-origin requests.
+- The authorization header is whitelisted for CORS preflight.
+- A wildcard or permissive regex is not set (tested by asserting unconfigured origins fail).
+"""
+
+from django.test import override_settings
+
+import pytest
+from rest_framework.test import APIClient
+
+
+# Standard GraphQL introspection query: fetch __schema and at least one type.
+# Fails fast if introspection is disabled.
+INTROSPECTION_QUERY = """
+    query IntrospectionQuery {
+        __schema {
+            types {
+                name
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.django_db
+class TestGraphQLIntrospection:
+    """Introspection must be enabled for docs build-time schema fetches."""
+
+    def test_introspection_query_returns_schema(self):
+        """POST /graphql/ with introspection query returns 200 and __schema with types.
+
+        This test guards the 'Introspection in production' decision: a future
+        Strawberry upgrade that disables introspection, or a config refactor that
+        blocks the query, must fail here rather than silently breaking the published
+        docs schema reference and GraphiQL's autocomplete.
+        """
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={"query": INTROSPECTION_QUERY},
+            format="json",
+        )
+
+        # Introspection must succeed.
+        assert response.status_code == 200, (
+            f"Introspection query failed with status {response.status_code}. "
+            "This may indicate introspection is disabled in Strawberry config or GraphQL schema."
+        )
+
+        data = response.json()
+
+        # Response must not contain errors.
+        assert "errors" not in data or not data.get("errors"), (
+            f"Introspection query returned errors: {data.get('errors')}"
+        )
+
+        # Response must contain __schema with at least one type.
+        assert "data" in data, "GraphQL response missing 'data' field"
+        assert "__schema" in data["data"], "Response missing '__schema' field"
+        assert "types" in data["data"]["__schema"], "__schema missing 'types' field"
+
+        # types must be a non-empty list (anti-vacuity check).
+        types_list = data["data"]["__schema"]["types"]
+        assert isinstance(types_list, list), f"'types' must be a list, got {type(types_list)}"
+        assert len(types_list) > 0, (
+            "Introspection returned an empty types list. The schema may be incorrectly configured."
+        )
+
+
+@pytest.mark.django_db
+class TestCORSPreflight:
+    """CORS preflight must allow configured origins and the authorization header.
+
+    Tests use override_settings to drive CORS configuration in-test, avoiding
+    dependence on ambient .env values.
+    """
+
+    @override_settings(
+        CORS_ALLOWED_ORIGINS=[
+            "https://schedule.vintasoftware.com",
+            "https://schedule-staging.vintasoftware.com",
+        ]
+    )
+    def test_configured_origin_preflight_succeeds(self):
+        """OPTIONS /graphql/ from a CORS_ALLOWED_ORIGINS origin echoes the origin.
+
+        Covers the 'CORS origins' and 'authorization header' decisions: the request
+        from the docs origin receives an Access-Control-Allow-Origin echo and may
+        include the authorization header in the actual request.
+        """
+        client = APIClient()
+
+        # Perform an OPTIONS preflight for a POST request with authorization header.
+        response = client.options(
+            "/graphql/",
+            HTTP_ORIGIN="https://schedule.vintasoftware.com",
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
+            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="authorization",
+        )
+
+        # Preflight must succeed.
+        assert response.status_code == 200, (
+            f"CORS preflight failed with status {response.status_code}. "
+            f"Response: {response.content.decode()}"
+        )
+
+        # Response must echo the requested origin in Access-Control-Allow-Origin.
+        allow_origin = response.get("Access-Control-Allow-Origin")
+        assert allow_origin == "https://schedule.vintasoftware.com", (
+            f"Expected Access-Control-Allow-Origin to echo the request origin, got {allow_origin!r}"
+        )
+
+        # Response must include authorization in Access-Control-Allow-Headers.
+        allow_headers = response.get("Access-Control-Allow-Headers", "").lower()
+        assert "authorization" in allow_headers, (
+            f"Expected 'authorization' in Access-Control-Allow-Headers, "
+            f"got {response.get('Access-Control-Allow-Headers')!r}"
+        )
+
+    @override_settings(
+        CORS_ALLOWED_ORIGINS=[
+            "https://schedule.vintasoftware.com",
+            "https://schedule-staging.vintasoftware.com",
+        ]
+    )
+    def test_unconfigured_origin_preflight_fails(self):
+        """OPTIONS /graphql/ from an unconfigured origin does NOT echo the origin.
+
+        This test has teeth: it FAILS if someone ever sets CORS_ALLOWED_ORIGINS
+        to a wildcard or permissive regex, which would be a security hole given
+        CORS_ALLOW_CREDENTIALS = True. The absence of an echo for an unconfigured
+        origin is the meaningful assertion; a missing header is the expected behavior.
+        """
+        client = APIClient()
+
+        # Perform an OPTIONS preflight from an origin NOT in CORS_ALLOWED_ORIGINS.
+        response = client.options(
+            "/graphql/",
+            HTTP_ORIGIN="https://evil.example.com",
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
+            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="authorization",
+        )
+
+        # Preflight response status is OK (200 or 200-range), but the origin is NOT echoed.
+        # Some CORS implementations return 200 with no echo for disallowed origins;
+        # others may vary. The key test is: the requested origin must NOT appear in
+        # the response header.
+        allow_origin = response.get("Access-Control-Allow-Origin")
+        assert allow_origin != "https://evil.example.com", (
+            f"CORS security failure: Access-Control-Allow-Origin echoed an unconfigured origin. "
+            f"This suggests CORS_ALLOWED_ORIGINS is set to a wildcard or permissive regex. "
+            f"Got Allow-Origin: {allow_origin!r}"
+        )

--- a/public_api/tests/test_docs_cors_and_introspection.py
+++ b/public_api/tests/test_docs_cors_and_introspection.py
@@ -5,7 +5,7 @@ Phase 1 of the Public API Docs backend implementation plan.
 Guarantees:
 - Introspection is enabled on /graphql/ (so docs build-time schema fetch works).
 - CORS allows the configured docs origins to make cross-origin requests.
-- The authorization header is whitelisted for CORS preflight.
+- The authorization header is allowed for CORS preflight.
 - A wildcard or permissive regex is not set (tested by asserting unconfigured origins fail).
 """
 
@@ -147,13 +147,13 @@ class TestCORSPreflight:
             HTTP_ACCESS_CONTROL_REQUEST_HEADERS="authorization",
         )
 
-        # Preflight response status is OK (200 or 200-range), but the origin is NOT echoed.
-        # Some CORS implementations return 200 with no echo for disallowed origins;
-        # others may vary. The key test is: the requested origin must NOT appear in
-        # the response header.
+        # Preflight response status is OK, but the origin is NOT echoed.
+        # When an origin is not in CORS_ALLOWED_ORIGINS and CORS_ALLOW_ALL_ORIGINS is off,
+        # django-cors-headers sets no Access-Control-Allow-Origin header.
         allow_origin = response.get("Access-Control-Allow-Origin")
-        assert allow_origin != "https://evil.example.com", (
-            f"CORS security failure: Access-Control-Allow-Origin echoed an unconfigured origin. "
-            f"This suggests CORS_ALLOWED_ORIGINS is set to a wildcard or permissive regex. "
+        assert allow_origin is None, (
+            f"CORS security failure: Access-Control-Allow-Origin header must not be set for unconfigured origins. "
+            f"A non-None value indicates either an echo of an unconfigured origin or a wildcard, "
+            f"both of which are security failures given CORS_ALLOW_CREDENTIALS=True. "
             f"Got Allow-Origin: {allow_origin!r}"
         )


### PR DESCRIPTION

## Summary

Phase 1 of the Public API Docs backend plan. It ships **tests only** — by design.

- Adds `public_api/tests/test_docs_cors_and_introspection.py`, locking in three properties the docs site depends on:
  1. GraphQL introspection answers on `POST /graphql/` and returns a non-empty `__schema.types` list.
  2. A CORS preflight from an origin in `CORS_ALLOWED_ORIGINS` echoes that origin and permits the `authorization` header.
  3. A preflight from an origin NOT in `CORS_ALLOWED_ORIGINS` gets no `Access-Control-Allow-Origin` header at all.
- Adds a comment to `.env.example` documenting the deployed production/staging origins. The localhost-only default value is unchanged on purpose — a developer's local value should stay localhost-only.

## Deliberate Non-Changes

- No change to `vinta_schedule_api/settings/base.py`. The production/staging origins are a **deploy-time env-var edit on Render**, not code — `settings/base.py` already reads `CORS_ALLOWED_ORIGINS` via `config(..., cast=Csv())`.
- `CORS_ALLOW_HEADERS` is untouched: it already spreads `corsheaders.defaults.default_headers`, which contains `authorization`.

## Why These Tests Matter

A future settings refactor, a `corsheaders` upgrade that changes `default_headers`, or a Strawberry upgrade that flips introspection off must now fail CI here rather than silently break the published docs explorer.

### Test 3 Note

During review it was caught that asserting `allow_origin != evil_origin` was toothless: with `CORS_ALLOW_ALL_ORIGINS=True` and `CORS_ALLOW_CREDENTIALS=False`, django-cors-headers returns a literal `*`, which passes that check while being exactly the misconfiguration the test exists to catch. It now asserts `allow_origin is None`, which covers both "not echoed" and "not wildcard". This was verified to fail on `Got Allow-Origin: '*'` when the wildcard config is applied.

## Required Manual Deploy Step

**Human, on Render:** append to `CORS_ALLOWED_ORIGINS` — production: `https://schedule.vintasoftware.com`; staging: `https://schedule-staging.vintasoftware.com`. Verify the deployed value after editing: a typo fails open into a broken explorer, visible only in the browser console. This must land before the frontend's explorer is exercised in production.

## Plan Reference

See `ai-plans/2026-07-16-PUBLIC_API_DOCS_BACKEND_IMPLEMENTATION_PLAN.md` for the full implementation plan.

## Test Plan

```bash