### PR TITLE
feat(organizations): enforce seat limits on every path that adds a member (billing plans and limits, phase 6a)

### DIFF
--- a/accounts/account_adapters.py
+++ b/accounts/account_adapters.py
@@ -23,6 +23,7 @@ from legal.services import ConsentService
 from organizations.exceptions import UserAlreadyHasMembershipError
 from organizations.models import get_active_organization_membership
 from organizations.services import OrganizationService
+from payments.exceptions import OverLimitError
 from users.models import Profile, User
 
 
@@ -149,6 +150,14 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         mirroring AccountAdapter) and calls provision_tenant_for_user with no
         organisation_name — social signups never carry one.  No-ops silently on
         UserAlreadyHasMembershipError (re-login or race).
+
+        ``OverLimitError`` (the inviting org is at its seat limit) is caught the
+        same way: this runs under allauth.headless views, not DRF, so
+        ``vinta_exception_handler`` never sees it and an uncaught raise here would
+        surface as a bare 500 mid-signup with the social account otherwise fully
+        created and committed. Falling through leaves the user membership-less
+        (gated) — the same outcome as "no pending invitation" — rather than
+        wedging the signup.
         """
         if not user.email:
             logger.warning(
@@ -163,6 +172,15 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             # Re-login or race: user already has a membership — no-op.
             logger.debug(
                 "Social user %s already has a membership; skipping re-provisioning.",
+                user.pk,
+            )
+            return
+        except OverLimitError:
+            # Inviting org is at its seat limit: leave the user membership-less
+            # (gated) instead of raising a 500 out of a headless view.
+            logger.info(
+                "Social user %s could not auto-join their inviting org: seat limit "
+                "reached. User remains membership-less (gated).",
                 user.pk,
             )
             return
@@ -341,6 +359,15 @@ class AccountAdapter(DefaultAccountAdapter):
         DI container global at the call site.
 
         Idempotent: swallows UserAlreadyHasMembershipError so re-confirmation is a no-op.
+
+        Also swallows ``OverLimitError`` (the inviting org is at its seat limit): this
+        adapter runs under allauth.headless views, not DRF, so
+        ``vinta_exception_handler`` never sees it. Left uncaught, it would surface as a
+        bare 500 *after* the email address is already marked verified — and under
+        ``ATOMIC_REQUESTS`` the whole request (including that verification) rolls back,
+        wedging the user with an unverified email and no way to make a retry succeed.
+        Falling through leaves the user membership-less (gated), matching the existing
+        no-pending-invitation and no-org-name branch below.
         """
         confirmed = super().confirm_email(request, email_address)
         if not confirmed:
@@ -368,6 +395,15 @@ class AccountAdapter(DefaultAccountAdapter):
             # Idempotent: re-confirmation or race — user already has a membership.
             logger.debug(
                 "User %s already has a membership; skipping re-provisioning.",
+                user.pk,
+            )
+            return confirmed
+        except OverLimitError:
+            # Inviting org is at its seat limit: leave the user membership-less
+            # (gated) instead of raising a 500 out of a headless view.
+            logger.info(
+                "User %s could not auto-join their inviting org: seat limit "
+                "reached. User remains membership-less (gated).",
                 user.pk,
             )
             return confirmed

--- a/accounts/tests/test_account_adapters.py
+++ b/accounts/tests/test_account_adapters.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings as django_settings
+from django.utils import timezone
 
 import pytest
 from allauth.socialaccount.models import SocialLogin
@@ -13,7 +14,43 @@ from accounts.account_adapters import (
     SocialAccountAdapter,
 )
 from legal.factories import UserConsentFactory
+from organizations.models import Organization, OrganizationInvitation, OrganizationMembership
+from payments.billing_constants import BillingState, LimitedResource, LimitKind
+from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
 from users.models import Profile, User
+
+
+def _org_at_seat_limit_with_pending_invitation(email: str) -> Organization:
+    """A one-seat organization already full, with a still-pending invitation to
+    ``email`` — the exact BLOCKER 1 scenario: signup would take the org over its
+    seat limit, so ``provision_tenant_for_user`` raises ``OverLimitError``."""
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=LimitedResource.ORGANIZATION_MEMBERS,
+        limit_value=1,
+        kind=LimitKind.PREPAID,
+    )
+    baker.make(OrganizationMembership, organization=organization, is_active=True)
+    baker.make(
+        OrganizationInvitation,
+        organization=organization,
+        email=email,
+        expires_at=now + datetime.timedelta(days=7),
+        accepted_at=None,
+        membership_user_id=None,
+    )
+    return organization
 
 
 @pytest.mark.django_db
@@ -211,6 +248,20 @@ class TestSocialAccountAdapter:
             result = adapter.deserialize_instance(object, data)
             assert result == "fallback"
 
+    def test_provision_org_membership_does_not_wedge_signup_at_the_seat_limit(self):
+        """BLOCKER 1: without catching OverLimitError, this raises out of a
+        headless (non-DRF) view — a bare 500 for social signup. With the fix,
+        the user is left membership-less (gated) instead."""
+        organization = _org_at_seat_limit_with_pending_invitation("dana@example.com")
+        new_user = baker.make(User, email="dana@example.com")
+        adapter = SocialAccountAdapter()
+
+        adapter._provision_org_membership(new_user)  # must not raise
+
+        assert not OrganizationMembership.objects.filter(
+            user=new_user, organization=organization
+        ).exists()
+
 
 @pytest.mark.django_db
 class TestAccountAdapter:
@@ -352,6 +403,29 @@ class TestAccountAdapter:
         with patch("accounts.account_adapters.logger.warning") as log_warn:
             adapter.send_unknown_account_sms(None)
             log_warn.assert_called_with("No phone number provided for sending unknown account SMS.")
+
+    def test_confirm_email_does_not_wedge_signup_at_the_seat_limit(self, adapter):
+        """BLOCKER 1: without catching OverLimitError, this raises out of a
+        headless (non-DRF) view *after* the email has already been marked
+        verified — under ATOMIC_REQUESTS the whole request (including that
+        verification) rolls back, wedging the user with an unverified email
+        and no way to make a retry succeed. With the fix, confirm_email still
+        reports success and the user is left membership-less (gated)."""
+        organization = _org_at_seat_limit_with_pending_invitation("erin@example.com")
+        new_user = baker.make(User, email="erin@example.com")
+        Profile.objects.create(user=new_user, pending_organization_name="")
+        email_address = MagicMock()
+        email_address.user = new_user
+
+        with patch(
+            "accounts.account_adapters.DefaultAccountAdapter.confirm_email", return_value=True
+        ):
+            confirmed = adapter.confirm_email(MagicMock(), email_address)
+
+        assert confirmed is True
+        assert not OrganizationMembership.objects.filter(
+            user=new_user, organization=organization
+        ).exists()
 
 
 @pytest.mark.django_db

--- a/accounts/tests/test_account_adapters.py
+++ b/accounts/tests/test_account_adapters.py
@@ -261,6 +261,11 @@ class TestSocialAccountAdapter:
         assert not OrganizationMembership.objects.filter(
             user=new_user, organization=organization
         ).exists()
+        # The invitation must remain pending -- that is what makes the user
+        # recoverable once a seat frees up. If it were marked accepted (or
+        # otherwise consumed) here, the seat would be lost with no membership
+        # to show for it.
+        assert OrganizationInvitation.objects.get(email="dana@example.com").accepted_at is None
 
 
 @pytest.mark.django_db
@@ -413,7 +418,9 @@ class TestAccountAdapter:
         reports success and the user is left membership-less (gated)."""
         organization = _org_at_seat_limit_with_pending_invitation("erin@example.com")
         new_user = baker.make(User, email="erin@example.com")
-        Profile.objects.create(user=new_user, pending_organization_name="")
+        profile = Profile.objects.create(
+            user=new_user, pending_organization_name="Erin's Stashed Org"
+        )
         email_address = MagicMock()
         email_address.user = new_user
 
@@ -426,6 +433,14 @@ class TestAccountAdapter:
         assert not OrganizationMembership.objects.filter(
             user=new_user, organization=organization
         ).exists()
+        # The invitation must remain pending -- that is what makes the user
+        # recoverable once a seat frees up.
+        assert OrganizationInvitation.objects.get(email="erin@example.com").accepted_at is None
+        # The stashed org name must not be cleared: it is only cleared once
+        # provisioning actually succeeds (membership is not None), and here it
+        # never gets that far -- OverLimitError is raised first.
+        profile.refresh_from_db()
+        assert profile.pending_organization_name == "Erin's Stashed Org"
 
 
 @pytest.mark.django_db

--- a/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
+++ b/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
@@ -157,21 +157,43 @@ One NIT was **declined with evidence**: moving `from di_core.containers import c
 
 **Final gates** (re-run independently by the orchestrator, not relayed): suite **4054 passed** (round 2: 4051; round 1: 4039; original: 4016; `origin/main` baseline 3969); `mypy` **305 errors / 57 files** — *below* the 308/58 baseline, with **zero `type: ignore` / `noqa` added across all four commits**; `ruff check` + `format --check` clean (479 files); `makemigrations --check` clean — **no migration in the whole phase after `0010`**; `check --deploy` unchanged at 5 pre-existing dev-settings warnings; main checkout clean; no AI co-author trailers.
 
+### Phase 6a — Enforce pre-paid limits: seats and invitations ✅
+
+- **Status**: reviewed clean (2 review rounds), PR open
+- **Models**: implementer Tier 3; reviewer Tier 4 both rounds; fixer Tier 2→3 (stepped up for scope)
+- **Branch**: `plan/billing-plans-and-limits/phase-6a` · **Base**: `main`
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/195
+- **Commits**: `463015b` implementation, `e0360c0` round 1, `46f0c67` tracking, `c4524d8` round 2
+
+Developed stacked on phase-5; **#194 merged mid-review**, so the PR targets `main`. `main` held only the merge commit beyond this branch (empty content diff), so no rebase was needed.
+
+The first phase that can block a real user. Guards `invite_user_to_organization`, `accept_invitation`, the invite branch of `provision_tenant_for_user`, and `reactivate` (moved into `OrganizationService.reactivate_membership` — the plan puts enforcement in the service layer, and the viewset version had no `bypass_limits`). `OverLimitError` renders byte-identically through REST and GraphQL, asserted by comparing the two responses to each other.
+
+**Two BLOCKERs, one of each failure mode** — and both lived outside the code the phase set out to change:
+
+1. **Seat limits wedged signup with a 500.** The guard on `provision_tenant_for_user` was correct, but its two callers are allauth adapters, and **allauth headless mounts as plain Django views, not DRF** — so `common/exception_handlers` never ran. Under `ATOMIC_REQUESTS` the 500 rolled back the email-verification write too, so the address stayed unverified and every retry failed identically; social signup rolled back the whole user row. Both adapters now fall through to the membership-less gated branch they already use for uninvited users, with the invitation left pending so the user is recoverable.
+2. **Resending an invitation was a false block.** The guard counted the invitation being resent, so an org at its exact ceiling could never resend — in precisely the state where it matters (seats just filled, one invite never arrived). The implementer had recorded this as an accepted corner case; review disagreed and was right. The exclusion machinery already existed one method over.
+
+**A reviewer finding that was wrong, and the fixer caught it.** Round 2 reported the same outside-the-transaction bug in `provision_tenant_for_user` that was real in `accept_invitation`. It does not exist there — that method carries a method-level `@transaction.atomic()` the other lacks. The fixer stash-tested it, found its new test green against pre-fix code, applied the harmless clarifying move anyway, and said plainly the test is not a regression guard. Recorded because **reviewer output needs verifying too, not just implementer output.**
+
+Also fixed: `accept_invitation` marked the invitation accepted outside its transaction (a window where a seat double-counts, permanently if that write fails); an invitation-write `IntegrityError` was reported to users as "you already have a membership"; three endpoints that can return 402 did not declare it; and the unlimited-path query budget was loose enough to absorb the next regression (now pinned to an exact count).
+
+**Gates** (re-run independently): suite **4094 passed** (phase-5 base 4054; +40); `mypy` **305 / 57** at baseline with **zero suppressions added**; `ruff` clean; `makemigrations --check` clean (no model changes); `schema.yml` verified in sync by regenerating to an empty diff. Each guard confirmed by deletion; the concurrency test races genuinely with a working negative control.
+
 ## Current phase
 
-**Phase 6a — Enforce pre-paid limits: seats and invitations** (implementer Tier 3)
+**Phase 6b — Enforce pre-paid limits: calendars, groups, bundles, availability** (implementer Tier 3, reviewer Tier 4)
 
-Base: `plan/billing-plans-and-limits/phase-5` · Branch: `plan/billing-plans-and-limits/phase-6a`
+Base: `plan/billing-plans-and-limits/phase-6a` · Branch: `plan/billing-plans-and-limits/phase-6b`
 
-Stacked on phase-5 rather than `main`, because phase-5 is still open as [PR #194](https://github.com/vintasoftware/vinta-schedule-api/pull/194). Phases 3 and 4 could target `main` only because their predecessors had already merged; that no longer holds. If #194 merges before 6a is integrated, rebase 6a onto `main` so its PR diff shows only 6a's work.
+Stacked on 6a, which is open as [PR #195](https://github.com/vintasoftware/vinta-schedule-api/pull/195). If #195 merges before 6b is integrated, retarget 6b's PR to `main` — do not assume the base branch still exists, since GitHub deletes it on merge (that is what broke 6a's first PR attempt).
 
-⚠️ **This phase must call `EntitlementService.check_seat_limit_for_invitation_accept(invitation)` on the accept path**, not `check_limit`. See the Phase 5 carried-forward note — accepting an invitation is net zero on seats, and using the generic entry point makes an organization unable to fill its last seat.
+⚠️ The plan's **Review models** note for 6b: the bulk sync writers at `calendar_integration/services/calendar_sync_service.py` are **the single most likely place for an unmetered path to survive**, and the plan's objective 1 depends on them. The bulk paths must check headroom *before* the write and import up to the ceiling with a recorded partial-import warning — the spec accepts partial import over unmetered creation.
 
 ## Remaining phases
 
 | Phase | Title | Impl | Reviewer | Fixer |
 |---|---|---|---|---|
-| 6b | Enforce pre-paid limits: calendars, groups, bundles, availability | 3 | 4 | — |
 | 6c | Enforce pre-paid limits: webhook subscriptions and API system users | 2 | — | — |
 | 7 | Meter event occurrences | 4 | 4 | — |
 | 8 | Enforce the post-paid allowance | 3 | — | — |

--- a/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
+++ b/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
@@ -161,7 +161,9 @@ One NIT was **declined with evidence**: moving `from di_core.containers import c
 
 **Phase 6a — Enforce pre-paid limits: seats and invitations** (implementer Tier 3)
 
-Base: `origin/main` · Branch: `plan/billing-plans-and-limits/phase-6a`
+Base: `plan/billing-plans-and-limits/phase-5` · Branch: `plan/billing-plans-and-limits/phase-6a`
+
+Stacked on phase-5 rather than `main`, because phase-5 is still open as [PR #194](https://github.com/vintasoftware/vinta-schedule-api/pull/194). Phases 3 and 4 could target `main` only because their predecessors had already merged; that no longer holds. If #194 merges before 6a is integrated, rebase 6a onto `main` so its PR diff shows only 6a's work.
 
 ⚠️ **This phase must call `EntitlementService.check_seat_limit_for_invitation_accept(invitation)` on the accept path**, not `check_limit`. See the Phase 5 carried-forward note — accepting an invitation is net zero on seats, and using the generic entry point makes an organization unable to fill its last seat.
 

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -218,6 +218,7 @@ class AppContainer(containers.DeclarativeContainer):
         webhook_membership_side_effects_service=webhook_membership_side_effects_service,
         audit_service=audit_service,
         subscription_service=subscription_service,
+        entitlement_service=entitlement_service,
     )
 
     public_api_auth_service = providers.Factory(

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -309,22 +309,27 @@ class OrganizationService:
         # handler to roll the request transaction back (REST does; a caller that
         # does not would silently commit a rejected invitation).
         if not bypass_limits:
-            # A resend reuses the still-pending row `get_or_create` below would find
-            # (same email/organization, not yet accepted); excluding it from the count
-            # makes the resend net-zero rather than a false block at the exact ceiling.
-            existing_invitation = OrganizationInvitation.objects.filter(
-                organization=organization,
-                email=email,
-                accepted_at__isnull=True,
-                membership_user_id__isnull=True,
-            ).first()
+
+            def _resolve_existing_invitation_id() -> int | None:
+                # A resend reuses the still-pending row `get_or_create` below would
+                # find (same email/organization, not yet accepted); excluding it from
+                # the count makes the resend net-zero rather than a false block at the
+                # exact ceiling. Resolved lazily -- only called once the ceiling is
+                # known to be finite -- so an `unlimited` organization never pays for
+                # this extra query.
+                existing_invitation = OrganizationInvitation.objects.filter(
+                    organization=organization,
+                    email=email,
+                    accepted_at__isnull=True,
+                    membership_user_id__isnull=True,
+                ).first()
+                return existing_invitation.pk if existing_invitation is not None else None
+
             result = self.entitlement_service.check_limit(
                 organization,
                 LimitedResource.ORGANIZATION_MEMBERS,
                 lock=True,
-                exclude_invitation_id=(
-                    existing_invitation.pk if existing_invitation is not None else None
-                ),
+                exclude_invitation_id_resolver=_resolve_existing_invitation_id,
             )
             if not result.allowed:
                 raise OverLimitError.from_check_result(result)
@@ -468,37 +473,42 @@ class OrganizationService:
                     organization=invitation.organization
                 ).exists():
                     raise UserAlreadyHasMembershipError()
-                try:
-                    with transaction.atomic():
-                        # Guard first, before the membership write, inside the same
-                        # transaction as the create — see check_limit's lock docs.
-                        if not bypass_limits:
-                            check_seat_limit = (
-                                self.entitlement_service.check_seat_limit_for_invitation_accept
-                            )
-                            result = check_seat_limit(invitation)
-                            if not result.allowed:
-                                raise OverLimitError.from_check_result(result)
+                with transaction.atomic():
+                    # Guard first, before the membership write, inside the same
+                    # transaction as the create — see check_limit's lock docs.
+                    if not bypass_limits:
+                        check_seat_limit = (
+                            self.entitlement_service.check_seat_limit_for_invitation_accept
+                        )
+                        result = check_seat_limit(invitation)
+                        if not result.allowed:
+                            raise OverLimitError.from_check_result(result)
+                    # Narrowed to just the create: an IntegrityError from the
+                    # invitation.save() below is a different failure (e.g. a
+                    # constraint on the invitation row itself) and must not be
+                    # reported as "you already have a membership" — that would be
+                    # a wrong, confusing error for something unrelated.
+                    try:
                         membership = OrganizationMembership.objects.create(
                             user=user,
                             organization=invitation.organization,
                             role=invitation.role,
                         )
-                        # Marking the invitation accepted must land in the same
-                        # transaction as the guard + membership create, not a
-                        # separate autocommit write after the block exits. Outside
-                        # a request (Celery, management command, shell) there is no
-                        # outer ATOMIC_REQUESTS transaction to fold this into: the
-                        # membership create would commit and release the row lock,
-                        # then a concurrent check could see the seat still "pending"
-                        # and count it twice, before this line ever runs — and if
-                        # this write then failed, the double-count would be
-                        # permanent.
-                        invitation.accepted_at = now
-                        invitation.membership_user_id = membership.user_id
-                        invitation.save()
-                except IntegrityError as e:
-                    raise UserAlreadyHasMembershipError() from e
+                    except IntegrityError as e:
+                        raise UserAlreadyHasMembershipError() from e
+                    # Marking the invitation accepted must land in the same
+                    # transaction as the guard + membership create, not a
+                    # separate autocommit write after the block exits. Outside
+                    # a request (Celery, management command, shell) there is no
+                    # outer ATOMIC_REQUESTS transaction to fold this into: the
+                    # membership create would commit and release the row lock,
+                    # then a concurrent check could see the seat still "pending"
+                    # and count it twice, before this line ever runs — and if
+                    # this write then failed, the double-count would be
+                    # permanent.
+                    invitation.accepted_at = now
+                    invitation.membership_user_id = membership.user_id
+                    invitation.save()
                 self.webhook_membership_side_effects_service.on_member_created(membership)
 
                 # Audit: the accepting user joins the org (new membership) and the
@@ -585,26 +595,38 @@ class OrganizationService:
                 organization=pending_invitation.organization
             ).exists():
                 raise UserAlreadyHasMembershipError()
-            try:
-                with transaction.atomic():
-                    # Guard first, before the membership write, inside the same
-                    # transaction as the create — see check_limit's lock docs.
-                    if not bypass_limits:
-                        result = self.entitlement_service.check_seat_limit_for_invitation_accept(
-                            pending_invitation
-                        )
-                        if not result.allowed:
-                            raise OverLimitError.from_check_result(result)
+            with transaction.atomic():
+                # Guard first, before the membership write, inside the same
+                # transaction as the create — see check_limit's lock docs.
+                if not bypass_limits:
+                    result = self.entitlement_service.check_seat_limit_for_invitation_accept(
+                        pending_invitation
+                    )
+                    if not result.allowed:
+                        raise OverLimitError.from_check_result(result)
+                # Narrowed to just the create: an IntegrityError from the
+                # pending_invitation.save() below is a different failure and must
+                # not be reported as "you already have a membership".
+                try:
                     membership = OrganizationMembership.objects.create(
                         user=user,
                         organization=pending_invitation.organization,
                         role=pending_invitation.role,
                     )
-            except IntegrityError as e:
-                raise UserAlreadyHasMembershipError() from e
-            pending_invitation.accepted_at = now
-            pending_invitation.membership_user_id = membership.user_id
-            pending_invitation.save()
+                except IntegrityError as e:
+                    raise UserAlreadyHasMembershipError() from e
+                # Marking the invitation accepted must land in the same
+                # transaction as the guard + membership create, not a separate
+                # autocommit write after the block exits. Outside a request
+                # (Celery, management command, shell) there is no outer
+                # ATOMIC_REQUESTS transaction to fold this into: the membership
+                # create would commit and release the row lock, then a concurrent
+                # check could see the seat still "pending" and count it twice,
+                # before this line ever runs — and if this write then failed, the
+                # double-count would be permanent.
+                pending_invitation.accepted_at = now
+                pending_invitation.membership_user_id = membership.user_id
+                pending_invitation.save()
             self.webhook_membership_side_effects_service.on_member_created(membership)
 
             # Audit: user joins the inviting org via the signup path; same shape as

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -296,22 +296,35 @@ class OrganizationService:
             root's subscription) inside this method's own transaction, so two concurrent
             invitations for the last seat serialize on that row and exactly one succeeds.
 
-        .. note::
-            A **resend** (re-inviting the same still-pending email/organization pair, which
-            resets the token/expiry rather than creating a new row) is checked identically to a
-            new invitation. It does not consume a new seat — the pending invitation already
-            counts toward the ceiling — so at the exact ceiling a resend is blocked even though
-            nothing new would be created. Narrower than the alternative (excluding the
-            in-place-reused invitation from the count) would require, which
-            ``EntitlementService.check_limit``'s own docs reserve for the accept path.
+        A **resend** (re-inviting the same still-pending email/organization pair, which resets
+        the token/expiry rather than creating a new row) resolves the still-pending invitation
+        being reused *before* the guard and excludes it from the count
+        (``EntitlementService.check_limit(..., exclude_invitation_id=...)``) — a resend is
+        net-zero on seats, exactly like an accept, since it creates nothing new. A genuinely
+        new invitation (no matching pending row) is still checked and blocked at the ceiling
+        as before.
         """
         # Guard first, before anything is written in this transaction — an
         # OverLimitError raised after a write would rely on the caller's exception
         # handler to roll the request transaction back (REST does; a caller that
         # does not would silently commit a rejected invitation).
         if not bypass_limits:
+            # A resend reuses the still-pending row `get_or_create` below would find
+            # (same email/organization, not yet accepted); excluding it from the count
+            # makes the resend net-zero rather than a false block at the exact ceiling.
+            existing_invitation = OrganizationInvitation.objects.filter(
+                organization=organization,
+                email=email,
+                accepted_at__isnull=True,
+                membership_user_id__isnull=True,
+            ).first()
             result = self.entitlement_service.check_limit(
-                organization, LimitedResource.ORGANIZATION_MEMBERS, lock=True
+                organization,
+                LimitedResource.ORGANIZATION_MEMBERS,
+                lock=True,
+                exclude_invitation_id=(
+                    existing_invitation.pk if existing_invitation is not None else None
+                ),
             )
             if not result.allowed:
                 raise OverLimitError.from_check_result(result)
@@ -471,11 +484,21 @@ class OrganizationService:
                             organization=invitation.organization,
                             role=invitation.role,
                         )
+                        # Marking the invitation accepted must land in the same
+                        # transaction as the guard + membership create, not a
+                        # separate autocommit write after the block exits. Outside
+                        # a request (Celery, management command, shell) there is no
+                        # outer ATOMIC_REQUESTS transaction to fold this into: the
+                        # membership create would commit and release the row lock,
+                        # then a concurrent check could see the seat still "pending"
+                        # and count it twice, before this line ever runs — and if
+                        # this write then failed, the double-count would be
+                        # permanent.
+                        invitation.accepted_at = now
+                        invitation.membership_user_id = membership.user_id
+                        invitation.save()
                 except IntegrityError as e:
                     raise UserAlreadyHasMembershipError() from e
-                invitation.accepted_at = now
-                invitation.membership_user_id = membership.user_id
-                invitation.save()
                 self.webhook_membership_side_effects_service.on_member_created(membership)
 
                 # Audit: the accepting user joins the org (new membership) and the
@@ -646,3 +669,44 @@ class OrganizationService:
                 }
             },
         )
+
+    @transaction.atomic()
+    def reactivate_membership(
+        self,
+        membership: OrganizationMembership,
+        bypass_limits: bool = False,
+    ) -> OrganizationMembership:
+        """Reactivate a member (set is_active=True), enforced here rather than at
+        the viewset — see the plan's Guiding Decisions ("Enforcement layer: service
+        layer, not viewsets") and the ``bypass_limits`` convention every guarded
+        method in this module follows.
+
+        Reactivating occupies a seat again (``OrganizationMembershipQuerySet
+        .occupying_a_seat`` only counts ``is_active=True`` rows), so — unlike every
+        other membership-lifecycle write — it is a capacity-raising write with no
+        accompanying ``OrganizationInvitation``/membership *create*, and would
+        otherwise be an unmetered path onto the ``organization_members`` limit.
+        Only checked when the member is currently inactive: an already-active
+        member is a no-op and must stay one even if the organization is at its
+        limit for an unrelated reason.
+
+        :param membership: The membership to reactivate.
+        :param bypass_limits: When True, skips the seat-limit guard below. Only
+            management commands and one-off repair scripts should pass this —
+            never a request-handling path.
+        :return: The (possibly already-active) membership, reactivated.
+        :raises OverLimitError: When reactivating would take the organization over
+            its seat limit.
+
+        Idempotency: reactivating an already-active member is a no-op success.
+        """
+        if not membership.is_active:
+            if not bypass_limits:
+                result = self.entitlement_service.check_limit(
+                    membership.organization, LimitedResource.ORGANIZATION_MEMBERS, lock=True
+                )
+                if not result.allowed:
+                    raise OverLimitError.from_check_result(result)
+            membership.is_active = True
+            membership.save(update_fields=["is_active"])
+        return membership

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -41,6 +41,9 @@ from organizations.models import (
     OrganizationMembership,
     OrganizationRole,
 )
+from payments.billing_constants import LimitedResource
+from payments.exceptions import OverLimitError
+from payments.services.entitlement_service import EntitlementService
 from payments.services.subscription_service import SubscriptionService
 from users.models import User
 from webhooks.services.webhook_membership_side_effects import WebhookMembershipSideEffectsService
@@ -61,12 +64,14 @@ class OrganizationService:
         ],
         audit_service: Annotated[AuditService, Provide["audit_service"]],
         subscription_service: Annotated[SubscriptionService, Provide["subscription_service"]],
+        entitlement_service: Annotated[EntitlementService, Provide["entitlement_service"]],
     ):
         self.calendar_service = calendar_service
         self.notification_service = notification_service
         self.webhook_membership_side_effects_service = webhook_membership_side_effects_service
         self.audit_service = audit_service
         self.subscription_service = subscription_service
+        self.entitlement_service = entitlement_service
 
     @transaction.atomic()
     def create_organization(
@@ -261,6 +266,7 @@ class OrganizationService:
         invited_by: User | None = None,
         role: str = OrganizationRole.MEMBER,
         send_email: bool = True,
+        bypass_limits: bool = False,
     ) -> OrganizationInvitation:
         """
         Invite a user to join the organization. if the invitation already exists, resets the token
@@ -282,7 +288,34 @@ class OrganizationService:
             notification service. When False the email is suppressed — the caller is responsible
             for delivering the invite link using the raw token attached to the returned instance
             as ``_raw_token``.
+        :param bypass_limits: When True, skips the seat-limit guard below. Only management
+            commands and one-off repair scripts should pass this — never a request-handling path.
+        :raises OverLimitError: When the organization is at its effective seat limit
+            (``organization_members``: active memberships plus other pending invitations).
+            Nothing is created. Checked and locked (``SELECT ... FOR UPDATE`` on the billing
+            root's subscription) inside this method's own transaction, so two concurrent
+            invitations for the last seat serialize on that row and exactly one succeeds.
+
+        .. note::
+            A **resend** (re-inviting the same still-pending email/organization pair, which
+            resets the token/expiry rather than creating a new row) is checked identically to a
+            new invitation. It does not consume a new seat — the pending invitation already
+            counts toward the ceiling — so at the exact ceiling a resend is blocked even though
+            nothing new would be created. Narrower than the alternative (excluding the
+            in-place-reused invitation from the count) would require, which
+            ``EntitlementService.check_limit``'s own docs reserve for the accept path.
         """
+        # Guard first, before anything is written in this transaction — an
+        # OverLimitError raised after a write would rely on the caller's exception
+        # handler to roll the request transaction back (REST does; a caller that
+        # does not would silently commit a rejected invitation).
+        if not bypass_limits:
+            result = self.entitlement_service.check_limit(
+                organization, LimitedResource.ORGANIZATION_MEMBERS, lock=True
+            )
+            if not result.allowed:
+                raise OverLimitError.from_check_result(result)
+
         token = generate_long_lived_token()
         token_hash = hash_long_lived_token(token)
         now = datetime.datetime.now(tz=datetime.UTC)
@@ -381,7 +414,9 @@ class OrganizationService:
             )
         return invitation
 
-    def accept_invitation(self, token: str, user: User) -> OrganizationMembership:
+    def accept_invitation(
+        self, token: str, user: User, bypass_limits: bool = False
+    ) -> OrganizationMembership:
         """
         Accept an invitation to join an organization.
 
@@ -394,11 +429,19 @@ class OrganizationService:
 
         :param token: Invitation token.
         :param user: User who is accepting the invitation.
+        :param bypass_limits: When True, skips the seat-limit guard below. Only management
+            commands and one-off repair scripts should pass this — never a request-handling path.
         :return: Created OrganizationMembership instance.
         :raises UserAlreadyHasMembershipError: When the user is already a member of the
             invitation's organization (same-org duplicate).
         :raises InvalidInvitationTokenError: When no valid, non-expired invitation
             matches the token and the user's email.
+        :raises OverLimitError: When accepting would take the organization over its seat
+            limit. Uses ``EntitlementService.check_seat_limit_for_invitation_accept`` rather
+            than the generic ``check_limit`` — accepting is net-zero on seats (the pending
+            invitation stops being pending and becomes the membership it already reserved
+            capacity for), so counting it on both sides would make an organization unable to
+            ever accept its own last outstanding invitation.
         """
         now = datetime.datetime.now(tz=datetime.UTC)
         invitations = OrganizationInvitation.objects.filter(
@@ -414,6 +457,15 @@ class OrganizationService:
                     raise UserAlreadyHasMembershipError()
                 try:
                     with transaction.atomic():
+                        # Guard first, before the membership write, inside the same
+                        # transaction as the create — see check_limit's lock docs.
+                        if not bypass_limits:
+                            check_seat_limit = (
+                                self.entitlement_service.check_seat_limit_for_invitation_accept
+                            )
+                            result = check_seat_limit(invitation)
+                            if not result.allowed:
+                                raise OverLimitError.from_check_result(result)
                         membership = OrganizationMembership.objects.create(
                             user=user,
                             organization=invitation.organization,
@@ -449,7 +501,10 @@ class OrganizationService:
 
     @transaction.atomic()
     def provision_tenant_for_user(
-        self, user: User, organization_name: str | None = None
+        self,
+        user: User,
+        organization_name: str | None = None,
+        bypass_limits: bool = False,
     ) -> OrganizationMembership | None:
         """
         Provision a tenant for a user on the signup / invite-accept path.
@@ -477,11 +532,20 @@ class OrganizationService:
         :param user: The user to provision a tenant for.
         :param organization_name: Optional name of the new organization to create when no
             pending invitation is found.
+        :param bypass_limits: When True, skips the seat-limit guard on the pending-invitation
+            (join) branch below. Only management commands and one-off repair scripts should
+            pass this — never a request-handling path. The ``organization_name`` (create) branch
+            is never seat-limited: it makes a brand-new organization with a single admin
+            membership, not a join against an existing organization's ceiling.
         :return: The created OrganizationMembership on the join/create branches; None on
             the no-op branch.
         :raises UserAlreadyHasMembershipError: On the pending-invitation branch, when the
             user is already a member of the invitation's organization.  On the
             organization_name branch, when the user already belongs to any organization.
+        :raises OverLimitError: On the pending-invitation branch, when joining would take the
+            organization over its seat limit. Uses the same net-zero-safe
+            ``check_seat_limit_for_invitation_accept`` as ``accept_invitation`` — this branch is
+            the signup-path equivalent of accepting an invitation.
         """
         now = datetime.datetime.now(tz=datetime.UTC)
         pending_invitation = OrganizationInvitation.objects.filter(
@@ -500,6 +564,14 @@ class OrganizationService:
                 raise UserAlreadyHasMembershipError()
             try:
                 with transaction.atomic():
+                    # Guard first, before the membership write, inside the same
+                    # transaction as the create — see check_limit's lock docs.
+                    if not bypass_limits:
+                        result = self.entitlement_service.check_seat_limit_for_invitation_accept(
+                            pending_invitation
+                        )
+                        if not result.allowed:
+                            raise OverLimitError.from_check_result(result)
                     membership = OrganizationMembership.objects.create(
                         user=user,
                         organization=pending_invitation.organization,

--- a/organizations/tests/services/test_invitation_limits.py
+++ b/organizations/tests/services/test_invitation_limits.py
@@ -364,3 +364,55 @@ class TestProvisionTenantForUserInviteBranchSeatLimitGuard:
 
         assert membership is not None
         assert membership.organization_id == organization.id
+
+
+@pytest.mark.django_db
+class TestReactivateMembershipSeatLimitGuard:
+    """SHOULD-FIX 2: the seat-limit guard lives in
+    ``OrganizationService.reactivate_membership``, not the viewset -- see the
+    plan's Guiding Decisions ("Enforcement layer: service layer, not
+    viewsets"). A caller that bypasses the viewset entirely (management
+    command, admin action, shell) must still hit the guard by default, and
+    must be able to opt out explicitly via ``bypass_limits``."""
+
+    def test_reactivate_at_the_limit_raises_and_leaves_the_member_inactive(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=1)
+        inactive_member = baker.make(
+            OrganizationMembership, organization=organization, is_active=False
+        )
+
+        with pytest.raises(OverLimitError):
+            service.reactivate_membership(inactive_member)
+
+        inactive_member.refresh_from_db()
+        assert inactive_member.is_active is False
+
+    def test_reactivate_with_headroom_succeeds(self, service):
+        organization = _organization_with_seat_limit(seat_limit=2, existing_active_members=1)
+        inactive_member = baker.make(
+            OrganizationMembership, organization=organization, is_active=False
+        )
+
+        reactivated = service.reactivate_membership(inactive_member)
+
+        assert reactivated.is_active is True
+        inactive_member.refresh_from_db()
+        assert inactive_member.is_active is True
+
+    def test_reactivating_an_already_active_member_is_a_no_op_even_at_the_limit(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=1)
+        active_member = OrganizationMembership.objects.filter(organization=organization).first()
+
+        reactivated = service.reactivate_membership(active_member)
+
+        assert reactivated.is_active is True
+
+    def test_bypass_limits_reactivates_anyway(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=1)
+        inactive_member = baker.make(
+            OrganizationMembership, organization=organization, is_active=False
+        )
+
+        reactivated = service.reactivate_membership(inactive_member, bypass_limits=True)
+
+        assert reactivated.is_active is True

--- a/organizations/tests/services/test_invitation_limits.py
+++ b/organizations/tests/services/test_invitation_limits.py
@@ -1,0 +1,366 @@
+"""``OrganizationService.invite_user_to_organization`` — the seat-limit guard.
+
+Phase 6a, spec Use-case 2: an organization at its seat limit cannot add another
+member. ``organization_members`` usage is active memberships **plus** pending
+invitations (``EntitlementService._count_organization_members``), so a pending
+invitation itself already occupies a seat — the second half of these tests pins
+that down directly, since a guard that only looked at ``OrganizationMembership``
+would let an organization invite arbitrarily many people past its ceiling as
+long as none of them had accepted yet.
+"""
+
+import datetime
+
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+
+from organizations.models import Organization, OrganizationInvitation, OrganizationMembership
+from organizations.services import OrganizationService
+from payments.billing_constants import BillingState, LimitedResource, LimitKind
+from payments.exceptions import OverLimitError
+from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
+
+
+def _organization_with_seat_limit(
+    seat_limit: int, existing_active_members: int = 0
+) -> Organization:
+    """A standalone (non-reseller) organization with a finite seat ceiling."""
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=LimitedResource.ORGANIZATION_MEMBERS,
+        limit_value=seat_limit,
+        kind=LimitKind.PREPAID,
+    )
+    if existing_active_members:
+        baker.make(
+            OrganizationMembership,
+            organization=organization,
+            is_active=True,
+            _quantity=existing_active_members,
+        )
+    return organization
+
+
+@pytest.fixture
+def service():
+    # Untyped deliberately: OrganizationService's constructor params are DI-injected
+    # (Provide[...]) and resolved at call time by the wired container, which mypy
+    # cannot see -- an explicit `-> OrganizationService` return annotation would make
+    # mypy check this body and flag the zero-arg call as missing every constructor
+    # argument. See organizations/tests/test_organization_creation_billing.py for the
+    # same pattern.
+    return OrganizationService()
+
+
+@pytest.mark.django_db
+class TestInviteAtTheSeatLimit:
+    def test_invite_at_the_limit_raises_and_creates_nothing(self, service):
+        organization = _organization_with_seat_limit(seat_limit=2, existing_active_members=2)
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.invite_user_to_organization(
+                email="blocked@example.com",
+                first_name="Blocked",
+                last_name="Invitee",
+                organization=organization,
+                send_email=False,
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.ORGANIZATION_MEMBERS
+        assert exc_info.value.current_usage == 2
+        assert exc_info.value.limit == 2
+        assert not OrganizationInvitation.objects.filter(email="blocked@example.com").exists()
+
+    def test_invite_with_headroom_succeeds(self, service):
+        organization = _organization_with_seat_limit(seat_limit=3, existing_active_members=1)
+
+        invitation = service.invite_user_to_organization(
+            email="fits@example.com",
+            first_name="Fits",
+            last_name="Invitee",
+            organization=organization,
+            send_email=False,
+        )
+
+        assert invitation.pk is not None
+        assert OrganizationInvitation.objects.filter(email="fits@example.com").exists()
+
+    def test_bypass_limits_creates_the_invitation_anyway(self, service):
+        """``bypass_limits=True`` is for management commands / repair scripts only,
+        but the escape hatch itself must work — the guarding ``if`` is the only
+        thing standing between this and a normal invite."""
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=1)
+
+        invitation = service.invite_user_to_organization(
+            email="bypassed@example.com",
+            first_name="Bypassed",
+            last_name="Invitee",
+            organization=organization,
+            send_email=False,
+            bypass_limits=True,
+        )
+
+        assert invitation.pk is not None
+        assert OrganizationInvitation.objects.filter(email="bypassed@example.com").exists()
+
+    def test_error_body_matches_the_shared_over_limit_contract(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=1)
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.invite_user_to_organization(
+                email="blocked2@example.com",
+                first_name="Blocked",
+                last_name="Two",
+                organization=organization,
+                send_email=False,
+            )
+
+        assert exc_info.value.as_error_body() == {
+            "detail": "Organization is at its limit for organization members.",
+            "code": "limit_exceeded",
+            "resource": "organization_members",
+            "current_usage": 1,
+            "limit": 1,
+            "remedy": "purchase_add_on",
+        }
+
+
+@pytest.mark.django_db
+class TestPendingInvitationsCountTowardTheCeiling:
+    def test_one_pending_invitation_at_a_limit_of_one_blocks_a_second(self, service):
+        """No active members at all — the ceiling is entirely consumed by a single
+        still-pending invitation, proving the counter reads
+        ``OrganizationInvitation``, not just ``OrganizationMembership``."""
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="already-pending@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.invite_user_to_organization(
+                email="second@example.com",
+                first_name="Second",
+                last_name="Invitee",
+                organization=organization,
+                send_email=False,
+            )
+
+        assert exc_info.value.current_usage == 1
+        assert not OrganizationInvitation.objects.filter(email="second@example.com").exists()
+
+    def test_expired_pending_invitations_do_not_count(self, service):
+        """An expired invitation can never become a seat, so it must not occupy one."""
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="expired@example.com",
+            expires_at=timezone.now() - datetime.timedelta(days=1),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        invitation = service.invite_user_to_organization(
+            email="fits-now@example.com",
+            first_name="Fits",
+            last_name="Now",
+            organization=organization,
+            send_email=False,
+        )
+
+        assert invitation.pk is not None
+
+    def test_accepted_invitations_do_not_double_count_with_their_membership(self, service):
+        """An accepted invitation's seat is the resulting membership row — counting
+        both would double-charge the same seat."""
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=1)
+        member = OrganizationMembership.objects.filter(organization=organization).first()
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="already-accepted@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=timezone.now(),
+            membership_user_id=member.user_id,
+        )
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.invite_user_to_organization(
+                email="blocked3@example.com",
+                first_name="Blocked",
+                last_name="Three",
+                organization=organization,
+                send_email=False,
+            )
+
+        # Usage is 1 (the active member), not 2 — the accepted invitation is not
+        # double-counted alongside the membership it turned into.
+        assert exc_info.value.current_usage == 1
+
+
+def _pending_invitation_and_token(organization: Organization, email: str):
+    from common.utils.authentication_utils import generate_long_lived_token, hash_long_lived_token
+
+    token = generate_long_lived_token()
+    invitation = baker.make(
+        OrganizationInvitation,
+        organization=organization,
+        email=email,
+        token_hash=hash_long_lived_token(token),
+        expires_at=timezone.now() + datetime.timedelta(days=7),
+        accepted_at=None,
+        membership_user_id=None,
+    )
+    return invitation, token
+
+
+@pytest.mark.django_db
+class TestAcceptInvitationSeatLimitGuard:
+    """``accept_invitation`` must use ``check_seat_limit_for_invitation_accept``,
+    not the generic ``check_limit`` — see the module docstring. These tests fail
+    if that call is ever replaced with a plain ``check_limit(delta=1)``."""
+
+    def test_accepting_the_last_pending_seat_succeeds(self, service):
+        """The positive control: the invitation being accepted must not count
+        against itself."""
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        user = baker.make("users.User", email="fills-seat@example.com")
+        invitation, token = _pending_invitation_and_token(organization, user.email)
+
+        membership = service.accept_invitation(token=token, user=user)
+
+        assert membership.organization_id == organization.id
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is not None
+
+    def test_accept_blocked_when_a_different_pending_invitation_fills_the_seat(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="unrelated-pending@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+        user = baker.make("users.User", email="blocked-acceptor@example.com")
+        invitation, token = _pending_invitation_and_token(organization, user.email)
+
+        with pytest.raises(OverLimitError):
+            service.accept_invitation(token=token, user=user)
+
+        assert not OrganizationMembership.objects.filter(
+            user=user, organization=organization
+        ).exists()
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is None
+
+    def test_bypass_limits_accepts_anyway(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="unrelated-pending2@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+        user = baker.make("users.User", email="bypassed-acceptor@example.com")
+        _invitation, token = _pending_invitation_and_token(organization, user.email)
+
+        membership = service.accept_invitation(token=token, user=user, bypass_limits=True)
+
+        assert membership.organization_id == organization.id
+
+
+@pytest.mark.django_db
+class TestProvisionTenantForUserInviteBranchSeatLimitGuard:
+    """The signup-path equivalent of ``accept_invitation`` — same net-zero-safe
+    entry point, same guard placement inside the same transaction as the write."""
+
+    def test_joining_via_the_last_pending_seat_succeeds(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        user = baker.make("users.User", email="signup-fills-seat@example.com")
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email=user.email,
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        membership = service.provision_tenant_for_user(user=user)
+
+        assert membership is not None
+        assert membership.organization_id == organization.id
+
+    def test_provision_blocked_when_a_different_pending_invitation_fills_the_seat(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="signup-unrelated-pending@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+        user = baker.make("users.User", email="signup-blocked@example.com")
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email=user.email,
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        with pytest.raises(OverLimitError):
+            service.provision_tenant_for_user(user=user)
+
+        assert not OrganizationMembership.objects.filter(
+            user=user, organization=organization
+        ).exists()
+
+    def test_bypass_limits_joins_anyway(self, service):
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="signup-unrelated-pending2@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+        user = baker.make("users.User", email="signup-bypassed@example.com")
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email=user.email,
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        membership = service.provision_tenant_for_user(user=user, bypass_limits=True)
+
+        assert membership is not None
+        assert membership.organization_id == organization.id

--- a/organizations/tests/test_seat_enforcement.py
+++ b/organizations/tests/test_seat_enforcement.py
@@ -293,6 +293,51 @@ class TestAcceptInvitationBlockedAtTheLimit:
 
 
 @pytest.mark.django_db
+class TestAcceptInvitationMarksAcceptedInsideTheSameTransaction:
+    """SHOULD-FIX 3: ``accept_invitation`` must mark the invitation accepted
+    inside the same ``transaction.atomic()`` block as the guard and the
+    membership create, not as a separate write after that block exits. Outside
+    a request (Celery, management command, shell) there is no outer
+    ``ATOMIC_REQUESTS`` transaction to fold a later failure into: if the
+    membership create commits and the invitation-accepted write then fails, the
+    membership exists while the invitation still reads as pending -- a
+    permanent double-count of that seat."""
+
+    def test_a_failure_marking_the_invitation_accepted_rolls_back_the_membership_too(self):
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        organization = _organization_with_seat_limit(seat_limit=2, existing_active_members=0)
+        invitee = baker.make(get_user_model(), email="atomic-accept@example.com")
+        token = generate_long_lived_token()
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email=invitee.email,
+            token_hash=hash_long_lived_token(token),
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        service = OrganizationService()
+        with (
+            patch.object(OrganizationInvitation, "save", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError),
+        ):
+            service.accept_invitation(token, invitee)
+
+        assert not OrganizationMembership.objects.filter(
+            user=invitee, organization=organization
+        ).exists(), (
+            "The membership committed even though marking the invitation accepted "
+            "failed -- the two writes must share one transaction."
+        )
+
+
+@pytest.mark.django_db
 class TestReactivationBlockedAtTheLimit:
     def test_reactivate_is_blocked_at_the_seat_limit(self):
         admin = baker.make(get_user_model(), email="reactivate-admin@example.com")
@@ -352,6 +397,49 @@ class TestReactivationBlockedAtTheLimit:
         response = client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+class TestResendAtTheCeiling:
+    """BLOCKER 2: a resend creates nothing new — the pending invitation being
+    resent already counts toward the ceiling — so it must be net-zero exactly
+    like an accept, not a false block at the exact limit."""
+
+    def test_resend_succeeds_at_the_seat_limit(self):
+        # The requesting admin itself occupies a seat, so the ceiling has to
+        # account for it: limit=2 covers the admin (1) plus the one pending
+        # invitation (1) -- exactly full, mirroring the finding's "4 active
+        # members + 1 pending invite at limit 5" scenario at a smaller scale.
+        admin = baker.make(get_user_model(), email="resend-admin@example.com")
+        organization = _organization_with_seat_limit(seat_limit=2, existing_active_members=0)
+        baker.make(
+            OrganizationMembership,
+            user=admin,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        pending_invitation = baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="already-pending@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+        original_token_hash = pending_invitation.token_hash
+
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        url = reverse("api:OrganizationInvitations-resend", kwargs={"pk": pending_invitation.pk})
+        response = client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        pending_invitation.refresh_from_db()
+        assert pending_invitation.token_hash != original_token_hash
+        assert OrganizationInvitation.objects.filter(organization=organization).count() == 1, (
+            "Resend must reuse the existing pending invitation, not create a second row."
+        )
 
 
 @pytest.mark.django_db
@@ -418,12 +506,20 @@ class TestUnlimitedPlanIsNeverBlocked:
                 send_email=False,
             )
 
-        assert len(second_call.captured_queries) == len(first_call.captured_queries), (
-            "Query count grew with existing usage even though the organization is "
-            "unlimited -- the unlimited path must never count usage. First call: "
-            f"{[q['sql'] for q in first_call.captured_queries]}\n"
-            f"Second call: {[q['sql'] for q in second_call.captured_queries]}"
-        )
+        # An absolute budget on each call, not a first-vs-second comparison:
+        # usage counting is O(1) in queries regardless of row count, so if the
+        # unlimited path started counting, both measurements would grow by the
+        # same fixed amount and a relative "second == first" comparison would
+        # still pass -- it pins nothing. 10 is the query count either call
+        # makes today; checked against both calls independently instead.
+        for label, call in (
+            ("first (empty org)", first_call),
+            ("second (20 pending invitations already in the database)", second_call),
+        ):
+            assert len(call.captured_queries) <= 10, (
+                f"Too many queries for the {label} invite -- the unlimited path "
+                f"must never count usage. Queries: {[q['sql'] for q in call.captured_queries]}"
+            )
         assert not [
             query
             for query in second_call.captured_queries

--- a/organizations/tests/test_seat_enforcement.py
+++ b/organizations/tests/test_seat_enforcement.py
@@ -1,0 +1,516 @@
+"""Phase 6a integration: the seat-limit guard blocks identically across every
+surface — REST invite, REST accept, the GraphQL ``createInvitation`` mutation,
+and member reactivation — with a byte-identical error body between REST and
+GraphQL, an ``unlimited`` organization is never blocked, and the row lock
+genuinely serializes a race for the last seat.
+
+Spec acceptance scenario 6 (race for the last seat) and scenario 7 (the partner
+API is not a bypass) are automated here.
+"""
+
+import datetime
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from organizations.models import (
+    Organization,
+    OrganizationInvitation,
+    OrganizationMembership,
+    OrganizationRole,
+)
+from organizations.services import OrganizationService
+from payments.billing_constants import BillingState, LimitedResource, LimitKind
+from payments.exceptions import OverLimitError
+from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
+from payments.services.entitlement_service import EntitlementService
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+SHARED_OVER_LIMIT_BODY = {
+    "detail": "Organization is at its limit for organization members.",
+    "code": "limit_exceeded",
+    "resource": "organization_members",
+    "current_usage": 1,
+    "limit": 1,
+    "remedy": "purchase_add_on",
+}
+
+CREATE_INVITATION_MUTATION = """
+mutation CreateInvitation($input: CreateInvitationInput!) {
+    createInvitation(input: $input) {
+        invitation { id email expiresAt }
+        token
+        inviteUrl
+    }
+}
+"""
+
+BARRIER_TIMEOUT_SECONDS = 10
+THREAD_JOIN_TIMEOUT_SECONDS = 30
+# Long enough that a non-locking implementation reliably interleaves its read
+# with the other thread's; short enough not to slow the suite noticeably.
+RACE_WINDOW_SECONDS = 0.5
+
+
+def _organization_with_seat_limit(
+    seat_limit: int,
+    existing_active_members: int = 0,
+    can_invite_organizations: bool = False,
+) -> Organization:
+    organization = baker.make(
+        Organization, parent=None, can_invite_organizations=can_invite_organizations
+    )
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=LimitedResource.ORGANIZATION_MEMBERS,
+        limit_value=seat_limit,
+        kind=LimitKind.PREPAID,
+    )
+    if existing_active_members:
+        baker.make(
+            OrganizationMembership,
+            organization=organization,
+            is_active=True,
+            _quantity=existing_active_members,
+        )
+    return organization
+
+
+@pytest.mark.django_db
+class TestInviteBlockedIdenticallyAcrossRestAndGraphQL:
+    """Use-case 2 (blocked with a useful message) and Use-case 7 (the partner API
+    is not a bypass), against organizations built identically so the two bodies
+    can be compared directly."""
+
+    def test_rest_invite_is_blocked_with_the_shared_over_limit_body(self):
+        admin = baker.make(get_user_model(), email="rest-admin@example.com")
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationMembership,
+            user=admin,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.post(
+            reverse("api:OrganizationInvitations-list"),
+            {"email": "rest-blocked@example.com", "first_name": "R", "last_name": "B"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        assert response.json() == SHARED_OVER_LIMIT_BODY
+        assert not OrganizationInvitation.objects.filter(email="rest-blocked@example.com").exists()
+
+    def test_graphql_invite_is_blocked_with_the_shared_over_limit_body(self):
+        reseller_org = _organization_with_seat_limit(
+            seat_limit=1, existing_active_members=1, can_invite_organizations=True
+        )
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="invitation")
+
+        from di_core.containers import container
+
+        client = APIClient()
+        with container.public_api_auth_service.override(auth_service):
+            response = client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_INVITATION_MUTATION,
+                    "variables": {
+                        "input": {
+                            "userEmail": "graphql-blocked@example.com",
+                            "organizationId": str(reseller_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        # createInvitation is a non-nullable field, so a resolver error nulls the
+        # whole `data` key per GraphQL error-propagation rules.
+        assert data["data"] is None
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["extensions"] == SHARED_OVER_LIMIT_BODY
+        assert not OrganizationInvitation.objects.filter(
+            email="graphql-blocked@example.com"
+        ).exists()
+
+    def test_rest_and_graphql_bodies_are_byte_identical(self):
+        """Not just each matching the same literal — the two responses compared
+        directly against each other, which is the actual contract."""
+        admin = baker.make(get_user_model(), email="compare-admin@example.com")
+        rest_org = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationMembership,
+            user=admin,
+            organization=rest_org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        rest_client = APIClient()
+        rest_client.force_authenticate(user=admin)
+        rest_response = rest_client.post(
+            reverse("api:OrganizationInvitations-list"),
+            {"email": "compare-rest@example.com", "first_name": "C", "last_name": "R"},
+            format="json",
+        )
+
+        graphql_org = _organization_with_seat_limit(
+            seat_limit=1, existing_active_members=1, can_invite_organizations=True
+        )
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="compare_integration", organization=graphql_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="invitation")
+
+        from di_core.containers import container
+
+        graphql_client = APIClient()
+        with container.public_api_auth_service.override(auth_service):
+            graphql_response = graphql_client.post(
+                "/graphql/",
+                data={
+                    "query": CREATE_INVITATION_MUTATION,
+                    "variables": {
+                        "input": {
+                            "userEmail": "compare-graphql@example.com",
+                            "organizationId": str(graphql_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert rest_response.json() == graphql_response.json()["errors"][0]["extensions"]
+
+
+@pytest.mark.django_db
+class TestAcceptInvitationBlockedAtTheLimit:
+    """Accepting an invitation must use the net-zero-safe entry point — see
+    ``check_seat_limit_for_invitation_accept``. A limit of 1 with 1 pending
+    invitation and 0 active members leaves the org exactly full of *pending*
+    seats, so if accept incorrectly used ``check_limit`` directly the accept
+    would be blocked at exactly the ceiling it is trying to fill."""
+
+    def _pending_invitation(self, organization, email):
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        token = generate_long_lived_token()
+        invitation = baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email=email,
+            token_hash=hash_long_lived_token(token),
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+        return invitation, token
+
+    def test_accepting_the_organizations_own_last_pending_invitation_succeeds(self):
+        """The positive control: accept must NOT be blocked by the very
+        invitation it is accepting."""
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        invitee = baker.make(get_user_model(), email="fills-last-seat@example.com")
+        _invitation, token = self._pending_invitation(organization, invitee.email)
+
+        client = APIClient()
+        client.force_authenticate(user=invitee)
+        response = client.post(reverse("accept-invitation"), {"token": token}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert OrganizationMembership.objects.filter(
+            user=invitee, organization=organization
+        ).exists()
+
+    def test_accept_is_blocked_when_a_different_pending_invitation_would_overflow(self):
+        """A *second*, unrelated pending invitation already fills the ceiling, so
+        accepting this one would take the org over its limit — this must block."""
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        # A different pending invitation occupies the organization's one seat.
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email="other-pending@example.com",
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+        invitee = baker.make(get_user_model(), email="blocked-acceptor@example.com")
+        invitation, token = self._pending_invitation(organization, invitee.email)
+
+        client = APIClient()
+        client.force_authenticate(user=invitee)
+        response = client.post(reverse("accept-invitation"), {"token": token}, format="json")
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        assert response.json() == SHARED_OVER_LIMIT_BODY
+        assert not OrganizationMembership.objects.filter(
+            user=invitee, organization=organization
+        ).exists()
+        invitation.refresh_from_db()
+        assert invitation.accepted_at is None
+
+
+@pytest.mark.django_db
+class TestReactivationBlockedAtTheLimit:
+    def test_reactivate_is_blocked_at_the_seat_limit(self):
+        admin = baker.make(get_user_model(), email="reactivate-admin@example.com")
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationMembership,
+            user=admin,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        inactive_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=False,
+        )
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        url = reverse(
+            "api:OrganizationMembers-reactivate", kwargs={"user_id": inactive_member.user_id}
+        )
+        response = client.post(url)
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        assert response.json() == SHARED_OVER_LIMIT_BODY
+        inactive_member.refresh_from_db()
+        assert inactive_member.is_active is False
+
+    def test_reactivating_an_already_active_member_is_a_no_op_even_at_the_limit(self):
+        """Idempotency must survive the guard: an already-active member's state
+        does not change, so re-affirming it must not be blocked by a ceiling it
+        does not push the organization past."""
+        admin = baker.make(get_user_model(), email="reactivate-admin2@example.com")
+        organization = _organization_with_seat_limit(seat_limit=1, existing_active_members=0)
+        baker.make(
+            OrganizationMembership,
+            user=admin,
+            organization=organization,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        already_active_member = baker.make(
+            OrganizationMembership,
+            organization=organization,
+            role=OrganizationRole.MEMBER,
+            is_active=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        url = reverse(
+            "api:OrganizationMembers-reactivate",
+            kwargs={"user_id": already_active_member.user_id},
+        )
+        response = client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+class TestUnlimitedPlanIsNeverBlocked:
+    """The plan's own rollout switch: every organization starts on ``unlimited``,
+    and this feature must not change behavior for one until it is migrated onto
+    a real plan."""
+
+    def test_invites_past_every_typical_threshold_succeed(self):
+        creator = baker.make(get_user_model(), email="unlimited-creator@example.com")
+        organization = OrganizationService().create_organization(
+            creator=creator, name="Unlimited Seat Org"
+        )
+        assert Subscription.objects.get(organization=organization).plan.slug == "unlimited"
+
+        service = OrganizationService()
+        for index in range(25):
+            invitation = service.invite_user_to_organization(
+                email=f"unlimited-member-{index}@example.com",
+                first_name="Member",
+                last_name=str(index),
+                organization=organization,
+                send_email=False,
+            )
+            assert invitation.pk is not None
+
+        assert OrganizationInvitation.objects.filter(organization=organization).count() == 25
+
+    def test_query_count_does_not_scale_with_existing_pending_invitations(self):
+        """Phase 5 deliberately skips usage counting on the unlimited path — this
+        pins that an org already sitting on a pile of pending invitations pays no
+        more query cost per invite than a brand-new org does."""
+        creator = baker.make(get_user_model(), email="unlimited-creator2@example.com")
+        organization = OrganizationService().create_organization(
+            creator=creator, name="Unlimited Query Count Org"
+        )
+        service = OrganizationService()
+
+        with CaptureQueriesContext(connection) as first_call:
+            service.invite_user_to_organization(
+                email="first-invite@example.com",
+                first_name="First",
+                last_name="Invite",
+                organization=organization,
+                send_email=False,
+            )
+
+        for index in range(20):
+            baker.make(
+                OrganizationInvitation,
+                organization=organization,
+                email=f"padding-{index}@example.com",
+                expires_at=timezone.now() + datetime.timedelta(days=7),
+                accepted_at=None,
+                membership_user_id=None,
+            )
+
+        with CaptureQueriesContext(connection) as second_call:
+            service.invite_user_to_organization(
+                email="second-invite@example.com",
+                first_name="Second",
+                last_name="Invite",
+                organization=organization,
+                send_email=False,
+            )
+
+        assert len(second_call.captured_queries) == len(first_call.captured_queries), (
+            "Query count grew with existing usage even though the organization is "
+            "unlimited -- the unlimited path must never count usage. First call: "
+            f"{[q['sql'] for q in first_call.captured_queries]}\n"
+            f"Second call: {[q['sql'] for q in second_call.captured_queries]}"
+        )
+        assert not [
+            query
+            for query in second_call.captured_queries
+            if "organizations_organizationinvitation" in query["sql"]
+            and "COUNT" in query["sql"].upper()
+        ], "The unlimited path counted pending-invitation usage nobody reads."
+
+
+def _run_two_racing_invites(organization: Organization, force_unlocked: bool) -> list[bool]:
+    """Two threads each try to invite into the last seat via the real,
+    production ``OrganizationService.invite_user_to_organization`` — not a
+    synthetic stand-in for it.
+
+    ``force_unlocked`` patches the exact ``EntitlementService.check_limit`` call
+    site the service uses to drop the row lock, and adds an artificial delay
+    between the check and the write on *both* variants so the race window is
+    deterministic rather than timing-dependent — mirroring
+    ``payments/tests/services/test_limit_concurrency.py``'s harness, applied to
+    the real invite path instead of a raw ``check_limit`` call.
+    """
+    start_barrier = threading.Barrier(2, timeout=BARRIER_TIMEOUT_SECONDS)
+    original_check_limit = EntitlementService.check_limit
+
+    def delayed_check_limit(self, *args, **kwargs):
+        if force_unlocked:
+            kwargs["lock"] = False
+        result = original_check_limit(self, *args, **kwargs)
+        # Widen the window between the check (and, when locked, the row lock it
+        # takes) and the invitation write that follows it in the same
+        # transaction, so the two threads are guaranteed to overlap.
+        threading.Event().wait(RACE_WINDOW_SECONDS)
+        return result
+
+    # Untyped deliberately: OrganizationService's constructor params are DI-injected
+    # (Provide[...]) and resolved at call time by the wired container, which mypy
+    # cannot see -- a fully-typed signature here would make mypy check this body and
+    # flag the zero-arg call as missing every constructor argument. See
+    # organizations/tests/test_organization_creation_billing.py for the same pattern.
+    def invite(index):
+        service = OrganizationService()
+        try:
+            start_barrier.wait(timeout=BARRIER_TIMEOUT_SECONDS)
+            try:
+                service.invite_user_to_organization(
+                    email=f"seat-racer-{index}@example.com",
+                    first_name="Racer",
+                    last_name=str(index),
+                    organization=organization,
+                    send_email=False,
+                )
+                return True
+            except OverLimitError:
+                return False
+        finally:
+            # Each thread owns its own connection; leaking it holds the row
+            # lock past the test and wedges the next one.
+            connection.close()
+
+    with patch.object(EntitlementService, "check_limit", delayed_check_limit):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(invite, index) for index in (0, 1)]
+            return [future.result(timeout=THREAD_JOIN_TIMEOUT_SECONDS) for future in futures]
+
+
+@pytest.mark.django_db(transaction=True)
+class TestConcurrentInvitesForTheLastSeat:
+    """Spec acceptance scenario 6: two admins inviting for one remaining seat at
+    the same time — exactly one succeeds, and the organization never exceeds its
+    limit."""
+
+    def test_two_threads_racing_for_the_last_seat_serialize_and_only_one_succeeds(self):
+        organization = _organization_with_seat_limit(seat_limit=3, existing_active_members=2)
+
+        verdicts = _run_two_racing_invites(organization, force_unlocked=False)
+
+        assert sorted(verdicts) == [False, True], f"exactly one thread must win, got {verdicts}"
+        assert OrganizationInvitation.objects.filter(organization=organization).count() == 1
+
+    def test_without_the_lock_the_race_overshoots(self):
+        """Negative control, proving the harness above genuinely races rather
+        than passing by accident (e.g. because SQLite/test-transaction quirks
+        serialize everything regardless of locking). With the row lock forced
+        off, both threads read the same pre-insert count and both create,
+        taking the organization over its limit."""
+        organization = _organization_with_seat_limit(seat_limit=3, existing_active_members=2)
+
+        verdicts = _run_two_racing_invites(organization, force_unlocked=True)
+
+        assert verdicts == [True, True]
+        assert OrganizationInvitation.objects.filter(organization=organization).count() == 2

--- a/organizations/tests/test_seat_enforcement.py
+++ b/organizations/tests/test_seat_enforcement.py
@@ -338,6 +338,48 @@ class TestAcceptInvitationMarksAcceptedInsideTheSameTransaction:
 
 
 @pytest.mark.django_db
+class TestProvisionTenantForUserMarksAcceptedInsideTheSameTransaction:
+    """SHOULD-FIX 1, Phase 6a verification review: ``provision_tenant_for_user``'s
+    pending-invitation (signup) branch has the exact same twin bug
+    ``accept_invitation`` had -- marking the invitation accepted after the inner
+    ``transaction.atomic()`` block that creates the membership has already exited,
+    instead of inside it. Signup is the higher-traffic of the two paths."""
+
+    def test_a_failure_marking_the_invitation_accepted_rolls_back_the_membership_too(self):
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        organization = _organization_with_seat_limit(seat_limit=2, existing_active_members=0)
+        invitee = baker.make(get_user_model(), email="atomic-provision@example.com")
+        token = generate_long_lived_token()
+        baker.make(
+            OrganizationInvitation,
+            organization=organization,
+            email=invitee.email,
+            token_hash=hash_long_lived_token(token),
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        service = OrganizationService()
+        with (
+            patch.object(OrganizationInvitation, "save", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError),
+        ):
+            service.provision_tenant_for_user(invitee)
+
+        assert not OrganizationMembership.objects.filter(
+            user=invitee, organization=organization
+        ).exists(), (
+            "The membership committed even though marking the invitation accepted "
+            "failed -- the two writes must share one transaction."
+        )
+
+
+@pytest.mark.django_db
 class TestReactivationBlockedAtTheLimit:
     def test_reactivate_is_blocked_at_the_seat_limit(self):
         admin = baker.make(get_user_model(), email="reactivate-admin@example.com")
@@ -510,14 +552,16 @@ class TestUnlimitedPlanIsNeverBlocked:
         # usage counting is O(1) in queries regardless of row count, so if the
         # unlimited path started counting, both measurements would grow by the
         # same fixed amount and a relative "second == first" comparison would
-        # still pass -- it pins nothing. 10 is the query count either call
-        # makes today; checked against both calls independently instead.
+        # still pass -- it pins nothing. 9 is the exact query count either call
+        # makes today (checked against both calls independently instead of a
+        # loose ceiling, so any change -- including a regression that pushes it
+        # back up -- fails loudly instead of silently eating slack).
         for label, call in (
             ("first (empty org)", first_call),
             ("second (20 pending invitations already in the database)", second_call),
         ):
-            assert len(call.captured_queries) <= 10, (
-                f"Too many queries for the {label} invite -- the unlimited path "
+            assert len(call.captured_queries) == 9, (
+                f"Query count changed for the {label} invite -- the unlimited path "
                 f"must never count usage. Queries: {[q['sql'] for q in call.captured_queries]}"
             )
         assert not [

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -879,6 +879,69 @@ class TestOrganizationService:
                 organization_service.accept_invitation(token=token, user=user)
 
     # -----------------------------------------------------------------------
+    # SHOULD-FIX 2, Phase 6a verification review: an IntegrityError raised by the
+    # *invitation* write (not the membership create) must not be reported as
+    # UserAlreadyHasMembershipError -- the ``try`` around the create is narrow
+    # enough that a failure saving the invitation propagates as itself.
+    # -----------------------------------------------------------------------
+
+    def test_accept_invitation_integrity_error_from_invitation_save_is_not_misreported(
+        self, organization_service, organization
+    ):
+        from django.db import IntegrityError as DjangoIntegrityError
+
+        from common.utils.authentication_utils import (
+            generate_long_lived_token,
+            hash_long_lived_token,
+        )
+
+        user = baker.make(User, email="accept_invitation_save_fails@example.com")
+        token = generate_long_lived_token()
+        token_hash = hash_long_lived_token(token)
+        baker.make(
+            OrganizationInvitation,
+            email=user.email,
+            organization=organization,
+            token_hash=token_hash,
+            expires_at=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+        with patch.object(
+            OrganizationInvitation,
+            "save",
+            side_effect=DjangoIntegrityError("some unrelated constraint"),
+        ):
+            with pytest.raises(DjangoIntegrityError):
+                organization_service.accept_invitation(token=token, user=user)
+
+        assert not OrganizationMembership.objects.filter(
+            user=user, organization=organization
+        ).exists()
+
+    def test_provision_tenant_for_user_integrity_error_from_invitation_save_is_not_misreported(
+        self, organization_service, organization
+    ):
+        from django.db import IntegrityError as DjangoIntegrityError
+
+        inviter = baker.make(User, email="inviter_provision_save_fails@example.com")
+        invitee = baker.make(User, email="invitee_provision_save_fails@example.com")
+        self._make_invitation(email=invitee.email, organization=organization, invited_by=inviter)
+
+        with patch.object(
+            OrganizationInvitation,
+            "save",
+            side_effect=DjangoIntegrityError("some unrelated constraint"),
+        ):
+            with pytest.raises(DjangoIntegrityError):
+                organization_service.provision_tenant_for_user(invitee)
+
+        assert not OrganizationMembership.objects.filter(
+            user=invitee, organization=organization
+        ).exists()
+
+    # -----------------------------------------------------------------------
     # Savepoint hygiene tests (FIX 1)
     # Prove that the transaction is NOT left poisoned after the IntegrityError
     # backstop fires in provision_tenant_for_user.  The savepoint wrapping in

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -60,6 +60,9 @@ from organizations.serializers import (
     UpdateMembershipRoleSerializer,
 )
 from organizations.services import OrganizationService
+from payments.billing_constants import LimitedResource
+from payments.exceptions import OverLimitError
+from payments.services.entitlement_service import EntitlementService
 
 
 logger = logging.getLogger(__name__)
@@ -657,6 +660,16 @@ class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
     # detail-route lookup instead of the (now non-existent) scalar pk.
     lookup_field = "user_id"
 
+    @inject
+    def __init__(
+        self,
+        *args,
+        entitlement_service: Annotated[EntitlementService, Provide["entitlement_service"]],
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.entitlement_service = entitlement_service
+
     def get_queryset(self):
         """Org-scoped queryset: return members of the caller's organization only."""
         user = self.request.user
@@ -735,21 +748,36 @@ class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
         summary="Reactivate an organization member",
         responses={
             200: OrganizationMembershipSerializer,
+            402: OpenApiResponse(description="Organization is at its seat limit"),
             403: OpenApiResponse(description="Not an admin"),
             404: OpenApiResponse(description="Member not found or cross-org"),
         },
     )
     @action(detail=True, methods=["post"], url_path="reactivate")
+    @transaction.atomic()
     def reactivate(self, request, user_id=None):
         """Reactivate a member (set is_active=True).
 
-        No guards — re-enabling is always safe.
+        Guards: reactivating occupies a seat again (``OrganizationMembershipQuerySet
+        .occupying_a_seat`` only counts ``is_active=True`` rows), so — unlike every other
+        member of this viewset — it is a capacity-raising write with no accompanying
+        ``OrganizationInvitation``/membership *create*, and would otherwise be an unmetered
+        path onto the ``organization_members`` limit. Only checked when the member is
+        currently inactive: an already-active member is a no-op and must stay one even if
+        the organization is at its limit for an unrelated reason.
 
         Idempotency: reactivating an already-active member is a no-op success.
         """
         target = (
             self.get_object()
         )  # Permission checks via IsOrganizationAdmin.has_object_permission
+
+        if not target.is_active:
+            result = self.entitlement_service.check_limit(
+                target.organization, LimitedResource.ORGANIZATION_MEMBERS, lock=True
+            )
+            if not result.allowed:
+                raise OverLimitError.from_check_result(result)
 
         # Reactivate (idempotent: no-op if already active)
         target.is_active = True

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from django.db import transaction
 
 from dependency_injector.wiring import Provide, inject
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import generics, status, views
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
@@ -60,9 +60,6 @@ from organizations.serializers import (
     UpdateMembershipRoleSerializer,
 )
 from organizations.services import OrganizationService
-from payments.billing_constants import LimitedResource
-from payments.exceptions import OverLimitError
-from payments.services.entitlement_service import EntitlementService
 
 
 logger = logging.getLogger(__name__)
@@ -548,6 +545,14 @@ class ServiceAccountViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+@extend_schema_view(
+    create=extend_schema(
+        responses={
+            201: OrganizationInvitationSerializer,
+            402: OpenApiResponse(description="Organization is at its seat limit"),
+        },
+    ),
+)
 class OrganizationInvitationViewSet(NoUpdateVintaScheduleModelViewSet):
     """
     A viewset for managing organization invitations.
@@ -595,6 +600,7 @@ class OrganizationInvitationViewSet(NoUpdateVintaScheduleModelViewSet):
         responses={
             200: OrganizationInvitationSerializer,
             400: OpenApiResponse(description="Invitation already accepted or service error"),
+            402: OpenApiResponse(description="Organization is at its seat limit"),
             403: OpenApiResponse(description="Not an active member"),
             404: OpenApiResponse(description="Invitation not found or cross-org"),
         },
@@ -664,11 +670,11 @@ class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
     def __init__(
         self,
         *args,
-        entitlement_service: Annotated[EntitlementService, Provide["entitlement_service"]],
+        organization_service: Annotated[OrganizationService, Provide["organization_service"]],
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        self.entitlement_service = entitlement_service
+        self.organization_service = organization_service
 
     def get_queryset(self):
         """Org-scoped queryset: return members of the caller's organization only."""
@@ -754,36 +760,20 @@ class OrganizationMembershipViewSet(ReadOnlyVintaScheduleModelViewSet):
         },
     )
     @action(detail=True, methods=["post"], url_path="reactivate")
-    @transaction.atomic()
     def reactivate(self, request, user_id=None):
         """Reactivate a member (set is_active=True).
 
-        Guards: reactivating occupies a seat again (``OrganizationMembershipQuerySet
-        .occupying_a_seat`` only counts ``is_active=True`` rows), so — unlike every other
-        member of this viewset — it is a capacity-raising write with no accompanying
-        ``OrganizationInvitation``/membership *create*, and would otherwise be an unmetered
-        path onto the ``organization_members`` limit. Only checked when the member is
-        currently inactive: an already-active member is a no-op and must stay one even if
-        the organization is at its limit for an unrelated reason.
-
-        Idempotency: reactivating an already-active member is a no-op success.
+        The seat-limit guard lives in ``OrganizationService.reactivate_membership``
+        (service layer, not the viewset — see the plan's Guiding Decisions), so this
+        action only resolves the target and serializes the result. Idempotency:
+        reactivating an already-active member is a no-op success.
         """
         target = (
             self.get_object()
         )  # Permission checks via IsOrganizationAdmin.has_object_permission
 
-        if not target.is_active:
-            result = self.entitlement_service.check_limit(
-                target.organization, LimitedResource.ORGANIZATION_MEMBERS, lock=True
-            )
-            if not result.allowed:
-                raise OverLimitError.from_check_result(result)
+        target = self.organization_service.reactivate_membership(target)
 
-        # Reactivate (idempotent: no-op if already active)
-        target.is_active = True
-        target.save(update_fields=["is_active"])
-
-        # Return the updated membership
         serializer = self.get_serializer(target)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -849,6 +839,23 @@ class AcceptInvitationView(generics.CreateAPIView):
 
     serializer_class = AcceptInvitationSerializer
     permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        responses={
+            201: AcceptInvitationSerializer,
+            400: OpenApiResponse(description="Already a member, or invalid token"),
+            402: OpenApiResponse(description="Organization is at its seat limit"),
+            404: OpenApiResponse(description="Invitation not found"),
+            409: OpenApiResponse(description="Duplicate invitation"),
+        },
+    )
+    def post(self, request, *args, **kwargs):
+        # drf-spectacular resolves a plain APIView's schema from the HTTP-verb
+        # method (`post`), not from `create` -- see OrganizationBrandingView's
+        # get/put/patch above for the same convention. `create` stays the
+        # override point (it holds the actual logic) since that is the DRF
+        # ``CreateAPIView`` convention every caller of this class expects.
+        return self.create(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):
         """Accept invitation and return success response.

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -5,8 +5,13 @@ from typing import Annotated
 from django.db import transaction
 
 from dependency_injector.wiring import Provide, inject
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
-from rest_framework import generics, status, views
+from drf_spectacular.utils import (
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+    inline_serializer,
+)
+from rest_framework import generics, serializers, status, views
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
@@ -842,7 +847,19 @@ class AcceptInvitationView(generics.CreateAPIView):
 
     @extend_schema(
         responses={
-            201: AcceptInvitationSerializer,
+            # `create` below returns {"message", "organization_id", "organization_name"},
+            # not an AcceptInvitationSerializer instance — describe the actual body.
+            201: OpenApiResponse(
+                response=inline_serializer(
+                    name="AcceptInvitationResponse",
+                    fields={
+                        "message": serializers.CharField(),
+                        "organization_id": serializers.IntegerField(),
+                        "organization_name": serializers.CharField(),
+                    },
+                ),
+                description="Invitation accepted",
+            ),
             400: OpenApiResponse(description="Already a member, or invalid token"),
             402: OpenApiResponse(description="Organization is at its seat limit"),
             404: OpenApiResponse(description="Invitation not found"),

--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -1,5 +1,10 @@
+from typing import TYPE_CHECKING
+
 from payments.billing_constants import LimitedResource
-from payments.services.billing_dataclasses import LimitCheckResult
+
+
+if TYPE_CHECKING:
+    from payments.services.billing_dataclasses import LimitCheckResult
 
 
 class BillingError(Exception):
@@ -161,6 +166,22 @@ class IncompleteBillingPlanError(BillingError):
         self.missing_resource_keys = missing_resource_keys
 
 
+class InvalidLimitCheckResultError(BillingError):
+    """Raised by ``OverLimitError.from_check_result`` when the ``LimitCheckResult``
+    it was given breaks the invariant ``EntitlementService.check_limit`` documents:
+    a blocked (``allowed=False``) result must carry non-``None``
+    ``current_usage``/``ceiling``/``remedy``, and this must never be called on an
+    ``allowed=True`` result at all.
+
+    A broken invariant in ``check_limit`` itself, not a runtime condition a caller
+    should ever hit. Inherits ``BillingError`` rather than plain ``ValueError`` —
+    ``PaymentError`` is itself a ``ValueError``, and several call sites across the
+    codebase wrap service calls in ``except ValueError as e: raise ...(str(e))``,
+    which would flatten this invariant violation into a user-facing validation
+    message instead of surfacing it as the programming error it is.
+    """
+
+
 class OverLimitError(BillingError):
     """Raised by a guarded service method when creating one more of a resource
     would take the organization past its effective ceiling.
@@ -236,7 +257,7 @@ class OverLimitError(BillingError):
         }
 
     @classmethod
-    def from_check_result(cls, result: LimitCheckResult) -> "OverLimitError":
+    def from_check_result(cls, result: "LimitCheckResult") -> "OverLimitError":
         """Build the error from a blocked ``EntitlementService.check_limit`` result.
 
         Every guarded creation path ends the same way: call ``check_limit`` and,
@@ -246,15 +267,17 @@ class OverLimitError(BillingError):
         only guaranteed non-None on the blocked branch" (see
         ``LimitCheckResult``'s docstring) at each of them.
 
-        :raises ValueError: if called on an ``allowed`` result, or on a blocked
-            one missing any of the three fields it is documented to carry —
-            both are programming errors (a broken ``check_limit`` invariant),
-            not a runtime condition a caller should ever hit.
+        :raises InvalidLimitCheckResultError: if called on an ``allowed`` result,
+            or on a blocked one missing any of the three fields it is documented
+            to carry — both are programming errors (a broken ``check_limit``
+            invariant), not a runtime condition a caller should ever hit.
         """
         if result.allowed:
-            raise ValueError("from_check_result() called on an allowed LimitCheckResult")
+            raise InvalidLimitCheckResultError(
+                "from_check_result() called on an allowed LimitCheckResult"
+            )
         if result.current_usage is None or result.ceiling is None or result.remedy is None:
-            raise ValueError(
+            raise InvalidLimitCheckResultError(
                 f"Blocked LimitCheckResult for {result.resource_key!r} is missing "
                 "current_usage/ceiling/remedy; EntitlementService.check_limit must "
                 "populate all three when allowed is False."

--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -1,4 +1,5 @@
 from payments.billing_constants import LimitedResource
+from payments.services.billing_dataclasses import LimitCheckResult
 
 
 class BillingError(Exception):
@@ -233,6 +234,37 @@ class OverLimitError(BillingError):
             "limit": self.limit,
             "remedy": self.remedy,
         }
+
+    @classmethod
+    def from_check_result(cls, result: LimitCheckResult) -> "OverLimitError":
+        """Build the error from a blocked ``EntitlementService.check_limit`` result.
+
+        Every guarded creation path ends the same way: call ``check_limit`` and,
+        if ``result.allowed`` is ``False``, raise this. Centralizing the
+        conversion here means every call site does the identical narrowing
+        exactly once, rather than repeating "current_usage/ceiling/remedy are
+        only guaranteed non-None on the blocked branch" (see
+        ``LimitCheckResult``'s docstring) at each of them.
+
+        :raises ValueError: if called on an ``allowed`` result, or on a blocked
+            one missing any of the three fields it is documented to carry —
+            both are programming errors (a broken ``check_limit`` invariant),
+            not a runtime condition a caller should ever hit.
+        """
+        if result.allowed:
+            raise ValueError("from_check_result() called on an allowed LimitCheckResult")
+        if result.current_usage is None or result.ceiling is None or result.remedy is None:
+            raise ValueError(
+                f"Blocked LimitCheckResult for {result.resource_key!r} is missing "
+                "current_usage/ceiling/remedy; EntitlementService.check_limit must "
+                "populate all three when allowed is False."
+            )
+        return cls(
+            resource_key=result.resource_key,
+            current_usage=result.current_usage,
+            limit=result.ceiling,
+            remedy=result.remedy,
+        )
 
 
 class NoDefaultBillingPlanError(PaymentError):

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -182,17 +182,16 @@ USAGE_COUNTERS: dict[str, UsageCounter] = {
 }
 
 
-def _reject_inapplicable_invitation_exclusion(
-    resource_key: str, exclude_invitation_id: int | None
-) -> None:
-    """``exclude_invitation_id`` is read by exactly one usage counter.
+def _reject_inapplicable_invitation_exclusion(resource_key: str, has_exclusion: bool) -> None:
+    """An invitation exclusion (eager id or lazy resolver) is read by exactly one
+    usage counter.
 
     Every other counter takes the ``UsageContext`` and ignores the field, so
-    passing it with any other ``resource_key`` is a no-op that *looks* like a seat
-    exclusion took place. Raising is the only way that mistake is visible; logging
-    would leave the caller with a wrong answer it believes.
+    passing one with any other ``resource_key`` is a no-op that *looks* like a
+    seat exclusion took place. Raising is the only way that mistake is visible;
+    logging would leave the caller with a wrong answer it believes.
     """
-    if exclude_invitation_id is not None and resource_key != LimitedResource.ORGANIZATION_MEMBERS:
+    if has_exclusion and resource_key != LimitedResource.ORGANIZATION_MEMBERS:
         raise InapplicableInvitationExclusionError(resource_key)
 
 
@@ -320,7 +319,7 @@ class EntitlementService:
             meaningful for ``organization_members``; passing it with another
             ``resource_key`` raises rather than being silently ignored.
         """
-        _reject_inapplicable_invitation_exclusion(resource_key, exclude_invitation_id)
+        _reject_inapplicable_invitation_exclusion(resource_key, exclude_invitation_id is not None)
         root = resolve_billing_root(organization)
         return self._count_usage(
             root,
@@ -362,6 +361,7 @@ class EntitlementService:
         delta: int = 1,
         lock: bool = False,
         exclude_invitation_id: int | None = None,
+        exclude_invitation_id_resolver: Callable[[], int | None] | None = None,
     ) -> LimitCheckResult:
         """Would creating ``delta`` more of ``resource_key`` stay within the ceiling?
 
@@ -406,8 +406,17 @@ class EntitlementService:
             a resend at the exact ceiling is net-zero rather than a false block. Only
             meaningful for ``organization_members``; passing it with any other
             ``resource_key`` raises, since it would otherwise be silently ignored.
+        :param exclude_invitation_id_resolver: Lazy alternative to ``exclude_invitation_id``
+            for a caller whose exclusion itself requires a query (e.g. resolving the
+            still-pending invitation a resend is reusing). Called at most once, and only
+            after the ceiling is known to be finite, so an ``unlimited`` organization never
+            pays for that query. Mutually exclusive with ``exclude_invitation_id``; same
+            ``organization_members``-only restriction.
         """
-        _reject_inapplicable_invitation_exclusion(resource_key, exclude_invitation_id)
+        _reject_inapplicable_invitation_exclusion(
+            resource_key,
+            exclude_invitation_id is not None or exclude_invitation_id_resolver is not None,
+        )
         root = resolve_billing_root(organization)
         if lock:
             # Discard the returned row: the point is the row lock, and the
@@ -428,6 +437,8 @@ class EntitlementService:
 
         # Narrowed by the ``is_unlimited`` return above: limit_value is not None here.
         ceiling = effective_limit.limit_value or 0
+        if exclude_invitation_id_resolver is not None:
+            exclude_invitation_id = exclude_invitation_id_resolver()
         current_usage = self._count_usage(
             root, resource_key, subscription, exclude_invitation_id=exclude_invitation_id
         )

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -59,14 +59,16 @@ class UsageContext:
     organization_ids: Sequence[int]
     subscription: Subscription | None = None
     exclude_invitation_id: int | None = None
-    """The invitation currently being accepted, if any.
+    """The invitation currently being accepted or resent, if any.
 
     Accepting an invitation is **net zero** on seat usage: the pending invitation
     stops being pending and becomes the membership it was already holding a seat
     for. Counting it on both sides would make the accept fail its own
     ``check_limit(delta=1)`` at exactly the ceiling, so an organization could
     never fill its last seat — it could invite up to the limit and then be unable
-    to let anybody in.
+    to let anybody in. Resending is the same shape: it reuses the still-pending
+    row rather than creating a new one, so excluding it makes the resend net-zero
+    too.
     """
 
 
@@ -396,10 +398,12 @@ class EntitlementService:
             the lock exists to prevent — and both callers would be allowed. If the
             project ever raises the isolation level, this guard has to be
             revisited, not just retested.
-        :param exclude_invitation_id: See ``UsageContext.exclude_invitation_id``.
-            **Callers other than the accept-invitation path must not pass this** —
-            prefer ``check_seat_limit_for_invitation_accept``, which is a call a
-            reviewer can see rather than a kwarg nobody can grep for. Only
+        :param exclude_invitation_id: See ``UsageContext.exclude_invitation_id``. Two
+            legitimate callers pass this: ``check_seat_limit_for_invitation_accept``
+            (the accept path — prefer that named entry point, a call a reviewer can
+            see, over passing this kwarg directly) and ``invite_user_to_organization``'s
+            resend branch, which excludes the still-pending invitation being reused so
+            a resend at the exact ceiling is net-zero rather than a false block. Only
             meaningful for ``organization_members``; passing it with any other
             ``resource_key`` raises, since it would otherwise be silently ignored.
         """

--- a/payments/tests/test_over_limit_error.py
+++ b/payments/tests/test_over_limit_error.py
@@ -128,3 +128,53 @@ def test_payment_error_keeps_its_value_error_lineage():
 
     assert issubclass(PaymentError, ValueError)
     assert issubclass(MissingBillingProfileError, ValueError)
+
+
+class TestFromCheckResultInvariantViolations:
+    """NIT, Phase 6a review: ``from_check_result`` raising a broken-invariant
+    signal must not be a bare ``ValueError`` -- ``PaymentError`` is itself a
+    ``ValueError``, so an upstream ``except ValueError`` wrapper (the same idiom
+    ``test_over_limit_error_is_not_a_value_error`` guards ``OverLimitError``
+    itself against) would flatten a genuine programming-error invariant
+    violation into a user-facing validation message."""
+
+    def _allowed_result(self):
+        from payments.services.billing_dataclasses import LimitCheckResult
+
+        return LimitCheckResult(
+            allowed=True,
+            resource_key=LimitedResource.ORGANIZATION_MEMBERS,
+            current_usage=None,
+            ceiling=None,
+        )
+
+    def _incomplete_blocked_result(self):
+        from payments.services.billing_dataclasses import LimitCheckResult
+
+        return LimitCheckResult(
+            allowed=False,
+            resource_key=LimitedResource.ORGANIZATION_MEMBERS,
+            current_usage=None,
+            ceiling=None,
+            remedy=None,
+        )
+
+    def test_called_on_an_allowed_result_raises_a_billing_error_not_a_bare_value_error(self):
+        from payments.exceptions import BillingError, InvalidLimitCheckResultError
+
+        with pytest.raises(InvalidLimitCheckResultError) as exc_info:
+            OverLimitError.from_check_result(self._allowed_result())
+
+        assert isinstance(exc_info.value, BillingError)
+        assert not isinstance(exc_info.value, ValueError)
+
+    def test_called_on_an_incomplete_blocked_result_raises_a_billing_error_not_a_bare_value_error(
+        self,
+    ):
+        from payments.exceptions import BillingError, InvalidLimitCheckResultError
+
+        with pytest.raises(InvalidLimitCheckResultError) as exc_info:
+            OverLimitError.from_check_result(self._incomplete_blocked_result())
+
+        assert isinstance(exc_info.value, BillingError)
+        assert not isinstance(exc_info.value, ValueError)

--- a/payments/tests/test_over_limit_error.py
+++ b/payments/tests/test_over_limit_error.py
@@ -12,7 +12,14 @@ from rest_framework.exceptions import NotFound
 
 from common.exception_handlers import vinta_exception_handler
 from payments.billing_constants import LimitedResource, LimitRemedy
-from payments.exceptions import OverLimitError
+from payments.exceptions import (
+    BillingError,
+    InvalidLimitCheckResultError,
+    MissingBillingProfileError,
+    OverLimitError,
+    PaymentError,
+)
+from payments.services.billing_dataclasses import LimitCheckResult
 
 
 def build_error():
@@ -85,8 +92,6 @@ class TestExceptionHandler:
 
 def test_over_limit_error_is_a_billing_error():
     """Keeps it catchable alongside the rest of the payments exception tree."""
-    from payments.exceptions import BillingError
-
     with pytest.raises(BillingError):
         raise build_error()
 
@@ -124,8 +129,6 @@ def test_over_limit_error_is_not_a_value_error():
 def test_payment_error_keeps_its_value_error_lineage():
     """The rest of the tree is unchanged: existing ``except ValueError`` handlers
     around payment-gateway calls must keep working."""
-    from payments.exceptions import MissingBillingProfileError, PaymentError
-
     assert issubclass(PaymentError, ValueError)
     assert issubclass(MissingBillingProfileError, ValueError)
 
@@ -139,8 +142,6 @@ class TestFromCheckResultInvariantViolations:
     violation into a user-facing validation message."""
 
     def _allowed_result(self):
-        from payments.services.billing_dataclasses import LimitCheckResult
-
         return LimitCheckResult(
             allowed=True,
             resource_key=LimitedResource.ORGANIZATION_MEMBERS,
@@ -149,8 +150,6 @@ class TestFromCheckResultInvariantViolations:
         )
 
     def _incomplete_blocked_result(self):
-        from payments.services.billing_dataclasses import LimitCheckResult
-
         return LimitCheckResult(
             allowed=False,
             resource_key=LimitedResource.ORGANIZATION_MEMBERS,
@@ -160,8 +159,6 @@ class TestFromCheckResultInvariantViolations:
         )
 
     def test_called_on_an_allowed_result_raises_a_billing_error_not_a_bare_value_error(self):
-        from payments.exceptions import BillingError, InvalidLimitCheckResultError
-
         with pytest.raises(InvalidLimitCheckResultError) as exc_info:
             OverLimitError.from_check_result(self._allowed_result())
 
@@ -171,8 +168,6 @@ class TestFromCheckResultInvariantViolations:
     def test_called_on_an_incomplete_blocked_result_raises_a_billing_error_not_a_bare_value_error(
         self,
     ):
-        from payments.exceptions import BillingError, InvalidLimitCheckResultError
-
         with pytest.raises(InvalidLimitCheckResultError) as exc_info:
             OverLimitError.from_check_result(self._incomplete_blocked_result())
 

--- a/public_api/extensions.py
+++ b/public_api/extensions.py
@@ -8,10 +8,40 @@ from pyrate_limiter import (
     Duration,
     Rate,
 )
+from rest_framework.views import set_rollback
 from strawberry.extensions import SchemaExtension
 from strawberry.utils.await_maybe import AsyncIteratorOrIterator
 
 from common.redis import ResilientLimiter
+from payments.exceptions import OverLimitError
+
+
+def over_limit_graphql_error(exc: OverLimitError) -> GraphQLError:
+    """Render ``OverLimitError`` as a GraphQL error, byte-identical to the REST body.
+
+    The shared over-limit contract (``OverLimitError.as_error_body()``) is carried
+    verbatim in the GraphQL error's ``extensions`` — the GraphQL spec's own
+    mechanism for attaching structured, machine-readable data to an error — so a
+    client handling the REST 402 body and a client handling this error's
+    ``extensions`` see the identical ``detail`` / ``code`` / ``resource`` /
+    ``current_usage`` / ``limit`` / ``remedy`` fields without either surface
+    restating the shape (mirrors ``common.exception_handlers.vinta_exception_handler``,
+    which renders the same dict as the REST response body).
+
+    Also rolls back the request transaction. Under ``ATOMIC_REQUESTS``, a REST
+    view relies on an *unhandled* exception propagating out of the view to
+    trigger a rollback — which is exactly what
+    ``common.exception_handlers.vinta_exception_handler`` compensates for by
+    calling ``set_rollback()`` before returning a ``Response``. GraphQL has the
+    same problem for a different reason: graphql-core catches every resolver
+    exception internally and always returns a normal 200 response with the
+    error embedded in ``errors``, so the view itself never sees an exception to
+    propagate. Without this, a write a guarded service made before it reached
+    the limit check (e.g. ``invite_user_to_organization``'s invitation row)
+    would commit while the client is told the request was rejected.
+    """
+    set_rollback()
+    return GraphQLError(exc.detail, extensions=exc.as_error_body())
 
 
 class OrganizationRateLimiter(SchemaExtension):

--- a/public_api/extensions.py
+++ b/public_api/extensions.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from typing import NoReturn
 
 from django.conf import settings
 from django.http import HttpRequest
@@ -16,8 +17,16 @@ from common.redis import ResilientLimiter
 from payments.exceptions import OverLimitError
 
 
-def over_limit_graphql_error(exc: OverLimitError) -> GraphQLError:
-    """Render ``OverLimitError`` as a GraphQL error, byte-identical to the REST body.
+def raise_over_limit_graphql_error(exc: OverLimitError) -> NoReturn:
+    """Roll back the request transaction and raise ``OverLimitError`` as a
+    GraphQL error, byte-identical to the REST body.
+
+    A raising function, not a value-returning one that a caller might forget to
+    ``raise``: this has a side effect (the rollback below), so a call site that
+    wrote ``over_limit_graphql_error(exc)`` without ``raise`` in front of it
+    would silently roll back the transaction and then fall through as if the
+    request had succeeded. Making the function itself raise removes that
+    footgun — there is no way to call it and continue.
 
     The shared over-limit contract (``OverLimitError.as_error_body()``) is carried
     verbatim in the GraphQL error's ``extensions`` — the GraphQL spec's own
@@ -39,9 +48,19 @@ def over_limit_graphql_error(exc: OverLimitError) -> GraphQLError:
     propagate. Without this, a write a guarded service made before it reached
     the limit check (e.g. ``invite_user_to_organization``'s invitation row)
     would commit while the client is told the request was rejected.
+
+    ``set_rollback()`` marks the **whole request's** transaction for rollback, not
+    just the current field. GraphQL executes a mutation document's root-level
+    fields serially in one transaction, so a document with more than one root
+    mutation field — e.g. ``mutation { a: createCalendar(...) b:
+    createInvitation(...) }`` where ``b`` hits this — rolls back ``a``'s write too,
+    even though the response still reports 200 with ``data.a`` populated: the
+    client is told ``a`` succeeded when its write did not survive. This is
+    documented rather than guarded against — rejecting multi-root-field
+    documents outright is out of scope here.
     """
     set_rollback()
-    return GraphQLError(exc.detail, extensions=exc.as_error_body())
+    raise GraphQLError(exc.detail, extensions=exc.as_error_body()) from exc
 
 
 class OrganizationRateLimiter(SchemaExtension):

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -54,7 +54,7 @@ from payments.exceptions import OverLimitError
 from payments.services.subscription_service import SubscriptionService
 from public_api.capabilities import assert_org_can_invite, assert_target_in_subtree
 from public_api.constants import PROVIDER_SCOPED_RESOURCES, PublicAPIResources
-from public_api.extensions import over_limit_graphql_error
+from public_api.extensions import raise_over_limit_graphql_error
 from public_api.models import ResourceAccess, SystemUser
 from public_api.permissions import IsAuthenticated, OrganizationResourceAccess
 from public_api.scoping import assert_calendar_in_owner_scope
@@ -991,8 +991,8 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         # token as invitation._raw_token (transient, never persisted in plaintext).
         #
         # Phase 6a: invite_user_to_organization raises OverLimitError at the organization's
-        # seat limit. Rendered identically to the REST 402 body via over_limit_graphql_error
-        # (Use-case 7 — the partner API is not a bypass).
+        # seat limit. Rendered identically to the REST 402 body via
+        # raise_over_limit_graphql_error (Use-case 7 — the partner API is not a bypass).
         try:
             invitation = deps.organization_service.invite_user_to_organization(
                 email=input.user_email,
@@ -1004,7 +1004,7 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                 send_email=input.send_email,
             )
         except OverLimitError as exc:
-            raise over_limit_graphql_error(exc) from exc
+            raise_over_limit_graphql_error(exc)
 
         raw_token: str | None = None
         invite_url: str | None = None

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -50,9 +50,11 @@ from calendar_integration.services.dataclasses import (
 from organizations.exceptions import NoServiceAccountConfiguredError, UserAlreadyHasMembershipError
 from organizations.models import Organization, OrganizationBranding, OrganizationMembership
 from organizations.services import OrganizationService
+from payments.exceptions import OverLimitError
 from payments.services.subscription_service import SubscriptionService
 from public_api.capabilities import assert_org_can_invite, assert_target_in_subtree
 from public_api.constants import PROVIDER_SCOPED_RESOURCES, PublicAPIResources
+from public_api.extensions import over_limit_graphql_error
 from public_api.models import ResourceAccess, SystemUser
 from public_api.permissions import IsAuthenticated, OrganizationResourceAccess
 from public_api.scoping import assert_calendar_in_owner_scope
@@ -987,15 +989,22 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         #
         # Phase 4: when send_email=False the service suppresses the email and attaches the raw
         # token as invitation._raw_token (transient, never persisted in plaintext).
-        invitation = deps.organization_service.invite_user_to_organization(
-            email=input.user_email,
-            first_name="",
-            last_name="",
-            organization=target_org,
-            invited_by=None,
-            role=input.role.to_model_role(),
-            send_email=input.send_email,
-        )
+        #
+        # Phase 6a: invite_user_to_organization raises OverLimitError at the organization's
+        # seat limit. Rendered identically to the REST 402 body via over_limit_graphql_error
+        # (Use-case 7 — the partner API is not a bypass).
+        try:
+            invitation = deps.organization_service.invite_user_to_organization(
+                email=input.user_email,
+                first_name="",
+                last_name="",
+                organization=target_org,
+                invited_by=None,
+                role=input.role.to_model_role(),
+                send_email=input.send_email,
+            )
+        except OverLimitError as exc:
+            raise over_limit_graphql_error(exc) from exc
 
         raw_token: str | None = None
         invite_url: str | None = None

--- a/public_api/tests/test_over_limit_graphql_error.py
+++ b/public_api/tests/test_over_limit_graphql_error.py
@@ -1,12 +1,12 @@
-"""``over_limit_graphql_error`` — the GraphQL rendering of ``OverLimitError``.
+"""``raise_over_limit_graphql_error`` — the GraphQL rendering of ``OverLimitError``.
 
 Mirrors ``payments/tests/test_over_limit_rollback.py``'s reasoning for REST,
 applied to GraphQL: graphql-core catches every resolver exception internally
 and always returns a normal 200 response with the error embedded in
 ``errors``, so — unlike an unhandled exception in a plain Django view — the
 request transaction never sees anything to propagate and roll back on its own.
-Without ``set_rollback()`` in ``over_limit_graphql_error``, a write a guarded
-resolver made before it hit the limit check would commit under
+Without ``set_rollback()`` in ``raise_over_limit_graphql_error``, a write a
+guarded resolver made before it hit the limit check would commit under
 ``ATOMIC_REQUESTS`` while the client is told the request was rejected.
 
 Exercised through a real request against a throwaway schema/urlconf, not by
@@ -28,7 +28,7 @@ from calendar_integration.models import CalendarGroup
 from organizations.models import Organization
 from payments.billing_constants import LimitedResource, LimitRemedy
 from payments.exceptions import OverLimitError
-from public_api.extensions import over_limit_graphql_error
+from public_api.extensions import raise_over_limit_graphql_error
 
 
 #: Mirrors payments/tests/test_over_limit_rollback.py's use of a ContextVar
@@ -56,7 +56,7 @@ class Mutation:
             organization_id=current_organization_id.get(),
             name="written-before-the-graphql-guard",
         )
-        raise over_limit_graphql_error(
+        raise_over_limit_graphql_error(
             OverLimitError(
                 resource_key=LimitedResource.CALENDAR_GROUPS,
                 current_usage=1,
@@ -150,7 +150,7 @@ class TestOverLimitGraphQLErrorRollsBackTheRequestTransaction:
             == 0
         ), (
             "The row written before the over-limit guard was committed. "
-            "over_limit_graphql_error swallowed the exception into a normal 200 "
+            "raise_over_limit_graphql_error swallowed the exception into a normal 200 "
             "response without calling set_rollback(), so ATOMIC_REQUESTS "
             "committed the request transaction."
         )

--- a/public_api/tests/test_over_limit_graphql_error.py
+++ b/public_api/tests/test_over_limit_graphql_error.py
@@ -1,0 +1,176 @@
+"""``over_limit_graphql_error`` — the GraphQL rendering of ``OverLimitError``.
+
+Mirrors ``payments/tests/test_over_limit_rollback.py``'s reasoning for REST,
+applied to GraphQL: graphql-core catches every resolver exception internally
+and always returns a normal 200 response with the error embedded in
+``errors``, so — unlike an unhandled exception in a plain Django view — the
+request transaction never sees anything to propagate and roll back on its own.
+Without ``set_rollback()`` in ``over_limit_graphql_error``, a write a guarded
+resolver made before it hit the limit check would commit under
+``ATOMIC_REQUESTS`` while the client is told the request was rejected.
+
+Exercised through a real request against a throwaway schema/urlconf, not by
+calling the helper directly — a direct-call test cannot observe transaction
+state and would pass identically whether or not ``set_rollback()`` is there.
+"""
+
+import contextvars
+from unittest import mock
+
+from django.db import connection
+from django.urls import path
+
+import pytest
+import strawberry
+from strawberry.django.views import GraphQLView
+
+from calendar_integration.models import CalendarGroup
+from organizations.models import Organization
+from payments.billing_constants import LimitedResource, LimitRemedy
+from payments.exceptions import OverLimitError
+from public_api.extensions import over_limit_graphql_error
+
+
+#: Mirrors payments/tests/test_over_limit_rollback.py's use of a ContextVar
+#: instead of class state, for the same reason: module-global class state
+#: would survive a mid-test failure and leak into later tests.
+current_organization_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "current_organization_id", default=None
+)
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def ping(self) -> bool:
+        return True
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def write_then_exceed_limit(self) -> bool:
+        """Stands in for a guarded GraphQL resolver: writes a row and *then*
+        raises, mirroring the real ordering risk this helper exists for."""
+        CalendarGroup.objects.create(
+            organization_id=current_organization_id.get(),
+            name="written-before-the-graphql-guard",
+        )
+        raise over_limit_graphql_error(
+            OverLimitError(
+                resource_key=LimitedResource.CALENDAR_GROUPS,
+                current_usage=1,
+                limit=1,
+                remedy=LimitRemedy.PURCHASE_ADD_ON,
+            )
+        )
+
+    @strawberry.mutation
+    def write_only(self) -> bool:
+        """Control: same write, no exception. Proves the write itself does
+        persist, so a passing rollback assertion cannot be an artifact of the
+        write never landing in the first place."""
+        CalendarGroup.objects.create(
+            organization_id=current_organization_id.get(),
+            name="written-and-kept",
+        )
+        return True
+
+
+test_schema = strawberry.Schema(query=Query, mutation=Mutation)
+
+urlpatterns = [
+    path("graphql-over-limit-test/", GraphQLView.as_view(schema=test_schema)),
+]
+
+
+@pytest.fixture
+def atomic_requests():
+    """See payments/tests/test_over_limit_rollback.py's identical fixture for
+    why this patches the live connection rather than using
+    ``override_settings(DATABASES=...)``."""
+    with mock.patch.dict(connection.settings_dict, {"ATOMIC_REQUESTS": True}):
+        yield
+
+
+@pytest.fixture
+def test_urlconf(settings):
+    settings.ROOT_URLCONF = __name__
+
+
+@pytest.fixture
+def organization():
+    org = Organization.objects.create(name="graphql-rollback-test-org")
+    token = current_organization_id.set(org.pk)
+    try:
+        yield org
+    finally:
+        current_organization_id.reset(token)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("test_urlconf", "atomic_requests")
+class TestOverLimitGraphQLErrorRollsBackTheRequestTransaction:
+    def test_the_control_write_persists_without_the_exception(self, anonymous_client, organization):
+        """Guards the guard: if this fails, the assertion below proves nothing."""
+        response = anonymous_client.post(
+            "/graphql-over-limit-test/",
+            data={"query": "mutation { writeOnly }"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert "errors" not in response.json()
+        assert (
+            CalendarGroup.objects.filter(
+                organization_id=organization.pk, name="written-and-kept"
+            ).count()
+            == 1
+        )
+
+    def test_nothing_written_before_the_guard_survives_the_response(
+        self, anonymous_client, organization
+    ):
+        """Without ``set_rollback()`` this row commits and the count is 1, while
+        the client is handed a structured over-limit error saying the write did
+        not happen."""
+        response = anonymous_client.post(
+            "/graphql-over-limit-test/",
+            data={"query": "mutation { writeThenExceedLimit }"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["errors"]) == 1
+        assert (
+            CalendarGroup.objects.filter(
+                organization_id=organization.pk, name="written-before-the-graphql-guard"
+            ).count()
+            == 0
+        ), (
+            "The row written before the over-limit guard was committed. "
+            "over_limit_graphql_error swallowed the exception into a normal 200 "
+            "response without calling set_rollback(), so ATOMIC_REQUESTS "
+            "committed the request transaction."
+        )
+
+    def test_the_error_extensions_are_still_the_shared_contract(
+        self, anonymous_client, organization
+    ):
+        """Rolling back must not change what the client receives."""
+        response = anonymous_client.post(
+            "/graphql-over-limit-test/",
+            data={"query": "mutation { writeThenExceedLimit }"},
+            content_type="application/json",
+        )
+
+        data = response.json()
+        assert data["errors"][0]["extensions"] == {
+            "detail": "Organization is at its limit for calendar groups.",
+            "code": "limit_exceeded",
+            "resource": "calendar_groups",
+            "current_usage": 1,
+            "limit": 1,
+            "remedy": "purchase_add_on",
+        }

--- a/schema.yml
+++ b/schema.yml
@@ -7512,6 +7512,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationInvitation'
           description: ''
+        '402':
+          description: Organization is at its seat limit
   /invitations{format}:
     get:
       operationId: invitations_formatted_list
@@ -7623,6 +7625,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationInvitation'
           description: ''
+        '402':
+          description: Organization is at its seat limit
   /invitations/{id}/:
     get:
       operationId: invitations_retrieve
@@ -7809,6 +7813,8 @@ paths:
           description: ''
         '400':
           description: Invitation already accepted or service error
+        '402':
+          description: Organization is at its seat limit
         '403':
           description: Not an active member
         '404':
@@ -7874,6 +7880,8 @@ paths:
           description: ''
         '400':
           description: Invitation already accepted or service error
+        '402':
+          description: Organization is at its seat limit
         '403':
           description: Not an active member
         '404':
@@ -7906,6 +7914,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/AcceptInvitation'
           description: ''
+        '400':
+          description: Already a member, or invalid token
+        '402':
+          description: Organization is at its seat limit
+        '404':
+          description: Invitation not found
+        '409':
+          description: Duplicate invitation
   /notifications/:
     get:
       operationId: notifications_list
@@ -8582,15 +8598,10 @@ paths:
       description: |-
         Reactivate a member (set is_active=True).
 
-        Guards: reactivating occupies a seat again (``OrganizationMembershipQuerySet
-        .occupying_a_seat`` only counts ``is_active=True`` rows), so — unlike every other
-        member of this viewset — it is a capacity-raising write with no accompanying
-        ``OrganizationInvitation``/membership *create*, and would otherwise be an unmetered
-        path onto the ``organization_members`` limit. Only checked when the member is
-        currently inactive: an already-active member is a no-op and must stay one even if
-        the organization is at its limit for an unrelated reason.
-
-        Idempotency: reactivating an already-active member is a no-op success.
+        The seat-limit guard lives in ``OrganizationService.reactivate_membership``
+        (service layer, not the viewset — see the plan's Guiding Decisions), so this
+        action only resolves the target and serializes the result. Idempotency:
+        reactivating an already-active member is a no-op success.
       summary: Reactivate an organization member
       parameters:
       - in: header
@@ -8643,15 +8654,10 @@ paths:
       description: |-
         Reactivate a member (set is_active=True).
 
-        Guards: reactivating occupies a seat again (``OrganizationMembershipQuerySet
-        .occupying_a_seat`` only counts ``is_active=True`` rows), so — unlike every other
-        member of this viewset — it is a capacity-raising write with no accompanying
-        ``OrganizationInvitation``/membership *create*, and would otherwise be an unmetered
-        path onto the ``organization_members`` limit. Only checked when the member is
-        currently inactive: an already-active member is a no-op and must stay one even if
-        the organization is at its limit for an unrelated reason.
-
-        Idempotency: reactivating an already-active member is a no-op success.
+        The seat-limit guard lives in ``OrganizationService.reactivate_membership``
+        (service layer, not the viewset — see the plan's Guiding Decisions), so this
+        action only resolves the target and serializes the result. Idempotency:
+        reactivating an already-active member is a no-op success.
       summary: Reactivate an organization member
       parameters:
       - in: header

--- a/schema.yml
+++ b/schema.yml
@@ -7912,8 +7912,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AcceptInvitation'
-          description: ''
+                $ref: '#/components/schemas/AcceptInvitationResponse'
+          description: Invitation accepted
         '400':
           description: Already a member, or invalid token
         '402':
@@ -12675,6 +12675,19 @@ components:
           type: string
       required:
       - token
+    AcceptInvitationResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        organization_id:
+          type: integer
+        organization_name:
+          type: string
+      required:
+      - message
+      - organization_id
+      - organization_name
     ActionEnum:
       enum:
       - create

--- a/schema.yml
+++ b/schema.yml
@@ -8582,7 +8582,13 @@ paths:
       description: |-
         Reactivate a member (set is_active=True).
 
-        No guards — re-enabling is always safe.
+        Guards: reactivating occupies a seat again (``OrganizationMembershipQuerySet
+        .occupying_a_seat`` only counts ``is_active=True`` rows), so — unlike every other
+        member of this viewset — it is a capacity-raising write with no accompanying
+        ``OrganizationInvitation``/membership *create*, and would otherwise be an unmetered
+        path onto the ``organization_members`` limit. Only checked when the member is
+        currently inactive: an already-active member is a no-op and must stay one even if
+        the organization is at its limit for an unrelated reason.
 
         Idempotency: reactivating an already-active member is a no-op success.
       summary: Reactivate an organization member
@@ -8625,6 +8631,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationMembership'
           description: ''
+        '402':
+          description: Organization is at its seat limit
         '403':
           description: Not an admin
         '404':
@@ -8635,7 +8643,13 @@ paths:
       description: |-
         Reactivate a member (set is_active=True).
 
-        No guards — re-enabling is always safe.
+        Guards: reactivating occupies a seat again (``OrganizationMembershipQuerySet
+        .occupying_a_seat`` only counts ``is_active=True`` rows), so — unlike every other
+        member of this viewset — it is a capacity-raising write with no accompanying
+        ``OrganizationInvitation``/membership *create*, and would otherwise be an unmetered
+        path onto the ``organization_members`` limit. Only checked when the member is
+        currently inactive: an already-active member is a no-op and must stay one even if
+        the organization is at its limit for an unrelated reason.
 
         Idempotency: reactivating an already-active member is a no-op success.
       summary: Reactivate an organization member
@@ -8685,6 +8699,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationMembership'
           description: ''
+        '402':
+          description: Organization is at its seat limit
         '403':
           description: Not an admin
         '404':


### PR DESCRIPTION

Phase 6a of the [billing plans and limits plan](../../../ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_IMPLEMENTATION_PLAN.md). Targets `main`, which now has phases [1](https://github.com/vintasoftware/vinta-schedule-api/pull/189), [2](https://github.com/vintasoftware/vinta-schedule-api/pull/190), [2b](https://github.com/vintasoftware/vinta-schedule-api/pull/191), [3](https://github.com/vintasoftware/vinta-schedule-api/pull/192), [4](https://github.com/vintasoftware/vinta-schedule-api/pull/193) and [5](https://github.com/vintasoftware/vinta-schedule-api/pull/194).

This was developed stacked on phase 5; #194 merged while it was in review, so it targets `main` directly. `main` contains only the merge commit beyond this branch — the content diff between them is empty, so no rebase was needed.

The first phase that can actually block a real user. Every path that raises an organization's seat count now checks the ceiling, and every surface renders the same error.

## Two failure modes, pulling in opposite directions

This phase is unusual in that being *too* permissive and being *too* strict are both defects, and the second is the one that bit hardest here:

- **An unmetered path** — any way to add a member that skips the guard defeats the plan's objective 1.
- **A false block** — an organization prevented from doing something it is entitled to. The spec's goal 6 says no organization may be blocked as a consequence of the rollout itself.

Review found one of each, and both were invisible from inside the code the phase set out to change.

## What changed

- `invite_user_to_organization`, `accept_invitation`, and the invite branch of `provision_tenant_for_user` check seats inside their existing `transaction.atomic` blocks.
- `reactivate` is guarded via a new `OrganizationService.reactivate_membership` — it raises the seat count without being a create, and would otherwise be unmetered.
- All guarded methods take `bypass_limits: bool = False`, per the plan's **Enforcement bypass** decision. It is unreachable from every request surface.
- `OverLimitError` renders **byte-identically** through REST and GraphQL, asserted by comparing the two responses against each other rather than against a shared literal.

The accept paths call `check_seat_limit_for_invitation_accept`, not the generic `check_limit`. Accepting is net zero on seats — the pending invitation stops counting as the membership starts — so the generic entry point would leave an organization unable to fill its last seat.

## BLOCKER 1 — seat limits wedged signup with a 500

The phase guarded `provision_tenant_for_user` correctly. But two allauth adapters call it, and **allauth headless mounts as plain Django views, not DRF** — so `common/exception_handlers` never ran and `OverLimitError` escaped as a 500.

The failure compounds nastily. Under `ATOMIC_REQUESTS` the 500 rolls the request back, which also undoes the email-verification write — so the user's address stayed unverified and **every retry 500'd identically**. The account was wedged with no message. Social signup was worse: the whole user row rolled back, so Google signup simply failed.

Both adapters now fall through to the membership-less gated branch they already use for uninvited users. The invitation stays pending, so the user is recoverable once a seat frees — asserted, not assumed.

## BLOCKER 2 — resending an invitation was a false block

`POST /invitations/{id}/resend/` ran the guard while the invitation being resent still counted as pending. At the exact ceiling it returned 402 for an operation that **creates nothing**.

The triggering state is the common one: an org that just filled its seats, with one invite that never arrived. The only workaround was revoke-then-reinvite. The implementer had recorded this as an accepted corner case; review disagreed, and it was right — the machinery to fix it already existed one method over. A resend now excludes its own invitation, exactly like an accept.

## Review notes

**Three rounds.** Round 1 found the two BLOCKERs above plus the `reactivate` guard sitting in the viewset (contradicting the plan's "Service layer, not viewsets" decision, and leaving it with no `bypass_limits`), and `accept_invitation` marking the invitation accepted *outside* its transaction — a window where a seat double-counts, permanently if that write fails.

**Round 2 flagged a finding that turned out to be wrong, and the fixer caught it.** It reported the same atomicity bug in `provision_tenant_for_user`. That method carries a method-level `@transaction.atomic()` that `accept_invitation` lacks, so the bug did not exist there. The fixer stash-tested it, found the new test green against pre-fix code, applied the (harmless) clarifying move anyway, and said plainly that the test is not a regression guard rather than claiming a red→green. Recorded here because reviewer output needs verifying too.

**The GraphQL rollback is deliberate and worth knowing about.** graphql-core catches resolver exceptions and always returns 200, so nothing propagates out to trigger `ATOMIC_REQUESTS`. `raise_over_limit_graphql_error` calls `set_rollback()` itself. That rolls back the **whole request**, so a multi-root-field mutation where a later field hits the limit returns 200 with the earlier field's data populated *and* its write rolled back. Documented at the call site, deliberately not guarded.

## Verification

Re-run independently by the orchestrator, not relayed:

- Full suite **4094 passed** (phase-5 base 4054; +40).
- `mypy` **305 errors / 57 files** — at baseline, **zero `type: ignore` / `noqa` added**.
- `ruff check` + `format --check` clean; `makemigrations --check` clean (no model changes); `schema.yml` verified in sync by regenerating and confirming an empty diff.
- Each guard confirmed by deleting it and watching specific tests fail, then restoring.
- The concurrency test races genuinely — real threads, separate connections, a barrier — with a `lock=False` negative control that demonstrably overshoots.

## Carried forward

- The unlimited-plan query count is now pinned to an exact number rather than a loose budget, so any future regression on the hot invite path fails loudly.
- Everything carried forward from phase 5 (availability-counter residual, add-on expiry, nullable `SystemUser.organization`) is unaffected by this phase.