### PR TITLE
Serve concept docs over HTTP endpoint (Phase 2)

### DIFF
--- a/ai-plans/TRACKING_PUBLIC_API_DOCS_BACKEND.md
+++ b/ai-plans/TRACKING_PUBLIC_API_DOCS_BACKEND.md
@@ -52,13 +52,34 @@ Also reclaimed 17.1 GB of Docker build cache mid-phase after `No space left on d
 
 **This is a `prepare-worktree` bug affecting all ~18 worktrees in this repo, not something specific to this plan.** Any worktree that boots its DB stack while the main stack is up reproduces it. Worth fixing upstream in the skill.
 
+### Phase 2 — Serve concept docs over HTTP ✅
+
+- Base: `plan/public-api-docs-backend/phase-1`
+- Branch: `plan/public-api-docs-backend/phase-2`
+- Model: tier 3 → `claude-sonnet-5` (implementer); reviewer `claude-sonnet-5`; fixer `claude-haiku-4-5`
+- Commits: `f1b0fdb` (endpoint), `9cf4b1a` (reviewer fixes), `da6a272` (tuple revert)
+
+Summary:
+
+- `public_api/docs_content.py` globs `docs/concepts/*.md` once at import into a `slug -> Path` allow-list. `get_concept_doc` does `_ALLOWLIST.get(slug)` — a dict key lookup, never a path join — which is the phase's load-bearing security property.
+- `PublicApiDocsViewSet` is a plain `ViewSet` (no model, no queryset), `AllowAny`, no auth classes, tagged `Docs`, registered at `public-api-docs` via the `RouteDict` pattern. Modeled on `legal/views.py`'s `PolicyDocumentViewSet` per the plan.
+- Serializers are plain `Serializer` subclasses over dicts. `schema.yml` regenerated: +152 lines, only the new endpoints' surface.
+- Verified end-to-end by the conductor: all six docs list with real titles; `calendar-groups` markdown is byte-identical to disk; unauthenticated access works; every traversal payload 404s.
+
+**Deviation from the plan (accepted, verified).** The plan specifies `lookup_value_regex = "[a-z0-9-]+"`. That attribute is **inert for routing** here: `vinta_schedule_api/urls.py:28` builds `DefaultRouter(use_regex_path=False)`, which emits `path()`-style routes, and DRF only consults `lookup_value_regex` when `use_regex_path=True`. A `ConceptDocSlugConverter` (regex `[a-z0-9-]+`) is registered as the `docs_slug` path converter instead, and the resolved pattern is confirmed to be `public-api-docs/<docs_slug:slug>/`. `lookup_value_regex` is retained because drf-spectacular reads it to emit `pattern: ^[a-z0-9-]+$` into `schema.yml` (present at `schema.yml:10394`, `:10432`), with a comment at the attribute saying so.
+
+**Reviewer BLOCKER — the traversal tests were vacuous.** The original payloads (`../settings`, `%2Fetc%2Fpasswd`, `../../pyproject`, …) all map to files that do not exist (`../settings.md`, …), so a naive `Path(dir) / f"{slug}.md"` implementation — the exact shape the plan says reviewers must reject — would **also** 404 on every one of them. The suite would have passed straight through the regression it exists to prevent. `docs/concepts/` sits two levels below the repo root, so `../../README` resolves to a real file. Payloads `../../README`, `../../AGENTS`, `../../CODE_OF_CONDUCT` were added. Proven empirically by the conductor: with the naive path-join applied, **all 5 original payloads PASSED and all 3 new payloads FAILED**.
+
+Other fixes this phase: `_extract_title` now strips fenced code blocks before searching, so a doc leading with a shell comment in a ``` fence can't publish a silently-wrong title; the URL converter moved out of a `views.py` import-time side effect into `public_api/converters.py` + `apps.py:ready()`.
+
+**A note on one conductor misstep:** a NIT was pushed to change `authentication_classes` from `()` to `[]` for literal spec conformance, which forced a `# noqa: RUF012` suppression. That was the wrong trade and contradicted repo precedent (`legal/views.py` uses tuples; `calendar_integration/token_views.py:80` uses `tuple()`). Reverted in `da6a272`; ruff is clean without the suppression.
+
 ## Current phase
 
-_None — Phase 1 integrating._
+_None — Phase 2 integrating._
 
 ## Remaining phases
 
-- **Phase 2** — Serve concept docs over HTTP (tier 3 → `claude-sonnet-5`); base: `plan/public-api-docs-backend/phase-1`
 - **Phase 3** — Serve the webhook event catalog (tier 2 → `claude-haiku-4-5`); base: `plan/public-api-docs-backend/phase-2`
 
 ## Deferred phases

--- a/public_api/apps.py
+++ b/public_api/apps.py
@@ -1,6 +1,13 @@
 from django.apps import AppConfig
+from django.urls import register_converter
 
 
 class PublicApiConfig(AppConfig):
     name = "public_api"
     verbose_name = "Public API"
+
+    def ready(self) -> None:
+        """Register URL converters when Django starts up."""
+        from public_api.converters import ConceptDocSlugConverter
+
+        register_converter(ConceptDocSlugConverter, "docs_slug")

--- a/public_api/converters.py
+++ b/public_api/converters.py
@@ -1,0 +1,20 @@
+class ConceptDocSlugConverter:
+    """Path converter restricting ``{slug}`` to ``[a-z0-9-]+``.
+
+    ``vinta_schedule_api.urls`` builds ``DefaultRouter(use_regex_path=False)``,
+    which generates ``path()``-style routes (``<converter:kwarg>``) rather than
+    ``re_path()`` regexes. In that mode DRF's router prefers a viewset's
+    ``lookup_value_converter`` over ``lookup_value_regex`` (the latter is only
+    consulted when ``use_regex_path=True``). Registering this converter is what
+    actually enforces the lowercase-alnum-hyphen charset at the URL-resolution
+    layer — anything else (dots, slashes, percent-encoded traversal segments)
+    never reaches the view at all.
+    """
+
+    regex = "[a-z0-9-]+"
+
+    def to_python(self, value: str) -> str:
+        return value
+
+    def to_url(self, value: str) -> str:
+        return value

--- a/public_api/docs_content.py
+++ b/public_api/docs_content.py
@@ -1,0 +1,73 @@
+import re
+from pathlib import Path
+from typing import TypedDict
+
+from django.conf import settings
+
+from rest_framework.exceptions import NotFound
+
+
+class ConceptDocSummary(TypedDict):
+    """Manifest entry for a concept doc: enough to render a listing/nav."""
+
+    slug: str
+    title: str
+
+
+class ConceptDoc(ConceptDocSummary):
+    """A single concept doc's full content, mirroring the frontend's ``ConceptDoc`` type."""
+
+    markdown: str
+
+
+_CONCEPTS_DIR = Path(settings.BASE_DIR) / "docs" / "concepts"
+
+# Allow-list of slug -> resolved absolute path, built once at import time by globbing
+# `docs/concepts/*.md`. This is the whole security property of this module: a request's
+# slug is only ever looked up as a *key* in this dict, never joined into a filesystem
+# path, so path traversal is structurally impossible rather than filtered.
+_ALLOWLIST: dict[str, Path] = {
+    path.stem: path.resolve() for path in sorted(_CONCEPTS_DIR.glob("*.md"))
+}
+
+_HEADING_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _extract_title(markdown: str, *, fallback_slug: str) -> str:
+    """Return the text of the first ``# `` heading in ``markdown``.
+
+    Falls back to a title-cased version of ``fallback_slug`` when the file has no
+    heading at all — a doc without a heading should still be listable, not raise.
+    """
+    match = _HEADING_RE.search(markdown)
+    if match is None:
+        return fallback_slug.replace("-", " ").title()
+    return match.group(1)
+
+
+def list_concept_docs() -> list[ConceptDocSummary]:
+    """Return one summary per allow-listed concept doc, sorted alphabetically by slug."""
+    summaries: list[ConceptDocSummary] = []
+    for slug in sorted(_ALLOWLIST):
+        markdown = _ALLOWLIST[slug].read_text()
+        summaries.append({"slug": slug, "title": _extract_title(markdown, fallback_slug=slug)})
+    return summaries
+
+
+def get_concept_doc(slug: str) -> ConceptDoc:
+    """Return the full content of the concept doc identified by ``slug``.
+
+    ``slug`` is looked up as a dict key against the allow-list built at import time —
+    it is never joined into a filesystem path. Raises :class:`NotFound` for any slug
+    that is not a key of the allow-list (unknown slug, path-traversal payload, etc).
+    """
+    path = _ALLOWLIST.get(slug)
+    if path is None:
+        raise NotFound(detail=f"Unknown concept doc slug '{slug}'.")
+
+    markdown = path.read_text()
+    return {
+        "slug": slug,
+        "title": _extract_title(markdown, fallback_slug=slug),
+        "markdown": markdown,
+    }

--- a/public_api/docs_content.py
+++ b/public_api/docs_content.py
@@ -31,6 +31,7 @@ _ALLOWLIST: dict[str, Path] = {
 }
 
 _HEADING_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+_FENCED_CODE_RE = re.compile(r"^```.*?^```", re.MULTILINE | re.DOTALL)
 
 
 def _extract_title(markdown: str, *, fallback_slug: str) -> str:
@@ -38,8 +39,13 @@ def _extract_title(markdown: str, *, fallback_slug: str) -> str:
 
     Falls back to a title-cased version of ``fallback_slug`` when the file has no
     heading at all — a doc without a heading should still be listable, not raise.
+
+    Strips fenced code blocks (``` ... ```) before searching to avoid matching
+    headings inside code examples (e.g. shell comments).
     """
-    match = _HEADING_RE.search(markdown)
+    # Remove fenced code blocks to avoid matching headings inside them
+    markdown_without_fences = _FENCED_CODE_RE.sub("", markdown)
+    match = _HEADING_RE.search(markdown_without_fences)
     if match is None:
         return fallback_slug.replace("-", " ").title()
     return match.group(1)

--- a/public_api/routes.py
+++ b/public_api/routes.py
@@ -1,5 +1,5 @@
 from common.types import RouteDict
-from public_api.views import SystemUserTokenViewSet
+from public_api.views import PublicApiDocsViewSet, SystemUserTokenViewSet
 
 
 routes: list[RouteDict] = [
@@ -7,5 +7,10 @@ routes: list[RouteDict] = [
         "regex": r"public-api-tokens",
         "viewset": SystemUserTokenViewSet,
         "basename": "PublicAPITokens",
+    },
+    {
+        "regex": r"public-api-docs",
+        "viewset": PublicApiDocsViewSet,
+        "basename": "PublicAPIDocs",
     },
 ]

--- a/public_api/serializers.py
+++ b/public_api/serializers.py
@@ -227,6 +227,28 @@ class SystemUserTokenSerializer(serializers.ModelSerializer):
         return obj.scoped_to_membership_user_id
 
 
+class ConceptDocSummarySerializer(serializers.Serializer):
+    """Read-only manifest entry for a concept doc (list view).
+
+    Plain ``Serializer`` over a :class:`public_api.docs_content.ConceptDocSummary`
+    dict — there is no model backing this.
+    """
+
+    slug = serializers.CharField(read_only=True)
+    title = serializers.CharField(read_only=True)
+
+
+class ConceptDocSerializer(ConceptDocSummarySerializer):
+    """Read-only representation of a single concept doc's full content.
+
+    Plain ``Serializer`` over a :class:`public_api.docs_content.ConceptDoc` dict —
+    there is no model backing this. Returns raw markdown; the frontend owns
+    rendering and sanitization.
+    """
+
+    markdown = serializers.CharField(read_only=True)
+
+
 class SystemUserTokenUpdateSerializer(serializers.Serializer):
     """Input serializer for updating a public-API token's resource grants (Phase 15).
 

--- a/public_api/tests/test_docs_content.py
+++ b/public_api/tests/test_docs_content.py
@@ -59,6 +59,11 @@ class TestExtractTitle:
 
         assert _extract_title(markdown, fallback_slug="my-doc-slug") == "My Doc Slug"
 
+    def test_ignores_heading_inside_fenced_code_block(self):
+        markdown = "```bash\n# install deps\n```\n\n# Real Title\n\nBody.\n"
+
+        assert _extract_title(markdown, fallback_slug="fallback") == "Real Title"
+
 
 class TestGetConceptDoc:
     def test_returns_markdown_byte_identical_to_file_on_disk(self):
@@ -80,6 +85,9 @@ class TestGetConceptDoc:
             "%2Fetc%2Fpasswd",
             "/etc/passwd",
             "../../pyproject",
+            "../../README",
+            "../../AGENTS",
+            "../../CODE_OF_CONDUCT",
         ],
     )
     def test_traversal_payloads_raise_not_found(self, slug):

--- a/public_api/tests/test_docs_content.py
+++ b/public_api/tests/test_docs_content.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+from django.conf import settings
+
+import pytest
+from rest_framework.exceptions import NotFound
+
+from public_api.docs_content import (
+    _ALLOWLIST,
+    _extract_title,
+    get_concept_doc,
+    list_concept_docs,
+)
+
+
+CONCEPTS_DIR = Path(settings.BASE_DIR) / "docs" / "concepts"
+
+EXPECTED_SLUGS = (
+    "availability",
+    "calendar-bundles",
+    "calendar-groups",
+    "calendars",
+    "events",
+    "recurrence",
+)
+
+
+class TestListConceptDocs:
+    def test_returns_all_six_real_files_with_real_titles(self):
+        summaries = list_concept_docs()
+
+        assert [summary["slug"] for summary in summaries] == sorted(EXPECTED_SLUGS)
+        for summary in summaries:
+            on_disk_markdown = (CONCEPTS_DIR / f"{summary['slug']}.md").read_text()
+            assert summary["title"] == _extract_title(
+                on_disk_markdown, fallback_slug=summary["slug"]
+            )
+
+    def test_returns_sorted_alphabetically_by_slug(self):
+        summaries = list_concept_docs()
+
+        slugs = [summary["slug"] for summary in summaries]
+        assert slugs == sorted(slugs)
+
+
+class TestExtractTitle:
+    def test_normal_heading_on_first_line(self):
+        markdown = "# My Title\n\nSome body text.\n"
+
+        assert _extract_title(markdown, fallback_slug="fallback") == "My Title"
+
+    def test_heading_not_on_first_line(self):
+        markdown = "> Some blockquote intro\n\n# My Title\n\nBody.\n"
+
+        assert _extract_title(markdown, fallback_slug="fallback") == "My Title"
+
+    def test_no_heading_falls_back_to_title_cased_slug(self):
+        markdown = "Just some text with no headings at all.\n"
+
+        assert _extract_title(markdown, fallback_slug="my-doc-slug") == "My Doc Slug"
+
+
+class TestGetConceptDoc:
+    def test_returns_markdown_byte_identical_to_file_on_disk(self):
+        doc = get_concept_doc("calendar-groups")
+
+        on_disk = (CONCEPTS_DIR / "calendar-groups.md").read_text()
+        assert doc["markdown"] == on_disk
+        assert doc["slug"] == "calendar-groups"
+
+    def test_unknown_slug_raises_not_found(self):
+        with pytest.raises(NotFound):
+            get_concept_doc("does-not-exist")
+
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "../settings",
+            "..%2Fsettings",
+            "%2Fetc%2Fpasswd",
+            "/etc/passwd",
+            "../../pyproject",
+        ],
+    )
+    def test_traversal_payloads_raise_not_found(self, slug):
+        with pytest.raises(NotFound):
+            get_concept_doc(slug)
+
+    def test_allowlist_contains_exactly_the_expected_slugs(self):
+        assert set(_ALLOWLIST.keys()) == set(EXPECTED_SLUGS)

--- a/public_api/tests/test_docs_endpoint.py
+++ b/public_api/tests/test_docs_endpoint.py
@@ -68,6 +68,9 @@ class TestPublicApiDocsRetrieve:
             "/public-api-docs/..%2F..%2Fsettings/",
             "/public-api-docs/%2Fetc%2Fpasswd/",
             "/public-api-docs//etc/passwd/",
+            "/public-api-docs/../../README/",
+            "/public-api-docs/../../AGENTS/",
+            "/public-api-docs/../../CODE_OF_CONDUCT/",
         ],
     )
     def test_traversal_payloads_never_read_a_file_outside_allowlist(self, anonymous_client, path):

--- a/public_api/tests/test_docs_endpoint.py
+++ b/public_api/tests/test_docs_endpoint.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from django.conf import settings
+
+import pytest
+from rest_framework import status
+
+
+CONCEPTS_DIR = Path(settings.BASE_DIR) / "docs" / "concepts"
+
+EXPECTED_SLUGS = (
+    "availability",
+    "calendar-bundles",
+    "calendar-groups",
+    "calendars",
+    "events",
+    "recurrence",
+)
+
+
+@pytest.mark.django_db
+class TestPublicApiDocsList:
+    def test_list_returns_all_six_docs(self, anonymous_client):
+        response = anonymous_client.get("/public-api-docs/")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert [entry["slug"] for entry in body] == sorted(EXPECTED_SLUGS)
+        for entry in body:
+            assert set(entry.keys()) == {"slug", "title"}
+            assert entry["title"]
+
+    def test_list_succeeds_unauthenticated(self, anonymous_client):
+        """Explicitly assert no credentials are required.
+
+        Every other route in this app requires auth; a future global
+        default-permission change must fail here first.
+        """
+        assert anonymous_client.get("/public-api-docs/").status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+class TestPublicApiDocsRetrieve:
+    def test_retrieve_returns_markdown_verbatim(self, anonymous_client):
+        response = anonymous_client.get("/public-api-docs/calendar-groups/")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["slug"] == "calendar-groups"
+        assert body["title"]
+        assert body["markdown"] == (CONCEPTS_DIR / "calendar-groups.md").read_text()
+
+    def test_retrieve_succeeds_unauthenticated(self, anonymous_client):
+        response = anonymous_client.get("/public-api-docs/calendar-groups/")
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_retrieve_unknown_slug_returns_404(self, anonymous_client):
+        response = anonymous_client.get("/public-api-docs/does-not-exist/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/public-api-docs/../settings/",
+            "/public-api-docs/..%2Fsettings/",
+            "/public-api-docs/..%2F..%2Fsettings/",
+            "/public-api-docs/%2Fetc%2Fpasswd/",
+            "/public-api-docs//etc/passwd/",
+        ],
+    )
+    def test_traversal_payloads_never_read_a_file_outside_allowlist(self, anonymous_client, path):
+        response = anonymous_client.get(path)
+
+        assert response.status_code in (status.HTTP_404_NOT_FOUND, status.HTTP_400_BAD_REQUEST)

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.db import transaction
-from django.urls import register_converter
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
@@ -219,31 +218,6 @@ class SystemUserTokenViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet)
         return self.update(request, *args, **kwargs)
 
 
-class _ConceptDocSlugConverter:
-    """Path converter restricting ``{slug}`` to ``[a-z0-9-]+``.
-
-    ``vinta_schedule_api.urls`` builds ``DefaultRouter(use_regex_path=False)``,
-    which generates ``path()``-style routes (``<converter:kwarg>``) rather than
-    ``re_path()`` regexes. In that mode DRF's router prefers a viewset's
-    ``lookup_value_converter`` over ``lookup_value_regex`` (the latter is only
-    consulted when ``use_regex_path=True``). Registering this converter is what
-    actually enforces the lowercase-alnum-hyphen charset at the URL-resolution
-    layer — anything else (dots, slashes, percent-encoded traversal segments)
-    never reaches the view at all.
-    """
-
-    regex = "[a-z0-9-]+"
-
-    def to_python(self, value: str) -> str:
-        return value
-
-    def to_url(self, value: str) -> str:
-        return value
-
-
-register_converter(_ConceptDocSlugConverter, "docs_slug")
-
-
 @extend_schema(tags=["Docs"])
 class PublicApiDocsViewSet(ViewSet):
     """Public, read-only viewset serving the repo's concept documentation.
@@ -261,10 +235,11 @@ class PublicApiDocsViewSet(ViewSet):
     """
 
     lookup_field = "slug"
+    # Inert for routing (lookup_value_converter does that); kept so drf-spectacular emits the pattern.
     lookup_value_regex = "[a-z0-9-]+"
     lookup_value_converter = "docs_slug"
     permission_classes = (AllowAny,)
-    authentication_classes = ()
+    authentication_classes = []  # noqa: RUF012
     http_method_names = ("get", "head", "options")
 
     @extend_schema(

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -239,7 +239,7 @@ class PublicApiDocsViewSet(ViewSet):
     lookup_value_regex = "[a-z0-9-]+"
     lookup_value_converter = "docs_slug"
     permission_classes = (AllowAny,)
-    authentication_classes = []  # noqa: RUF012
+    authentication_classes = ()
     http_method_names = ("get", "head", "options")
 
     @extend_schema(

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -1,21 +1,26 @@
 import logging
 
 from django.db import transaction
+from django.urls import register_converter
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
+from rest_framework.viewsets import GenericViewSet, ViewSet
 
 from organizations.models import get_active_organization_membership
 from organizations.permissions import IsOrganizationAdmin
 from public_api.constants import PROVIDER_SCOPED_RESOURCES
+from public_api.docs_content import get_concept_doc, list_concept_docs
 from public_api.models import ResourceAccess, SystemUser
 from public_api.serializers import (
+    ConceptDocSerializer,
+    ConceptDocSummarySerializer,
     SystemUserTokenCreateSerializer,
     SystemUserTokenResponseSerializer,
     SystemUserTokenSerializer,
@@ -212,3 +217,80 @@ class SystemUserTokenViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet)
         """
         # For this endpoint, PATCH = PUT (full replacement, not merge)
         return self.update(request, *args, **kwargs)
+
+
+class _ConceptDocSlugConverter:
+    """Path converter restricting ``{slug}`` to ``[a-z0-9-]+``.
+
+    ``vinta_schedule_api.urls`` builds ``DefaultRouter(use_regex_path=False)``,
+    which generates ``path()``-style routes (``<converter:kwarg>``) rather than
+    ``re_path()`` regexes. In that mode DRF's router prefers a viewset's
+    ``lookup_value_converter`` over ``lookup_value_regex`` (the latter is only
+    consulted when ``use_regex_path=True``). Registering this converter is what
+    actually enforces the lowercase-alnum-hyphen charset at the URL-resolution
+    layer — anything else (dots, slashes, percent-encoded traversal segments)
+    never reaches the view at all.
+    """
+
+    regex = "[a-z0-9-]+"
+
+    def to_python(self, value: str) -> str:
+        return value
+
+    def to_url(self, value: str) -> str:
+        return value
+
+
+register_converter(_ConceptDocSlugConverter, "docs_slug")
+
+
+@extend_schema(tags=["Docs"])
+class PublicApiDocsViewSet(ViewSet):
+    """Public, read-only viewset serving the repo's concept documentation.
+
+    ``ConceptDoc`` content is not a model — it is markdown files read from a
+    bounded allow-list under ``docs/concepts/`` (see ``public_api.docs_content``).
+    This viewset intentionally does not build on the ``*VintaScheduleModelViewSet``
+    family, nor even ``ReadOnlyModelViewSet``: those bases assume a queryset and a
+    model, and there is neither here — only dicts. Mirrors the shape of
+    ``legal.views.PolicyDocumentViewSet`` (public, ``AllowAny``, read-only,
+    registered via the same ``RouteDict`` pattern), which is the closest existing
+    precedent for a public document-serving endpoint.
+
+    Unauthenticated by design: this is public documentation, not tenant data.
+    """
+
+    lookup_field = "slug"
+    lookup_value_regex = "[a-z0-9-]+"
+    lookup_value_converter = "docs_slug"
+    permission_classes = (AllowAny,)
+    authentication_classes = ()
+    http_method_names = ("get", "head", "options")
+
+    @extend_schema(
+        summary="List the available concept docs",
+        responses={200: ConceptDocSummarySerializer(many=True)},
+    )
+    def list(self, request: Request) -> Response:
+        """GET /public-api-docs/ — one entry per allow-listed concept doc."""
+        serializer = ConceptDocSummarySerializer(list_concept_docs(), many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Retrieve a single concept doc's raw markdown",
+        responses={
+            200: ConceptDocSerializer,
+            404: OpenApiResponse(description="Unknown slug (including any traversal attempt)"),
+        },
+    )
+    def retrieve(self, request: Request, slug: str | None = None) -> Response:
+        """GET /public-api-docs/{slug}/ — raw markdown for one concept doc.
+
+        ``slug`` is looked up as a key of the allow-list built in
+        ``public_api.docs_content``; never joined into a filesystem path. Any
+        slug not a key of the allow-list — including path-traversal payloads —
+        404s via ``get_concept_doc``.
+        """
+        doc = get_concept_doc(slug or "")
+        serializer = ConceptDocSerializer(doc)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/schema.yml
+++ b/schema.yml
@@ -10331,6 +10331,119 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProfilePictureUploadParams'
           description: ''
+  /public-api-docs/:
+    get:
+      operationId: public_api_docs_list
+      description: GET /public-api-docs/ — one entry per allow-listed concept doc.
+      summary: List the available concept docs
+      tags:
+      - Docs
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ConceptDocSummary'
+          description: ''
+  /public-api-docs{format}:
+    get:
+      operationId: public_api_docs_formatted_list
+      description: GET /public-api-docs/ — one entry per allow-listed concept doc.
+      summary: List the available concept docs
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      tags:
+      - Docs
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ConceptDocSummary'
+          description: ''
+  /public-api-docs/{slug}/:
+    get:
+      operationId: public_api_docs_retrieve
+      description: |-
+        GET /public-api-docs/{slug}/ — raw markdown for one concept doc.
+
+        ``slug`` is looked up as a key of the allow-list built in
+        ``public_api.docs_content``; never joined into a filesystem path. Any
+        slug not a key of the allow-list — including path-traversal payloads —
+        404s via ``get_concept_doc``.
+      summary: Retrieve a single concept doc's raw markdown
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9-]+$
+        required: true
+      tags:
+      - Docs
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConceptDoc'
+          description: ''
+        '404':
+          description: Unknown slug (including any traversal attempt)
+  /public-api-docs/{slug}{format}:
+    get:
+      operationId: public_api_docs_formatted_retrieve
+      description: |-
+        GET /public-api-docs/{slug}/ — raw markdown for one concept doc.
+
+        ``slug`` is looked up as a key of the allow-list built in
+        ``public_api.docs_content``; never joined into a filesystem path. Any
+        slug not a key of the allow-list — including path-traversal payloads —
+        404s via ``get_concept_doc``.
+      summary: Retrieve a single concept doc's raw markdown
+      parameters:
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9-]+$
+        required: true
+      tags:
+      - Docs
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConceptDoc'
+          description: ''
+        '404':
+          description: Unknown slug (including any traversal attempt)
   /public-api-tokens/:
     get:
       operationId: public_api_tokens_list
@@ -13347,6 +13460,45 @@ components:
         * `resource` - Resource Calendar
         * `virtual` - Virtual Calendar
         * `bundle` - Bundle Calendar
+    ConceptDoc:
+      type: object
+      description: |-
+        Read-only representation of a single concept doc's full content.
+
+        Plain ``Serializer`` over a :class:`public_api.docs_content.ConceptDoc` dict —
+        there is no model backing this. Returns raw markdown; the frontend owns
+        rendering and sanitization.
+      properties:
+        slug:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+        markdown:
+          type: string
+          readOnly: true
+      required:
+      - markdown
+      - slug
+      - title
+    ConceptDocSummary:
+      type: object
+      description: |-
+        Read-only manifest entry for a concept doc (list view).
+
+        Plain ``Serializer`` over a :class:`public_api.docs_content.ConceptDocSummary`
+        dict — there is no model backing this.
+      properties:
+        slug:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+      required:
+      - slug
+      - title
     ConsentCreate:
       type: object
       description: |-


### PR DESCRIPTION

## Summary

Phase 2 of the Public API Docs backend plan. Stacked on #186 (Phase 1) — review that first.

Adds a public, unauthenticated, read-only endpoint serving the repo's concept documentation as raw markdown, so the docs frontend can render it at build time and this repo stays the single source of truth.

## Endpoints

- `GET /public-api-docs/` → one entry per doc (`slug`, `title`), six today: availability, calendar-bundles, calendar-groups, calendars, events, recurrence. Title comes from each file's first `# ` heading.
- `GET /public-api-docs/{slug}/` → `slug`, `title`, and the file's raw markdown, verbatim. The frontend owns rendering and sanitization.

## The load-bearing security property

`public_api/docs_content.py` globs `docs/concepts/*.md` once at import into a `slug -> Path` allow-list. `get_concept_doc` does `_ALLOWLIST.get(slug)` — a dict key lookup. A request string is never joined into a filesystem path, which makes traversal structurally impossible rather than filtered. Per the plan, reviewers should reject any change that reintroduces `Path(concepts_dir) / f"{slug}.md"`.

## Review improvements

The traversal tests were vacuous in the original state. The original payloads (`../settings`, `%2Fetc%2Fpasswd`, `../../pyproject`, …) all map to files that don't exist (`../settings.md` and friends), so a naive path-join implementation would 404 on them too — the suite would have passed straight through the exact regression it exists to prevent. Since `docs/concepts/` sits two levels below the repo root, `../../README` resolves to a real file. Payloads `../../README`, `../../AGENTS`, `../../CODE_OF_CONDUCT` were added, and this was proven empirically: with a naive path-join applied, all 5 original payloads passed while all 3 new ones failed.

## Implementation notes

The plan specifies `lookup_value_regex = "[a-z0-9-]+"`, but that attribute is inert here: `vinta_schedule_api/urls.py:28` builds `DefaultRouter(use_regex_path=False)`, which emits `path()`-style routes, and DRF only consults `lookup_value_regex` when `use_regex_path=True`. A `ConceptDocSlugConverter` is registered as the `docs_slug` path converter instead (via `public_api/converters.py` + `apps.py:ready()`), giving `public-api-docs/<docs_slug:slug>/`. `lookup_value_regex` is retained, with a comment, because drf-spectacular reads it to emit `pattern: ^[a-z0-9-]+$` into `schema.yml`.

Also: `_extract_title` strips fenced code blocks before searching, so a doc leading with a shell comment inside a ``` fence can't publish a silently-wrong title.

## schema.yml changes

`schema.yml` is regenerated (+152 lines, only this endpoint's surface). Per the plan, that file syncs into the frontend repo and drives its codegen, so expect new `PublicAPIDocs*` operations to appear there on the next sync. Nothing consumes them, and that is expected — the frontend fetches these with a plain build-time `fetch`, not the generated client.

## Verification

`pytest public_api/tests/` → 852 passed; `check --deploy` clean; `makemigrations --check` clean. Endpoint verified end-to-end: all six docs list with real titles, `calendar-groups` markdown is byte-identical to disk, unauthenticated access works, every traversal payload 404s.