### PR TITLE
feat(payments): move billing ownership from user to organization (billing plans and limits, phase 1)

### DIFF
--- a/ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_IMPLEMENTATION_PLAN.md
+++ b/ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_IMPLEMENTATION_PLAN.md
@@ -61,7 +61,13 @@ organization = models.OneToOneField(
     on_delete=models.CASCADE,
     related_name="billing_profile",
 )
+contact_first_name = models.CharField(max_length=255)
+contact_last_name = models.CharField(max_length=255, blank=True)
+contact_email = models.EmailField()
+contact_phone = models.CharField(max_length=50, blank=True)
 ```
+
+`contact_first_name` and `contact_email` are required; `contact_last_name` and `contact_phone` are optional. These four fields carry the payer identity the payment gateway needs (MercadoPago hard-400s on a null payer email) now that billing is organization-owned rather than user-owned — there is no longer a `User` to source a name/email/phone from. This is distinct from the `is_billing_owner` membership flag described under **Data Model Changes** and gated in Phase 9, which governs who may *manage* billing rather than what identity is sent to the gateway.
 
 The `user` property on `Payment` (@payments/models.py:103) and `BillingAddress` (@payments/models.py:39) become `organization`. `BillingProfileSerializer` (@payments/serializers.py:56) and its `create`/`update` overrides at lines 81 and 92 resolve the organization from `request.organization` rather than `request.user`.
 

--- a/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
+++ b/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
@@ -1,0 +1,89 @@
+# Tracking — Billing Plans and Limits
+
+- **Feature**: Billing Plans and Limits
+- **Plan**: @ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_IMPLEMENTATION_PLAN.md
+- **Spec**: @ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_SPEC.md
+- **Plan id**: `BILLING_PLANS_AND_LIMITS` (kebab: `billing-plans-and-limits`)
+- **Started**: 2026-07-18
+- **Last updated**: 2026-07-18
+
+## Feature flag
+
+**None.** The plan deliberately declares no feature flag — see the "No feature flag" row in the plan's **Guiding Decisions**. The rollout switch is the plan catalog itself: every organization is seeded onto an `unlimited` plan whose `PlanLimit.limit_value` is NULL, so enforcement code runs but cannot block. Rollback for any organization is a `change_plan` back to `unlimited`, no deploy.
+
+Consequence: there is no flag-removal phase. Instead **every enforcement phase carries a test asserting an `unlimited` organization sees unchanged behavior** — that test set is the equivalent of a flag-off suite.
+
+## Run options
+
+| Option | Value | Source |
+|---|---|---|
+| `pause_between_phases` | `false` | config default |
+| `generate_inline_comments` | `true` | **user override** (config default `false`) |
+| `full_test_suite` | `true` | **user override** (config default `false`) |
+| `use_worktree` | `true` | config default |
+| `commit_strategy_resolved` | `stacked-branches` | user answer (`commit_strategy: ask`) |
+| `worktree_path` | `.claude/worktrees/plan-billing-plans-and-limits` | prepare-worktree |
+| `worktree_branch` | `plan-billing-plans-and-limits` | prepare-worktree |
+| `worktree_summary` | `.vinta-ai-workflows/worktrees/plan-billing-plans-and-limits.yaml` | prepare-worktree |
+| `sandbox_tier` | `enforced` | probed (`sandbox-exec` present) |
+
+`WORKROOT` = `.claude/worktrees/plan-billing-plans-and-limits`
+`BASE_BRANCH` = `plan-billing-plans-and-limits` (at `0361419`)
+
+## Agent models
+
+Implementer per-phase from the plan's `**Suggested AI model**:` line. Others from `.vinta-ai-workflows.yaml` `agent_models`, with per-phase `**Review models**:` overrides taking precedence:
+
+- reviewer: Tier 3 default; Tier 4 on Phases 1, 2, 4, 5, 6b, 7, 9, 11, 13, 14
+- fixer: Tier 2 default; Tier 3 on Phases 5 and 13
+- worktree_prep: Tier 1 (done)
+- integrate: Tier 1
+
+## Environment notes
+
+- Local `main` is **1 commit ahead of `origin/main`** (the plan commit `0361419`, unpushed). Phase PRs will show the plan file in phase-1's diff until `main` is pushed.
+- The two forked docker volumes (`..._dbdata`, `..._floci_data`) need creating before compose first boots — expected on the first `docker compose run` of Phase 1.
+- A concurrent commit `0a039dc "chore: Update vinta-ai-workflows"` landed on `main` mid-session, bumping the workflows package to 0.3.0 and updating the prepare-worktree skill. Not related to this plan.
+
+## Completed phases
+
+_None yet._
+
+## Current phase
+
+**Phase 1 — Move billing ownership to the organization** (implementer Tier 3, reviewer Tier 4)
+
+Base: `plan-billing-plans-and-limits` · Branch: `plan/billing-plans-and-limits/phase-1`
+
+## Remaining phases
+
+| Phase | Title | Impl | Reviewer | Fixer |
+|---|---|---|---|---|
+| 2 | Authenticate provider webhooks and make them idempotent | 3 | 4 | — |
+| 2b | Stripe adapter behind the provider abstraction *(parallel track)* | 3 | — | — |
+| 3 | Plan catalog, limits, and entitlements | 3 | — | — |
+| 4 | Place every organization on a plan | 3 | 4 | — |
+| 5 | Effective limits and usage counting | 4 | 4 | 3 |
+| 6a | Enforce pre-paid limits: seats and invitations | 3 | — | — |
+| 6b | Enforce pre-paid limits: calendars, groups, bundles, availability | 3 | 4 | — |
+| 6c | Enforce pre-paid limits: webhook subscriptions and API system users | 2 | — | — |
+| 7 | Meter event occurrences | 4 | 4 | — |
+| 8 | Enforce the post-paid allowance | 3 | — | — |
+| 9 | Upgrade, add-on purchase, and proration | 3 | 4 | — |
+| 10 | Grace, dunning, and the restricted transition | 3 | — | — |
+| 11 | Restricted enforcement and sync pause | 3 | 4 | — |
+| 12 | Usage API and approaching-limit warnings | 2 | — | — |
+| 13 | Cycle close, overage charge, and reconciliation | 4 | 4 | 3 |
+
+## Deferred phases
+
+**Phase 14 — Roll organizations onto real plans.** Deferred by user decision at run start.
+
+Gated on signal this run cannot produce:
+1. Phases 1–13 merged.
+2. Phase 13 reconciliation running clean against the Stripe sandbox for at least one simulated cycle.
+3. **The real plan limit values and paid tier numbers from product** — the plan's **Open Questions** item 4. Phase 3 seeds only `unlimited` and a placeholder `free`.
+
+Executing it without (3) would seed invented tiers and migrate organizations onto limits nobody agreed to — the exact outcome spec objective 4 sets at zero.
+
+No cross-repo phases in this plan. No flag-removal phase (no flag declared).

--- a/payments/admin.py
+++ b/payments/admin.py
@@ -1,0 +1,111 @@
+from django.contrib import admin
+
+from payments.models import (
+    BillingAddress,
+    BillingPlan,
+    BillingProfile,
+    Payment,
+    PaymentStatusUpdate,
+    Refund,
+    RefundStatusUpdate,
+    Subscription,
+    SubscriptionStatusUpdate,
+)
+
+
+@admin.register(BillingPlan)
+class BillingPlanAdmin(admin.ModelAdmin):
+    """Admin interface for the catalog ``BillingPlan``.
+
+    Phase 1 only carries the plan's own fields; ``PlanLimit`` / ``PlanEntitlement``
+    inlines and catalog seeding land in a later phase.
+    """
+
+    list_display = (
+        "id",
+        "slug",
+        "name",
+        "is_active",
+        "is_default_for_new_organizations",
+        "monthly_price",
+        "currency",
+    )
+    list_filter = ("is_active", "is_default_for_new_organizations", "currency")
+    search_fields = ("slug", "name")
+    ordering = ("slug",)
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(BillingAddress)
+class BillingAddressAdmin(admin.ModelAdmin):
+    list_display = ("id", "city", "state", "country", "zip_code")
+    search_fields = ("city", "state", "country", "zip_code")
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(BillingProfile)
+class BillingProfileAdmin(admin.ModelAdmin):
+    list_display = ("organization", "document_type", "document_number")
+    search_fields = ("organization__name", "document_number")
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(Subscription)
+class SubscriptionAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "organization",
+        "plan",
+        "status",
+        "billing_state",
+        "billing_interval",
+        "current_period_start",
+        "current_period_end",
+    )
+    list_filter = ("status", "billing_state", "billing_interval", "payment_provider")
+    search_fields = ("organization__name", "external_id")
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(Payment)
+class PaymentAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "billing_profile",
+        "value",
+        "currency",
+        "payment_provider",
+        "status",
+    )
+    list_filter = ("status", "payment_provider")
+    search_fields = ("external_id", "billing_profile__organization__name")
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(Refund)
+class RefundAdmin(admin.ModelAdmin):
+    list_display = ("id", "payment", "value", "currency", "status")
+    list_filter = ("status",)
+    search_fields = ("external_id",)
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(PaymentStatusUpdate)
+class PaymentStatusUpdateAdmin(admin.ModelAdmin):
+    list_display = ("id", "payment", "status", "created")
+    list_filter = ("status",)
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(SubscriptionStatusUpdate)
+class SubscriptionStatusUpdateAdmin(admin.ModelAdmin):
+    list_display = ("id", "subscription", "status", "created")
+    list_filter = ("status",)
+    readonly_fields = ("created", "modified")
+
+
+@admin.register(RefundStatusUpdate)
+class RefundStatusUpdateAdmin(admin.ModelAdmin):
+    list_display = ("id", "refund", "status", "created")
+    list_filter = ("status",)
+    readonly_fields = ("created", "modified")

--- a/payments/billing_constants.py
+++ b/payments/billing_constants.py
@@ -1,0 +1,23 @@
+from django.db.models import TextChoices
+from django.utils.translation import gettext as _
+
+
+class BillingState(TextChoices):
+    """Billing lifecycle state of an organization's ``Subscription``.
+
+    The spec's lifecycle diagram is the authority on the transitions between
+    these states (see the Billing Plans and Limits spec).
+    """
+
+    FREE = ("free", _("Free"))
+    ACTIVE = ("active", _("Active"))
+    GRACE = ("grace", _("Grace period"))
+    RESTRICTED = ("restricted", _("Restricted"))
+    CANCELLED = ("cancelled", _("Cancelled"))
+
+
+class BillingInterval(TextChoices):
+    """Billing cadence for a ``Subscription``."""
+
+    MONTHLY = ("monthly", _("Monthly"))
+    ANNUAL = ("annual", _("Annual"))

--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -17,3 +17,12 @@ class SubscriptionExternalIdMissingInNotificationError(PaymentAdapterError):
 class MissingBillingProfileError(PaymentError):
     def __init__(self, message="User does not have a billing profile"):
         super().__init__(message)
+
+
+class BillingProfileContactEmailMissingError(PaymentError):
+    def __init__(
+        self,
+        message="BillingProfile.contact_email is required to send the payer identity "
+        "to the payment gateway",
+    ):
+        super().__init__(message)

--- a/payments/migrations/0003_organization_owned_billing.py
+++ b/payments/migrations/0003_organization_owned_billing.py
@@ -9,6 +9,16 @@
 # an `organization` FK), and Postgres will not let a column backing a live FK constraint
 # be dropped without first dropping the dependent constraints. The reverse path recreates
 # the prior (`user`-owned) schema in the same way.
+#
+# The `billing_profile` FK on `payments_payment` and the `subscription` FK on
+# `payments_subscriptionstatusupdate` are dropped for the same reason (they point at
+# `payments_billingprofile` / `payments_subscription`) and re-added below. Both source
+# tables are transitively empty (they FK to the equally-empty tables being rebuilt), so
+# dropping and re-adding these columns loses no data either. The re-`AddField` calls at
+# `payment.billing_profile` and `subscriptionstatusupdate.subscription` below use
+# `preserve_default=False` on a non-null column: if either table were ever non-empty,
+# this makes the migration fail loudly (an `IntegrityError` on the implied backfill)
+# rather than silently defaulting existing rows to `NULL` and losing the association.
 import django.db.models.deletion
 import django.utils.timezone
 import model_utils.fields
@@ -127,6 +137,10 @@ class Migration(migrations.Migration):
                         to="organizations.organization",
                     ),
                 ),
+                ("contact_first_name", models.CharField(max_length=255)),
+                ("contact_last_name", models.CharField(blank=True, max_length=255)),
+                ("contact_email", models.EmailField(max_length=254)),
+                ("contact_phone", models.CharField(blank=True, max_length=50)),
                 ("document_type", models.CharField(max_length=50)),
                 ("document_number", models.CharField(max_length=50)),
                 (
@@ -281,7 +295,10 @@ class Migration(migrations.Migration):
             preserve_default=False,
         ),
         # --- Genuine pre-existing bug: RefundStatusUpdate.status used PaymentStatuses
-        #     instead of RefundStatuses. ---
+        #     instead of RefundStatuses. `payments_refundstatusupdate` is empty in every
+        #     environment (it FKs to `payments_refund`, which FKs to the equally-empty
+        #     `payments_payment`), so there is no pre-existing row whose status value
+        #     would fall outside the new (narrower) `RefundStatuses` choices. ---
         migrations.AlterField(
             model_name="refundstatusupdate",
             name="status",

--- a/payments/migrations/0003_organization_owned_billing.py
+++ b/payments/migrations/0003_organization_owned_billing.py
@@ -1,0 +1,300 @@
+# Phase 1 of billing plans and limits: move billing ownership from the user to the
+# organization, and repair the dead `Subscription.plan` seam.
+#
+# Destructive rebuild of `payments_billingprofile` and `payments_subscription` — both
+# tables are empty in every environment (no code writes to them today), so no data
+# migration is needed. Both tables (and the FK fields on `Payment` /
+# `SubscriptionStatusUpdate` that point at them) are dropped and recreated rather than
+# altered in place: `BillingProfile`'s primary key changes identity (from a `user` FK to
+# an `organization` FK), and Postgres will not let a column backing a live FK constraint
+# be dropped without first dropping the dependent constraints. The reverse path recreates
+# the prior (`user`-owned) schema in the same way.
+import django.db.models.deletion
+import django.utils.timezone
+import model_utils.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organizations", "0014_organization_external_event_update_policy"),
+        ("payments", "0002_initial"),
+    ]
+
+    operations = [
+        # --- Drop the FK fields that depend on the tables being rebuilt. ---
+        migrations.RemoveField(
+            model_name="payment",
+            name="billing_profile",
+        ),
+        migrations.RemoveField(
+            model_name="payment",
+            name="subscription",
+        ),
+        migrations.RemoveField(
+            model_name="subscriptionstatusupdate",
+            name="subscription",
+        ),
+        # --- Drop the tables being rebuilt. ---
+        migrations.DeleteModel(
+            name="Subscription",
+        ),
+        migrations.DeleteModel(
+            name="BillingProfile",
+        ),
+        # --- New catalog model the rebuilt Subscription.plan resolves to. ---
+        migrations.CreateModel(
+            name="BillingPlan",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                (
+                    "created",
+                    model_utils.fields.AutoCreatedField(
+                        db_index=True,
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="created",
+                    ),
+                ),
+                (
+                    "modified",
+                    model_utils.fields.AutoLastModifiedField(
+                        db_index=True,
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="modified",
+                    ),
+                ),
+                ("meta", models.JSONField(blank=True, default=dict, verbose_name="meta")),
+                ("slug", models.SlugField(max_length=100, unique=True)),
+                ("name", models.CharField(max_length=255)),
+                ("is_active", models.BooleanField(db_index=True, default=True)),
+                ("is_default_for_new_organizations", models.BooleanField(default=False)),
+                ("monthly_price", models.DecimalField(decimal_places=2, max_digits=10)),
+                (
+                    "annual_price",
+                    models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+                ),
+                ("currency", models.CharField(max_length=3)),
+                ("grace_period_days", models.PositiveIntegerField(blank=True, null=True)),
+            ],
+            options={
+                "constraints": [
+                    models.UniqueConstraint(
+                        condition=models.Q(("is_default_for_new_organizations", True)),
+                        fields=("is_default_for_new_organizations",),
+                        name="uniq_default_billing_plan",
+                    )
+                ],
+            },
+        ),
+        # --- Recreate BillingProfile, keyed on Organization instead of User. ---
+        migrations.CreateModel(
+            name="BillingProfile",
+            fields=[
+                (
+                    "created",
+                    model_utils.fields.AutoCreatedField(
+                        db_index=True,
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="created",
+                    ),
+                ),
+                (
+                    "modified",
+                    model_utils.fields.AutoLastModifiedField(
+                        db_index=True,
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="modified",
+                    ),
+                ),
+                ("meta", models.JSONField(blank=True, default=dict, verbose_name="meta")),
+                (
+                    "organization",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name="billing_profile",
+                        serialize=False,
+                        to="organizations.organization",
+                    ),
+                ),
+                ("document_type", models.CharField(max_length=50)),
+                ("document_number", models.CharField(max_length=50)),
+                (
+                    "billing_address",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="billing_profile",
+                        to="payments.billingaddress",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        # --- Recreate Subscription, resolving to an organization + a real plan FK. ---
+        migrations.CreateModel(
+            name="Subscription",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                (
+                    "created",
+                    model_utils.fields.AutoCreatedField(
+                        db_index=True,
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="created",
+                    ),
+                ),
+                (
+                    "modified",
+                    model_utils.fields.AutoLastModifiedField(
+                        db_index=True,
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="modified",
+                    ),
+                ),
+                ("meta", models.JSONField(blank=True, default=dict, verbose_name="meta")),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("active", "Active"),
+                            ("paused", "Paused"),
+                            ("cancelled", "Cancelled"),
+                            ("pending", "Pending"),
+                            ("pending_send", "Pending send"),
+                            ("error", "Error"),
+                            ("unknown", "Unknown"),
+                        ],
+                        default="pending_send",
+                        max_length=50,
+                    ),
+                ),
+                (
+                    "billing_state",
+                    models.CharField(
+                        choices=[
+                            ("free", "Free"),
+                            ("active", "Active"),
+                            ("grace", "Grace period"),
+                            ("restricted", "Restricted"),
+                            ("cancelled", "Cancelled"),
+                        ],
+                        db_index=True,
+                        default="free",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "billing_interval",
+                    models.CharField(
+                        choices=[("monthly", "Monthly"), ("annual", "Annual")],
+                        default="monthly",
+                        max_length=10,
+                    ),
+                ),
+                ("current_period_start", models.DateTimeField()),
+                ("current_period_end", models.DateTimeField(db_index=True)),
+                (
+                    "grace_period_ends_at",
+                    models.DateTimeField(blank=True, db_index=True, null=True),
+                ),
+                ("external_id", models.CharField(blank=True, db_index=True, max_length=255)),
+                ("plan_external_id", models.CharField(blank=True, max_length=255)),
+                (
+                    "payment_provider",
+                    models.CharField(
+                        choices=[("mercadopago", "MercadoPago")], max_length=50
+                    ),
+                ),
+                (
+                    "organization",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="subscription",
+                        to="organizations.organization",
+                    ),
+                ),
+                (
+                    "plan",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="subscriptions",
+                        to="payments.billingplan",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        # --- Re-add the FK fields that were dropped above, now pointing at the
+        #     rebuilt tables. ---
+        migrations.AddField(
+            model_name="payment",
+            name="billing_profile",
+            field=models.ForeignKey(
+                default=None,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="payments",
+                to="payments.billingprofile",
+            ),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="payment",
+            name="subscription",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="payments",
+                to="payments.subscription",
+            ),
+        ),
+        migrations.AddField(
+            model_name="subscriptionstatusupdate",
+            name="subscription",
+            field=models.ForeignKey(
+                default=None,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="status_updates",
+                to="payments.subscription",
+            ),
+            preserve_default=False,
+        ),
+        # --- Genuine pre-existing bug: RefundStatusUpdate.status used PaymentStatuses
+        #     instead of RefundStatuses. ---
+        migrations.AlterField(
+            model_name="refundstatusupdate",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("pending_send", "Pending Send"),
+                    ("pending", "Pending"),
+                    ("approved", "Approved"),
+                    ("rejected", "Rejected"),
+                    ("failed", "Failed"),
+                    ("unknown", "Unknown"),
+                ],
+                max_length=50,
+            ),
+        ),
+    ]

--- a/payments/models.py
+++ b/payments/models.py
@@ -57,7 +57,7 @@ class BillingPlan(BaseModel):
 
     subscriptions: "RelatedManager[Subscription]"
 
-    class Meta:
+    class Meta(BaseModel.Meta):
         constraints: ClassVar = [
             UniqueConstraint(
                 fields=["is_default_for_new_organizations"],
@@ -77,6 +77,14 @@ class BillingProfile(BaseModel):
         on_delete=models.CASCADE,
         related_name="billing_profile",
     )
+    # Payer identity sent to the payment gateway. Distinct from the future
+    # `OrganizationMembership.is_billing_owner` (Phase 9), which is about who may
+    # *manage* billing — these fields are about what the gateway needs to charge
+    # the organization (e.g. MercadoPago rejects a payer with no email).
+    contact_first_name = models.CharField(max_length=255)
+    contact_last_name = models.CharField(max_length=255, blank=True)
+    contact_email = models.EmailField()
+    contact_phone = models.CharField(max_length=50, blank=True)
     document_type = models.CharField(max_length=50)
     document_number = models.CharField(max_length=50)
     billing_address = models.OneToOneField(
@@ -88,6 +96,19 @@ class BillingProfile(BaseModel):
 
 
 class Subscription(BaseModel):
+    """An organization's subscription to a ``BillingPlan``.
+
+    Two status concepts coexist here and share member names (``active``,
+    ``cancelled``, ``pending``) — do not conflate them:
+
+    - ``status`` (``SubscriptionStatuses``) mirrors the provider-reported state of
+      the subscription, fed by ``SubscriptionStatusUpdate`` rows as the gateway
+      reports them (e.g. MercadoPago's ``authorized`` / ``paused`` / ``cancelled``).
+    - ``billing_state`` (``BillingState``) is this app's internal billing
+      lifecycle (free / active / grace / restricted / cancelled) used to gate
+      access. It is derived from, but not identical to, ``status``.
+    """
+
     organization = models.OneToOneField(
         "organizations.Organization", on_delete=models.CASCADE, related_name="subscription"
     )

--- a/payments/models.py
+++ b/payments/models.py
@@ -1,22 +1,20 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
+from django.db.models import Q, UniqueConstraint
 
 from common.models import BaseModel
+from payments.billing_constants import BillingInterval, BillingState
 from payments.constants import (
     PaymentProviders,
     PaymentStatuses,
     RefundStatuses,
     SubscriptionStatuses,
 )
-from users.models import User
 
 
 if TYPE_CHECKING:
     from django_stubs_ext.db.models.manager import RelatedManager
-
-    from organizations.models import SubscriptionPlan
 
 
 class BillingAddress(BaseModel):
@@ -32,18 +30,52 @@ class BillingAddress(BaseModel):
     billing_profile: "BillingProfile"
 
     def __str__(self):
-        return (
-            f"{self.id} {self.user} - {self.city} - {self.state} - {self.country} - {self.zip_code}"
-        )
+        return f"{self.id} {self.organization} - {self.city} - {self.state} - {self.country} - {self.zip_code}"
 
     @property
-    def user(self):
-        return getattr(self, "billing_profile", None) and self.billing_profile.user
+    def organization(self):
+        return getattr(self, "billing_profile", None) and self.billing_profile.organization
+
+
+class BillingPlan(BaseModel):
+    """Catalog plan that a ``Subscription`` is sold against.
+
+    This is a minimal forward reference: only the fields needed for
+    ``Subscription.plan`` to resolve to a real model exist here. The full
+    catalog — ``PlanLimit``, ``PlanEntitlement``, plan seeding, and admin
+    inlines — lands in a later phase (plan catalog, limits, and entitlements).
+    """
+
+    slug = models.SlugField(max_length=100, unique=True)
+    name = models.CharField(max_length=255)
+    is_active = models.BooleanField(default=True, db_index=True)
+    is_default_for_new_organizations = models.BooleanField(default=False)
+    monthly_price = models.DecimalField(max_digits=10, decimal_places=2)
+    annual_price = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
+    currency = models.CharField(max_length=3)
+    grace_period_days = models.PositiveIntegerField(null=True, blank=True)
+
+    subscriptions: "RelatedManager[Subscription]"
+
+    class Meta:
+        constraints: ClassVar = [
+            UniqueConstraint(
+                fields=["is_default_for_new_organizations"],
+                condition=Q(is_default_for_new_organizations=True),
+                name="uniq_default_billing_plan",
+            )
+        ]
+
+    def __str__(self):
+        return self.name
 
 
 class BillingProfile(BaseModel):
-    user = models.OneToOneField(
-        User, primary_key=True, on_delete=models.CASCADE, related_name="billing_profile"
+    organization = models.OneToOneField(
+        "organizations.Organization",
+        primary_key=True,
+        on_delete=models.CASCADE,
+        related_name="billing_profile",
     )
     document_type = models.CharField(max_length=50)
     document_number = models.CharField(max_length=50)
@@ -52,31 +84,34 @@ class BillingProfile(BaseModel):
     )
 
     def __str__(self):
-        return f"{self.pk} {self.user} - {self.document_type} - {self.document_number}"
+        return f"{self.pk} {self.organization} - {self.document_type} - {self.document_number}"
 
 
 class Subscription(BaseModel):
+    organization = models.OneToOneField(
+        "organizations.Organization", on_delete=models.CASCADE, related_name="subscription"
+    )
+    plan = models.ForeignKey(BillingPlan, on_delete=models.PROTECT, related_name="subscriptions")
     status = models.CharField(
         max_length=50, choices=SubscriptionStatuses, default=SubscriptionStatuses.PENDING_SEND
     )
-    external_id = models.CharField(max_length=255, blank=True)
-    billing_profile = models.ForeignKey(
-        BillingProfile, on_delete=models.CASCADE, related_name="subscriptions"
+    billing_state = models.CharField(
+        max_length=20, choices=BillingState, default=BillingState.FREE, db_index=True
     )
-    start_date = models.DateField()
-    end_date = models.DateField()
-
-    membership: "SubscriptionPlan"
+    billing_interval = models.CharField(
+        max_length=10, choices=BillingInterval, default=BillingInterval.MONTHLY
+    )
+    current_period_start = models.DateTimeField()
+    current_period_end = models.DateTimeField(db_index=True)
+    grace_period_ends_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    external_id = models.CharField(max_length=255, blank=True, db_index=True)
+    plan_external_id = models.CharField(max_length=255, blank=True)
+    payment_provider = models.CharField(max_length=50, choices=PaymentProviders)
 
     def __str__(self):
-        return f"{self.id} - {self.status} - {self.start_date} - {self.end_date}"
-
-    @property
-    def plan(self):
-        try:
-            return self.membership.tier
-        except ObjectDoesNotExist:
-            return None
+        return (
+            f"{self.id} - {self.status} - {self.current_period_start} - {self.current_period_end}"
+        )
 
 
 class Payment(BaseModel):
@@ -98,11 +133,11 @@ class Payment(BaseModel):
     status_updates: "RelatedManager[PaymentStatusUpdate]"
 
     def __str__(self):
-        return f"{self.id} {self.user} - {self.value} - {self.payment_provider} - {self.status} - {self.created.isoformat()}"
+        return f"{self.id} {self.organization} - {self.value} - {self.payment_provider} - {self.status} - {self.created.isoformat()}"
 
     @property
-    def user(self):
-        return getattr(self, "billing_profile", None) and self.billing_profile.user
+    def organization(self):
+        return getattr(self, "billing_profile", None) and self.billing_profile.organization
 
 
 class Refund(BaseModel):
@@ -142,9 +177,9 @@ class SubscriptionStatusUpdate(BaseModel):
 
 class RefundStatusUpdate(BaseModel):
     refund = models.ForeignKey(Refund, on_delete=models.CASCADE, related_name="status_updates")
-    status = models.CharField(max_length=50, choices=PaymentStatuses)
+    status = models.CharField(max_length=50, choices=RefundStatuses)
     description = models.TextField(blank=True)
     external_id = models.CharField(max_length=255, blank=True)
 
     def __str__(self):
-        return f"{self.id} {self.payment} - {self.status} - {self.created.isoformat()}"
+        return f"{self.id} {self.refund} - {self.status} - {self.created.isoformat()}"

--- a/payments/serializers.py
+++ b/payments/serializers.py
@@ -1,5 +1,6 @@
 import django_virtual_models as v
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 from payments.models import BillingAddress, BillingProfile, Subscription
 from payments.virtual_models import (
@@ -19,14 +20,12 @@ class SubscriptionSerializer(v.VirtualModelSerializer):
         virtual_model = SubscriptionVirtualModel
         fields = (
             "id",
-            "status",
             "billing_state",
             "current_period_start",
             "current_period_end",
         )
         read_only_fields = (
             "id",
-            "status",
             "billing_state",
             "current_period_start",
             "current_period_end",
@@ -68,6 +67,10 @@ class BillingProfileSerializer(v.VirtualModelSerializer):
         virtual_model = BillingProfileVirtualModel
         fields = (
             "id",
+            "contact_first_name",
+            "contact_last_name",
+            "contact_email",
+            "contact_phone",
             "document_type",
             "document_number",
             "billing_address",
@@ -84,10 +87,16 @@ class BillingProfileSerializer(v.VirtualModelSerializer):
         """
         Create a new BillingProfile and its related BillingAddress.
         """
+        organization = self.context["request"].organization
+        if organization is None:
+            raise PermissionDenied(
+                "An active organization is required to create a billing profile."
+            )
+
         billing_address_data = validated_data.pop("billing_address")
         billing_address = BillingAddress.objects.create(**billing_address_data)
         billing_profile = BillingProfile.objects.create(
-            organization=self.context["request"].organization,
+            organization=organization,
             billing_address=billing_address,
             **validated_data,
         )

--- a/payments/serializers.py
+++ b/payments/serializers.py
@@ -20,14 +20,16 @@ class SubscriptionSerializer(v.VirtualModelSerializer):
         fields = (
             "id",
             "status",
-            "start_date",
-            "end_date",
+            "billing_state",
+            "current_period_start",
+            "current_period_end",
         )
         read_only_fields = (
             "id",
             "status",
-            "start_date",
-            "end_date",
+            "billing_state",
+            "current_period_start",
+            "current_period_end",
         )
 
 
@@ -58,7 +60,7 @@ class BillingProfileSerializer(v.VirtualModelSerializer):
     Serializer for BillingProfile virtual model.
     """
 
-    id = serializers.IntegerField(source="user_id", read_only=True)  # noqa: A003
+    id = serializers.IntegerField(source="organization_id", read_only=True)  # noqa: A003
     billing_address = BillingAddressSerializer()
 
     class Meta:
@@ -85,7 +87,9 @@ class BillingProfileSerializer(v.VirtualModelSerializer):
         billing_address_data = validated_data.pop("billing_address")
         billing_address = BillingAddress.objects.create(**billing_address_data)
         billing_profile = BillingProfile.objects.create(
-            user=self.context["request"].user, billing_address=billing_address, **validated_data
+            organization=self.context["request"].organization,
+            billing_address=billing_address,
+            **validated_data,
         )
         return billing_profile
 

--- a/payments/services/payment_adapters/base.py
+++ b/payments/services/payment_adapters/base.py
@@ -1,6 +1,6 @@
 import json
+import logging
 from abc import abstractmethod
-from venv import logger
 
 from payments.exceptions import PaymentExternalIdMissingInNotificationError
 from payments.services.dataclasses import (
@@ -8,6 +8,9 @@ from payments.services.dataclasses import (
     PaymentStatusUpdate,
     Refund,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class BasePaymentAdapter:

--- a/payments/services/payment_service.py
+++ b/payments/services/payment_service.py
@@ -9,6 +9,7 @@ from dependency_injector.wiring import Provide, inject
 from organizations.models import Organization
 from payments.billing_constants import BillingInterval
 from payments.constants import PaymentStatuses, RefundStatuses, SubscriptionStatuses
+from payments.exceptions import BillingProfileContactEmailMissingError, MissingBillingProfileError
 from payments.models import BillingAddress as BillingAddressModel
 from payments.models import BillingPlan as BillingPlanModel
 from payments.models import BillingProfile as BillingProfileModel
@@ -97,15 +98,18 @@ class PaymentService[
         )
 
     def _serialize_billing_profile(self, billing_profile: BillingProfileModel) -> BillingProfile:
-        # Billing is owned by the organization, not a person: the payer identity the
-        # gateway sees is the organization's name. There is no per-organization
-        # email/phone to source here yet, so those stay unset.
+        # Billing is owned by the organization, not a person, but the gateway still
+        # requires a payer identity (MercadoPago hard-400s on a null payer email).
+        # `contact_*` on BillingProfile is the organization's designated billing
+        # contact, sourced explicitly rather than left null.
+        if not billing_profile.contact_email:
+            raise BillingProfileContactEmailMissingError
         return BillingProfile(
             pk=billing_profile.pk,
-            first_name=billing_profile.organization.name,
-            last_name=None,
-            email=None,
-            phone=None,
+            first_name=billing_profile.contact_first_name,
+            last_name=billing_profile.contact_last_name or None,
+            email=billing_profile.contact_email,
+            phone=billing_profile.contact_phone or None,
             document_type=billing_profile.document_type,
             document_number=billing_profile.document_number,
             billing_address=self._serialize_billing_address(billing_profile.billing_address),
@@ -236,9 +240,20 @@ class PaymentService[
         payment_external_id = subscription_payment_data.external_id
         payment = self.get_payment_by_external_id(payment_external_id)
         if not payment:
+            billing_profile = BillingProfileModel.objects.filter(
+                organization=subscription.organization
+            ).first()
+            if billing_profile is None:
+                logger.warning(
+                    "Cannot create payment for subscription %s: organization %s has no "
+                    "billing profile.",
+                    subscription.id,
+                    subscription.organization_id,
+                )
+                return None
             payment = PaymentModel.objects.create(
                 external_id=payment_external_id,
-                billing_profile=subscription.organization.billing_profile,
+                billing_profile=billing_profile,
                 value=subscription_payment_data.value,
                 currency=subscription_payment_data.currency,
                 status=subscription_payment_data.status,
@@ -255,7 +270,16 @@ class PaymentService[
         )
 
     def _serialize_subscription(self, subscription: SubscriptionModel) -> Subscription:
-        organization_billing_profile = subscription.organization.billing_profile
+        organization_billing_profile = BillingProfileModel.objects.filter(
+            organization=subscription.organization
+        ).first()
+        if organization_billing_profile is None:
+            logger.warning(
+                "Cannot serialize subscription %s: organization %s has no billing profile.",
+                subscription.id,
+                subscription.organization_id,
+            )
+            raise MissingBillingProfileError
         return Subscription(
             id=subscription.id,
             plan=self.subscription_plan_factory.make_plan_from_subscription(subscription),
@@ -282,10 +306,8 @@ class PaymentService[
         current_period_end: datetime.datetime,
         billing_interval: str = BillingInterval.MONTHLY,
     ) -> SubscriptionModel:
-        try:
-            _ = organization.billing_profile
-        except BillingProfileModel.DoesNotExist as e:
-            raise ValueError("Organization does not have a billing profile") from e
+        if not BillingProfileModel.objects.filter(organization=organization).exists():
+            raise MissingBillingProfileError
 
         subscription = SubscriptionModel.objects.create(
             organization=organization,

--- a/payments/services/payment_service.py
+++ b/payments/services/payment_service.py
@@ -1,13 +1,16 @@
 import datetime
+import logging
 from dataclasses import asdict
 from decimal import Decimal
 from typing import Annotated
-from venv import logger
 
 from dependency_injector.wiring import Provide, inject
 
+from organizations.models import Organization
+from payments.billing_constants import BillingInterval
 from payments.constants import PaymentStatuses, RefundStatuses, SubscriptionStatuses
 from payments.models import BillingAddress as BillingAddressModel
+from payments.models import BillingPlan as BillingPlanModel
 from payments.models import BillingProfile as BillingProfileModel
 from payments.models import Payment as PaymentModel
 from payments.models import PaymentStatusUpdate as PaymentStatusUpdateModel
@@ -27,7 +30,9 @@ from payments.services.dataclasses import (
 from payments.services.payment_adapters.base import BasePaymentAdapter
 from payments.services.subscription_adapters.base import BaseSubscriptionAdapter
 from payments.services.subscription_plan_factory.base import BaseSubscriptionPlanFactory
-from users.models import User
+
+
+logger = logging.getLogger(__name__)
 
 
 class PaymentService[
@@ -48,7 +53,7 @@ class PaymentService[
 
     def create_payment(
         self,
-        user: User,
+        organization: Organization,
         currency: str,
         amount: Decimal,
         description: str,
@@ -56,9 +61,9 @@ class PaymentService[
         payment_token: str,
     ) -> PaymentModel:
         try:
-            billing_profile = user.billing_profile
+            billing_profile = organization.billing_profile
         except BillingProfileModel.DoesNotExist as e:
-            raise ValueError("User does not have a billing profile") from e
+            raise ValueError("Organization does not have a billing profile") from e
 
         payment = PaymentModel.objects.create(
             billing_profile=billing_profile,
@@ -92,12 +97,15 @@ class PaymentService[
         )
 
     def _serialize_billing_profile(self, billing_profile: BillingProfileModel) -> BillingProfile:
+        # Billing is owned by the organization, not a person: the payer identity the
+        # gateway sees is the organization's name. There is no per-organization
+        # email/phone to source here yet, so those stay unset.
         return BillingProfile(
             pk=billing_profile.pk,
-            first_name=billing_profile.user.profile.first_name,
-            last_name=billing_profile.user.profile.last_name,
-            email=billing_profile.user.email,
-            phone=billing_profile.user.phone_number,
+            first_name=billing_profile.organization.name,
+            last_name=None,
+            email=None,
+            phone=None,
             document_type=billing_profile.document_type,
             document_number=billing_profile.document_number,
             billing_address=self._serialize_billing_address(billing_profile.billing_address),
@@ -230,7 +238,7 @@ class PaymentService[
         if not payment:
             payment = PaymentModel.objects.create(
                 external_id=payment_external_id,
-                billing_profile=subscription.billing_profile,
+                billing_profile=subscription.organization.billing_profile,
                 value=subscription_payment_data.value,
                 currency=subscription_payment_data.currency,
                 status=subscription_payment_data.status,
@@ -247,14 +255,15 @@ class PaymentService[
         )
 
     def _serialize_subscription(self, subscription: SubscriptionModel) -> Subscription:
+        organization_billing_profile = subscription.organization.billing_profile
         return Subscription(
             id=subscription.id,
             plan=self.subscription_plan_factory.make_plan_from_subscription(subscription),
             status=subscription.status,
             external_id=subscription.external_id,
-            billing_profile=self._serialize_billing_profile(subscription.billing_profile),
-            start_date=subscription.start_date.strftime("%Y-%m-%d"),
-            end_date=subscription.end_date.strftime("%Y-%m-%d"),
+            billing_profile=self._serialize_billing_profile(organization_billing_profile),
+            start_date=subscription.current_period_start.strftime("%Y-%m-%d"),
+            end_date=subscription.current_period_end.strftime("%Y-%m-%d"),
         )
 
     def create_subscription_plan(self, plan: Plan) -> CreatedPlan:
@@ -267,20 +276,25 @@ class PaymentService[
 
     def create_subscription(
         self,
-        user: User,
-        start_date: datetime.date,
-        end_date: datetime.date,
+        organization: Organization,
+        plan: BillingPlanModel,
+        current_period_start: datetime.datetime,
+        current_period_end: datetime.datetime,
+        billing_interval: str = BillingInterval.MONTHLY,
     ) -> SubscriptionModel:
         try:
-            billing_profile = user.billing_profile
+            _ = organization.billing_profile
         except BillingProfileModel.DoesNotExist as e:
-            raise ValueError("User does not have a billing profile") from e
+            raise ValueError("Organization does not have a billing profile") from e
 
         subscription = SubscriptionModel.objects.create(
-            billing_profile=billing_profile,
-            start_date=start_date,
-            end_date=end_date,
+            organization=organization,
+            plan=plan,
+            billing_interval=billing_interval,
+            current_period_start=current_period_start,
+            current_period_end=current_period_end,
             status=SubscriptionStatuses.PENDING_SEND,
+            payment_provider=self.subscription_gateway.provider,
         )
 
         SubscriptionStatusUpdate.objects.create(

--- a/payments/tests/services/test_payment_services.py
+++ b/payments/tests/services/test_payment_services.py
@@ -5,12 +5,14 @@ from unittest.mock import MagicMock
 import pytest
 from model_bakery import baker
 
+from organizations.models import Organization
 from payments.constants import (
     PaymentProviders,
     PaymentStatuses,
     RefundStatuses,
     SubscriptionStatuses,
 )
+from payments.models import BillingPlan
 from payments.services.dataclasses import (
     BillingAddress as BillingAddressDataclass,
 )
@@ -56,6 +58,11 @@ class MockSubscriptionPlanFactory(BaseSubscriptionPlanFactory):
 
 
 @pytest.fixture
+def organization():
+    return baker.make(Organization)
+
+
+@pytest.fixture
 def billing_address():
     return baker.make(
         "payments.BillingAddress",
@@ -69,14 +76,19 @@ def billing_address():
 
 
 @pytest.fixture
-def billing_profile(user, billing_address):
+def billing_profile(organization, billing_address):
     return baker.make(
         "payments.BillingProfile",
-        user=user,
+        organization=organization,
         document_type="CPF",
         document_number="12345678900",
         billing_address=billing_address,
     )
+
+
+@pytest.fixture
+def billing_plan():
+    return baker.make(BillingPlan)
 
 
 @pytest.fixture
@@ -113,7 +125,7 @@ def test_success_create_payment(payment_service, billing_profile):
     payment_service.payment_gateway.process.return_value = "payment_12345"
 
     created_payment = payment_service.create_payment(
-        user=billing_profile.user,
+        organization=billing_profile.organization,
         currency="BRL",
         amount=Decimal("100"),
         description="Test Payment",
@@ -374,29 +386,35 @@ def test_success_update_subscription_plan(payment_service, subscription_adapter)
 
 
 @pytest.mark.django_db
-def test_success_create_subscription(payment_service, subscription_adapter, billing_profile):
+def test_success_create_subscription(
+    payment_service, subscription_adapter, billing_profile, billing_plan
+):
     # Create a subscription
     now = datetime.datetime.now(tz=datetime.UTC)
 
     # Create subscription
     created_subscription = payment_service.create_subscription(
-        user=billing_profile.user,
-        start_date=now.date(),
-        end_date=(now + datetime.timedelta(days=30)).date(),
+        organization=billing_profile.organization,
+        plan=billing_plan,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
     )
     assert created_subscription.pk is not None
     assert created_subscription.status == SubscriptionStatuses.PENDING_SEND
 
 
 @pytest.mark.django_db
-def test_success_process_subscription(payment_service, subscription_adapter, billing_profile):
+def test_success_process_subscription(
+    payment_service, subscription_adapter, billing_profile, billing_plan
+):
     # Create a subscription
     now = datetime.datetime.now(tz=datetime.UTC)
 
     created_subscription = payment_service.create_subscription(
-        user=billing_profile.user,
-        start_date=now.date(),
-        end_date=(now + datetime.timedelta(days=30)).date(),
+        organization=billing_profile.organization,
+        plan=billing_plan,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
     )
 
     # Set up mock for create_subscription method
@@ -420,16 +438,20 @@ def test_success_process_subscription(payment_service, subscription_adapter, bil
 
 
 @pytest.mark.django_db
-def test_success_cancel_subscription(payment_service, subscription_adapter, billing_profile):
+def test_success_cancel_subscription(
+    payment_service, subscription_adapter, billing_profile, billing_plan
+):
     # Create a subscription
     now = datetime.datetime.now(tz=datetime.UTC)
     subscription = baker.make(
         "payments.Subscription",
-        billing_profile=billing_profile,
-        start_date=now.date(),
-        end_date=(now + datetime.timedelta(days=30)).date(),
+        organization=billing_profile.organization,
+        plan=billing_plan,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
         status=SubscriptionStatuses.ACTIVE,
         external_id="sub_12345",
+        payment_provider=PaymentProviders.MERCADOPAGO,
     )
 
     # Cancel subscription
@@ -447,17 +469,19 @@ def test_success_cancel_subscription(payment_service, subscription_adapter, bill
 
 @pytest.mark.django_db
 def test_success_receive_subscription_payment_update(
-    payment_service, subscription_adapter, billing_profile, billing_address, user
+    payment_service, subscription_adapter, billing_profile, billing_address, billing_plan, user
 ):
     # Create a subscription
     now = datetime.datetime.now(tz=datetime.UTC)
     subscription = baker.make(
         "payments.Subscription",
-        billing_profile=billing_profile,
-        start_date=now.date(),
-        end_date=(now + datetime.timedelta(days=30)).date(),
+        organization=billing_profile.organization,
+        plan=billing_plan,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
         status=SubscriptionStatuses.ACTIVE,
         external_id="sub_12345",
+        payment_provider=PaymentProviders.MERCADOPAGO,
     )
 
     # Set up mock for receive_payment_update method

--- a/payments/tests/services/test_payment_services.py
+++ b/payments/tests/services/test_payment_services.py
@@ -13,6 +13,7 @@ from payments.constants import (
     SubscriptionStatuses,
 )
 from payments.models import BillingPlan
+from payments.models import Payment as PaymentModel
 from payments.services.dataclasses import (
     BillingAddress as BillingAddressDataclass,
 )
@@ -142,6 +143,35 @@ def test_success_create_payment(payment_service, billing_profile):
     assert created_payment.payment_method == "credit_card"
     assert created_payment.description == "Test Payment"
     assert created_payment.billing_profile == billing_profile
+
+
+@pytest.mark.django_db
+def test_create_payment_raises_when_billing_profile_missing_contact_email(
+    payment_service, organization, billing_address
+):
+    """`_serialize_billing_profile` must raise a clear error rather than silently
+    send the payment gateway a null payer email."""
+    from payments.exceptions import BillingProfileContactEmailMissingError
+    from payments.models import BillingProfile as BillingProfileModel
+
+    billing_profile = BillingProfileModel.objects.create(
+        organization=organization,
+        contact_first_name="Ada",
+        contact_email="",
+        document_type="CPF",
+        document_number="12345678900",
+        billing_address=billing_address,
+    )
+
+    with pytest.raises(BillingProfileContactEmailMissingError):
+        payment_service.create_payment(
+            organization=billing_profile.organization,
+            currency="BRL",
+            amount=Decimal("100"),
+            description="Test Payment",
+            payment_method="credit_card",
+            payment_token="card_token_123",
+        )
 
 
 @pytest.mark.django_db
@@ -544,3 +574,57 @@ def test_success_receive_subscription_payment_update(
     assert result.status == "approved"
     assert result.description == "Payment approved"
     assert result.external_id == "update_123"
+
+
+@pytest.mark.django_db
+def test_receive_subscription_payment_update_without_billing_profile_returns_none(
+    payment_service, subscription_adapter, organization, billing_plan
+):
+    """A subscription whose organization has no `BillingProfile` must not raise
+    `RelatedObjectDoesNotExist` on the unauthenticated provider webhook path — it
+    should log a warning and return `None` instead of a 500."""
+    now = datetime.datetime.now(tz=datetime.UTC)
+    subscription = baker.make(
+        "payments.Subscription",
+        organization=organization,
+        plan=billing_plan,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+        status=SubscriptionStatuses.ACTIVE,
+        external_id="sub_no_profile",
+        payment_provider=PaymentProviders.MERCADOPAGO,
+    )
+
+    from payments.services.dataclasses import SubscriptionPayment
+
+    subscription_payment = SubscriptionPayment(
+        id=None,
+        value=Decimal("100"),
+        currency="USD",
+        payment_provider=PaymentProviders.MERCADOPAGO,
+        external_id="payment_no_profile",
+        status=PaymentStatuses.APPROVED,
+        billing_profile=None,
+        payment_method="credit_card",
+        description="Subscription payment",
+        status_updates=[],
+        subscription_external_id=subscription.external_id,
+    )
+
+    status_update = PaymentStatusUpdateDataclass(
+        id=None,
+        status="approved",
+        description="Payment approved",
+        update_external_id="update_456",
+    )
+
+    subscription_adapter.receive_payment_update.return_value = (
+        subscription_payment,
+        status_update,
+    )
+
+    update_payload = {"id": "update_456", "type": "payment"}
+    result = payment_service.receive_subscription_payment_update(update_payload)
+
+    assert result is None
+    assert not PaymentModel.objects.filter(external_id="payment_no_profile").exists()

--- a/payments/tests/test_models.py
+++ b/payments/tests/test_models.py
@@ -1,0 +1,115 @@
+import datetime
+
+import pytest
+from model_bakery import baker
+
+from organizations.models import Organization
+from payments.constants import PaymentProviders, RefundStatuses
+from payments.models import (
+    BillingAddress,
+    BillingPlan,
+    BillingProfile,
+    Payment,
+    Refund,
+    RefundStatusUpdate,
+    Subscription,
+)
+
+
+@pytest.fixture
+def organization():
+    return baker.make(Organization)
+
+
+@pytest.fixture
+def billing_address():
+    return baker.make(BillingAddress)
+
+
+@pytest.fixture
+def billing_profile(organization, billing_address):
+    return baker.make(
+        BillingProfile,
+        organization=organization,
+        billing_address=billing_address,
+    )
+
+
+@pytest.fixture
+def billing_plan():
+    return baker.make(BillingPlan)
+
+
+@pytest.mark.django_db
+class TestBillingProfile:
+    def test_billing_profile_reachable_from_organization(self, organization, billing_profile):
+        """The organization is the primary key: `organization.billing_profile` round-trips."""
+        assert organization.billing_profile == billing_profile
+        assert billing_profile.organization == organization
+        assert billing_profile.pk == organization.pk
+
+    def test_billing_address_organization_property(self, billing_profile):
+        assert billing_profile.billing_address.organization == billing_profile.organization
+
+
+@pytest.mark.django_db
+class TestSubscription:
+    def test_plan_resolves_without_raising(self, organization, billing_plan):
+        """`Subscription.plan` is now a real field, not the old broken property."""
+        now = datetime.datetime.now(tz=datetime.UTC)
+        subscription = baker.make(
+            Subscription,
+            organization=organization,
+            plan=billing_plan,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+            payment_provider=PaymentProviders.MERCADOPAGO,
+        )
+
+        assert subscription.plan == billing_plan
+
+    def test_organization_round_trips(self, organization, billing_plan):
+        now = datetime.datetime.now(tz=datetime.UTC)
+        subscription = baker.make(
+            Subscription,
+            organization=organization,
+            plan=billing_plan,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+            payment_provider=PaymentProviders.MERCADOPAGO,
+        )
+
+        assert organization.subscription == subscription
+
+
+@pytest.mark.django_db
+class TestPayment:
+    def test_organization_property(self, billing_profile):
+        payment = baker.make(Payment, billing_profile=billing_profile)
+
+        assert payment.organization == billing_profile.organization
+
+
+@pytest.mark.django_db
+class TestRefundStatusUpdate:
+    def test_str_does_not_raise(self, billing_profile):
+        payment = baker.make(Payment, billing_profile=billing_profile)
+        refund = baker.make(Refund, payment=payment)
+        status_update = baker.make(
+            RefundStatusUpdate,
+            refund=refund,
+            status=RefundStatuses.PENDING,
+        )
+
+        # The old __str__ referenced `self.payment`, which does not exist on
+        # RefundStatusUpdate — this must not raise AttributeError.
+        rendered = str(status_update)
+
+        assert str(refund) in rendered
+
+    def test_status_field_uses_refund_statuses_choices(self):
+        """The old bug used PaymentStatuses (which includes e.g. `in_mediation`,
+        not a valid RefundStatuses member) for this field."""
+        field = RefundStatusUpdate._meta.get_field("status")
+
+        assert set(field.choices) == set(RefundStatuses.choices)

--- a/payments/tests/test_models.py
+++ b/payments/tests/test_models.py
@@ -1,10 +1,13 @@
 import datetime
 
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
 import pytest
 from model_bakery import baker
 
 from organizations.models import Organization
-from payments.constants import PaymentProviders, RefundStatuses
+from payments.constants import PaymentProviders, PaymentStatuses, RefundStatuses
 from payments.models import (
     BillingAddress,
     BillingPlan,
@@ -38,6 +41,24 @@ def billing_profile(organization, billing_address):
 @pytest.fixture
 def billing_plan():
     return baker.make(BillingPlan)
+
+
+@pytest.mark.django_db
+class TestBillingPlan:
+    def test_only_one_default_plan_allowed(self):
+        """The `uniq_default_billing_plan` partial unique constraint enforces at
+        most one `is_default_for_new_organizations=True` row."""
+        baker.make(BillingPlan, is_default_for_new_organizations=True)
+
+        with pytest.raises(IntegrityError):
+            baker.make(BillingPlan, is_default_for_new_organizations=True)
+
+    def test_multiple_non_default_plans_allowed(self):
+        """The partial constraint only applies to `True` rows."""
+        baker.make(BillingPlan, is_default_for_new_organizations=False)
+        baker.make(BillingPlan, is_default_for_new_organizations=False)
+
+        assert BillingPlan.objects.filter(is_default_for_new_organizations=False).count() == 2
 
 
 @pytest.mark.django_db
@@ -113,3 +134,16 @@ class TestRefundStatusUpdate:
         field = RefundStatusUpdate._meta.get_field("status")
 
         assert set(field.choices) == set(RefundStatuses.choices)
+
+    def test_full_clean_rejects_payment_only_status(self, billing_profile):
+        """A `PaymentStatuses`-only value (e.g. `in_mediation`) is not a valid
+        `RefundStatuses` member and must fail `full_clean()`."""
+        payment = baker.make(Payment, billing_profile=billing_profile)
+        refund = baker.make(Refund, payment=payment)
+        status_update = RefundStatusUpdate(
+            refund=refund,
+            status=PaymentStatuses.IN_MEDIATION,
+        )
+
+        with pytest.raises(ValidationError):
+            status_update.full_clean()

--- a/payments/tests/views/test_billing_profile_view_set.py
+++ b/payments/tests/views/test_billing_profile_view_set.py
@@ -4,7 +4,7 @@ import pytest
 from model_bakery import baker
 from rest_framework import status
 
-from organizations.models import Organization, OrganizationMembership
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
 from payments.models import BillingAddress, BillingProfile
 
 
@@ -15,10 +15,23 @@ def organization():
 
 @pytest.fixture
 def membership(user, organization):
+    """An active ADMIN membership: billing profile writes require admin (SHOULD-FIX 4)."""
     return baker.make(
         OrganizationMembership,
         user=user,
         organization=organization,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def non_admin_membership(user, organization):
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=organization,
+        role=OrganizationRole.MEMBER,
         is_active=True,
     )
 
@@ -79,34 +92,109 @@ class TestBillingProfileViewSet:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_retrieve_billing_profile_cross_organization_not_found(
+    def test_retrieve_billing_profile_cross_organization_isolation(
         self, auth_client, membership, organization
     ):
-        """A member of org A cannot read org B's billing profile.
+        """A member of org A only ever sees org A's billing profile, never org B's,
+        even when both organizations have a profile of their own.
 
-        org A (the caller's org) has no billing profile of its own here; org B's
-        exists but the caller is never resolved into org B's context, so the
-        lookup 404s instead of leaking org B's data.
+        This proves tenant isolation on data, not merely absence of data: unlike a
+        setup where org B has a profile but org A does not (which would 404 even
+        against un-scoped, user-keyed code), both orgs have distinct profiles here.
         """
+        org_a_address = baker.make(BillingAddress)
+        baker.make(
+            BillingProfile,
+            organization=organization,
+            document_type="SSN",
+            document_number="AAA",
+            billing_address=org_a_address,
+        )
         other_organization = baker.make(Organization)
-        other_billing_address = baker.make(BillingAddress)
+        org_b_address = baker.make(BillingAddress)
         baker.make(
             BillingProfile,
             organization=other_organization,
             document_type="SSN",
-            document_number="999999999",
-            billing_address=other_billing_address,
+            document_number="BBB",
+            billing_address=org_b_address,
         )
 
         url = reverse("api:BillingProfile-retrieve")
         response = auth_client.get(url)
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["document_number"] == "AAA"
+
+    def test_retrieve_billing_profile_switches_with_active_org_header(
+        self, auth_client, user, organization
+    ):
+        """A user who is an active member of both org A and org B gets the profile
+        of whichever org the `X-Organization-Id` header selects, for each org in
+        turn."""
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        other_organization = baker.make(Organization)
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=other_organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        org_a_address = baker.make(BillingAddress)
+        baker.make(
+            BillingProfile,
+            organization=organization,
+            document_type="SSN",
+            document_number="AAA",
+            billing_address=org_a_address,
+        )
+        org_b_address = baker.make(BillingAddress)
+        baker.make(
+            BillingProfile,
+            organization=other_organization,
+            document_type="SSN",
+            document_number="BBB",
+            billing_address=org_b_address,
+        )
+
+        url = reverse("api:BillingProfile-retrieve")
+
+        response_a = auth_client.get(url, HTTP_X_ORGANIZATION_ID=str(organization.pk))
+        assert response_a.status_code == status.HTTP_200_OK
+        assert response_a.data["document_number"] == "AAA"
+
+        response_b = auth_client.get(url, HTTP_X_ORGANIZATION_ID=str(other_organization.pk))
+        assert response_b.status_code == status.HTTP_200_OK
+        assert response_b.data["document_number"] == "BBB"
+
+    def test_retrieve_billing_profile_header_names_non_member_org_forbidden(
+        self, auth_client, membership, organization
+    ):
+        """A header naming an organization the caller does not belong to is
+        rejected with 403, not silently ignored or resolved to the caller's org."""
+        non_member_organization = baker.make(Organization)
+
+        url = reverse("api:BillingProfile-retrieve")
+        response = auth_client.get(url, HTTP_X_ORGANIZATION_ID=str(non_member_organization.pk))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_create_billing_profile_success(self, auth_client, membership, organization):
         """Test successfully creating a billing profile."""
         url = reverse("api:BillingProfile-create")
         data = {
+            "contact_first_name": "Ada",
+            "contact_last_name": "Lovelace",
+            "contact_email": "billing@example.com",
+            "contact_phone": "+1-555-0100",
             "document_type": "SSN",
             "document_number": "123456789",
             "billing_address": {
@@ -133,7 +221,82 @@ class TestBillingProfileViewSet:
         billing_profile = BillingProfile.objects.get(organization=organization)
         assert billing_profile.document_type == "SSN"
         assert billing_profile.document_number == "123456789"
+        assert billing_profile.contact_email == "billing@example.com"
         assert billing_profile.billing_address.street_name == "Main Street"
+
+    def test_create_billing_profile_duplicate_returns_conflict(
+        self, auth_client, membership, organization
+    ):
+        """A second POST for an organization that already has a billing profile
+        returns 409 instead of hitting the PK unique violation as a 500."""
+        baker.make(BillingProfile, organization=organization)
+
+        url = reverse("api:BillingProfile-create")
+        data = {
+            "contact_first_name": "Ada",
+            "contact_email": "billing@example.com",
+            "document_type": "SSN",
+            "document_number": "123456789",
+            "billing_address": {
+                "street_name": "Main Street",
+                "street_number": "123",
+                "city": "New York",
+                "state": "NY",
+                "country": "US",
+                "zip_code": "10001",
+            },
+        }
+
+        response = auth_client.post(url, data, format="json")
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert BillingProfile.objects.filter(organization=organization).count() == 1
+
+    def test_create_billing_profile_no_membership_forbidden(self, auth_client):
+        """A user with no active organization membership cannot create a billing
+        profile — `request.organization` is None, so the write must be rejected
+        rather than hit an IntegrityError."""
+        url = reverse("api:BillingProfile-create")
+        data = {
+            "contact_first_name": "Ada",
+            "contact_email": "billing@example.com",
+            "document_type": "SSN",
+            "document_number": "123456789",
+            "billing_address": {
+                "street_name": "Main Street",
+                "street_number": "123",
+                "city": "New York",
+                "state": "NY",
+                "country": "US",
+                "zip_code": "10001",
+            },
+        }
+
+        response = auth_client.post(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_create_billing_profile_non_admin_forbidden(self, auth_client, non_admin_membership):
+        """A non-admin member may not create the organization's billing profile."""
+        url = reverse("api:BillingProfile-create")
+        data = {
+            "contact_first_name": "Ada",
+            "contact_email": "billing@example.com",
+            "document_type": "SSN",
+            "document_number": "123456789",
+            "billing_address": {
+                "street_name": "Main Street",
+                "street_number": "123",
+                "city": "New York",
+                "state": "NY",
+                "country": "US",
+                "zip_code": "10001",
+            },
+        }
+
+        response = auth_client.post(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_create_billing_profile_invalid_data(self, auth_client, membership):
         """Test creating billing profile with invalid data."""
@@ -242,6 +405,31 @@ class TestBillingProfileViewSet:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_update_billing_profile_no_membership_forbidden(self, auth_client):
+        """A user with no active organization membership cannot update a billing
+        profile. `IsOrganizationAdmin` (gating writes, SHOULD-FIX 4) denies a
+        membership-less caller before the lookup is even attempted."""
+        url = reverse("api:BillingProfile-update")
+        data = {"document_type": "SSN", "document_number": "123456789"}
+
+        response = auth_client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_update_billing_profile_non_admin_forbidden(
+        self, auth_client, non_admin_membership, organization
+    ):
+        """A non-admin member may not update the organization's billing profile,
+        even when one already exists."""
+        baker.make(BillingProfile, organization=organization)
+
+        url = reverse("api:BillingProfile-update")
+        data = {"document_type": "SSN", "document_number": "123456789"}
+
+        response = auth_client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_partial_update_billing_profile_success(self, auth_client, membership, organization):
         """Test successfully partially updating a billing profile with PATCH."""
         # Create existing billing address and profile
@@ -331,6 +519,31 @@ class TestBillingProfileViewSet:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_partial_update_billing_profile_no_membership_forbidden(self, auth_client):
+        """A user with no active organization membership cannot partially update a
+        billing profile. `IsOrganizationAdmin` (gating writes, SHOULD-FIX 4) denies
+        a membership-less caller before the lookup is even attempted."""
+        url = reverse("api:BillingProfile-partial_update")
+        data = {"document_number": "NEW123"}
+
+        response = auth_client.patch(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_partial_update_billing_profile_non_admin_forbidden(
+        self, auth_client, non_admin_membership, organization
+    ):
+        """A non-admin member may not partially update the organization's billing
+        profile, even when one already exists."""
+        baker.make(BillingProfile, organization=organization)
+
+        url = reverse("api:BillingProfile-partial_update")
+        data = {"document_number": "NEW123"}
+
+        response = auth_client.patch(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     def test_all_endpoints_require_authentication(self, anonymous_client):
         """Test that all billing profile endpoints require authentication."""
         endpoints = [
@@ -379,6 +592,8 @@ class TestBillingProfileViewSet:
         """Test creating billing profile with minimal required address data."""
         url = reverse("api:BillingProfile-create")
         data = {
+            "contact_first_name": "Ada",
+            "contact_email": "billing@example.com",
             "document_type": "ID",
             "document_number": "987654321",
             "billing_address": {

--- a/payments/tests/views/test_billing_profile_view_set.py
+++ b/payments/tests/views/test_billing_profile_view_set.py
@@ -4,17 +4,29 @@ import pytest
 from model_bakery import baker
 from rest_framework import status
 
+from organizations.models import Organization, OrganizationMembership
 from payments.models import BillingAddress, BillingProfile
-from users.models import Profile
+
+
+@pytest.fixture
+def organization():
+    return baker.make(Organization)
+
+
+@pytest.fixture
+def membership(user, organization):
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=organization,
+        is_active=True,
+    )
 
 
 @pytest.mark.django_db
 class TestBillingProfileViewSet:
-    def test_retrieve_billing_profile_success(self, auth_client, user):
+    def test_retrieve_billing_profile_success(self, auth_client, membership, organization):
         """Test successfully retrieving a billing profile."""
-        # Create a profile for the user
-        _profile = baker.make(Profile, user=user, first_name="John", last_name="Doe")
-
         # Create billing address and profile
         billing_address = baker.make(
             BillingAddress,
@@ -29,7 +41,7 @@ class TestBillingProfileViewSet:
         )
         _billing_profile = baker.make(
             BillingProfile,
-            user=user,
+            organization=organization,
             document_type="SSN",
             document_number="123456789",
             billing_address=billing_address,
@@ -39,14 +51,22 @@ class TestBillingProfileViewSet:
         response = auth_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["id"] == user.pk
+        assert response.data["id"] == organization.pk
         assert response.data["document_type"] == "SSN"
         assert response.data["document_number"] == "123456789"
         assert response.data["billing_address"]["street_name"] == "Main Street"
         assert response.data["billing_address"]["city"] == "New York"
 
-    def test_retrieve_billing_profile_not_found(self, auth_client, user):
+    def test_retrieve_billing_profile_not_found(self, auth_client, membership):
         """Test retrieving billing profile when it doesn't exist."""
+        url = reverse("api:BillingProfile-retrieve")
+        response = auth_client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_retrieve_billing_profile_no_membership(self, auth_client):
+        """A user with no active organization membership cannot resolve a billing
+        profile at all — the active org resolves to None and the lookup 404s."""
         url = reverse("api:BillingProfile-retrieve")
         response = auth_client.get(url)
 
@@ -59,11 +79,32 @@ class TestBillingProfileViewSet:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_create_billing_profile_success(self, auth_client, user):
-        """Test successfully creating a billing profile."""
-        # Create a profile for the user
-        baker.make(Profile, user=user, first_name="John", last_name="Doe")
+    def test_retrieve_billing_profile_cross_organization_not_found(
+        self, auth_client, membership, organization
+    ):
+        """A member of org A cannot read org B's billing profile.
 
+        org A (the caller's org) has no billing profile of its own here; org B's
+        exists but the caller is never resolved into org B's context, so the
+        lookup 404s instead of leaking org B's data.
+        """
+        other_organization = baker.make(Organization)
+        other_billing_address = baker.make(BillingAddress)
+        baker.make(
+            BillingProfile,
+            organization=other_organization,
+            document_type="SSN",
+            document_number="999999999",
+            billing_address=other_billing_address,
+        )
+
+        url = reverse("api:BillingProfile-retrieve")
+        response = auth_client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_create_billing_profile_success(self, auth_client, membership, organization):
+        """Test successfully creating a billing profile."""
         url = reverse("api:BillingProfile-create")
         data = {
             "document_type": "SSN",
@@ -83,22 +124,19 @@ class TestBillingProfileViewSet:
         response = auth_client.post(url, data, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data["id"] == user.pk
+        assert response.data["id"] == organization.pk
         assert response.data["document_type"] == "SSN"
         assert response.data["document_number"] == "123456789"
         assert response.data["billing_address"]["street_name"] == "Main Street"
 
         # Verify the billing profile was created in the database
-        billing_profile = BillingProfile.objects.get(user=user)
+        billing_profile = BillingProfile.objects.get(organization=organization)
         assert billing_profile.document_type == "SSN"
         assert billing_profile.document_number == "123456789"
         assert billing_profile.billing_address.street_name == "Main Street"
 
-    def test_create_billing_profile_invalid_data(self, auth_client, user):
+    def test_create_billing_profile_invalid_data(self, auth_client, membership):
         """Test creating billing profile with invalid data."""
-        # Create a profile for the user
-        baker.make(Profile, user=user, first_name="John", last_name="Doe")
-
         url = reverse("api:BillingProfile-create")
         data = {
             "document_type": "",  # Empty required field
@@ -132,11 +170,8 @@ class TestBillingProfileViewSet:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_update_billing_profile_success(self, auth_client, user):
+    def test_update_billing_profile_success(self, auth_client, membership, organization):
         """Test successfully updating a billing profile with PUT."""
-        # Create a profile for the user
-        baker.make(Profile, user=user, first_name="John", last_name="Doe")
-
         # Create existing billing address and profile
         billing_address = baker.make(
             BillingAddress,
@@ -149,7 +184,7 @@ class TestBillingProfileViewSet:
         )
         billing_profile = baker.make(
             BillingProfile,
-            user=user,
+            organization=organization,
             document_type="DL",
             document_number="OLD123",
             billing_address=billing_address,
@@ -187,7 +222,7 @@ class TestBillingProfileViewSet:
         assert billing_address.street_name == "New Street"
         assert billing_address.city == "New City"
 
-    def test_update_billing_profile_not_found(self, auth_client, user):
+    def test_update_billing_profile_not_found(self, auth_client, membership):
         """Test updating billing profile when it doesn't exist."""
         url = reverse("api:BillingProfile-update")
         data = {
@@ -207,11 +242,8 @@ class TestBillingProfileViewSet:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_partial_update_billing_profile_success(self, auth_client, user):
+    def test_partial_update_billing_profile_success(self, auth_client, membership, organization):
         """Test successfully partially updating a billing profile with PATCH."""
-        # Create a profile for the user
-        baker.make(Profile, user=user, first_name="John", last_name="Doe")
-
         # Create existing billing address and profile
         billing_address = baker.make(
             BillingAddress,
@@ -224,7 +256,7 @@ class TestBillingProfileViewSet:
         )
         billing_profile = baker.make(
             BillingProfile,
-            user=user,
+            organization=organization,
             document_type="DL",
             document_number="OLD123",
             billing_address=billing_address,
@@ -251,11 +283,10 @@ class TestBillingProfileViewSet:
         assert billing_address.street_name == "Old Street"
         assert billing_address.city == "Updated City"
 
-    def test_partial_update_billing_profile_address_only(self, auth_client, user):
+    def test_partial_update_billing_profile_address_only(
+        self, auth_client, membership, organization
+    ):
         """Test partially updating only the billing address."""
-        # Create a profile for the user
-        baker.make(Profile, user=user, first_name="John", last_name="Doe")
-
         # Create existing billing address and profile
         billing_address = baker.make(
             BillingAddress,
@@ -268,7 +299,7 @@ class TestBillingProfileViewSet:
         )
         _billing_profile = baker.make(
             BillingProfile,
-            user=user,
+            organization=organization,
             document_type="DL",
             document_number="OLD123",
             billing_address=billing_address,
@@ -291,7 +322,7 @@ class TestBillingProfileViewSet:
             response.data["billing_address"]["neighborhood"] == "New Neighborhood"
         )  # Should be updated
 
-    def test_partial_update_billing_profile_not_found(self, auth_client, user):
+    def test_partial_update_billing_profile_not_found(self, auth_client, membership):
         """Test partially updating billing profile when it doesn't exist."""
         url = reverse("api:BillingProfile-partial_update")
         data = {"document_number": "NEW123"}
@@ -316,11 +347,8 @@ class TestBillingProfileViewSet:
                 f"Failed for {endpoint_name}"
             )
 
-    def test_billing_profile_relationships(self, auth_client, user):
-        """Test that billing profile correctly relates to user and billing address."""
-        # Create a profile for the user
-        _profile = baker.make(Profile, user=user, first_name="John", last_name="Doe")
-
+    def test_billing_profile_relationships(self, organization):
+        """Test that billing profile correctly relates to the organization and address."""
         # Create billing address and profile
         billing_address = baker.make(
             BillingAddress,
@@ -333,25 +361,22 @@ class TestBillingProfileViewSet:
         )
         billing_profile = baker.make(
             BillingProfile,
-            user=user,
+            organization=organization,
             document_type="SSN",
             document_number="123456789",
             billing_address=billing_address,
         )
 
         # Test that the billing profile is correctly linked
-        assert billing_profile.user == user
+        assert billing_profile.organization == organization
         assert billing_profile.billing_address == billing_address
         assert billing_address.billing_profile == billing_profile
 
-        # Test that we can access the billing profile through the user
-        assert user.billing_profile == billing_profile
+        # Test that we can access the billing profile through the organization
+        assert organization.billing_profile == billing_profile
 
-    def test_create_billing_profile_with_minimal_address_data(self, auth_client, user):
+    def test_create_billing_profile_with_minimal_address_data(self, auth_client, membership):
         """Test creating billing profile with minimal required address data."""
-        # Create a profile for the user
-        baker.make(Profile, user=user, first_name="John", last_name="Doe")
-
         url = reverse("api:BillingProfile-create")
         data = {
             "document_type": "ID",

--- a/payments/views.py
+++ b/payments/views.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ViewSet
 
+from common.utils.view_utils import TenantScopedViewMixin
 from payments.models import BillingProfile
 from payments.serializers import BillingProfileSerializer
 
@@ -72,6 +73,7 @@ class PaymentsViewSet(ViewSet):
 
 
 class BillingProfileViewSet(
+    TenantScopedViewMixin,
     GenericVirtualModelViewMixin,
     GenericViewSet,
 ):
@@ -82,7 +84,9 @@ class BillingProfileViewSet(
     permission_classes = (IsAuthenticated,)
 
     def get_billing_profile(self):
-        return get_object_or_404(self.get_queryset(), pk=self.request.user.pk)
+        organization = self.request.organization  # type: ignore[attr-defined]
+        organization_pk = organization.pk if organization is not None else None
+        return get_object_or_404(self.get_queryset(), pk=organization_pk)
 
     @extend_schema(
         summary="Retrieve billing profile",

--- a/payments/views.py
+++ b/payments/views.py
@@ -1,16 +1,19 @@
 from typing import TYPE_CHECKING, Annotated
 
+from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 
 from dependency_injector.wiring import Provide, inject
 from django_virtual_models.generic_views import GenericVirtualModelViewMixin
 from drf_spectacular.utils import extend_schema
+from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ViewSet
 
 from common.utils.view_utils import TenantScopedViewMixin
+from organizations.permissions import IsOrganizationAdmin
 from payments.models import BillingProfile
 from payments.serializers import BillingProfileSerializer
 
@@ -83,6 +86,31 @@ class BillingProfileViewSet(
     lookup_field = "pk"
     permission_classes = (IsAuthenticated,)
 
+    #: Writes touch the organization's tax document number and payer identity, not
+    #: just "my own" data, so they are gated to org admins. Reads stay open to any
+    #: authenticated member (IsAuthenticated, above).
+    write_actions = (
+        "create_billing_profile",
+        "update_billing_profile",
+        "partial_update_billing_profile",
+    )
+
+    def get_permissions(self):
+        if self.action in self.write_actions:
+            return [IsAuthenticated(), IsOrganizationAdmin()]
+        return super().get_permissions()
+
+    def get_queryset(self) -> QuerySet[BillingProfile]:
+        # Chain the organization filter on top of the virtual-model-optimized base
+        # queryset (GenericVirtualModelViewMixin.get_queryset()) rather than
+        # constructing a fresh queryset, so scoping doesn't undo the serializer's
+        # select_related/prefetch optimization.
+        queryset = super().get_queryset()
+        organization = self.request.organization  # type: ignore[attr-defined]
+        if organization is None:
+            return queryset.none()
+        return queryset.filter(organization=organization)
+
     def get_billing_profile(self):
         organization = self.request.organization  # type: ignore[attr-defined]
         organization_pk = organization.pk if organization is not None else None
@@ -90,7 +118,7 @@ class BillingProfileViewSet(
 
     @extend_schema(
         summary="Retrieve billing profile",
-        description="Retrieve the billing profile of the authenticated user.",
+        description="Retrieve the billing profile of the active organization.",
         responses={200: BillingProfileSerializer},
     )
     @action(
@@ -107,7 +135,7 @@ class BillingProfileViewSet(
 
     @extend_schema(
         summary="Create billing profile",
-        description="Create a new billing profile for the authenticated user.",
+        description="Create a new billing profile for the active organization.",
         responses={201: BillingProfileSerializer},
     )
     @action(
@@ -117,6 +145,12 @@ class BillingProfileViewSet(
         url_name="create",
     )
     def create_billing_profile(self, request, *args, **kwargs):
+        if self.get_queryset().exists():
+            return Response(
+                {"detail": "A billing profile already exists for this organization."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         billing_profile = serializer.save()
@@ -128,7 +162,7 @@ class BillingProfileViewSet(
 
     @extend_schema(
         summary="Update billing profile",
-        description="Update the billing profile of the authenticated user.",
+        description="Update the billing profile of the active organization.",
         responses={200: BillingProfileSerializer},
     )
     @action(
@@ -147,7 +181,7 @@ class BillingProfileViewSet(
 
     @extend_schema(
         summary="Partially update billing profile",
-        description="Partially update the billing profile of the authenticated user.",
+        description="Partially update the billing profile of the active organization.",
         responses={200: BillingProfileSerializer},
     )
     @action(

--- a/schema.yml
+++ b/schema.yml
@@ -1007,7 +1007,7 @@ paths:
   /billing-profile/create_billing_profile/:
     post:
       operationId: billing_profile_create_billing_profile_create
-      description: Create a new billing profile for the authenticated user.
+      description: Create a new billing profile for the active organization.
       summary: Create billing profile
       parameters:
       - in: header
@@ -1047,7 +1047,7 @@ paths:
   /billing-profile/create_billing_profile{format}:
     post:
       operationId: billing_profile_create_billing_profile_formatted_create
-      description: Create a new billing profile for the authenticated user.
+      description: Create a new billing profile for the active organization.
       summary: Create billing profile
       parameters:
       - in: header
@@ -1094,7 +1094,7 @@ paths:
   /billing-profile/partial_update_billing_profile/:
     patch:
       operationId: billing_profile_partial_update_billing_profile_partial_update
-      description: Partially update the billing profile of the authenticated user.
+      description: Partially update the billing profile of the active organization.
       summary: Partially update billing profile
       parameters:
       - in: header
@@ -1133,7 +1133,7 @@ paths:
   /billing-profile/partial_update_billing_profile{format}:
     patch:
       operationId: billing_profile_partial_update_billing_profile_formatted_partial_update
-      description: Partially update the billing profile of the authenticated user.
+      description: Partially update the billing profile of the active organization.
       summary: Partially update billing profile
       parameters:
       - in: header
@@ -1179,7 +1179,7 @@ paths:
   /billing-profile/retrieve_billing_profile/:
     get:
       operationId: billing_profile_retrieve_billing_profile_retrieve
-      description: Retrieve the billing profile of the authenticated user.
+      description: Retrieve the billing profile of the active organization.
       summary: Retrieve billing profile
       parameters:
       - in: header
@@ -1207,7 +1207,7 @@ paths:
   /billing-profile/retrieve_billing_profile{format}:
     get:
       operationId: billing_profile_retrieve_billing_profile_formatted_retrieve
-      description: Retrieve the billing profile of the authenticated user.
+      description: Retrieve the billing profile of the active organization.
       summary: Retrieve billing profile
       parameters:
       - in: header
@@ -1242,7 +1242,7 @@ paths:
   /billing-profile/update_billing_profile/:
     put:
       operationId: billing_profile_update_billing_profile_update
-      description: Update the billing profile of the authenticated user.
+      description: Update the billing profile of the active organization.
       summary: Update billing profile
       parameters:
       - in: header
@@ -1282,7 +1282,7 @@ paths:
   /billing-profile/update_billing_profile{format}:
     put:
       operationId: billing_profile_update_billing_profile_formatted_update
-      description: Update the billing profile of the authenticated user.
+      description: Update the billing profile of the active organization.
       summary: Update billing profile
       parameters:
       - in: header
@@ -12909,6 +12909,19 @@ components:
         id:
           type: integer
           readOnly: true
+        contact_first_name:
+          type: string
+          maxLength: 255
+        contact_last_name:
+          type: string
+          maxLength: 255
+        contact_email:
+          type: string
+          format: email
+          maxLength: 254
+        contact_phone:
+          type: string
+          maxLength: 50
         document_type:
           type: string
           maxLength: 50
@@ -12927,6 +12940,8 @@ components:
           readOnly: true
       required:
       - billing_address
+      - contact_email
+      - contact_first_name
       - created
       - document_number
       - document_type
@@ -14769,6 +14784,19 @@ components:
         id:
           type: integer
           readOnly: true
+        contact_first_name:
+          type: string
+          maxLength: 255
+        contact_last_name:
+          type: string
+          maxLength: 255
+        contact_email:
+          type: string
+          format: email
+          maxLength: 254
+        contact_phone:
+          type: string
+          maxLength: 50
         document_type:
           type: string
           maxLength: 50

--- a/schema.yml
+++ b/schema.yml
@@ -1009,6 +1009,17 @@ paths:
       operationId: billing_profile_create_billing_profile_create
       description: Create a new billing profile for the authenticated user.
       summary: Create billing profile
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       tags:
       - billing-profile
       requestBody:
@@ -1039,6 +1050,16 @@ paths:
       description: Create a new billing profile for the authenticated user.
       summary: Create billing profile
       parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       - in: path
         name: format
         schema:
@@ -1075,6 +1096,17 @@ paths:
       operationId: billing_profile_partial_update_billing_profile_partial_update
       description: Partially update the billing profile of the authenticated user.
       summary: Partially update billing profile
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       tags:
       - billing-profile
       requestBody:
@@ -1104,6 +1136,16 @@ paths:
       description: Partially update the billing profile of the authenticated user.
       summary: Partially update billing profile
       parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       - in: path
         name: format
         schema:
@@ -1139,6 +1181,17 @@ paths:
       operationId: billing_profile_retrieve_billing_profile_retrieve
       description: Retrieve the billing profile of the authenticated user.
       summary: Retrieve billing profile
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       tags:
       - billing-profile
       security:
@@ -1157,6 +1210,16 @@ paths:
       description: Retrieve the billing profile of the authenticated user.
       summary: Retrieve billing profile
       parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       - in: path
         name: format
         schema:
@@ -1181,6 +1244,17 @@ paths:
       operationId: billing_profile_update_billing_profile_update
       description: Update the billing profile of the authenticated user.
       summary: Update billing profile
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       tags:
       - billing-profile
       requestBody:
@@ -1211,6 +1285,16 @@ paths:
       description: Update the billing profile of the authenticated user.
       summary: Update billing profile
       parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
       - in: path
         name: format
         schema:

--- a/users/models.py
+++ b/users/models.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING
-
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -8,10 +6,6 @@ from common.models import BaseModel
 from s3direct_overrides.model_fields import S3DirectImageField
 
 from .managers import UserManager
-
-
-if TYPE_CHECKING:
-    from payments.models import BillingProfile
 
 
 class User(AbstractBaseUser, PermissionsMixin, BaseModel):
@@ -33,7 +27,6 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel):
 
     objects: UserManager = UserManager()
     profile: "Profile"
-    billing_profile: "BillingProfile"
 
     USERNAME_FIELD = "email"
 


### PR DESCRIPTION

Phase 1 of the [billing plans and limits plan](../../../ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_IMPLEMENTATION_PLAN.md), implementing the spec at [ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_SPEC.md](../../../ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_SPEC.md).

This is the **one-way door** the spec names: billing moves from being owned by a `User` to being owned by an `Organization`. It lands first, deliberately, before any money can flow. Nothing else in the plan can be built until this is correct.

## Why this is safe to do destructively

`payments_billingprofile` and `payments_subscription` are rebuilt rather than migrated in place. That is sanctioned because both tables — along with `organizations_organizationtier` and `organizations_subscriptionplan` — are empty in every environment: nothing assigns `Organization.tier`, and the only writes to those models live in tests.

**Reviewer action:** please confirm emptiness in staging and production before this deploys. The migration fails loudly rather than losing rows if the assumption is wrong (`preserve_default=False` on a non-null re-added column), but the check is worth doing by hand.

## What changed

**Ownership move**
- `BillingProfile.user` (a `OneToOneField` primary key) becomes `BillingProfile.organization`.
- `Subscription` gains real `organization`, `plan`, `billing_state`, `billing_interval`, `current_period_start`/`_end`, `grace_period_ends_at`, `plan_external_id`, and `payment_provider` fields.
- `BillingProfileViewSet` mixes in `TenantScopedViewMixin` and resolves by active organization.

**Dead-seam repair.** These were pre-existing defects, not regressions introduced here:
- `Subscription.membership` was a bare type annotation with no field and no migration, so `Subscription.plan` raised `AttributeError` — which the `except ObjectDoesNotExist` around it never caught. Both removed; `plan` is now a real FK.
- `RefundStatusUpdate.status` used `PaymentStatuses` instead of `RefundStatuses`, and its `__str__` referenced a nonexistent `self.payment`.
- Two modules did `from venv import logger` instead of importing the stdlib `logging`.

**Payer identity.** `BillingProfile` gains `contact_first_name`, `contact_last_name`, `contact_email`, `contact_phone`. With billing no longer user-owned there is no `User` to source a payer from, and MercadoPago hard-400s on a null `payer.email`. These are provider-payload data and are deliberately distinct from the future `is_billing_owner` membership flag, which governs *who may manage* billing rather than *what identity is sent to the gateway*. The plan's Data Model Changes section was amended to record this.

## Reviewer notes

**Breaking change for API clients.** The billing-profile `id` field changes source from `user_id` to `organization_id`. The field name and type are unchanged, so this does **not** show up as a schema diff — a client that persisted the old `id` will silently read a different entity. This needs a client handoff before merge.

**Permissions widened, then narrowed.** Moving the resource from "a user's own billing data" to "the organization's tax document number" meant any member — including one invited a minute ago — could read and overwrite it. Write actions are now gated on `IsOrganizationAdmin`. The plan's `IsBillingOwnerOrAdmin` is Phase 9's job and is intentionally not built here.

**Scope taken on deliberately.** A minimal `BillingPlan` model is pulled forward from Phase 3 because `Subscription.plan` cannot reference a model that does not exist. Phase 3 extends it with `PlanLimit`/`PlanEntitlement` and seeding; no destructive redo is required. Its one DB constraint ships with a test rather than untested.

**`Subscription` carries two status concepts.** `status` (`SubscriptionStatuses`) is the provider-reported state fed by `SubscriptionStatusUpdate`; `billing_state` (`BillingState`) is the internal billing lifecycle Phase 10's state machine will drive. They share member names (`active`, `cancelled`, `pending`), so the boundary is documented in the model docstring and `status` is dropped from the serializer until a consumer needs it.

## Verification

Every gate was run and independently re-run by the orchestrator, not taken from the implementing agent's report:

- Full suite: **3693 passed**, 0 failed (baseline before this phase: 3679 — 14 new tests).
- `ruff check` / `ruff format --check`: clean.
- `mypy .`: 322 errors in 59 files, exactly matching the pre-existing baseline; zero in `payments/`.
- `makemigrations --check`: no changes detected.
- **Migration reverses**: verified forward → `migrate payments 0002` → forward again, both before and after the review fixes edited migration `0003` in place. The first implementation attempt failed on Postgres FK dependencies and had to be rewritten as drop-FK → `DeleteModel` → `CreateModel` → re-add-FK.

## Review findings addressed

An adversarial review raised three BLOCKERs, all fixed in `2368c27`:

1. **Broken provider payload** — the payer dataclass emitted a null email, which MercadoPago rejects with a hard 400. Every `create_payment`/`process_subscription` path would have failed against the live gateway while the test suite stayed green, because nothing tested the serialized payload.
2. **Webhook 500-loop** — an unguarded reverse 1:1 (`subscription.organization.billing_profile`) would raise `RelatedObjectDoesNotExist` on the unauthenticated provider webhook once Phase 4 gives every organization a subscription while most have no billing profile. Worth noting this is a Phase 1 change that only detonates on Phase 4's data — Phase 1's own tests could not have caught it.
3. **`request.organization` may be `None`** for an authenticated user with zero memberships, giving `IntegrityError` → 500 on write. A genuine regression introduced by this phase; the previous `request.user` was never `None`.

Plus: the cross-organization isolation test was vacuous (it passed for the trivial reason that no profile existed, and would have passed against the old user-keyed code) and has been replaced with real isolation, active-org-header switching, and non-member-org cases.