### PR TITLE
feat(payments): guard webhook subscriptions and API system users, add entitlement gates (billing plans and limits, phase 6c)

### DIFF
--- a/accounts/tests/test_account_adapters.py
+++ b/accounts/tests/test_account_adapters.py
@@ -20,6 +20,11 @@ from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
 from users.models import Profile, User
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 def _org_at_seat_limit_with_pending_invitation(email: str) -> Organization:
     """A one-seat organization already full, with a still-pending invitation to
     ``email`` — the exact BLOCKER 1 scenario: signup would take the org over its

--- a/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
+++ b/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
@@ -220,13 +220,46 @@ Also: the "exact complement of `live_of_type`" docstring was factually wrong (`P
 
 **Out of scope, spotted while fixing**: `CalendarQuerySet.update()` (`calendar_integration/querysets.py`) raises `AttributeError: 'CalendarQuerySet' object has no attribute '_meta'` — it reads `self._meta` where it means `self.model._meta`, so **any** `.update()` on a Calendar queryset is broken. Pre-existing, unrelated to this phase, not fixed here.
 
+### Phase 6c — Enforce pre-paid limits: webhook subscriptions and API system users ✅
+
+- **Status**: reviewed clean (3 rounds), PR open
+- **Models**: implementer Tier 2; reviewer Tier 3→4 (stepped up for the security surface); fixer Tier 2→4 rounds 1–2, Tier 3 round 3
+- **Branch**: `plan/billing-plans-and-limits/phase-6c` · **Base**: `plan/billing-plans-and-limits/phase-6b`
+- **PR**: https://github.com/vintasoftware/vinta-schedule-api/pull/197
+- **Commits**: `8c46f02` implementation, `bd07aed` rounds 1–2, `5796cc9` round 3
+
+**Closes spec objective 1 for pre-paid resources.** All 7 `kind=prepaid` members of `LimitedResource` have a guarded creation path with a blocking test, machine-checked by `payments/tests/test_prepaid_resource_coverage.py`, which derives the prepaid set from the seeded plan's own `PlanLimit.kind` and asserts the registry bidirectionally. `event_occurrences` is the one deliberate exclusion (postpaid, Phase 8).
+
+**The biggest finding was the first round's own fix.** The implementation changed `has_entitlement` to fail **open** on a missing subscription, after 106 test failures from calendar-integration fixtures that build orgs with no `Subscription`. It argued symmetry with `get_effective_limit`. **That symmetry is invalid**: for a numeric ceiling "we don't know" → NULL → unlimited, which coincides with what the rollout seeds; for a **boolean** gate "we don't know" → `True` grants **paid** features, strictly more than `free`. Rollout safety was already covered by the backfill migration, so the branch fired only when billing state was already broken — granting the most access to exactly those orgs. Ops deleting a `Subscription` to re-provision would hand a `free` org the entire partner API in that window. **Reverted; `entitlement_service.py` has zero net diff against 6b.** The fixtures were the defect and were fixed instead (autouse provisioning fixture, 20 modules opting out via `@pytest.mark.no_auto_subscription`).
+
+Two more BLOCKERs: **the entitlement gate was bypassable** — the plan names `authenticate` as the chokepoint, but `_get_write_adapter_for_calendar` builds an adapter for the calendar's *owner*, so a Google-authenticated actor could write to a Microsoft calendar ungated; and **`create_system_user(organization=None)`**, an explicitly supported admin path, started 500ing.
+
+**Two `@inject` landmines, neither billing-related, both invisible to the suite:**
+1. **Silent no-op under `from __future__ import annotations`** — dependency_injector cannot read `Provide[...]` from a stringified annotation and returns the function unpatched. The branding guard passed every test while doing nothing.
+2. **Admin autodiscovery beats DI wiring** — `@admin.register` constructs `SystemUserAdmin` before `DICoreConfig.ready()` wires the container, so its injected service was permanently `None`: **every** admin-created system user raised `ValueError`, independent of billing. A live production bug.
+
+**⚠️ Follow-up: sweep the codebase for both `@inject` patterns.** Neither is detectable by tests.
+
+Also: `resolve_branding` had to be **split** rather than gated — it also backs `validate_return_url`, so gating it wholesale would break the OAuth return flow for every downstream tenant of a reseller that downgraded off `white_label_branding`. And `_get_write_adapter_for_calendar` now **raises** rather than returning `None` (callers traced individually; the calendar webhook service is the one place where skipping the remote work is intended, and it catches explicitly — otherwise the provider gets a 500 and retries until the channel expires).
+
+**Gate-integrity note.** The implementation regressed `mypy` 305/57 → 309/60 and reported "net new: zero". Its `git stash` verification left the new **untracked** test files on disk, so it measured the phase against itself. **Use `git stash -u` or a clean checkout of the base branch when establishing a baseline.**
+
+**Gates** (re-run independently in the container): suite **4200 passed** (6b base 4148; +52); `mypy` **305 / 57** at baseline; `ruff` clean (493 files); `makemigrations --check` clean; `schema.yml` unchanged; 5 × `noqa: S106`, all test dummy credentials.
+
+**Carried forward from 6c:**
+- `ADVANCED_SCHEDULING` is a declared `Entitlement` with **no gate anywhere**. Recorded so it is not mistaken for covered.
+- `SystemUserAdmin`'s changelist raises `ImproperlyConfigured: QuerySet must be filtered by 'organization'` — pre-existing, unrelated.
+- The `@inject` sweep above.
+
 ## Current phase
 
-**Phase 6c — Enforce pre-paid limits: webhook subscriptions and API system users** (implementer Tier 2)
+**None — paused after Phase 6c for a human decision.** See "Stack depth" below.
 
-Base: `plan/billing-plans-and-limits/phase-6b` · Branch: `plan/billing-plans-and-limits/phase-6c`
+## Stack depth — needs a human call
 
-Closes the "no unmetered path" objective for pre-paid resources, and adds the boolean entitlement gates (`partner_api`, `external_calendar_google` / `external_calendar_microsoft`, `white_label_branding`) at the three chokepoints the plan names.
+Phases 6b ([#196](https://github.com/vintasoftware/vinta-schedule-api/pull/196)) and 6c ([#197](https://github.com/vintasoftware/vinta-schedule-api/pull/197)) are **open and not yet reviewed by a human**. Phases 1–5 and 6a are merged.
+
+Continuing to Phase 7 would stack a third unreviewed phase on top. Phase 7 (Meter event occurrences, Tier 4) introduces the post-paid metering model that Phases 8 and 13 build on, so a human review of 6b/6c that requires changes would force a rebase of everything above it.
 
 ⚠️ **Carry 6b's lesson forward.** Before guarding a creation path, write down which usage counter it feeds and check that any predicate the guard uses to decide what is "new" is the *same* predicate that counter counts with — ideally by literally reusing it from the queryset. Four defects in this plan have come from two predicates that were supposed to agree and did not, most recently one that let an entire provider's calendar list be created unmetered.
 
@@ -241,7 +274,6 @@ Closes the "no unmetered path" objective for pre-paid resources, and adds the bo
 
 | Phase | Title | Impl | Reviewer | Fixer |
 |---|---|---|---|---|
-| 6c | Enforce pre-paid limits: webhook subscriptions and API system users | 2 | — | — |
 | 7 | Meter event occurrences | 4 | 4 | — |
 | 8 | Enforce the post-paid allowance | 3 | — | — |
 | 9 | Upgrade, add-on purchase, and proration | 3 | 4 | — |

--- a/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
+++ b/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
@@ -230,6 +230,13 @@ Closes the "no unmetered path" objective for pre-paid resources, and adds the bo
 
 ⚠️ **Carry 6b's lesson forward.** Before guarding a creation path, write down which usage counter it feeds and check that any predicate the guard uses to decide what is "new" is the *same* predicate that counter counts with — ideally by literally reusing it from the queryset. Four defects in this plan have come from two predicates that were supposed to agree and did not, most recently one that let an entire provider's calendar list be created unmetered.
 
+**Carried forward from 6c:**
+
+- ⚠️ **`Entitlement.ADVANCED_SCHEDULING` is declared but ungated.** It is a member of the closed `Entitlement` set in `payments/billing_constants.py` and is seeded on both plans (`True` on `unlimited`, `False` on `free`), but **no code anywhere checks it**. Phase 6c gated the four entitlements its body names; this fifth one was out of scope. Recorded here so the "all entitlements are enforced" reading of 6c's acceptance is not made by mistake — an organization on a plan that omits `advanced_scheduling` is not restricted in any way today. Needs either a gate (its own phase) or removal from the enum.
+- **Entitlements now have two enforcement points for external calendars**, not one. `CalendarService.authenticate` gates the *authenticated account's* provider; `CalendarService._get_write_adapter_for_calendar` gates the *calendar's* provider, which can differ (an actor authenticated with Google writing to a Microsoft calendar owned by someone else). Anyone adding a third path that resolves a provider adapter must gate it too — "authenticate is the single chokepoint" is false and is pinned as false by `TestWriteAdapterProviderGate`.
+- **`resolve_branding` is deliberately split in two.** `resolve_branding_for_display` carries the `white_label_branding` gate and is for presentation callers; plain `resolve_branding` is ungated and is what `validate_return_url` reads, because gating an OAuth allowlist on a cosmetic entitlement turns a downgrade into an auth-flow lockout for a reseller's whole subtree. Do not merge them back.
+- **Test fixtures now provision subscriptions automatically.** `conftest.py`'s autouse `provision_default_subscription` gives every `Organization` created in a test the `unlimited` subscription production's `OrganizationService` would have given it — because `has_entitlement` fails closed on a plan-less organization and ~640 tests were building organizations production cannot produce. Modules that manage their own `Subscription` rows opt out with `@pytest.mark.no_auto_subscription`.
+
 ## Remaining phases
 
 | Phase | Title | Impl | Reviewer | Fixer |

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -2282,19 +2282,20 @@ class ExternalEventChangeRequestMutations:
             )
 
         # Authenticate the CalendarService and resolve the write adapter.
-        # Phase 6c: authenticate() raises OverLimitError when the organization lacks the
-        # entitlement for the calendar's provider (external_calendar_google /
-        # external_calendar_microsoft). Rendered via raise_over_limit_graphql_error (also
-        # rolls back the request transaction -- see that function's docstring for why
-        # that matters under ATOMIC_REQUESTS).
+        # Phase 6c: both of these raise OverLimitError when the organization lacks the
+        # relevant external-calendar entitlement -- authenticate() on the *authenticated
+        # account's* provider, _get_write_adapter_for_calendar() on the *calendar's*
+        # (they can differ; see that method's docstring). Rendered via
+        # raise_over_limit_graphql_error (also rolls back the request transaction -- see
+        # that function's docstring for why that matters under ATOMIC_REQUESTS).
         try:
             deps.calendar_service.authenticate(
                 account=owner_social_account,
                 organization=org,
             )
+            write_adapter = deps.calendar_service._get_write_adapter_for_calendar(calendar)
         except OverLimitError as exc:
             raise_over_limit_graphql_error(exc)
-        write_adapter = deps.calendar_service._get_write_adapter_for_calendar(calendar)
         if write_adapter is None:
             raise GraphQLError("Could not resolve a write adapter for the calendar's provider.")
 

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -2282,10 +2282,18 @@ class ExternalEventChangeRequestMutations:
             )
 
         # Authenticate the CalendarService and resolve the write adapter.
-        deps.calendar_service.authenticate(
-            account=owner_social_account,
-            organization=org,
-        )
+        # Phase 6c: authenticate() raises OverLimitError when the organization lacks the
+        # entitlement for the calendar's provider (external_calendar_google /
+        # external_calendar_microsoft). Rendered via raise_over_limit_graphql_error (also
+        # rolls back the request transaction -- see that function's docstring for why
+        # that matters under ATOMIC_REQUESTS).
+        try:
+            deps.calendar_service.authenticate(
+                account=owner_social_account,
+                organization=org,
+            )
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
         write_adapter = deps.calendar_service._get_write_adapter_for_calendar(calendar)
         if write_adapter is None:
             raise GraphQLError("Could not resolve a write adapter for the calendar's provider.")

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -168,6 +168,21 @@ _PROVIDER_ENTITLEMENTS: dict[str, str] = {
 }
 
 
+def _provider_for_account(account: object) -> str | None:
+    """The ``CalendarProvider`` an account authenticates against, or ``None`` when it
+    cannot be determined without resolving an adapter.
+
+    ``None`` is returned for a bare ``User``: which of that user's social accounts is
+    used is ``get_calendar_adapter_for_account``'s decision, so the caller has to gate
+    after resolution instead. Every other case is readable off the object.
+    """
+    if isinstance(account, GoogleCalendarServiceAccount):
+        return CalendarProvider.GOOGLE
+    if isinstance(account, User):
+        return None
+    return getattr(account, "provider", None)
+
+
 def _resolve_owner_membership_user_id(user: User, organization: Organization) -> int | None:
     """Resolve the membership-scoped owner id for a CalendarOwnership write.
 
@@ -224,6 +239,9 @@ class CalendarService(BaseCalendarService):
         self.external_event_change_request_service = external_event_change_request_service
         self.booking_policy_service = booking_policy_service
         self.entitlement_service = entitlement_service
+        # Set by authenticate(bypass_limits=True); disables every provider entitlement
+        # guard on this instance, not just the authenticate-time one.
+        self._bypass_entitlement_limits = False
         # Per-instance calendar lookup cache: keyed on (organization_id, id_or_external_id).
         # This replaces the @lru_cache approach which was keyed only on id/external_id and
         # could return a cached Calendar from a different organization when the service
@@ -406,6 +424,23 @@ class CalendarService(BaseCalendarService):
             }
         ), token.account
 
+    def _assert_provider_entitlement(self, provider: str | None) -> None:
+        """Raise ``OverLimitError`` if ``provider`` is gated and the organization is not
+        entitled to it.
+
+        Providers with no ``_PROVIDER_ENTITLEMENTS`` entry (INTERNAL, APPLE, ICS) are
+        ungated: the spec's closed ``Entitlement`` set only names Google and Microsoft.
+        A no-op when the service has no ``entitlement_service`` injected, or when
+        ``authenticate(bypass_limits=True)`` put this instance in bypass mode.
+        """
+        if self._bypass_entitlement_limits or self.entitlement_service is None:
+            return
+        entitlement_key = _PROVIDER_ENTITLEMENTS.get(provider) if provider else None
+        if entitlement_key is None or self.organization is None:
+            return
+        if not self.entitlement_service.has_entitlement(self.organization, entitlement_key):
+            raise OverLimitError.from_missing_entitlement(entitlement_key)
+
     def authenticate(
         self,
         account: "User | SocialAccount | GoogleCalendarServiceAccount",
@@ -420,14 +455,16 @@ class CalendarService(BaseCalendarService):
             ``CalendarOwnership``).
         :param organization: Calendar organization instance.
         :param bypass_limits: When True, skips the ``external_calendar_google`` /
-            ``external_calendar_microsoft`` entitlement guard below. Only management
-            commands and one-off repair scripts should pass this -- never a
-            request-handling path.
+            ``external_calendar_microsoft`` entitlement guard below, and every guard on
+            this service instance for the rest of its life (writes resolved through
+            ``_get_write_adapter_for_calendar`` included). Only management commands and
+            one-off repair scripts should pass this -- never a request-handling path.
         :raises OverLimitError: When the resolved account's provider is Google or
-            Microsoft and the organization lacks the matching entitlement. This is
-            the common chokepoint both connection paths flow through -- every caller
-            that authenticates a Google or Microsoft account, including calendar
-            sync, routes through here.
+            Microsoft and the organization lacks the matching entitlement. Every caller
+            that authenticates a Google or Microsoft account, including calendar sync,
+            routes through here -- but this is **not** the only enforcement point:
+            ``_get_write_adapter_for_calendar`` gates on the *calendar's* provider,
+            which can differ from the authenticated account's. See its docstring.
         """
         if isinstance(account, User):
             self.user_or_token = account
@@ -436,19 +473,23 @@ class CalendarService(BaseCalendarService):
         else:
             self.user_or_token = None
         self.organization = organization
+        self._bypass_entitlement_limits = bypass_limits
+
+        # Gate *before* `get_calendar_adapter_for_account` where the provider can be read
+        # off `account` without resolving an adapter. That call refreshes an expired
+        # access token while constructing the adapter -- an outbound provider call and a
+        # token mutation. Doing that work for a request we are about to reject with a 402
+        # is both wasteful and a side effect on data the caller has no entitlement to
+        # touch. The `User` branch is the exception: which social account it resolves to
+        # is `get_calendar_adapter_for_account`'s decision, so it can only be gated after.
+        early_provider = _provider_for_account(account)
+        if early_provider is not None:
+            self._assert_provider_entitlement(early_provider)
+
         self.calendar_adapter, self.account = self.get_calendar_adapter_for_account(account)
 
-        if not bypass_limits and self.entitlement_service is not None:
-            provider = (
-                CalendarProvider.GOOGLE
-                if isinstance(self.account, GoogleCalendarServiceAccount)
-                else getattr(self.account, "provider", None)
-            )
-            entitlement_key = _PROVIDER_ENTITLEMENTS.get(provider) if provider else None
-            if entitlement_key is not None and not self.entitlement_service.has_entitlement(
-                organization, entitlement_key
-            ):
-                raise OverLimitError.from_missing_entitlement(entitlement_key)
+        if early_provider is None:
+            self._assert_provider_entitlement(_provider_for_account(self.account))
 
         # Reset the per-instance calendar lookup cache whenever the auth context changes.
         # This ensures no stale cross-organization entries survive a re-authentication.
@@ -1263,6 +1304,31 @@ class CalendarService(BaseCalendarService):
         return self._get_bundle_service()._collect_bundle_attendees(child_calendars, event_data)
 
     def _get_write_adapter_for_calendar(self, calendar: Calendar) -> CalendarAdapter | None:
+        """Resolve the adapter to write ``calendar`` through, gated on the calendar's own
+        provider entitlement.
+
+        :raises OverLimitError: When ``calendar.provider`` is Google or Microsoft and the
+            organization lacks the matching entitlement.
+
+        **This is a second enforcement point, not a redundant one.** ``authenticate()``
+        gates the *authenticated account's* provider; this method resolves an adapter
+        from the *calendar's* provider, which need not be the same one. Concretely: an
+        organization entitled to ``external_calendar_google`` but not
+        ``external_calendar_microsoft`` has a Microsoft calendar ``C`` owned by a user who
+        holds a Microsoft ``SocialAccount``. An actor authenticates with their Google
+        account — ``authenticate()`` passes, correctly. Any write to ``C`` then reaches
+        the branch below, which resolves that owner and builds a **Microsoft** adapter via
+        the *static* ``get_calendar_adapter_for_account``, bypassing the instance the
+        authenticate-time gate ran against. Without this check that is unmetered,
+        ungated Microsoft traffic.
+
+        Raises rather than returning ``None``: several callers treat ``None`` as "no
+        external sync configured" and complete the local write silently
+        (``if write_adapter := ...``). Silently diverging local and provider state on a
+        billing decision is worse than a loud, recoverable 402.
+        """
+        self._assert_provider_entitlement(calendar.provider)
+
         # if the authenticated account doesn't own the calendar:
         if not self.account or not (
             (

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -139,7 +139,7 @@ from calendar_integration.services.type_guards import (
     is_initialized_or_authenticated_calendar_service,
 )
 from organizations.models import Organization, OrganizationMembership
-from payments.billing_constants import LimitedResource
+from payments.billing_constants import Entitlement, LimitedResource
 from payments.exceptions import OverLimitError
 from public_api.models import SystemUser
 from users.models import User
@@ -157,6 +157,15 @@ logger = logging.getLogger(__name__)
 
 # Sentinel for partial updates: distinguishes "omit capacity" from "explicit null"
 _UNCHANGED = object()
+
+# The boolean entitlement gating each external provider, checked in `authenticate()` --
+# the chokepoint both the Google and Microsoft connection paths flow through. Providers
+# with no entry (INTERNAL, APPLE, ICS) are ungated: the spec's `Entitlement` closed set
+# only names Google and Microsoft.
+_PROVIDER_ENTITLEMENTS: dict[str, str] = {
+    CalendarProvider.GOOGLE: Entitlement.EXTERNAL_CALENDAR_GOOGLE,
+    CalendarProvider.MICROSOFT: Entitlement.EXTERNAL_CALENDAR_MICROSOFT,
+}
 
 
 def _resolve_owner_membership_user_id(user: User, organization: Organization) -> int | None:
@@ -401,6 +410,7 @@ class CalendarService(BaseCalendarService):
         self,
         account: "User | SocialAccount | GoogleCalendarServiceAccount",
         organization: Organization,
+        bypass_limits: bool = False,
     ) -> None:
         """
         Authenticate the service with the provided account.
@@ -409,6 +419,15 @@ class CalendarService(BaseCalendarService):
             the owning ``User`` is used for record attribution (e.g.
             ``CalendarOwnership``).
         :param organization: Calendar organization instance.
+        :param bypass_limits: When True, skips the ``external_calendar_google`` /
+            ``external_calendar_microsoft`` entitlement guard below. Only management
+            commands and one-off repair scripts should pass this -- never a
+            request-handling path.
+        :raises OverLimitError: When the resolved account's provider is Google or
+            Microsoft and the organization lacks the matching entitlement. This is
+            the common chokepoint both connection paths flow through -- every caller
+            that authenticates a Google or Microsoft account, including calendar
+            sync, routes through here.
         """
         if isinstance(account, User):
             self.user_or_token = account
@@ -418,6 +437,18 @@ class CalendarService(BaseCalendarService):
             self.user_or_token = None
         self.organization = organization
         self.calendar_adapter, self.account = self.get_calendar_adapter_for_account(account)
+
+        if not bypass_limits and self.entitlement_service is not None:
+            provider = (
+                CalendarProvider.GOOGLE
+                if isinstance(self.account, GoogleCalendarServiceAccount)
+                else getattr(self.account, "provider", None)
+            )
+            entitlement_key = _PROVIDER_ENTITLEMENTS.get(provider) if provider else None
+            if entitlement_key is not None and not self.entitlement_service.has_entitlement(
+                organization, entitlement_key
+            ):
+                raise OverLimitError.from_missing_entitlement(entitlement_key)
 
         # Reset the per-instance calendar lookup cache whenever the auth context changes.
         # This ensures no stale cross-organization entries survive a re-authentication.

--- a/calendar_integration/services/calendar_webhook_service.py
+++ b/calendar_integration/services/calendar_webhook_service.py
@@ -83,6 +83,7 @@ from calendar_integration.services.type_guards import (
     is_authenticated_calendar_service,
     is_initialized_or_authenticated_calendar_service,
 )
+from payments.exceptions import OverLimitError
 
 
 if TYPE_CHECKING:
@@ -413,6 +414,20 @@ class CalendarWebhookService:
         except (ServiceNotAuthenticatedError, Calendar.DoesNotExist):
             # Calendar not found or not authenticated - we'll still record the webhook event
             pass
+        except OverLimitError as exc:
+            # The organization lost the calendar's provider entitlement. Unlike the
+            # interactive REST/GraphQL callers of _get_write_adapter_for_calendar (which
+            # keep the 402 -- a user asking to connect a calendar should be told why),
+            # this webhook caller has no user to tell: Google/Microsoft's server-to-server
+            # push has nowhere to route a 402 to, and would just retry against a 500 until
+            # the channel expires. Degrade to the static-validation fallback below and
+            # still record the event, mirroring _authenticate_or_skip's reasoning for the
+            # scheduled sync tasks.
+            logger.info(
+                "Skipping write-adapter resolution for webhook on calendar %s: %s",
+                calendar_external_id,
+                exc.as_error_body()["detail"],
+            )
 
         # Handle provider-specific validation/parsing
         # Use static validation if we don't have an authenticated adapter

--- a/calendar_integration/services/external_event_change_request_service.py
+++ b/calendar_integration/services/external_event_change_request_service.py
@@ -45,7 +45,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 from django.db import transaction
 from django.utils import timezone
 
-from dependency_injector.wiring import Provide, inject
+from dependency_injector.wiring import Provide
 from vintasend.constants import NotificationTypes
 from vintasend.services.notification_service import NotificationContextDict
 
@@ -91,13 +91,22 @@ class ExternalEventChangeRequestService:
     provider changes are intercepted under the ``CHANGE_REQUEST`` or
     ``FORBIDDEN`` policy.
 
-    Constructor arguments are DI-injected:
+    Constructor arguments are supplied by the DI container, which passes them
+    explicitly (see ``di_core/containers.py``) rather than through ``@inject``. There is
+    deliberately **no** ``@inject`` here: this module carries
+    ``from __future__ import annotations``, which stringifies the ``Annotated[...,
+    Provide[...]]`` markers ``@inject`` introspects at wiring time, making the decorator
+    a silent no-op (``dependency_injector`` emits ``DIWiringWarning`` and returns the
+    function unpatched). Leaving it on would imply a wiring mechanism that is not
+    running. See ``organizations.models.resolve_branding_for_display`` for the
+    deferred-container-import pattern used where injection is actually needed under
+    the same constraint.
+
     - ``audit_service``: emits audit trail entries for each state transition.
     - ``notification_service``: dispatches in-app notifications to eligible
       approvers when a new ``PENDING`` request is created.
     """
 
-    @inject
     def __init__(
         self,
         audit_service: Annotated[AuditService | None, Provide["audit_service"]] = None,

--- a/calendar_integration/tasks/calendar_sync_tasks.py
+++ b/calendar_integration/tasks/calendar_sync_tasks.py
@@ -20,7 +20,14 @@ logger = logging.getLogger(__name__)
 
 
 def _authenticate_or_skip(calendar_service, account, organization) -> bool:
-    """Authenticate the service, treating a missing provider entitlement as a **skip**.
+    """Authenticate the service, treating a missing provider entitlement at
+    authenticate-time as a **skip**.
+
+    Only wraps ``calendar_service.authenticate(...)``: the *account's* provider
+    entitlement gate. It does not, and cannot, catch the separate, calendar-scoped
+    gate on ``_get_write_adapter_for_calendar`` -- no caller in this module reaches
+    that method today, so the distinction is not yet observable, but a future task
+    that did would need its own guard around that call, not this one.
 
     Every task in this module is scheduled, not user-triggered. An organization whose
     plan omits `external_calendar_google` / `external_calendar_microsoft` would otherwise

--- a/calendar_integration/tasks/calendar_sync_tasks.py
+++ b/calendar_integration/tasks/calendar_sync_tasks.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Annotated, Literal
 
 from allauth.socialaccount.models import SocialAccount
@@ -11,7 +12,38 @@ from calendar_integration.models import (
 )
 from calendar_integration.services.calendar_service import CalendarService
 from organizations.models import Organization
+from payments.exceptions import OverLimitError
 from vinta_schedule_api.celery import app
+
+
+logger = logging.getLogger(__name__)
+
+
+def _authenticate_or_skip(calendar_service, account, organization) -> bool:
+    """Authenticate the service, treating a missing provider entitlement as a **skip**.
+
+    Every task in this module is scheduled, not user-triggered. An organization whose
+    plan omits `external_calendar_google` / `external_calendar_microsoft` would otherwise
+    turn each scheduled run into a hard task failure: these tasks declare no
+    `autoretry_for`, and `CELERY_TASK_ACKS_LATE=True` means a raising task is redelivered
+    and fails again, so a billing state that is *working as intended* would manufacture a
+    permanent stream of alarming failures.
+
+    "Not entitled to sync" is a legitimate terminal state for a sync run, so it is logged
+    and the task returns successfully. The org still cannot sync -- the guard did its job;
+    it just does not pretend the scheduler is broken. Interactive callers (REST/GraphQL)
+    keep the 402, since a user asking to connect a calendar should be told why it failed.
+    """
+    try:
+        calendar_service.authenticate(account=account, organization=organization)
+    except OverLimitError as exc:
+        logger.info(
+            "Skipping calendar sync for organization %s: %s",
+            organization.pk,
+            exc.as_error_body()["detail"],
+        )
+        return False
+    return True
 
 
 @app.task
@@ -48,7 +80,8 @@ def import_account_calendars_task(
 
     if not account:
         return
-    calendar_service.authenticate(account=account, organization=organization)
+    if not _authenticate_or_skip(calendar_service, account, organization):
+        return
     calendar_service.import_account_calendars(sync_after_import=sync_after_import)
 
 
@@ -90,7 +123,8 @@ def sync_calendar_task(
     if not account or not calendar_sync:
         return
 
-    calendar_service.authenticate(account=account, organization=organization)
+    if not _authenticate_or_skip(calendar_service, account, organization):
+        return
     calendar_service.sync_events(calendar_sync)
 
 
@@ -143,5 +177,6 @@ def import_organization_calendar_resources_task(
     if not account:
         return
 
-    calendar_service.authenticate(account=account, organization=organization)
+    if not _authenticate_or_skip(calendar_service, account, organization):
+        return
     calendar_service.import_organization_calendar_resources(import_workflow_state)

--- a/calendar_integration/tests/services/test_availability_limit_concurrency.py
+++ b/calendar_integration/tests/services/test_availability_limit_concurrency.py
@@ -47,6 +47,11 @@ from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
 from payments.services.entitlement_service import EntitlementService
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 BARRIER_TIMEOUT_SECONDS = 10
 THREAD_JOIN_TIMEOUT_SECONDS = 30
 # Long enough that a non-locking implementation reliably interleaves the two

--- a/calendar_integration/tests/services/test_calendar_limits.py
+++ b/calendar_integration/tests/services/test_calendar_limits.py
@@ -31,6 +31,11 @@ from payments.exceptions import OverLimitError
 from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 def _organization_with_limit(resource_key: str, limit_value: int | None) -> Organization:
     """A standalone (non-reseller) organization with a ceiling on ``resource_key``.
 

--- a/calendar_integration/tests/test_google_calendar_webhooks.py
+++ b/calendar_integration/tests/test_google_calendar_webhooks.py
@@ -7,8 +7,10 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 import pytest
+from model_bakery import baker
 
 from calendar_integration.constants import (
     CalendarProvider,
@@ -30,6 +32,8 @@ from calendar_integration.services.calendar_adapters.google_calendar_adapter imp
 )
 from calendar_integration.services.calendar_service import CalendarService
 from organizations.models import Organization
+from payments.billing_constants import BillingState, Entitlement
+from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
 
 
 @override_settings(GOOGLE_CLIENT_ID="test_client_id", GOOGLE_CLIENT_SECRET="test_client_secret")
@@ -492,3 +496,81 @@ class GoogleCalendarWebhookIntegrationTest(TestCase):
         args = mock_handle_webhook.call_args[0]
         assert args[0] == CalendarProvider.GOOGLE
         assert hasattr(args[1], "META")  # Check it's an HttpRequest object
+
+
+class GoogleCalendarWebhookOverLimitEntitlementTest(TestCase):
+    """Phase 6c BLOCKER: an ``OverLimitError`` raised by the entitlement-gated
+    ``_get_write_adapter_for_calendar`` must not 500 the webhook endpoint.
+
+    ``_get_write_adapter_for_calendar`` (the second, calendar-provider-scoped
+    entitlement gate) raises ``OverLimitError`` when the organization has lost the
+    calendar's provider entitlement. The webhook flow's only job on that path is to
+    fall back to static validation and still record the ``CalendarWebhookEvent`` --
+    exactly what it already does for ``ServiceNotAuthenticatedError`` /
+    ``Calendar.DoesNotExist``. Before the fix, ``OverLimitError`` was not in that
+    caught tuple, so it escaped to ``webhook_views.py``'s bare ``except Exception``
+    and turned into an HTTP 500, with no ``CalendarWebhookEvent`` row recorded --
+    exactly what Google/Microsoft retry against until the channel expires.
+    """
+
+    # This test builds its own Subscription row (OneToOne with Organization), so it
+    # opts out of conftest's autouse `provision_default_subscription`.
+    pytestmark = pytest.mark.no_auto_subscription
+
+    def setUp(self):
+        self.organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+        now = timezone.now()
+        subscription = baker.make(
+            Subscription,
+            organization=self.organization,
+            plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+            billing_state=BillingState.FREE,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+        )
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=Entitlement.EXTERNAL_CALENDAR_GOOGLE,
+            is_enabled=False,
+        )
+        self.calendar = Calendar.objects.create(
+            name="Entitlement Test Calendar",
+            organization=self.organization,
+            provider=CalendarProvider.GOOGLE,
+            external_id="entitlement-test-calendar-id",
+        )
+        self.webhook_url = reverse(
+            "calendar_integration:google_webhook", kwargs={"organization_id": self.organization.id}
+        )
+
+    @patch.object(CalendarService, "_get_calendar_by_external_id")
+    def test_over_limit_error_from_write_adapter_does_not_500(self, mock_get_calendar):
+        """``_get_calendar_by_external_id`` is stubbed to return the calendar
+        directly: a real incoming webhook can't authenticate the facade (there is
+        no user session on a provider's server-to-server push), so this lookup
+        already always raises ``ServiceNotAuthenticatedError`` today -- a case the
+        pre-existing ``except`` clause already handles and is not what this test is
+        about. Stubbing only this call isolates the actual defect: with a real
+        (unmocked) calendar looked up, ``_get_write_adapter_for_calendar`` runs for
+        real against the real, container-wired ``entitlement_service`` and is what
+        raises the ``OverLimitError`` this test asserts does not escape as a 500.
+        """
+        mock_get_calendar.return_value = self.calendar
+
+        headers = {
+            "HTTP_X_GOOG_CHANNEL_ID": "test-channel-id",
+            "HTTP_X_GOOG_RESOURCE_ID": "test-resource-id",
+            "HTTP_X_GOOG_RESOURCE_URI": (
+                "https://www.googleapis.com/calendar/v3/calendars/"
+                "entitlement-test-calendar-id/events"
+            ),
+            "HTTP_X_GOOG_RESOURCE_STATE": "exists",
+            "HTTP_X_GOOG_CHANNEL_TOKEN": "test-token",
+        }
+
+        response = self.client.post(self.webhook_url, **headers)
+
+        assert response.status_code != 500
+        assert response.status_code == 200
+        assert CalendarWebhookEvent.objects.filter(organization=self.organization).exists()

--- a/calendar_integration/tests/test_sync_limit_enforcement.py
+++ b/calendar_integration/tests/test_sync_limit_enforcement.py
@@ -23,6 +23,7 @@ directly -- the same seam identified there -- proving:
 import datetime
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from django.utils import timezone
 
 import pytest
@@ -652,6 +653,17 @@ class TestSyncPathIsWiredThroughDI:
         assert isinstance(sync_service._context.entitlement_service, EntitlementService)
 
 
+# The Google adapter refuses to construct without these. Both tests below pass a
+# bare `User` to `authenticate()`, so -- per `_provider_for_account`'s docstring --
+# the entitlement gate can only run *after* `get_calendar_adapter_for_account`
+# resolves and builds the adapter, exactly like the production path once
+# credentials are configured.
+_with_google_credentials = override_settings(
+    GOOGLE_CLIENT_ID="test-google-client-id",
+    GOOGLE_CLIENT_SECRET="test-google-client-secret",  # noqa: S106 - dummy value, not a credential
+)
+
+
 @pytest.mark.django_db
 class TestSyncTasksSkipRatherThanFailOnMissingEntitlement:
     """Phase 6c: an unentitled organization must make scheduled syncs a **skip**, not a
@@ -697,6 +709,7 @@ class TestSyncTasksSkipRatherThanFailOnMissingEntitlement:
         )
         return organization, account
 
+    @_with_google_credentials
     def test_import_account_calendars_task_returns_instead_of_raising(self):
         from calendar_integration.tasks.calendar_sync_tasks import import_account_calendars_task
 
@@ -712,6 +725,7 @@ class TestSyncTasksSkipRatherThanFailOnMissingEntitlement:
 
         imported.assert_not_called()
 
+    @_with_google_credentials
     def test_sync_calendar_task_returns_instead_of_raising(self):
         from calendar_integration.tasks.calendar_sync_tasks import sync_calendar_task
 

--- a/calendar_integration/tests/test_sync_limit_enforcement.py
+++ b/calendar_integration/tests/test_sync_limit_enforcement.py
@@ -32,19 +32,35 @@ from model_bakery import baker
 from calendar_integration.constants import (
     CalendarOrganizationResourceImportStatus,
     CalendarProvider,
+    CalendarSyncStatus,
     CalendarType,
     CalendarVisibility,
 )
-from calendar_integration.models import Calendar, CalendarOrganizationResourcesImport
+from calendar_integration.models import (
+    Calendar,
+    CalendarOrganizationResourcesImport,
+    CalendarSync,
+)
 from calendar_integration.services.calendar_service import CalendarService
 from calendar_integration.services.calendar_service_context import CalendarServiceContext
 from calendar_integration.services.calendar_sync_service import CalendarSyncService
 from calendar_integration.services.dataclasses import CalendarResourceData
 from organizations.models import Organization
-from payments.billing_constants import BillingState, LimitedResource, LimitKind
-from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
+from payments.billing_constants import BillingState, Entitlement, LimitedResource, LimitKind
+from payments.models import (
+    BillingPlan,
+    Subscription,
+    SubscriptionEntitlement,
+    SubscriptionPlanLimit,
+)
 from payments.services.entitlement_service import EntitlementService
+from payments.services.subscription_service import SubscriptionService
 from users.models import Profile, User
+
+
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
 
 
 class FakeHost:
@@ -599,6 +615,12 @@ class TestSyncPathIsWiredThroughDI:
 
     def test_authenticated_facade_gives_the_sync_service_an_entitlement_service(self):
         organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+        # This module opts out of the autouse subscription fixture, and `authenticate()`
+        # gates on `external_calendar_google` — which fails closed without a
+        # subscription. Provision the same `unlimited` subscription production would.
+        SubscriptionService().create_subscription_for_organization(
+            organization, plan=BillingPlan.objects.get(slug="unlimited")
+        )
         user = User.objects.create_user(email="di-sync@example.com", password="pw")  # noqa: S106
         Profile.objects.create(user=user)
         account = SocialAccount.objects.create(
@@ -628,3 +650,93 @@ class TestSyncPathIsWiredThroughDI:
             sync_service = service._get_sync_service()
 
         assert isinstance(sync_service._context.entitlement_service, EntitlementService)
+
+
+@pytest.mark.django_db
+class TestSyncTasksSkipRatherThanFailOnMissingEntitlement:
+    """Phase 6c: an unentitled organization must make scheduled syncs a **skip**, not a
+    task failure.
+
+    These tasks are scheduled, declare no ``autoretry_for``, and run under
+    ``CELERY_TASK_ACKS_LATE=True`` -- so letting ``OverLimitError`` escape would turn a
+    billing state that is working exactly as intended into a permanent stream of hard
+    task failures and redeliveries. Interactive callers (REST/GraphQL) keep the 402;
+    only the scheduled path degrades to a logged skip.
+
+    Confirmed to fail when ``_authenticate_or_skip`` is replaced by a bare
+    ``calendar_service.authenticate(...)``.
+    """
+
+    def _unentitled_org_and_account(self):
+        organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+        now = timezone.now()
+        subscription = baker.make(
+            Subscription,
+            organization=organization,
+            plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+            billing_state=BillingState.FREE,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+        )
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=Entitlement.EXTERNAL_CALENDAR_GOOGLE,
+            is_enabled=False,
+        )
+        user = User.objects.create_user(email="skip-sync@example.com", password="pw")  # noqa: S106
+        Profile.objects.create(user=user)
+        account = SocialAccount.objects.create(
+            user=user, provider=CalendarProvider.GOOGLE, uid="skip-12345"
+        )
+        SocialToken.objects.create(
+            account=account,
+            token="access",  # noqa: S106
+            token_secret="refresh",  # noqa: S106
+            expires_at=timezone.now() + datetime.timedelta(hours=1),
+        )
+        return organization, account
+
+    def test_import_account_calendars_task_returns_instead_of_raising(self):
+        from calendar_integration.tasks.calendar_sync_tasks import import_account_calendars_task
+
+        organization, account = self._unentitled_org_and_account()
+
+        # No exception, and the task never reaches import_account_calendars().
+        with patch.object(CalendarService, "import_account_calendars") as imported:
+            import_account_calendars_task(
+                account_type="social_account",
+                account_id=account.id,
+                organization_id=organization.id,
+            )
+
+        imported.assert_not_called()
+
+    def test_sync_calendar_task_returns_instead_of_raising(self):
+        from calendar_integration.tasks.calendar_sync_tasks import sync_calendar_task
+
+        organization, account = self._unentitled_org_and_account()
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.GOOGLE,
+            external_id="skip-cal-1",
+        )
+        calendar_sync = baker.make(
+            CalendarSync,
+            organization=organization,
+            calendar=calendar,
+            status=CalendarSyncStatus.NOT_STARTED,
+            start_datetime=timezone.now(),
+            end_datetime=timezone.now() + datetime.timedelta(days=1),
+        )
+
+        with patch.object(CalendarService, "sync_events") as synced:
+            sync_calendar_task(
+                account_type="social_account",
+                account_id=account.id,
+                calendar_sync_id=calendar_sync.id,
+                organization_id=organization.id,
+            )
+
+        synced.assert_not_called()

--- a/conftest.py
+++ b/conftest.py
@@ -106,6 +106,109 @@ def mock_external_calendar_clients(monkeypatch):
     )
 
 
+def _reseed_default_billing_plan():
+    """Recreate the ``unlimited`` plan that migration ``0007_seed_billing_plans`` seeds.
+
+    ``@pytest.mark.django_db(transaction=True)`` tests run against a real
+    ``TransactionTestCase``, which *flushes* every table afterwards and (without
+    ``serialized_rollback``) does not restore data created by data migrations. So the
+    seeded plan catalog disappears for every test that runs after the first transactional
+    one, and any organization created from then on has no default plan to land on.
+
+    Keep the shape in sync with ``payments/migrations/0007_seed_billing_plans.py``: a
+    ``PlanLimit`` row for **every** ``LimitedResource`` (``assert_plan_is_complete``
+    refuses a plan that omits one) with a NULL ceiling, and every ``Entitlement`` granted.
+    """
+    from payments.billing_constants import Entitlement, LimitedResource, LimitKind
+    from payments.models import BillingPlan, PlanEntitlement, PlanLimit
+
+    postpaid = {LimitedResource.EVENT_OCCURRENCES}
+    plan, _ = BillingPlan.objects.update_or_create(
+        slug="unlimited",
+        defaults={
+            "name": "Unlimited",
+            "is_active": True,
+            "is_default_for_new_organizations": True,
+            "monthly_price": 0,
+            "annual_price": None,
+            "currency": "USD",
+            "grace_period_days": None,
+        },
+    )
+    for resource_key in LimitedResource.values:
+        PlanLimit.objects.update_or_create(
+            plan=plan,
+            resource_key=resource_key,
+            defaults={
+                "limit_value": None,
+                "kind": (LimitKind.POSTPAID if resource_key in postpaid else LimitKind.PREPAID),
+                "overage_unit_price": None,
+            },
+        )
+    for entitlement_key in Entitlement.values:
+        PlanEntitlement.objects.update_or_create(
+            plan=plan, entitlement_key=entitlement_key, defaults={"is_enabled": True}
+        )
+    return plan
+
+
+@pytest.fixture(autouse=True)
+def provision_default_subscription(request):
+    """Give every ``Organization`` created during a test the ``Subscription`` production
+    would have given it.
+
+    Production organizations are created through ``OrganizationService``, which calls
+    ``SubscriptionService.create_subscription_for_organization`` — so Phase 4's "no
+    plan-less state" invariant holds for every billing root, and every one of them lands
+    on the seeded ``unlimited`` plan (``is_default_for_new_organizations=True``), whose
+    ``_sync_entitlements`` writes every entitlement enabled. Tests that build an
+    ``Organization`` with ``baker.make`` bypass that service and produce an organization
+    in a state production cannot reach: no ``Subscription`` at all.
+
+    ``EntitlementService.has_entitlement`` fails **closed** on that state, deliberately
+    (see its docstring): for a boolean gate, "we don't know" resolving to *granted* would
+    hand paid features to exactly the organizations whose billing state is corrupt. So the
+    plan-less fixture — not the production semantics — is what has to change, and this is
+    that change applied once instead of in every fixture in the suite.
+
+    Reseller children are skipped by ``create_subscription_for_organization`` itself (they
+    pool against their billing root), so this stays consistent with ``resolve_billing_root``.
+
+    Opt out with ``@pytest.mark.no_auto_subscription`` when a test builds its own
+    ``Subscription`` — ``Subscription.organization`` is a ``OneToOneField``, so a second
+    row raises ``IntegrityError`` — or when it deliberately exercises the plan-less state.
+    """
+    if request.node.get_closest_marker("no_auto_subscription"):
+        yield
+        return
+
+    from django.db.models.signals import post_save
+
+    from organizations.models import Organization
+
+    def _provision(sender, instance, created, raw=False, **kwargs):
+        if not created or raw:
+            return
+        from payments.exceptions import NoDefaultBillingPlanError
+        from payments.services.subscription_service import SubscriptionService
+
+        try:
+            SubscriptionService().create_subscription_for_organization(instance)
+        except NoDefaultBillingPlanError:
+            _reseed_default_billing_plan()
+            SubscriptionService().create_subscription_for_organization(instance)
+
+    post_save.connect(
+        _provision, sender=Organization, dispatch_uid="conftest_provision_default_subscription"
+    )
+    try:
+        yield
+    finally:
+        post_save.disconnect(
+            sender=Organization, dispatch_uid="conftest_provision_default_subscription"
+        )
+
+
 @pytest.fixture
 def user_password():
     from users.factories import DEFAULT_TEST_USER_PASSWORD

--- a/conftest.py
+++ b/conftest.py
@@ -189,14 +189,22 @@ def provision_default_subscription(request):
     def _provision(sender, instance, created, raw=False, **kwargs):
         if not created or raw:
             return
+        # Deferred import: `di_core.containers.container` is only *assigned* in
+        # `DICoreConfig.ready()` -- a module-level import binds `None` forever. The
+        # container-built service is what production and the rest of this phase's
+        # tests use (see e.g. `public_api/tests/test_system_user_limits.py`'s
+        # `service` fixture and `payments/tests/test_prepaid_resource_coverage.py`'s
+        # `_container()` helper) rather than a hand-constructed one.
+        from di_core.containers import container
         from payments.exceptions import NoDefaultBillingPlanError
-        from payments.services.subscription_service import SubscriptionService
 
+        assert container is not None, "DI container is only assigned in DICoreConfig.ready()"
+        subscription_service = container.subscription_service()
         try:
-            SubscriptionService().create_subscription_for_organization(instance)
+            subscription_service.create_subscription_for_organization(instance)
         except NoDefaultBillingPlanError:
             _reseed_default_billing_plan()
-            SubscriptionService().create_subscription_for_organization(instance)
+            subscription_service.create_subscription_for_organization(instance)
 
     post_save.connect(
         _provision, sender=Organization, dispatch_uid="conftest_provision_default_subscription"

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -153,6 +153,7 @@ class AppContainer(containers.DeclarativeContainer):
 
     webhook_service = providers.Factory(
         WebhookService,
+        entitlement_service=entitlement_service,
     )
 
     webhook_calendar_side_effects_service = providers.Factory(
@@ -226,6 +227,7 @@ class AppContainer(containers.DeclarativeContainer):
     public_api_auth_service = providers.Factory(
         PublicAPIAuthService,
         audit_service=audit_service,
+        entitlement_service=entitlement_service,
     )
 
     consent_service = providers.Factory(

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -19,6 +19,7 @@ from organizations.managers import (
     OrganizationInvitationManager,
     OrganizationMembershipManager,
 )
+from payments.billing_constants import Entitlement
 
 
 if TYPE_CHECKING:
@@ -518,13 +519,45 @@ def resolve_branding(org: Organization) -> OrganizationBranding | None:
 
     If no reseller ancestor exists, returns None (vinta default branding applies).
 
+    Gated on the ``white_label_branding`` entitlement (resolved at the reseller's own
+    billing root, which may differ from the branding root when the reseller itself
+    pools against a grandparent -- see ``payments.services.subscription_service.
+    resolve_billing_root``). A reseller whose plan does not grant the entitlement is
+    treated identically to one with no branding row: every caller already falls back
+    to the vinta default in that case (``branding_for_tenant``'s ``_vinta_default_branding()``,
+    ``validate_return_url``'s not-allowed shape, ``notification_contexts``'s default
+    sender), so revoking the entitlement degrades gracefully rather than erroring.
+
+    The ``EntitlementService`` is pulled from the DI container directly (a deferred,
+    function-body-local import) rather than via ``@inject``/``Provide[...]``:
+    ``organizations/models.py`` carries ``from __future__ import annotations``, which
+    stringifies every annotation in the module, including the ``Annotated[...,
+    Provide[...]]`` marker ``@inject`` needs to introspect at wiring time. Decorating
+    this function with ``@inject`` under that combination is a *silent* no-op --
+    ``dependency_injector`` emits a ``DIWiringWarning`` and returns the function
+    unpatched, so the parameter would always take its default and the guard below
+    would never run. Precedent for the deferred-import pattern instead: the
+    ``di_container`` fixture in the root ``conftest.py``, which imports ``container``
+    the same way for the same reason (a module-level import would bind ``None``,
+    since the container is only assigned in ``DICoreConfig.ready()`` after import
+    time).
+
     Args:
         org: The Organization instance to resolve branding for.
 
     Returns:
-        The OrganizationBranding row of the reseller ancestor, or None if unset/no reseller.
+        The OrganizationBranding row of the reseller ancestor, or None if unset, no
+        reseller, or the reseller's plan does not grant ``white_label_branding``.
     """
     branding_root = org.get_branding_root()
     if branding_root is None:
+        return None
+
+    from di_core.containers import container
+
+    entitlement_service = container.entitlement_service() if container is not None else None
+    if entitlement_service is not None and not entitlement_service.has_entitlement(
+        branding_root, Entitlement.WHITE_LABEL_BRANDING
+    ):
         return None
     return getattr(branding_root, "branding", None)

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -20,6 +20,7 @@ from organizations.managers import (
     OrganizationMembershipManager,
 )
 from payments.billing_constants import Entitlement
+from payments.entitlement_cache import has_entitlement_cached
 
 
 if TYPE_CHECKING:
@@ -519,14 +520,42 @@ def resolve_branding(org: Organization) -> OrganizationBranding | None:
 
     If no reseller ancestor exists, returns None (vinta default branding applies).
 
-    Gated on the ``white_label_branding`` entitlement (resolved at the reseller's own
-    billing root, which may differ from the branding root when the reseller itself
-    pools against a grandparent -- see ``payments.services.subscription_service.
-    resolve_billing_root``). A reseller whose plan does not grant the entitlement is
-    treated identically to one with no branding row: every caller already falls back
-    to the vinta default in that case (``branding_for_tenant``'s ``_vinta_default_branding()``,
-    ``validate_return_url``'s not-allowed shape, ``notification_contexts``'s default
-    sender), so revoking the entitlement degrades gracefully rather than erroring.
+    **Deliberately ungated.** The ``white_label_branding`` entitlement is applied by
+    ``resolve_branding_for_display`` instead, because not every caller of this function
+    is presenting branding. ``public_api.queries.validate_return_url`` reads
+    ``return_url_allowlist`` off the row to answer whether an OAuth return URL is
+    permitted — an **auth-flow** decision, not a cosmetic one. Gating that would mean a
+    reseller downgrading off a cosmetic entitlement silently breaks the OAuth return
+    flow for every tenant underneath it, which is a lockout, not a downgrade.
+
+    Args:
+        org: The Organization instance to resolve branding for.
+
+    Returns:
+        The OrganizationBranding row of the reseller ancestor, or None if unset/no reseller.
+    """
+    branding_root = org.get_branding_root()
+    if branding_root is None:
+        return None
+    return getattr(branding_root, "branding", None)
+
+
+def resolve_branding_for_display(org: Organization) -> OrganizationBranding | None:
+    """``resolve_branding``, gated on the ``white_label_branding`` entitlement.
+
+    Use this for every **presentation** caller — anything that renders the reseller's
+    app name, logo, colors, or support address (``branding_for_tenant``,
+    ``organizations.notification_contexts``). Use plain ``resolve_branding`` when the
+    row is being read for a non-cosmetic decision, i.e. ``validate_return_url``'s
+    allowlist check.
+
+    The entitlement is resolved at the reseller's own billing root, which may differ
+    from the branding root when the reseller itself pools against a grandparent — see
+    ``payments.services.subscription_service.resolve_billing_root``. A reseller whose
+    plan does not grant the entitlement is treated identically to one with no branding
+    row: every presentation caller already falls back to the vinta default in that case
+    (``branding_for_tenant``'s ``_vinta_default_branding()``, ``notification_contexts``'s
+    default sender), so revoking degrades gracefully rather than erroring.
 
     The ``EntitlementService`` is pulled from the DI container directly (a deferred,
     function-body-local import) rather than via ``@inject``/``Provide[...]``:
@@ -542,12 +571,10 @@ def resolve_branding(org: Organization) -> OrganizationBranding | None:
     since the container is only assigned in ``DICoreConfig.ready()`` after import
     time).
 
-    Args:
-        org: The Organization instance to resolve branding for.
-
-    Returns:
-        The OrganizationBranding row of the reseller ancestor, or None if unset, no
-        reseller, or the reseller's plan does not grant ``white_label_branding``.
+    Fails **closed** when the container itself is unavailable, matching
+    ``PublicApiSystemUserMiddleware._has_partner_api_entitlement`` on the identical
+    condition: an unresolvable entitlement service denies. Here that costs a reseller
+    its logo until DI is repaired, which is the cheap direction to be wrong in.
     """
     branding_root = org.get_branding_root()
     if branding_root is None:
@@ -555,9 +582,10 @@ def resolve_branding(org: Organization) -> OrganizationBranding | None:
 
     from di_core.containers import container
 
-    entitlement_service = container.entitlement_service() if container is not None else None
-    if entitlement_service is not None and not entitlement_service.has_entitlement(
-        branding_root, Entitlement.WHITE_LABEL_BRANDING
+    if container is None:
+        return None
+    if not has_entitlement_cached(
+        container.entitlement_service(), branding_root, Entitlement.WHITE_LABEL_BRANDING
     ):
         return None
     return getattr(branding_root, "branding", None)

--- a/organizations/notification_contexts.py
+++ b/organizations/notification_contexts.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from vintasend.exceptions import NotificationContextGenerationError
 from vintasend.services.notification_service import register_context
 
-from organizations.models import OrganizationInvitation, resolve_branding
+from organizations.models import OrganizationInvitation, resolve_branding_for_display
 
 
 # Vinta Schedule default branding values (used when no reseller branding is configured)
@@ -50,8 +50,10 @@ def organization_invitation_context(
         invited_by_name = f"{first_name} {last_name}"
 
     # Resolve branding: walks to the nearest reseller ancestor and uses its branding row.
-    # If no reseller ancestor or no branding row, returns None → vinta defaults apply.
-    branding_row = resolve_branding(invitation.organization)
+    # If no reseller ancestor, no branding row, or no `white_label_branding` entitlement,
+    # returns None → vinta defaults apply. This is a presentation caller (the invitation
+    # email's app name / logo / colors / support address), so it uses the gated variant.
+    branding_row = resolve_branding_for_display(invitation.organization)
 
     # Build the branding context dict with resolved values or vinta defaults.
     branding_context = {

--- a/organizations/tests/services/test_invitation_limits.py
+++ b/organizations/tests/services/test_invitation_limits.py
@@ -23,6 +23,11 @@ from payments.exceptions import OverLimitError
 from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 def _organization_with_seat_limit(
     seat_limit: int, existing_active_members: int = 0
 ) -> Organization:

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -1,9 +1,15 @@
 """Tests for OrganizationBranding model and resolve_branding function (Phase 6)."""
 
+import datetime
+
+from django.utils import timezone
+
 import pytest
 from model_bakery import baker
 
 from organizations.models import Organization, OrganizationBranding, resolve_branding
+from payments.billing_constants import BillingState, Entitlement
+from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
 
 
 @pytest.mark.django_db
@@ -108,3 +114,81 @@ class TestResolveBranding:
 
         # Should only have one OrganizationBranding row for this org
         assert OrganizationBranding.objects.filter(organization=reseller).count() == 1
+
+
+def _reseller_with_entitlement(entitlement_key: str, is_enabled: bool) -> Organization:
+    """A reseller organization whose subscription carries an explicit
+    ``SubscriptionEntitlement`` row for ``entitlement_key``."""
+    reseller = baker.make(Organization, can_invite_organizations=True)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=reseller,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionEntitlement,
+        subscription=subscription,
+        entitlement_key=entitlement_key,
+        is_enabled=is_enabled,
+    )
+    return reseller
+
+
+@pytest.mark.django_db
+class TestResolveBrandingEntitlementGate:
+    """Phase 6c: ``white_label_branding`` gates branding resolution.
+
+    A reseller whose plan does not grant the entitlement is treated identically
+    to one with no branding row at all -- every caller of ``resolve_branding``
+    already falls back to the vinta default in that case, so this degrades
+    gracefully rather than erroring.
+    """
+
+    def test_branding_is_hidden_when_the_entitlement_is_disabled(self):
+        reseller = _reseller_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=False)
+        baker.make(OrganizationBranding, organization=reseller)
+
+        assert resolve_branding(reseller) is None
+
+    def test_branding_is_hidden_when_the_entitlement_row_is_missing(self):
+        """No row at all is how a revoked grant is represented -- same outcome as
+        an explicit ``is_enabled=False`` row."""
+        reseller = baker.make(Organization, can_invite_organizations=True)
+        now = timezone.now()
+        baker.make(
+            Subscription,
+            organization=reseller,
+            plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+            billing_state=BillingState.FREE,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+        )
+        baker.make(OrganizationBranding, organization=reseller)
+
+        assert resolve_branding(reseller) is None
+
+    def test_branding_is_returned_when_the_entitlement_is_enabled(self):
+        reseller = _reseller_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=True)
+        branding = baker.make(OrganizationBranding, organization=reseller)
+
+        result = resolve_branding(reseller)
+        assert result is not None
+        assert result.id == branding.id
+
+    def test_unlimited_plan_reseller_is_never_blocked(self):
+        """The rollout's kill switch: every organization is on ``unlimited`` until
+        deliberately migrated, so this must see byte-for-byte unchanged behavior."""
+        from payments.services.subscription_service import SubscriptionService
+
+        reseller = baker.make(Organization, can_invite_organizations=True)
+        plan = BillingPlan.objects.get(slug="unlimited")
+        SubscriptionService().create_subscription_for_organization(reseller, plan=plan)
+        branding = baker.make(OrganizationBranding, organization=reseller)
+
+        result = resolve_branding(reseller)
+        assert result is not None
+        assert result.id == branding.id

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -7,9 +7,19 @@ from django.utils import timezone
 import pytest
 from model_bakery import baker
 
-from organizations.models import Organization, OrganizationBranding, resolve_branding
+from organizations.models import (
+    Organization,
+    OrganizationBranding,
+    resolve_branding,
+    resolve_branding_for_display,
+)
 from payments.billing_constants import BillingState, Entitlement
 from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
+
+
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
 
 
 @pytest.mark.django_db
@@ -139,20 +149,23 @@ def _reseller_with_entitlement(entitlement_key: str, is_enabled: bool) -> Organi
 
 
 @pytest.mark.django_db
-class TestResolveBrandingEntitlementGate:
-    """Phase 6c: ``white_label_branding`` gates branding resolution.
+class TestResolveBrandingForDisplayEntitlementGate:
+    """Phase 6c: ``white_label_branding`` gates branding resolution for *presentation*.
 
-    A reseller whose plan does not grant the entitlement is treated identically
-    to one with no branding row at all -- every caller of ``resolve_branding``
-    already falls back to the vinta default in that case, so this degrades
-    gracefully rather than erroring.
+    A reseller whose plan does not grant the entitlement is treated identically to one
+    with no branding row at all -- every presentation caller already falls back to the
+    vinta default in that case, so this degrades gracefully rather than erroring.
+
+    The gate lives on ``resolve_branding_for_display``, not on ``resolve_branding``:
+    ``validate_return_url`` reads the same row to make an auth-flow decision and must
+    not be gated. ``TestResolveBrandingIsUngated`` below pins that split.
     """
 
     def test_branding_is_hidden_when_the_entitlement_is_disabled(self):
         reseller = _reseller_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=False)
         baker.make(OrganizationBranding, organization=reseller)
 
-        assert resolve_branding(reseller) is None
+        assert resolve_branding_for_display(reseller) is None
 
     def test_branding_is_hidden_when_the_entitlement_row_is_missing(self):
         """No row at all is how a revoked grant is represented -- same outcome as
@@ -169,13 +182,22 @@ class TestResolveBrandingEntitlementGate:
         )
         baker.make(OrganizationBranding, organization=reseller)
 
-        assert resolve_branding(reseller) is None
+        assert resolve_branding_for_display(reseller) is None
+
+    def test_branding_is_hidden_when_the_reseller_has_no_subscription(self):
+        """``has_entitlement`` fails closed on a plan-less organization, and this
+        caller inherits that. Cosmetic degradation, not a lockout -- which is exactly
+        why the *ungated* ``resolve_branding`` exists for the allowlist reader."""
+        reseller = baker.make(Organization, can_invite_organizations=True)
+        baker.make(OrganizationBranding, organization=reseller)
+
+        assert resolve_branding_for_display(reseller) is None
 
     def test_branding_is_returned_when_the_entitlement_is_enabled(self):
         reseller = _reseller_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=True)
         branding = baker.make(OrganizationBranding, organization=reseller)
 
-        result = resolve_branding(reseller)
+        result = resolve_branding_for_display(reseller)
         assert result is not None
         assert result.id == branding.id
 
@@ -187,6 +209,38 @@ class TestResolveBrandingEntitlementGate:
         reseller = baker.make(Organization, can_invite_organizations=True)
         plan = BillingPlan.objects.get(slug="unlimited")
         SubscriptionService().create_subscription_for_organization(reseller, plan=plan)
+        branding = baker.make(OrganizationBranding, organization=reseller)
+
+        result = resolve_branding_for_display(reseller)
+        assert result is not None
+        assert result.id == branding.id
+
+
+@pytest.mark.django_db
+class TestResolveBrandingIsUngated:
+    """``resolve_branding`` must stay entitlement-free.
+
+    ``public_api.queries.validate_return_url`` reads ``return_url_allowlist`` off this
+    row to decide whether an OAuth return URL may be honoured. If the cosmetic
+    ``white_label_branding`` entitlement gated it, a reseller downgrading off that
+    entitlement would return ``{allowed: False, sanitized_url: None}`` for every tenant
+    underneath it -- breaking the OAuth return flow across the whole subtree. An
+    auth-flow lockout caused by a billing change to a logo is not an acceptable
+    degradation, so these two resolvers are deliberately separate functions.
+    """
+
+    def test_returns_the_row_even_without_the_entitlement(self):
+        reseller = _reseller_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=False)
+        branding = baker.make(OrganizationBranding, organization=reseller)
+
+        result = resolve_branding(reseller)
+        assert result is not None
+        assert result.id == branding.id
+        # ... and the gated sibling does hide it, so the split is real, not incidental.
+        assert resolve_branding_for_display(reseller) is None
+
+    def test_returns_the_row_for_a_reseller_with_no_subscription(self):
+        reseller = baker.make(Organization, can_invite_organizations=True)
         branding = baker.make(OrganizationBranding, organization=reseller)
 
         result = resolve_branding(reseller)

--- a/organizations/tests/test_seat_enforcement.py
+++ b/organizations/tests/test_seat_enforcement.py
@@ -44,6 +44,11 @@ from public_api.models import ResourceAccess
 from public_api.services import PublicAPIAuthService
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 SHARED_OVER_LIMIT_BODY = {
     "detail": "Organization is at its limit for organization members.",
     "code": "limit_exceeded",

--- a/organizations/tests/test_seat_enforcement.py
+++ b/organizations/tests/test_seat_enforcement.py
@@ -31,9 +31,14 @@ from organizations.models import (
     OrganizationRole,
 )
 from organizations.services import OrganizationService
-from payments.billing_constants import BillingState, LimitedResource, LimitKind
+from payments.billing_constants import BillingState, Entitlement, LimitedResource, LimitKind
 from payments.exceptions import OverLimitError
-from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
+from payments.models import (
+    BillingPlan,
+    Subscription,
+    SubscriptionEntitlement,
+    SubscriptionPlanLimit,
+)
 from payments.services.entitlement_service import EntitlementService
 from public_api.models import ResourceAccess
 from public_api.services import PublicAPIAuthService
@@ -89,6 +94,20 @@ def _organization_with_seat_limit(
         limit_value=seat_limit,
         kind=LimitKind.PREPAID,
     )
+    if can_invite_organizations:
+        # Phase 6c: a reseller org used to exercise the GraphQL surface needs
+        # `partner_api` granted, or `PublicApiSystemUserMiddleware`'s entitlement
+        # gate blocks it before the seat-limit guard this test targets ever runs.
+        # A real reseller on any real plan carries this row (every seeded plan
+        # grants it); this fixture only needs to say so explicitly because it
+        # builds a bare `Subscription` rather than going through
+        # `SubscriptionService`, which is what normally syncs it.
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=Entitlement.PARTNER_API,
+            is_enabled=True,
+        )
     if existing_active_members:
         baker.make(
             OrganizationMembership,

--- a/payments/entitlement_cache.py
+++ b/payments/entitlement_cache.py
@@ -2,14 +2,21 @@
 
 ``EntitlementService.has_entitlement`` costs a billing-root walk (a query per level of
 the ``parent`` chain) plus a subscription fetch plus an entitlement-row fetch. Phase 6c
-puts it on the two hottest surfaces in the public API:
+puts it on the two hottest call sites:
 
-- ``PublicApiSystemUserMiddleware`` checks ``partner_api`` on **every** GraphQL request.
+- ``PublicApiSystemUserMiddleware._has_partner_api_entitlement`` checks ``partner_api``
+  on every request that resolved an authenticated organization.
 - ``resolve_branding_for_display`` runs on ``brandingForTenant``, an *unauthenticated*
   public query whose ``tenant_id`` is attacker-supplied.
 
-Both are answering the same question repeatedly within one request. This memo makes the
-second and later asks free.
+The memo itself is not GraphQL-specific: ``entitlement_request_cache()`` is opened in
+``PublicApiSystemUserMiddleware.__call__``, which wraps ``self.get_response(...)`` --
+and that middleware is registered globally in ``MIDDLEWARE``, so it activates for
+*every* request the middleware stack handles, REST included, not just the ``/graphql/``
+path the two call sites above happen to be reached from.
+
+Both call sites can answer the same question repeatedly within one request. This memo
+makes the second and later asks free.
 
 **Scope is opt-in and explicit.** The cache only exists inside an
 ``entitlement_request_cache()`` block; outside one, ``has_entitlement_cached`` is a plain

--- a/payments/entitlement_cache.py
+++ b/payments/entitlement_cache.py
@@ -1,0 +1,75 @@
+"""A per-request memo for boolean entitlement checks.
+
+``EntitlementService.has_entitlement`` costs a billing-root walk (a query per level of
+the ``parent`` chain) plus a subscription fetch plus an entitlement-row fetch. Phase 6c
+puts it on the two hottest surfaces in the public API:
+
+- ``PublicApiSystemUserMiddleware`` checks ``partner_api`` on **every** GraphQL request.
+- ``resolve_branding_for_display`` runs on ``brandingForTenant``, an *unauthenticated*
+  public query whose ``tenant_id`` is attacker-supplied.
+
+Both are answering the same question repeatedly within one request. This memo makes the
+second and later asks free.
+
+**Scope is opt-in and explicit.** The cache only exists inside an
+``entitlement_request_cache()`` block; outside one, ``has_entitlement_cached`` is a plain
+pass-through to the service. That is the point: a process-lifetime or thread-local cache
+would go stale across Celery tasks and management commands, where a plan change made
+mid-process must be visible immediately. A request is short enough that an entitlement
+cannot meaningfully change inside it — and if it did, the request already read the old
+value once.
+
+Backed by a ``ContextVar``, so it is correct under ASGI/async views and never leaks
+between concurrently-handled requests the way a module-level dict would.
+"""
+
+import contextlib
+import contextvars
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from organizations.models import Organization
+    from payments.services.entitlement_service import EntitlementService
+
+
+_entitlement_cache: contextvars.ContextVar[dict[tuple[int, str], bool] | None] = (
+    contextvars.ContextVar("entitlement_request_cache", default=None)
+)
+
+
+@contextlib.contextmanager
+def entitlement_request_cache():
+    """Activate the memo for the duration of the block.
+
+    Re-entrant: a nested block reuses the outer cache rather than shadowing it, so a
+    middleware-scoped cache is not silently discarded by an inner helper.
+    """
+    if _entitlement_cache.get() is not None:
+        yield
+        return
+    token = _entitlement_cache.set({})
+    try:
+        yield
+    finally:
+        _entitlement_cache.reset(token)
+
+
+def has_entitlement_cached(
+    entitlement_service: "EntitlementService",
+    organization: "Organization",
+    entitlement_key: str,
+) -> bool:
+    """``entitlement_service.has_entitlement``, memoized when a cache is active.
+
+    Keyed on the *asked-for* organization rather than its billing root: resolving the
+    root is itself part of the cost being avoided.
+    """
+    cache = _entitlement_cache.get()
+    if cache is None:
+        return entitlement_service.has_entitlement(organization, entitlement_key)
+
+    key = (organization.pk, entitlement_key)
+    if key not in cache:
+        cache[key] = entitlement_service.has_entitlement(organization, entitlement_key)
+    return cache[key]

--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from payments.billing_constants import LimitedResource
+from payments.billing_constants import Entitlement, LimitedResource, LimitRemedy
 
 
 if TYPE_CHECKING:
@@ -287,6 +287,39 @@ class OverLimitError(BillingError):
             current_usage=result.current_usage,
             limit=result.ceiling,
             remedy=result.remedy,
+        )
+
+    @classmethod
+    def from_missing_entitlement(cls, entitlement_key: str) -> "OverLimitError":
+        """Build the error for a denied boolean feature gate (``Entitlement``, not
+        ``LimitedResource``).
+
+        An entitlement has no usage count or ceiling to report -- it is granted or
+        it is not -- so ``current_usage``/``limit`` are both ``0`` (0 of an
+        allowance of 0) rather than ``None``: the shared contract's ``current_usage``
+        and ``limit`` fields are typed as ``int`` on every surface that renders this
+        error, and every existing renderer (``vinta_exception_handler``,
+        ``raise_over_limit_graphql_error``) reads them unconditionally.
+
+        ``remedy`` is always ``upgrade_plan`` -- unlike a pre-paid ceiling, an
+        entitlement cannot be lifted by purchasing more of the same resource; only a
+        plan that grants it does. This intentionally does not consult billing state
+        the way ``EntitlementService._resolve_remedy_for`` does for limits: an
+        organization in grace/restricted is already told to resolve billing by
+        whichever limit check it hits first on the same request, and duplicating
+        that lookup here would mean re-fetching the subscription this call has no
+        other reason to need.
+        """
+        try:
+            label = Entitlement(entitlement_key).label.lower()
+        except ValueError:
+            label = entitlement_key
+        return cls(
+            resource_key=entitlement_key,
+            current_usage=0,
+            limit=0,
+            remedy=LimitRemedy.UPGRADE_PLAN,
+            detail=f"Organization does not have the {label} entitlement.",
         )
 
 

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -507,37 +507,24 @@ class EntitlementService:
     def has_entitlement(self, organization: Organization, entitlement_key: str) -> bool:
         """Is the boolean feature gate ``entitlement_key`` granted to ``organization``?
 
-        Resolved at the billing root, like limits. **Unlike limits, an existing
-        subscription fails closed on the entitlement itself**: an absent or
-        disabled ``SubscriptionEntitlement`` row on a real ``Subscription`` means
-        "not granted", not "granted". The asymmetry is deliberate --
+        Resolved at the billing root, like limits. **Unlike limits, this fails
+        closed**: an absent ``SubscriptionEntitlement`` row means "not granted",
+        not "granted". The asymmetry is deliberate —
         ``SubscriptionService._sync_entitlements`` *deletes* rows for entitlements
-        the current plan does not carry, so absence there is how a revoked grant is
-        represented. Failing open on that case would hand every feature to every
+        the current plan does not carry, so absence is how a revoked grant is
+        represented. Failing open here would hand every feature to every
         organization whose plan omits it, whereas failing open on a limit only
         risks under-charging.
-
-        A **missing subscription entirely** is a different condition and is treated
-        like every other "we don't know" case in this service (see
-        ``get_effective_limit``): it fails open. Every billing root is expected to
-        hold exactly one ``Subscription`` (Phase 4's "no plan-less state"
-        invariant), so this branch should be unreachable for a legitimately
-        provisioned organization -- it exists for the same reason the limits side
-        fails open on the identical condition: a data gap or broken invariant must
-        never silently convert into a total lockout on every gated feature, which
-        the rollout's "no organization is blocked as a consequence of the rollout
-        itself" rule forbids just as much for entitlements as for limits.
         """
         subscription = self._get_root_subscription(organization)
         if subscription is None:
             logger.warning(
-                "No subscription resolved for organization %s; treating entitlement %s as "
-                "granted (fail-open). Every billing root is expected to hold exactly one "
-                "Subscription -- this indicates a broken invariant, not a normal state.",
+                "No subscription resolved for organization %s; denying entitlement %s. "
+                "Every billing root is expected to hold exactly one Subscription.",
                 organization.pk,
                 entitlement_key,
             )
-            return True
+            return False
         entitlement = subscription.entitlements.filter(entitlement_key=entitlement_key).first()
         return entitlement is not None and entitlement.is_enabled
 

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -507,24 +507,37 @@ class EntitlementService:
     def has_entitlement(self, organization: Organization, entitlement_key: str) -> bool:
         """Is the boolean feature gate ``entitlement_key`` granted to ``organization``?
 
-        Resolved at the billing root, like limits. **Unlike limits, this fails
-        closed**: an absent ``SubscriptionEntitlement`` row means "not granted",
-        not "granted". The asymmetry is deliberate —
+        Resolved at the billing root, like limits. **Unlike limits, an existing
+        subscription fails closed on the entitlement itself**: an absent or
+        disabled ``SubscriptionEntitlement`` row on a real ``Subscription`` means
+        "not granted", not "granted". The asymmetry is deliberate --
         ``SubscriptionService._sync_entitlements`` *deletes* rows for entitlements
-        the current plan does not carry, so absence is how a revoked grant is
-        represented. Failing open here would hand every feature to every
+        the current plan does not carry, so absence there is how a revoked grant is
+        represented. Failing open on that case would hand every feature to every
         organization whose plan omits it, whereas failing open on a limit only
         risks under-charging.
+
+        A **missing subscription entirely** is a different condition and is treated
+        like every other "we don't know" case in this service (see
+        ``get_effective_limit``): it fails open. Every billing root is expected to
+        hold exactly one ``Subscription`` (Phase 4's "no plan-less state"
+        invariant), so this branch should be unreachable for a legitimately
+        provisioned organization -- it exists for the same reason the limits side
+        fails open on the identical condition: a data gap or broken invariant must
+        never silently convert into a total lockout on every gated feature, which
+        the rollout's "no organization is blocked as a consequence of the rollout
+        itself" rule forbids just as much for entitlements as for limits.
         """
         subscription = self._get_root_subscription(organization)
         if subscription is None:
             logger.warning(
-                "No subscription resolved for organization %s; denying entitlement %s. "
-                "Every billing root is expected to hold exactly one Subscription.",
+                "No subscription resolved for organization %s; treating entitlement %s as "
+                "granted (fail-open). Every billing root is expected to hold exactly one "
+                "Subscription -- this indicates a broken invariant, not a normal state.",
                 organization.pk,
                 entitlement_key,
             )
-            return False
+            return True
         entitlement = subscription.entitlements.filter(entitlement_key=entitlement_key).first()
         return entitlement is not None and entitlement.is_enabled
 

--- a/payments/tests/services/subscription_plan_factory/test_billing_plan_factory.py
+++ b/payments/tests/services/subscription_plan_factory/test_billing_plan_factory.py
@@ -11,6 +11,11 @@ from payments.models import BillingPlan, Subscription
 from payments.services.subscription_plan_factory.billing_plan_factory import BillingPlanFactory
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 @pytest.fixture
 def organization():
     return baker.make(Organization)

--- a/payments/tests/services/test_entitlement_service.py
+++ b/payments/tests/services/test_entitlement_service.py
@@ -618,5 +618,17 @@ class TestHasEntitlement:
         """
         assert service.has_entitlement(organization, Entitlement.WHITE_LABEL_BRANDING) is False
 
-    def test_missing_subscription_denies(self, service, organization):
-        assert service.has_entitlement(organization, Entitlement.PARTNER_API) is False
+    def test_missing_subscription_fails_open(self, service, organization):
+        """Deliberately the opposite of ``test_missing_entitlement_row_is_denied``.
+
+        A missing *row* on a real subscription is how a revoked grant is
+        represented (fail closed). A missing *subscription entirely* is the same
+        "we don't know" condition ``get_effective_limit`` already fails open on --
+        every billing root is expected to hold exactly one ``Subscription`` (the
+        "no plan-less state" invariant), so this case should be unreachable for a
+        legitimately provisioned organization. Failing closed here would turn a
+        broken invariant into a total lockout on every gated feature, which the
+        rollout's "no organization is blocked as a consequence of the rollout
+        itself" rule forbids for entitlements exactly as much as for limits.
+        """
+        assert service.has_entitlement(organization, Entitlement.PARTNER_API) is True

--- a/payments/tests/services/test_entitlement_service.py
+++ b/payments/tests/services/test_entitlement_service.py
@@ -39,6 +39,11 @@ from payments.services.entitlement_service import USAGE_COUNTERS, EntitlementSer
 from webhooks.models import WebhookConfiguration
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 @pytest.fixture
 def service():
     return EntitlementService()
@@ -618,17 +623,25 @@ class TestHasEntitlement:
         """
         assert service.has_entitlement(organization, Entitlement.WHITE_LABEL_BRANDING) is False
 
-    def test_missing_subscription_fails_open(self, service, organization):
-        """Deliberately the opposite of ``test_missing_entitlement_row_is_denied``.
+    def test_missing_subscription_denies(self, service, organization):
+        """A missing subscription denies, and deliberately does **not** mirror
+        ``get_effective_limit``'s fail-open on the same condition.
 
-        A missing *row* on a real subscription is how a revoked grant is
-        represented (fail closed). A missing *subscription entirely* is the same
-        "we don't know" condition ``get_effective_limit`` already fails open on --
-        every billing root is expected to hold exactly one ``Subscription`` (the
-        "no plan-less state" invariant), so this case should be unreachable for a
-        legitimately provisioned organization. Failing closed here would turn a
-        broken invariant into a total lockout on every gated feature, which the
-        rollout's "no organization is blocked as a consequence of the rollout
-        itself" rule forbids for entitlements exactly as much as for limits.
+        The two are only superficially the same "we don't know". For a numeric
+        ceiling, not knowing resolves to ``limit_value=None`` -- unlimited --
+        which is what the rollout actually seeds, so failing open there changes
+        nothing. For a boolean gate, not knowing would resolve to *granted*, which
+        hands out paid features the ``free`` plan does not carry. Same phrase,
+        opposite consequence.
+
+        Rollout safety does not depend on this branch either: migration
+        ``0009_backfill_unlimited_subscriptions`` plus
+        ``is_default_for_new_organizations`` put every billing root on
+        ``unlimited``, whose ``_sync_entitlements`` writes every entitlement
+        enabled. This branch only fires once that invariant is already broken --
+        e.g. ops deleting a ``Subscription`` to re-provision an organization -- and
+        failing open would grant the *most* access to exactly the organizations
+        whose billing state is corrupt. A loud, recoverable 402 is the better
+        failure.
         """
-        assert service.has_entitlement(organization, Entitlement.PARTNER_API) is True
+        assert service.has_entitlement(organization, Entitlement.PARTNER_API) is False

--- a/payments/tests/services/test_limit_concurrency.py
+++ b/payments/tests/services/test_limit_concurrency.py
@@ -35,6 +35,11 @@ from payments.services.entitlement_service import EntitlementService
 from users.models import User
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 BARRIER_TIMEOUT_SECONDS = 10
 THREAD_JOIN_TIMEOUT_SECONDS = 30
 # Long enough that a non-locking implementation reliably interleaves its read with

--- a/payments/tests/services/test_payment_services.py
+++ b/payments/tests/services/test_payment_services.py
@@ -49,6 +49,11 @@ from payments.services.subscription_adapters.base import (
 from payments.services.subscription_plan_factory.base import BaseSubscriptionPlanFactory
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 class MockSubscriptionPlanFactory(BaseSubscriptionPlanFactory):
     def make_plan_from_subscription(self, subscription):
         return CreatedPlan(

--- a/payments/tests/services/test_pooled_limits.py
+++ b/payments/tests/services/test_pooled_limits.py
@@ -29,6 +29,11 @@ from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
 from payments.services.entitlement_service import EntitlementService
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 @pytest.fixture
 def service():
     return EntitlementService()

--- a/payments/tests/services/test_subscription_service.py
+++ b/payments/tests/services/test_subscription_service.py
@@ -32,6 +32,11 @@ from payments.services.subscription_service import (
 )
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 @pytest.fixture
 def service():
     return SubscriptionService()

--- a/payments/tests/test_admin.py
+++ b/payments/tests/test_admin.py
@@ -24,6 +24,11 @@ from payments.models import BillingPlan, PlanLimit, Subscription
 from payments.services.subscription_service import SubscriptionService
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 @pytest.fixture
 def superuser():
     return get_user_model().objects.create_superuser(

--- a/payments/tests/test_backfill_migration.py
+++ b/payments/tests/test_backfill_migration.py
@@ -38,6 +38,12 @@ from payments.exceptions import MissingSeedBillingPlanError
 from payments.models import BillingPlan, Subscription
 
 
+# This module is *about* the plan-less state the backfill migration repairs, so it opts
+# out of conftest's autouse `provision_default_subscription` — that fixture would provision
+# the very subscriptions these tests assert the migration creates.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 migration_module = importlib.import_module(
     "payments.migrations.0009_backfill_unlimited_subscriptions"
 )

--- a/payments/tests/test_conftest_default_subscription_fixture.py
+++ b/payments/tests/test_conftest_default_subscription_fixture.py
@@ -1,0 +1,36 @@
+"""Phase 6c review: the root ``conftest.py``'s autouse ``provision_default_subscription``
+fixture must build its ``SubscriptionService`` from the DI container, not hand-construct
+one, matching what the rest of this phase's own tests were moved onto (see
+``public_api/tests/test_system_user_limits.py``'s ``service`` fixture and
+``payments/tests/test_prepaid_resource_coverage.py``'s ``_container()`` helper).
+
+``SubscriptionService`` happens to take no injected dependencies today, so a
+hand-constructed instance behaves identically to a container-built one -- this test
+is about wiring, not behavior: it proves the fixture actually asks the container
+(so a future dependency added to ``SubscriptionService`` -- and wired only via the
+container -- is not silently missed here the way BLOCKER 4 was).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from model_bakery import baker
+
+from organizations.models import Organization
+
+
+@pytest.mark.django_db
+class TestProvisionDefaultSubscriptionFixtureUsesTheContainer:
+    def test_creating_an_organization_asks_the_container_for_the_subscription_service(self):
+        from di_core.containers import container
+
+        assert container is not None, "DI container is only assigned in DICoreConfig.ready()"
+
+        mock_subscription_service = MagicMock()
+
+        with container.subscription_service.override(mock_subscription_service):
+            organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+
+        mock_subscription_service.create_subscription_for_organization.assert_called_once_with(
+            organization
+        )

--- a/payments/tests/test_models.py
+++ b/payments/tests/test_models.py
@@ -19,6 +19,11 @@ from payments.models import (
 )
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 @pytest.fixture
 def organization():
     return baker.make(Organization)

--- a/payments/tests/test_prepaid_resource_coverage.py
+++ b/payments/tests/test_prepaid_resource_coverage.py
@@ -18,6 +18,7 @@ resource, and nothing was created.
 """
 
 import datetime
+from typing import TYPE_CHECKING
 
 from django.utils import timezone
 
@@ -30,15 +31,36 @@ from calendar_integration.services.calendar_group_service import CalendarGroupSe
 from calendar_integration.services.calendar_service import CalendarService
 from calendar_integration.services.dataclasses import CalendarGroupInputData
 from organizations.models import Organization, OrganizationInvitation, OrganizationMembership
-from organizations.services import OrganizationService
 from payments.billing_constants import BillingState, LimitedResource, LimitKind
 from payments.exceptions import OverLimitError
 from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
 from public_api.models import SystemUser
-from public_api.services import PublicAPIAuthService
 from webhooks.constants import WebhookEventType
 from webhooks.models import WebhookConfiguration
 from webhooks.services.webhook_service import WebhookService
+
+
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
+if TYPE_CHECKING:
+    from di_core.containers import AppContainer
+
+
+def _container() -> "AppContainer":
+    """The wired DI container, narrowed for mypy.
+
+    Imported inside the function body on purpose: ``di_core.containers.container`` is
+    only *assigned* in ``DICoreConfig.ready()``, so a module-level ``from ... import
+    container`` binds ``None`` forever. The root ``conftest.py``'s ``di_container``
+    fixture defers the import for the same reason.
+    """
+    from di_core.containers import container
+
+    assert container is not None, "DI container is only assigned in DICoreConfig.ready()"
+    return container
 
 
 def _organization_with_limit(resource_key: str, limit_value: int) -> Organization:
@@ -69,7 +91,7 @@ def _probe_organization_members() -> None:
     baker.make(OrganizationMembership, organization=organization, is_active=True)
 
     with pytest.raises(OverLimitError) as exc_info:
-        OrganizationService().invite_user_to_organization(
+        _container().organization_service().invite_user_to_organization(
             email="blocked@example.com",
             first_name="Blocked",
             last_name="Invitee",
@@ -78,7 +100,9 @@ def _probe_organization_members() -> None:
         )
 
     assert exc_info.value.resource_key == LimitedResource.ORGANIZATION_MEMBERS
-    assert not OrganizationInvitation.objects.filter(email="blocked@example.com").exists()
+    assert not OrganizationInvitation.objects.filter(
+        organization=organization, email="blocked@example.com"
+    ).exists()
 
 
 def _probe_resource_calendars() -> None:
@@ -193,7 +217,7 @@ def _probe_public_api_system_users() -> None:
         long_lived_token_hash="coverage-seed-hash",
     )
 
-    service = PublicAPIAuthService()
+    service = _container().public_api_auth_service()
 
     with pytest.raises(OverLimitError) as exc_info:
         service.create_system_user(
@@ -202,7 +226,9 @@ def _probe_public_api_system_users() -> None:
         )
 
     assert exc_info.value.resource_key == LimitedResource.PUBLIC_API_SYSTEM_USERS
-    assert not SystemUser.objects.filter(integration_name="coverage-blocked-integration").exists()
+    assert not SystemUser.objects.filter(
+        organization=organization, integration_name="coverage-blocked-integration"
+    ).exists()
 
 
 # Every currently-known ``kind=prepaid`` ``LimitedResource`` member maps to a probe
@@ -234,12 +260,25 @@ class TestEveryPrepaidLimitedResourceHasAGuardedCreationPath:
         )
 
     def test_every_prepaid_resource_has_a_registered_probe(self):
-        missing = self._prepaid_resource_keys() - GUARDED_CREATION_PROBES.keys()
+        prepaid = self._prepaid_resource_keys()
+
+        missing = prepaid - GUARDED_CREATION_PROBES.keys()
         assert not missing, (
             f"No guarded-creation-path probe registered for {sorted(missing)}. Every "
             "kind=prepaid LimitedResource member must have one registered in "
             "GUARDED_CREATION_PROBES -- this is the closing acceptance check for "
             "spec objective 1 on pre-paid resources."
+        )
+
+        # ...and the other direction, so the registry cannot rot the other way: a probe
+        # left behind for a resource that was renamed, deleted, or flipped to postpaid
+        # would otherwise keep passing while testing a path nothing routes through, and
+        # the check above would still report full coverage.
+        stale = GUARDED_CREATION_PROBES.keys() - prepaid
+        assert not stale, (
+            f"GUARDED_CREATION_PROBES has probes for {sorted(stale)}, which are not "
+            "kind=prepaid LimitedResource members. Remove them, or fix the catalog if "
+            "the resource was meant to stay pre-paid."
         )
 
     def test_event_occurrences_is_postpaid_not_prepaid(self):

--- a/payments/tests/test_prepaid_resource_coverage.py
+++ b/payments/tests/test_prepaid_resource_coverage.py
@@ -1,0 +1,257 @@
+"""Phase 6c's closing acceptance check: every ``kind=prepaid`` ``LimitedResource``
+member has a guarded creation path.
+
+This is the acceptance condition for spec objective 1 on pre-paid resources
+("no unmetered creation path exists for any limited resource").
+
+The set of prepaid resource keys is derived from the seeded ``unlimited`` plan's
+own ``PlanLimit.kind`` classification -- the catalog's real data, not a hand-typed
+Python set -- so a new ``LimitedResource`` member added later without a
+registered probe fails this test loudly instead of silently passing. See
+``payments/tests/test_plan_seed_migration.py`` for the seed migration guarantee
+this relies on: every ``LimitedResource`` member has a row on ``unlimited``.
+
+Each probe below drives the *real* guarded service method (not a hand-built
+queryset assertion) against an organization sitting exactly at its ceiling, and
+asserts both halves: the call raises ``OverLimitError`` naming the right
+resource, and nothing was created.
+"""
+
+import datetime
+
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+
+from calendar_integration.constants import CalendarType
+from calendar_integration.models import AvailableTime, Calendar, CalendarGroup
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import CalendarGroupInputData
+from organizations.models import Organization, OrganizationInvitation, OrganizationMembership
+from organizations.services import OrganizationService
+from payments.billing_constants import BillingState, LimitedResource, LimitKind
+from payments.exceptions import OverLimitError
+from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
+from public_api.models import SystemUser
+from public_api.services import PublicAPIAuthService
+from webhooks.constants import WebhookEventType
+from webhooks.models import WebhookConfiguration
+from webhooks.services.webhook_service import WebhookService
+
+
+def _organization_with_limit(resource_key: str, limit_value: int) -> Organization:
+    """A standalone (non-reseller) organization sitting exactly at ``limit_value``
+    for ``resource_key`` -- one more of anything must be refused."""
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=resource_key,
+        limit_value=limit_value,
+        kind=LimitKind.PREPAID,
+    )
+    return organization
+
+
+def _probe_organization_members() -> None:
+    organization = _organization_with_limit(LimitedResource.ORGANIZATION_MEMBERS, 1)
+    baker.make(OrganizationMembership, organization=organization, is_active=True)
+
+    with pytest.raises(OverLimitError) as exc_info:
+        OrganizationService().invite_user_to_organization(
+            email="blocked@example.com",
+            first_name="Blocked",
+            last_name="Invitee",
+            organization=organization,
+            send_email=False,
+        )
+
+    assert exc_info.value.resource_key == LimitedResource.ORGANIZATION_MEMBERS
+    assert not OrganizationInvitation.objects.filter(email="blocked@example.com").exists()
+
+
+def _probe_resource_calendars() -> None:
+    organization = _organization_with_limit(LimitedResource.RESOURCE_CALENDARS, 1)
+    baker.make(
+        Calendar,
+        organization=organization,
+        calendar_type=CalendarType.RESOURCE,
+        external_id="coverage-seed-resource",
+    )
+
+    service = CalendarService()
+    service.initialize_without_provider(organization=organization)
+
+    with pytest.raises(OverLimitError) as exc_info:
+        service.create_resource_calendar(name="Blocked Room")
+
+    assert exc_info.value.resource_key == LimitedResource.RESOURCE_CALENDARS
+    assert not Calendar.objects.filter(organization=organization, name="Blocked Room").exists()
+
+
+def _probe_calendar_groups() -> None:
+    organization = _organization_with_limit(LimitedResource.CALENDAR_GROUPS, 1)
+    baker.make(CalendarGroup, organization=organization)
+
+    service = CalendarGroupService()
+    service.initialize(organization=organization)
+
+    with pytest.raises(OverLimitError) as exc_info:
+        service.create_group(CalendarGroupInputData(name="Blocked Group"))
+
+    assert exc_info.value.resource_key == LimitedResource.CALENDAR_GROUPS
+    assert not CalendarGroup.objects.filter(
+        organization=organization, name="Blocked Group"
+    ).exists()
+
+
+def _probe_bundle_calendars() -> None:
+    organization = _organization_with_limit(LimitedResource.BUNDLE_CALENDARS, 1)
+    baker.make(
+        Calendar,
+        organization=organization,
+        calendar_type=CalendarType.BUNDLE,
+        external_id="coverage-seed-bundle",
+    )
+
+    service = CalendarService()
+    service.initialize_without_provider(organization=organization)
+
+    with pytest.raises(OverLimitError) as exc_info:
+        service.create_bundle_calendar(name="Blocked Bundle")
+
+    assert exc_info.value.resource_key == LimitedResource.BUNDLE_CALENDARS
+    assert not Calendar.objects.filter(organization=organization, name="Blocked Bundle").exists()
+
+
+def _probe_availability_windows() -> None:
+    organization = _organization_with_limit(LimitedResource.AVAILABILITY_WINDOWS, 1)
+    calendar = baker.make(
+        Calendar,
+        organization=organization,
+        calendar_type=CalendarType.RESOURCE,
+        manage_available_windows=True,
+    )
+    baker.make(AvailableTime, organization=organization, calendar=calendar, timezone="UTC")
+
+    service = CalendarService()
+    service.initialize_without_provider(organization=organization)
+    start = datetime.datetime(2026, 1, 1, 9, 0, tzinfo=datetime.UTC)
+    end = datetime.datetime(2026, 1, 1, 17, 0, tzinfo=datetime.UTC)
+
+    with pytest.raises(OverLimitError) as exc_info:
+        service.create_available_time(
+            calendar=calendar, start_time=start, end_time=end, timezone="UTC"
+        )
+
+    assert exc_info.value.resource_key == LimitedResource.AVAILABILITY_WINDOWS
+    assert AvailableTime.objects.filter(organization=organization, calendar=calendar).count() == 1
+
+
+def _probe_webhook_subscriptions() -> None:
+    organization = _organization_with_limit(LimitedResource.WEBHOOK_SUBSCRIPTIONS, 1)
+    baker.make(
+        WebhookConfiguration,
+        organization=organization,
+        event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+        url="https://example.com/coverage-seed",
+    )
+
+    service = WebhookService()
+
+    with pytest.raises(OverLimitError) as exc_info:
+        service.create_configuration(
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/coverage-blocked",
+            headers={},
+        )
+
+    assert exc_info.value.resource_key == LimitedResource.WEBHOOK_SUBSCRIPTIONS
+    assert not WebhookConfiguration.objects.filter(
+        organization=organization, url="https://example.com/coverage-blocked"
+    ).exists()
+
+
+def _probe_public_api_system_users() -> None:
+    organization = _organization_with_limit(LimitedResource.PUBLIC_API_SYSTEM_USERS, 1)
+    baker.make(
+        SystemUser,
+        organization=organization,
+        integration_name="coverage-seed-integration",
+        long_lived_token_hash="coverage-seed-hash",
+    )
+
+    service = PublicAPIAuthService()
+
+    with pytest.raises(OverLimitError) as exc_info:
+        service.create_system_user(
+            integration_name="coverage-blocked-integration",
+            organization=organization,
+        )
+
+    assert exc_info.value.resource_key == LimitedResource.PUBLIC_API_SYSTEM_USERS
+    assert not SystemUser.objects.filter(integration_name="coverage-blocked-integration").exists()
+
+
+# Every currently-known ``kind=prepaid`` ``LimitedResource`` member maps to a probe
+# that drives its real guarded creation path. ``event_occurrences`` is the one
+# ``LimitedResource`` member deliberately absent: it is ``kind=postpaid`` (Phase 8's
+# allowance guard, not a pre-paid ceiling), so it is correctly excluded below rather
+# than missing by oversight -- the test asserts that distinction explicitly.
+GUARDED_CREATION_PROBES = {
+    LimitedResource.ORGANIZATION_MEMBERS: _probe_organization_members,
+    LimitedResource.RESOURCE_CALENDARS: _probe_resource_calendars,
+    LimitedResource.CALENDAR_GROUPS: _probe_calendar_groups,
+    LimitedResource.BUNDLE_CALENDARS: _probe_bundle_calendars,
+    LimitedResource.AVAILABILITY_WINDOWS: _probe_availability_windows,
+    LimitedResource.WEBHOOK_SUBSCRIPTIONS: _probe_webhook_subscriptions,
+    LimitedResource.PUBLIC_API_SYSTEM_USERS: _probe_public_api_system_users,
+}
+
+
+@pytest.mark.django_db
+class TestEveryPrepaidLimitedResourceHasAGuardedCreationPath:
+    def _prepaid_resource_keys(self) -> set[str]:
+        """The catalog's own classification, not a hand-typed literal: a new
+        ``LimitedResource`` member seeded as ``kind=prepaid`` on ``unlimited``
+        without a corresponding probe below fails this test loudly."""
+        return set(
+            BillingPlan.objects.get(slug="unlimited")
+            .limits.filter(kind=LimitKind.PREPAID)
+            .values_list("resource_key", flat=True)
+        )
+
+    def test_every_prepaid_resource_has_a_registered_probe(self):
+        missing = self._prepaid_resource_keys() - GUARDED_CREATION_PROBES.keys()
+        assert not missing, (
+            f"No guarded-creation-path probe registered for {sorted(missing)}. Every "
+            "kind=prepaid LimitedResource member must have one registered in "
+            "GUARDED_CREATION_PROBES -- this is the closing acceptance check for "
+            "spec objective 1 on pre-paid resources."
+        )
+
+    def test_event_occurrences_is_postpaid_not_prepaid(self):
+        """Pins the one deliberate exclusion from ``GUARDED_CREATION_PROBES`` to a
+        real assertion about the catalog, rather than leaving it as an unverified
+        comment that could silently go stale."""
+        assert LimitedResource.EVENT_OCCURRENCES not in self._prepaid_resource_keys()
+
+    @pytest.mark.parametrize(
+        "resource_key,probe",
+        list(GUARDED_CREATION_PROBES.items()),
+        ids=list(GUARDED_CREATION_PROBES.keys()),
+    )
+    def test_probe_blocks_at_the_ceiling(self, resource_key, probe):
+        probe()

--- a/payments/tests/test_prepaid_surface_contracts.py
+++ b/payments/tests/test_prepaid_surface_contracts.py
@@ -11,13 +11,16 @@ So this module drives the HTTP/admin surfaces themselves for the two resources P
 added, and asserts both the status and the *shared body*
 (``OverLimitError.as_error_body()``: ``detail`` / ``code`` / ``resource`` /
 ``current_usage`` / ``limit`` / ``remedy``) -- REST as a 402 response body, GraphQL as the
-same dict carried verbatim in the error's ``extensions``, admin as a non-500 error message.
+same dict carried verbatim in the error's ``extensions``, admin (driven through
+``django.test.Client`` against the real ``admin:public_api_systemuser_add`` URL, not
+``ModelAdmin.save_model`` called directly) as a 200 re-render of the add form with the
+limit surfaced as a field error.
 """
 
 import datetime
 
-from django.contrib.admin.sites import AdminSite
-from django.contrib.messages import ERROR
+from django.contrib.auth import get_user_model
+from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
 
@@ -40,11 +43,13 @@ from payments.models import (
     SubscriptionEntitlement,
     SubscriptionPlanLimit,
 )
-from public_api.admin import SystemUserAdmin
 from public_api.constants import PublicAPIResources
 from public_api.models import ResourceAccess, SystemUser
 from webhooks.constants import WebhookEventType
 from webhooks.models import WebhookConfiguration
+
+
+User = get_user_model()
 
 
 # This module builds its own Subscription rows (OneToOne with Organization), so it
@@ -94,6 +99,32 @@ def _organization_at_ceiling(
             is_enabled=True,
         )
     return organization
+
+
+def _admin_client() -> Client:
+    superuser = User.objects.create_superuser(
+        email="prepaid-surface-admin@example.com",
+        password="adminpassword",  # noqa: S106
+    )
+    client = Client()
+    client.force_login(superuser)
+    return client
+
+
+def _empty_resource_access_inline_formset_data() -> dict:
+    """Management-form data for ``SystemUserAdmin``'s ``ResourceAccessInline``.
+
+    Django admin's ``_changeform_view`` requires every inline's formset management
+    form fields in the POST body, even when adding zero inline rows -- the prefix is
+    ``ResourceAccess.system_user``'s ``related_name`` (``available_resources``), not
+    the model name.
+    """
+    return {
+        "available_resources-TOTAL_FORMS": "0",
+        "available_resources-INITIAL_FORMS": "0",
+        "available_resources-MIN_NUM_FORMS": "0",
+        "available_resources-MAX_NUM_FORMS": "1000",
+    }
 
 
 def _admin_membership(organization: Organization) -> OrganizationMembership:
@@ -295,11 +326,14 @@ class TestPublicApiSystemUserSurfaces:
         ).exists()
 
     def test_admin_create_reports_an_error_instead_of_a_500(self):
-        """``SystemUserAdmin.save_model`` must not let ``OverLimitError`` escape.
+        """The real ``admin:public_api_systemuser_add`` endpoint, over-limit.
 
-        There is no HTTP status to assert here -- an escaping exception renders Django's
-        500 debug page, so the observable contract is "``save_model`` returns, and the
-        admin user is shown an ERROR message".
+        ``SystemUserAdminForm.clean()`` must reject the create with a field error
+        *before* ``ModelAdmin._changeform_view`` ever reaches ``response_add`` --
+        which would otherwise be called with ``obj.pk is None`` (the guarded
+        ``save_model`` never ran) and 500 with ``NoReverseMatch`` reversing
+        ``admin:public_api_systemuser_change`` for a ``None`` pk, instead of the 200
+        field-error re-render asserted here.
         """
         organization = _organization_at_ceiling(LimitedResource.PUBLIC_API_SYSTEM_USERS, 1)
         baker.make(
@@ -308,19 +342,23 @@ class TestPublicApiSystemUserSurfaces:
             integration_name="admin-seed",
             long_lived_token_hash="admin-seed-hash",
         )
+        client = _admin_client()
 
-        model_admin = SystemUserAdmin(SystemUser, AdminSite())
-        request = _admin_request()
-        form = _fake_form({"integration_name": "admin-blocked", "organization": organization})
+        response = client.post(
+            reverse("admin:public_api_systemuser_add"),
+            data={
+                "organization": str(organization.pk),
+                "integration_name": "admin-blocked",
+                **_empty_resource_access_inline_formset_data(),
+            },
+        )
 
-        model_admin.save_model(request, SystemUser(), form, change=False)
-
+        assert response.status_code == status.HTTP_200_OK
         assert not SystemUser.objects.filter(
             organization=organization, integration_name="admin-blocked"
         ).exists()
-        level, message = request._messages_recorded[-1]
-        assert level == ERROR
-        assert "public api system user" in message.lower() or "limit" in message.lower()
+        content = response.content.decode()
+        assert "public api system user" in content.lower() or "limit" in content.lower()
 
     def test_admin_create_without_an_organization_still_works(self):
         """``SystemUser.organization`` is ``null=True`` and ``save_model`` branches
@@ -328,53 +366,21 @@ class TestPublicApiSystemUserSurfaces:
         must skip it rather than resolve a billing root from ``None``, which raised
         ``AttributeError`` -> admin 500 on an explicitly supported path.
         """
-        model_admin = SystemUserAdmin(SystemUser, AdminSite())
-        request = _admin_request()
-        form = _fake_form({"integration_name": "orgless-token", "organization": None})
+        client = _admin_client()
 
-        model_admin.save_model(request, SystemUser(), form, change=False)
+        response = client.post(
+            reverse("admin:public_api_systemuser_add"),
+            data={
+                "organization": "",
+                "integration_name": "orgless-token",
+                **_empty_resource_access_inline_formset_data(),
+            },
+        )
 
+        assert response.status_code == 302
         # `SystemUser.objects` refuses an unfiltered query on an OrganizationModel;
         # an org-less row has no organization to filter by, so this is the one legitimate
         # use of the unscoped manager here.
         created = SystemUser.original_manager.filter(integration_name="orgless-token").first()
         assert created is not None
         assert created.organization_id is None
-        level, message = request._messages_recorded[-1]
-        assert level != ERROR
-        assert "all organizations" in message
-
-
-# ---------------------------------------------------------------------------
-# Admin test doubles
-# ---------------------------------------------------------------------------
-
-
-class _FakeForm:
-    def __init__(self, cleaned_data):
-        self.cleaned_data = cleaned_data
-
-
-def _fake_form(cleaned_data):
-    return _FakeForm(cleaned_data)
-
-
-def _admin_request():
-    """A request object that records ``message_user`` output.
-
-    ``ModelAdmin.message_user`` goes through ``django.contrib.messages``, which needs a
-    session + message storage a bare ``RequestFactory`` request does not have. Recording
-    the calls directly keeps the test about ``save_model``'s behaviour rather than about
-    the messages framework's plumbing.
-    """
-    from django.test import RequestFactory
-
-    request = RequestFactory().post("/admin/public_api/systemuser/add/")
-    request._messages_recorded = []
-
-    class _Recorder:
-        def add(self, level, message, extra_tags=""):
-            request._messages_recorded.append((level, message))
-
-    request._messages = _Recorder()
-    return request

--- a/payments/tests/test_prepaid_surface_contracts.py
+++ b/payments/tests/test_prepaid_surface_contracts.py
@@ -1,0 +1,380 @@
+"""Phase 6c: every *surface* over a guarded pre-paid creation path returns the shared
+over-limit contract.
+
+``test_prepaid_resource_coverage.py`` proves each ``kind=prepaid`` resource has a guarded
+creation *service*. That rests on a load-bearing claim -- "every REST, GraphQL, and admin
+call site routes through this single function" -- which nothing pinned. If a surface grew
+its own creation path, or swallowed / reshaped the error on the way out, the coverage
+suite would stay green while a real client saw a 500, a 200, or an unrecognisable body.
+
+So this module drives the HTTP/admin surfaces themselves for the two resources Phase 6c
+added, and asserts both the status and the *shared body*
+(``OverLimitError.as_error_body()``: ``detail`` / ``code`` / ``resource`` /
+``current_usage`` / ``limit`` / ``remedy``) -- REST as a 402 response body, GraphQL as the
+same dict carried verbatim in the error's ``extensions``, admin as a non-500 error message.
+"""
+
+import datetime
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages import ERROR
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from payments.billing_constants import (
+    BillingState,
+    Entitlement,
+    LimitedResource,
+    LimitKind,
+    LimitRemedy,
+)
+from payments.models import (
+    BillingPlan,
+    Subscription,
+    SubscriptionEntitlement,
+    SubscriptionPlanLimit,
+)
+from public_api.admin import SystemUserAdmin
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess, SystemUser
+from webhooks.constants import WebhookEventType
+from webhooks.models import WebhookConfiguration
+
+
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
+ERROR_BODY_KEYS = {"detail", "code", "resource", "current_usage", "limit", "remedy"}
+
+
+def _container():
+    from di_core.containers import container
+
+    assert container is not None, "DI container is only assigned in DICoreConfig.ready()"
+    return container
+
+
+def _organization_at_ceiling(
+    resource_key: str, limit_value: int, *, can_invite_organizations: bool = False
+) -> Organization:
+    """An organization with a finite ceiling on ``resource_key`` and every entitlement
+    granted (so the ``partner_api`` gate never masks the limit under test)."""
+    organization = baker.make(
+        Organization, parent=None, can_invite_organizations=can_invite_organizations
+    )
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=resource_key,
+        limit_value=limit_value,
+        kind=LimitKind.PREPAID,
+    )
+    for entitlement_key in Entitlement.values:
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=entitlement_key,
+            is_enabled=True,
+        )
+    return organization
+
+
+def _admin_membership(organization: Organization) -> OrganizationMembership:
+    from users.factories import UserFactory
+
+    user = UserFactory().create_user()
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=organization,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+def _assert_shared_error_body(body: dict, resource_key: str) -> None:
+    assert set(body.keys()) == ERROR_BODY_KEYS, body
+    assert body["code"] == "limit_exceeded"
+    assert body["resource"] == resource_key
+    assert body["remedy"] in set(LimitRemedy.values)
+    assert body["detail"]
+
+
+# ---------------------------------------------------------------------------
+# webhook_subscriptions
+# ---------------------------------------------------------------------------
+
+CREATE_WEBHOOK_MUTATION = """
+mutation CreateWebhookConfiguration($input: CreateWebhookConfigurationInput!) {
+    createWebhookConfiguration(input: $input) {
+        configuration { id }
+        errorMessage
+    }
+}
+"""
+
+
+def _seed_webhook(organization: Organization) -> WebhookConfiguration:
+    return baker.make(
+        WebhookConfiguration,
+        organization=organization,
+        event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+        url="https://example.com/seed",
+    )
+
+
+@pytest.mark.django_db
+class TestWebhookSubscriptionSurfaces:
+    def test_rest_create_returns_the_shared_402(self):
+        organization = _organization_at_ceiling(LimitedResource.WEBHOOK_SUBSCRIPTIONS, 1)
+        _seed_webhook(organization)
+        membership = _admin_membership(organization)
+
+        client = APIClient()
+        client.force_authenticate(user=membership.user)
+        response = client.post(
+            reverse("api:WebhookConfigurations-list"),
+            {
+                "event_type": WebhookEventType.CALENDAR_EVENT_CREATED,
+                "url": "https://example.com/blocked",
+                "headers": {},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        _assert_shared_error_body(response.json(), LimitedResource.WEBHOOK_SUBSCRIPTIONS)
+        assert not WebhookConfiguration.objects.filter(
+            organization=organization, url="https://example.com/blocked"
+        ).exists()
+
+    def test_graphql_create_carries_the_same_body_in_extensions(self):
+        organization = _organization_at_ceiling(LimitedResource.WEBHOOK_SUBSCRIPTIONS, 1)
+        _seed_webhook(organization)
+
+        auth_service = _container().public_api_auth_service()
+        system_user, token = auth_service.create_system_user(
+            integration_name="webhook-surface-token",
+            organization=organization,
+            bypass_limits=True,
+        )
+        baker.make(
+            ResourceAccess,
+            system_user=system_user,
+            resource_name=PublicAPIResources.WEBHOOK_CONFIGURATION,
+        )
+
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_WEBHOOK_MUTATION,
+                "variables": {
+                    "input": {
+                        "eventType": WebhookEventType.CALENDAR_EVENT_CREATED,
+                        "url": "https://example.com/blocked-gql",
+                        "headers": {},
+                    }
+                },
+            },
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+
+        # graphql-core always answers 200 and puts the failure in `errors`.
+        assert response.status_code == status.HTTP_200_OK
+        errors = response.json()["errors"]
+        _assert_shared_error_body(errors[0]["extensions"], LimitedResource.WEBHOOK_SUBSCRIPTIONS)
+        assert not WebhookConfiguration.objects.filter(
+            organization=organization, url="https://example.com/blocked-gql"
+        ).exists()
+
+
+# ---------------------------------------------------------------------------
+# public_api_system_users
+# ---------------------------------------------------------------------------
+
+CREATE_SYSTEM_USER_TOKEN_MUTATION = """
+mutation CreateSystemUserToken($input: CreateSystemUserTokenInput!) {
+    createSystemUserToken(input: $input) {
+        token
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestPublicApiSystemUserSurfaces:
+    def test_rest_create_returns_the_shared_402(self):
+        organization = _organization_at_ceiling(LimitedResource.PUBLIC_API_SYSTEM_USERS, 1)
+        baker.make(
+            SystemUser,
+            organization=organization,
+            integration_name="surface-seed",
+            long_lived_token_hash="surface-seed-hash",
+        )
+        membership = _admin_membership(organization)
+
+        client = APIClient()
+        client.force_authenticate(user=membership.user)
+        response = client.post(
+            reverse("api:PublicAPITokens-list"),
+            {
+                "integration_name": "surface-blocked",
+                "available_resources": [PublicAPIResources.CALENDAR],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        _assert_shared_error_body(response.json(), LimitedResource.PUBLIC_API_SYSTEM_USERS)
+        assert not SystemUser.objects.filter(
+            organization=organization, integration_name="surface-blocked"
+        ).exists()
+
+    def test_graphql_create_carries_the_same_body_in_extensions(self):
+        """``createSystemUserToken`` is the reseller-facing minting path -- a *different*
+        entry point from the REST serializer, routed through the same guarded service."""
+        organization = _organization_at_ceiling(
+            LimitedResource.PUBLIC_API_SYSTEM_USERS, 1, can_invite_organizations=True
+        )
+        auth_service = _container().public_api_auth_service()
+        system_user, token = auth_service.create_system_user(
+            integration_name="systemuser-surface-token",
+            organization=organization,
+            bypass_limits=True,
+        )
+        # `createSystemUserToken` maps to the SYSTEM_USER resource in
+        # `public_api.permissions`; ORGANIZATION is what `assert_org_can_invite` reads.
+        for resource_name in (
+            PublicAPIResources.SYSTEM_USER,
+            PublicAPIResources.ORGANIZATION,
+            PublicAPIResources.CALENDAR,
+        ):
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource_name)
+
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": CREATE_SYSTEM_USER_TOKEN_MUTATION,
+                "variables": {
+                    "input": {
+                        "organizationId": str(organization.id),
+                        "integrationName": "surface-blocked-gql",
+                        "resources": [PublicAPIResources.CALENDAR],
+                    }
+                },
+            },
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        errors = response.json()["errors"]
+        _assert_shared_error_body(errors[0]["extensions"], LimitedResource.PUBLIC_API_SYSTEM_USERS)
+        assert not SystemUser.objects.filter(
+            organization=organization, integration_name="surface-blocked-gql"
+        ).exists()
+
+    def test_admin_create_reports_an_error_instead_of_a_500(self):
+        """``SystemUserAdmin.save_model`` must not let ``OverLimitError`` escape.
+
+        There is no HTTP status to assert here -- an escaping exception renders Django's
+        500 debug page, so the observable contract is "``save_model`` returns, and the
+        admin user is shown an ERROR message".
+        """
+        organization = _organization_at_ceiling(LimitedResource.PUBLIC_API_SYSTEM_USERS, 1)
+        baker.make(
+            SystemUser,
+            organization=organization,
+            integration_name="admin-seed",
+            long_lived_token_hash="admin-seed-hash",
+        )
+
+        model_admin = SystemUserAdmin(SystemUser, AdminSite())
+        request = _admin_request()
+        form = _fake_form({"integration_name": "admin-blocked", "organization": organization})
+
+        model_admin.save_model(request, SystemUser(), form, change=False)
+
+        assert not SystemUser.objects.filter(
+            organization=organization, integration_name="admin-blocked"
+        ).exists()
+        level, message = request._messages_recorded[-1]
+        assert level == ERROR
+        assert "public api system user" in message.lower() or "limit" in message.lower()
+
+    def test_admin_create_without_an_organization_still_works(self):
+        """``SystemUser.organization`` is ``null=True`` and ``save_model`` branches
+        explicitly on the org-less case ("access to all organizations"). The limit guard
+        must skip it rather than resolve a billing root from ``None``, which raised
+        ``AttributeError`` -> admin 500 on an explicitly supported path.
+        """
+        model_admin = SystemUserAdmin(SystemUser, AdminSite())
+        request = _admin_request()
+        form = _fake_form({"integration_name": "orgless-token", "organization": None})
+
+        model_admin.save_model(request, SystemUser(), form, change=False)
+
+        # `SystemUser.objects` refuses an unfiltered query on an OrganizationModel;
+        # an org-less row has no organization to filter by, so this is the one legitimate
+        # use of the unscoped manager here.
+        created = SystemUser.original_manager.filter(integration_name="orgless-token").first()
+        assert created is not None
+        assert created.organization_id is None
+        level, message = request._messages_recorded[-1]
+        assert level != ERROR
+        assert "all organizations" in message
+
+
+# ---------------------------------------------------------------------------
+# Admin test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeForm:
+    def __init__(self, cleaned_data):
+        self.cleaned_data = cleaned_data
+
+
+def _fake_form(cleaned_data):
+    return _FakeForm(cleaned_data)
+
+
+def _admin_request():
+    """A request object that records ``message_user`` output.
+
+    ``ModelAdmin.message_user`` goes through ``django.contrib.messages``, which needs a
+    session + message storage a bare ``RequestFactory`` request does not have. Recording
+    the calls directly keeps the test about ``save_model``'s behaviour rather than about
+    the messages framework's plumbing.
+    """
+    from django.test import RequestFactory
+
+    request = RequestFactory().post("/admin/public_api/systemuser/add/")
+    request._messages_recorded = []
+
+    class _Recorder:
+        def add(self, level, message, extra_tags=""):
+            request._messages_recorded.append((level, message))
+
+    request._messages = _Recorder()
+    return request

--- a/public_api/admin/system_user.py
+++ b/public_api/admin/system_user.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
 from django import forms
 from django.contrib import (
@@ -10,9 +10,75 @@ from django.http import HttpRequest
 
 from dependency_injector.wiring import Provide, inject
 
+from payments.billing_constants import LimitedResource
 from payments.exceptions import OverLimitError
 from public_api.models import ResourceAccess, SystemUser
 from public_api.services import PublicAPIAuthService
+
+
+if TYPE_CHECKING:
+    from payments.services.entitlement_service import EntitlementService
+
+
+class SystemUserAdminForm(forms.ModelForm):
+    """Rejects a create that would exceed the organization's
+    ``public_api_system_users`` ceiling *before* Django's admin
+    ``_changeform_view`` reaches ``response_add``.
+
+    Without this, ``SystemUserAdmin.save_model`` catches ``OverLimitError`` and
+    returns ``None`` (no save), and ``_changeform_view`` still calls
+    ``response_add(request, new_object)`` with ``new_object.pk is None``.
+    ``response_add`` unconditionally reverses the change URL with that ``None``
+    pk (``admin.utils.quote`` passes it through unchanged, and Django's admin
+    object-URL pattern happens to accept the stringified ``"None"`` without
+    raising ``NoReverseMatch`` on this version) and, since the default POST
+    reaches neither the popup nor the ``"_continue"``/``"_addanother"`` branches
+    that would use that malformed URL, falls through to a 302 redirect to the
+    changelist -- with the ERROR message this ``save_model`` already queues
+    *and* a bogus "was added successfully" SUCCESS message from ``response_add``
+    itself, which has no idea the save was skipped. Confirmed via a direct
+    request/response probe: no exception, but two contradictory messages and no
+    row. This validation instead surfaces the limit as a single, correct field
+    error on a 200 re-render, matching every other guarded surface's contract.
+
+    Only guards creation: an edit (``self.instance.pk is not None``) does not
+    add a new unit of usage, so it never needs this check, matching
+    ``SystemUserAdmin.save_model``'s own ``change`` early-return. Uses
+    ``check_limit`` without ``lock=True`` -- this is a UX pre-check, not the
+    authoritative one; ``PublicAPIAuthService.create_system_user`` still takes
+    the row lock and re-checks inside its own transaction at save time, so a
+    concurrent create racing this validation is still caught correctly, just
+    without a friendly form error.
+    """
+
+    class Meta:
+        model = SystemUser
+        fields = ("organization", "integration_name")
+
+    @inject
+    def clean(
+        self,
+        entitlement_service: Annotated[
+            "EntitlementService | None", Provide["entitlement_service"]
+        ] = None,
+    ) -> dict[str, Any] | None:
+        cleaned_data = super().clean()
+        if self.instance.pk is not None or cleaned_data is None or entitlement_service is None:
+            return cleaned_data
+
+        organization = cleaned_data.get("organization")
+        if organization is None:
+            # Org-less tokens are unmetered by design (see create_system_user).
+            return cleaned_data
+
+        result = entitlement_service.check_limit(
+            organization, LimitedResource.PUBLIC_API_SYSTEM_USERS
+        )
+        if not result.allowed:
+            raise forms.ValidationError(
+                {"organization": OverLimitError.from_check_result(result).as_error_body()["detail"]}
+            )
+        return cleaned_data
 
 
 class ResourceAccessInline(admin.TabularInline):
@@ -29,6 +95,7 @@ class ResourceAccessInline(admin.TabularInline):
 
 @admin.register(SystemUser)
 class SystemUserAdmin(admin.ModelAdmin):
+    form = SystemUserAdminForm
     list_display = ("organization", "integration_name", "is_active", "created", "modified")
     search_fields = ("integration_name", "organization__name")
     list_filter = ("organization", "created", "modified")
@@ -65,32 +132,33 @@ class SystemUserAdmin(admin.ModelAdmin):
         self.message_user(request, f"{updated_count} system user(s) deactivated.")
 
     @inject
-    def __init__(
-        self,
-        *args,
-        public_api_auth_service: Annotated[
-            PublicAPIAuthService | None, Provide["public_api_auth_service"]
-        ] = None,
-        **kwargs,
-    ):
-        self.public_api_auth_service = public_api_auth_service
-        super().__init__(*args, **kwargs)
-
     def save_model(
         self,
         request: HttpRequest,
         obj: SystemUser,
         form: forms.Form,
         change: bool,
+        public_api_auth_service: Annotated[
+            PublicAPIAuthService | None, Provide["public_api_auth_service"]
+        ] = None,
     ) -> None:
-        if not self.public_api_auth_service:
+        # Injected here (per call), not on __init__: django.contrib.admin's
+        # autodiscovery instantiates every registered ModelAdmin -- including this
+        # one, since @admin.register runs at import time -- before di_core's
+        # AppConfig.ready() calls container.wire() (django.contrib.admin is
+        # imported earlier in INSTALLED_APPS than the internal apps di_core wires).
+        # An @inject on __init__ would permanently freeze the globally-registered
+        # singleton's public_api_auth_service at None. save_model is only ever
+        # called per-request, well after wiring has completed, matching
+        # OrganizationAdmin.save_model's identical pattern.
+        if not public_api_auth_service:
             raise ValueError("PublicAPIAuthService is not provided")
 
         if change:
             return super().save_model(request, obj, form, change)
 
         try:
-            instance, token = self.public_api_auth_service.create_system_user(
+            instance, token = public_api_auth_service.create_system_user(
                 integration_name=form.cleaned_data["integration_name"],
                 organization=form.cleaned_data["organization"],
             )

--- a/public_api/admin/system_user.py
+++ b/public_api/admin/system_user.py
@@ -10,6 +10,7 @@ from django.http import HttpRequest
 
 from dependency_injector.wiring import Provide, inject
 
+from payments.exceptions import OverLimitError
 from public_api.models import ResourceAccess, SystemUser
 from public_api.services import PublicAPIAuthService
 
@@ -88,10 +89,17 @@ class SystemUserAdmin(admin.ModelAdmin):
         if change:
             return super().save_model(request, obj, form, change)
 
-        instance, token = self.public_api_auth_service.create_system_user(
-            integration_name=form.cleaned_data["integration_name"],
-            organization=form.cleaned_data["organization"],
-        )
+        try:
+            instance, token = self.public_api_auth_service.create_system_user(
+                integration_name=form.cleaned_data["integration_name"],
+                organization=form.cleaned_data["organization"],
+            )
+        except OverLimitError as exc:
+            # Phase 6c: the organization is at its `public_api_system_users` ceiling.
+            # Surface it as an admin error message; letting it escape renders a 500
+            # traceback for what is an ordinary, actionable business outcome.
+            self.message_user(request, exc.as_error_body()["detail"], messages.ERROR)
+            return None
 
         obj.id = instance.id
         obj.long_lived_token_hash = instance.long_lived_token_hash

--- a/public_api/middlewares.py
+++ b/public_api/middlewares.py
@@ -1,18 +1,25 @@
 from collections.abc import Callable
-from typing import Annotated, cast
+from typing import TYPE_CHECKING, Annotated, cast
 
 from django.http import (
     HttpRequest,
     HttpResponse,
+    JsonResponse,
 )
 
 from dependency_injector.wiring import Provide, inject
 
 from organizations.models import Organization
+from payments.billing_constants import Entitlement
+from payments.exceptions import OverLimitError
 from public_api.exceptions import InvalidAuthorizationHeaderError, PublicAPIServiceUnavailableError
 from public_api.models import SystemUser
 from public_api.services import PublicAPIAuthService
 from public_api.types import PublicApiHttpRequest
+
+
+if TYPE_CHECKING:
+    from payments.services.entitlement_service import EntitlementService
 
 
 class PublicApiSystemUserMiddleware:
@@ -77,6 +84,33 @@ class PublicApiSystemUserMiddleware:
             return None
         return Organization.objects.filter(id=organization_id).first()
 
+    @inject
+    def _has_partner_api_entitlement(
+        self,
+        organization: Organization,
+        entitlement_service: Annotated[
+            "EntitlementService | None", Provide["entitlement_service"]
+        ] = None,
+    ) -> bool:
+        """Is ``organization`` (or its billing root) entitled to use the partner API?
+
+        Fails closed defensively when DI wiring itself is broken (``entitlement_service``
+        is ``None``): denying an authenticated request beats silently granting every
+        organization unrestricted API access because a container failed to wire.
+
+        Under normal operation this cannot lock out a legitimate organization:
+        ``EntitlementService.has_entitlement`` resolves at the billing root, and every
+        billing root always holds exactly one ``Subscription`` (the "no plan-less
+        state" invariant from Phase 4) whose entitlement rows are synced from its plan
+        on creation -- including the seeded ``unlimited`` default, which grants every
+        ``Entitlement`` member. An org only loses this gate by being placed on a plan
+        that explicitly omits or disables ``partner_api``, which is the intended
+        enforcement, not an accident of a missing row.
+        """
+        if entitlement_service is None:
+            return False
+        return entitlement_service.has_entitlement(organization, Entitlement.PARTNER_API)
+
     def __call__(self, request: HttpRequest) -> HttpResponse:
         # ignore middleware if request is not the graphql endpoint
 
@@ -94,5 +128,21 @@ class PublicApiSystemUserMiddleware:
                 extended_request.public_api_system_user.organization
                 or self._get_organization_from_request(extended_request)
             )
+
+        # Entitlement gate: an organization without `partner_api` cannot use the
+        # GraphQL API at all, not just individual mutations. Scoped to requests that
+        # actually resolved an authenticated organization above (anonymous / public
+        # GraphQL queries -- e.g. brandingForTenant -- never reach here, since
+        # `public_api_organization` stays None for them) so this can never reject an
+        # unauthenticated request the normal `IsAuthenticated` permission class would
+        # otherwise handle. Bypasses GraphQL execution entirely and returns a real
+        # HTTP 402 (rather than the graphql-core-swallowed 200 + `errors` shape a
+        # resolver-level rejection would produce), matching the plan's contract for
+        # this specific chokepoint.
+        if extended_request.public_api_organization is not None and not (
+            self._has_partner_api_entitlement(extended_request.public_api_organization)
+        ):
+            error = OverLimitError.from_missing_entitlement(Entitlement.PARTNER_API)
+            return JsonResponse(error.as_error_body(), status=402)
 
         return self.get_response(extended_request)

--- a/public_api/middlewares.py
+++ b/public_api/middlewares.py
@@ -11,6 +11,7 @@ from dependency_injector.wiring import Provide, inject
 
 from organizations.models import Organization
 from payments.billing_constants import Entitlement
+from payments.entitlement_cache import entitlement_request_cache, has_entitlement_cached
 from payments.exceptions import OverLimitError
 from public_api.exceptions import InvalidAuthorizationHeaderError, PublicAPIServiceUnavailableError
 from public_api.models import SystemUser
@@ -109,7 +110,7 @@ class PublicApiSystemUserMiddleware:
         """
         if entitlement_service is None:
             return False
-        return entitlement_service.has_entitlement(organization, Entitlement.PARTNER_API)
+        return has_entitlement_cached(entitlement_service, organization, Entitlement.PARTNER_API)
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         # ignore middleware if request is not the graphql endpoint
@@ -118,31 +119,38 @@ class PublicApiSystemUserMiddleware:
         extended_request.public_api_system_user = None
         extended_request.public_api_organization = None
 
-        if extended_request.get_full_path().startswith("/graphql/"):
-            extended_request.public_api_system_user = self._get_system_user_from_request(
-                extended_request
-            )
+        # Scope the per-request entitlement memo around the whole GraphQL request, not
+        # just the gate below: `resolve_branding_for_display` checks
+        # `white_label_branding` inside resolvers, and `brandingForTenant` /
+        # `validateReturnUrl` are unauthenticated public queries with an
+        # attacker-supplied `tenant_id`. See `payments/entitlement_cache.py` for why the
+        # cache is scoped rather than process-wide.
+        with entitlement_request_cache():
+            if extended_request.get_full_path().startswith("/graphql/"):
+                extended_request.public_api_system_user = self._get_system_user_from_request(
+                    extended_request
+                )
 
-        if extended_request.public_api_system_user:
-            extended_request.public_api_organization = (
-                extended_request.public_api_system_user.organization
-                or self._get_organization_from_request(extended_request)
-            )
+            if extended_request.public_api_system_user:
+                extended_request.public_api_organization = (
+                    extended_request.public_api_system_user.organization
+                    or self._get_organization_from_request(extended_request)
+                )
 
-        # Entitlement gate: an organization without `partner_api` cannot use the
-        # GraphQL API at all, not just individual mutations. Scoped to requests that
-        # actually resolved an authenticated organization above (anonymous / public
-        # GraphQL queries -- e.g. brandingForTenant -- never reach here, since
-        # `public_api_organization` stays None for them) so this can never reject an
-        # unauthenticated request the normal `IsAuthenticated` permission class would
-        # otherwise handle. Bypasses GraphQL execution entirely and returns a real
-        # HTTP 402 (rather than the graphql-core-swallowed 200 + `errors` shape a
-        # resolver-level rejection would produce), matching the plan's contract for
-        # this specific chokepoint.
-        if extended_request.public_api_organization is not None and not (
-            self._has_partner_api_entitlement(extended_request.public_api_organization)
-        ):
-            error = OverLimitError.from_missing_entitlement(Entitlement.PARTNER_API)
-            return JsonResponse(error.as_error_body(), status=402)
+            # Entitlement gate: an organization without `partner_api` cannot use the
+            # GraphQL API at all, not just individual mutations. Scoped to requests that
+            # actually resolved an authenticated organization above (anonymous / public
+            # GraphQL queries -- e.g. brandingForTenant -- never reach here, since
+            # `public_api_organization` stays None for them) so this can never reject an
+            # unauthenticated request the normal `IsAuthenticated` permission class would
+            # otherwise handle. Bypasses GraphQL execution entirely and returns a real
+            # HTTP 402 (rather than the graphql-core-swallowed 200 + `errors` shape a
+            # resolver-level rejection would produce), matching the plan's contract for
+            # this specific chokepoint.
+            if extended_request.public_api_organization is not None and not (
+                self._has_partner_api_entitlement(extended_request.public_api_organization)
+            ):
+                error = OverLimitError.from_missing_entitlement(Entitlement.PARTNER_API)
+                return JsonResponse(error.as_error_body(), status=402)
 
-        return self.get_response(extended_request)
+            return self.get_response(extended_request)

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1083,7 +1083,12 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                 f"Valid values are: {', '.join(sorted(valid_values))}."
             )
 
-        # Mint the system user and persist ResourceAccess rows (mirrors REST create)
+        # Mint the system user and persist ResourceAccess rows (mirrors REST create).
+        # Phase 6c: create_system_user raises OverLimitError at the organization's
+        # public_api_system_users ceiling. Caught outside the IntegrityError branch and
+        # rendered via raise_over_limit_graphql_error (also rolls back the request
+        # transaction -- see that function's docstring for why that matters under
+        # ATOMIC_REQUESTS).
         try:
             with transaction.atomic():
                 system_user, plaintext_token = deps.public_api_auth_service.create_system_user(
@@ -1097,6 +1102,8 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                         for resource_name in dict.fromkeys(input.resources)
                     ]
                 )
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
         except IntegrityError as e:
             raise GraphQLError(
                 f"A token with integration_name '{input.integration_name}' already exists."
@@ -1169,7 +1176,12 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                 f"Allowed resources are: {', '.join(sorted(PROVIDER_SCOPED_RESOURCES))}."
             )
 
-        # Create the system user and resource-access rows atomically
+        # Create the system user and resource-access rows atomically.
+        # Phase 6c: create_system_user raises OverLimitError at the organization's
+        # public_api_system_users ceiling. Caught outside the IntegrityError branch and
+        # rendered via raise_over_limit_graphql_error (also rolls back the request
+        # transaction -- see that function's docstring for why that matters under
+        # ATOMIC_REQUESTS).
         try:
             with transaction.atomic():
                 system_user, plaintext_token = deps.public_api_auth_service.create_system_user(
@@ -1184,6 +1196,8 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                         for resource_name in dict.fromkeys(input.available_resources)
                     ]
                 )
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
         except IntegrityError as e:
             # Only convert to "already exists" when the integration_name uniqueness constraint
             # fired; a ResourceAccess constraint failure would have a different message and
@@ -1318,6 +1332,10 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
 
         headers: dict = cast(dict, input.headers) if input.headers is not None else {}
 
+        # Phase 6c: create_configuration raises OverLimitError at the organization's
+        # webhook_subscriptions ceiling. Caught before the ValueError branch and rendered
+        # via raise_over_limit_graphql_error (also rolls back the request transaction --
+        # see that function's docstring for why that matters under ATOMIC_REQUESTS).
         try:
             configuration = deps.webhook_service.create_configuration(
                 organization=org,
@@ -1325,6 +1343,8 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                 url=input.url,
                 headers=headers,
             )
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
         except ValueError as e:
             raise GraphQLError(str(e)) from e
 

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -48,7 +48,12 @@ from calendar_integration.models import (
     ExternalEventChangeRequest,
 )
 from calendar_integration.services.ics_service import CalendarEventICSService
-from organizations.models import Organization, OrganizationMembership, resolve_branding
+from organizations.models import (
+    Organization,
+    OrganizationMembership,
+    resolve_branding,
+    resolve_branding_for_display,
+)
 from public_api.capabilities import assert_org_can_invite
 from public_api.permissions import (
     IsAuthenticated,
@@ -1467,8 +1472,10 @@ class Query:
             # Unknown tenant ID returns the vinta default (no enumeration oracle)
             return _vinta_default_branding()
 
-        # Resolve branding by walking up the parent chain to the nearest reseller
-        branding = resolve_branding(org)
+        # Resolve branding by walking up the parent chain to the nearest reseller.
+        # Presentation caller -> gated on `white_label_branding`; a reseller without it
+        # renders the vinta default, same as an unbranded subtree.
+        branding = resolve_branding_for_display(org)
         if branding is None:
             # Unbranded subtree returns the vinta default
             return _vinta_default_branding()
@@ -1526,6 +1533,10 @@ class Query:
             # Unknown / unparseable tenant — same shape as not-allowed (no oracle).
             return not_allowed
 
+        # Deliberately the UNGATED `resolve_branding`. This is an auth-flow decision
+        # (may this OAuth return URL be honoured?), not a cosmetic one: gating it would
+        # let a reseller's downgrade off a cosmetic entitlement break the OAuth return
+        # flow for every tenant underneath it. See `resolve_branding`'s docstring.
         branding = resolve_branding(org)
         if branding is None:
             # Unbranded subtree — same shape as not-allowed (no oracle).

--- a/public_api/services.py
+++ b/public_api/services.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING, Annotated, Any
 
 from django.db import transaction
@@ -19,6 +20,9 @@ from public_api.models import SystemUser
 if TYPE_CHECKING:
     from organizations.models import Organization, OrganizationMembership
     from payments.services.entitlement_service import EntitlementService
+
+
+logger = logging.getLogger(__name__)
 
 
 class PublicAPIAuthService:
@@ -57,7 +61,7 @@ class PublicAPIAuthService:
     def create_system_user(
         self,
         integration_name: str,
-        organization: "Organization",
+        organization: "Organization | None",
         scoped_to_membership: "OrganizationMembership | None" = None,
         bypass_limits: bool = False,
     ) -> tuple[SystemUser, str]:
@@ -65,7 +69,11 @@ class PublicAPIAuthService:
         Create a new system user with a long-lived token.
 
         :param integration_name: Unique name identifying the integration.
-        :param organization: The organization this system user belongs to.
+        :param organization: The organization this system user belongs to, or ``None``
+            for an org-less token with access to all organizations. ``SystemUser.
+            organization`` is ``null=True``, ``SystemUserAdmin`` exposes it with no
+            custom form, and that admin's ``save_model`` branches explicitly on the
+            org-less case -- so ``None`` is a supported input, not a defect.
         :param scoped_to_membership: Optional OrganizationMembership to scope this token to.
             When set, the token may only read/write data belonging to calendars owned by the
             membership's user within that organization.
@@ -85,10 +93,25 @@ class PublicAPIAuthService:
             ``deleted_at__isnull=True``. A freshly created row defaults to both, so it is
             unconditionally "live" and always feeds the same counter this check reads:
             there is no separate predicate to keep in sync.
+
+            **Not checked at all when ``organization is None``.** There is no
+            organization to resolve a billing root from -- ``resolve_billing_root(None)``
+            has no answer -- and an org-less token is unmetered by design, which
+            ``_count_public_api_system_users``'s own docstring already states (it counts
+            per-organization). Guarding it would 500 a previously-working, explicitly
+            supported admin path. Logged at WARNING so an unmetered credential is at
+            least visible in the record.
         :return: Tuple of (system_user, plaintext_token). The plaintext token is exposed
             once and never persisted; only the hash is stored.
         """
-        if not bypass_limits and self.entitlement_service is not None:
+        if organization is None:
+            logger.warning(
+                "Creating org-less system user %r: no organization to resolve a billing "
+                "root from, so the public_api_system_users limit is not enforced for it. "
+                "This credential has access to all organizations and is unmetered.",
+                integration_name,
+            )
+        elif not bypass_limits and self.entitlement_service is not None:
             result = self.entitlement_service.check_limit(
                 organization, LimitedResource.PUBLIC_API_SYSTEM_USERS, lock=True
             )
@@ -109,13 +132,21 @@ class PublicAPIAuthService:
         # Audit: a system-user (API integration credential) is provisioned for the org.
         # No acting Django User is threaded here, so the actor is the system; when the
         # token is membership-scoped, that membership is the affected party.
-        self.audit_service.record(
-            organization_id=organization.id,
-            action=AuditAction.CREATE,
-            actor=self.audit_service.system_actor(),
-            subject=self.audit_service.subject_from_instance(system_user),
-            affected_membership_ids=(
-                [scoped_to_membership.user_id] if scoped_to_membership is not None else []
-            ),
-        )
+        #
+        # Skipped entirely for an org-less token: `AuditService.record` requires an
+        # `organization_id` (the audit trail is org-scoped by design and has no sentinel
+        # for "all organizations"), and this line previously raised `AttributeError` on
+        # `None` — the org-less admin path never reached a successful return. The WARNING
+        # logged above is the record for this case until the audit trail grows a
+        # cross-organization scope.
+        if organization is not None:
+            self.audit_service.record(
+                organization_id=organization.id,
+                action=AuditAction.CREATE,
+                actor=self.audit_service.system_actor(),
+                subject=self.audit_service.subject_from_instance(system_user),
+                affected_membership_ids=(
+                    [scoped_to_membership.user_id] if scoped_to_membership is not None else []
+                ),
+            )
         return system_user, token

--- a/public_api/services.py
+++ b/public_api/services.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Annotated, Any
 
+from django.db import transaction
+
 from dependency_injector.wiring import Provide, inject
 
 from audit.constants import AuditAction
@@ -9,11 +11,14 @@ from common.utils.authentication_utils import (
     hash_long_lived_token,
     verify_long_lived_token,
 )
+from payments.billing_constants import LimitedResource
+from payments.exceptions import OverLimitError
 from public_api.models import SystemUser
 
 
 if TYPE_CHECKING:
     from organizations.models import Organization, OrganizationMembership
+    from payments.services.entitlement_service import EntitlementService
 
 
 class PublicAPIAuthService:
@@ -21,8 +26,12 @@ class PublicAPIAuthService:
     def __init__(
         self,
         audit_service: Annotated[AuditService, Provide["audit_service"]],
+        entitlement_service: Annotated[
+            "EntitlementService | None", Provide["entitlement_service"]
+        ] = None,
     ) -> None:
         self.audit_service = audit_service
+        self.entitlement_service = entitlement_service
 
     def check_system_user_token(self, system_user_id: int, token: str) -> tuple[SystemUser, bool]:
         """
@@ -44,11 +53,13 @@ class PublicAPIAuthService:
 
         return system_user, verify_long_lived_token(token, system_user.long_lived_token_hash)
 
+    @transaction.atomic()
     def create_system_user(
         self,
         integration_name: str,
         organization: "Organization",
         scoped_to_membership: "OrganizationMembership | None" = None,
+        bypass_limits: bool = False,
     ) -> tuple[SystemUser, str]:
         """
         Create a new system user with a long-lived token.
@@ -59,9 +70,31 @@ class PublicAPIAuthService:
             When set, the token may only read/write data belonging to calendars owned by the
             membership's user within that organization.
             When None (default), the token has org-wide access (legacy default).
+        :param bypass_limits: When True, skips the ``public_api_system_users`` limit guard
+            below. Only management commands and one-off repair scripts should pass this --
+            never a request-handling path.
+        :raises OverLimitError: When the organization is at its effective
+            ``public_api_system_users`` ceiling. Nothing is created. Checked and locked
+            (``SELECT ... FOR UPDATE`` on the billing root's subscription) inside this
+            method's own transaction (every call site -- the REST serializer, both GraphQL
+            mutations, and the admin -- routes through this single creation function), so
+            two concurrent creates for the last unit of capacity serialize on that row.
+
+            The counter this guards (``EntitlementService._count_public_api_system_users``)
+            counts ``SystemUser.objects.live()`` -- ``is_active=True`` and
+            ``deleted_at__isnull=True``. A freshly created row defaults to both, so it is
+            unconditionally "live" and always feeds the same counter this check reads:
+            there is no separate predicate to keep in sync.
         :return: Tuple of (system_user, plaintext_token). The plaintext token is exposed
             once and never persisted; only the hash is stored.
         """
+        if not bypass_limits and self.entitlement_service is not None:
+            result = self.entitlement_service.check_limit(
+                organization, LimitedResource.PUBLIC_API_SYSTEM_USERS, lock=True
+            )
+            if not result.allowed:
+                raise OverLimitError.from_check_result(result)
+
         token = generate_long_lived_token()
         create_kwargs: dict[str, Any] = {
             "organization": organization,

--- a/public_api/tests/test_entitlement_gates.py
+++ b/public_api/tests/test_entitlement_gates.py
@@ -1,0 +1,272 @@
+"""Phase 6c: boolean entitlement gates.
+
+Spec use-case 2 (blocked with a useful message) and use-case 7 (the partner API
+is not a bypass), applied to the three named chokepoints:
+
+- ``partner_api`` in ``PublicApiSystemUserMiddleware`` -- an organization without
+  it cannot use the GraphQL API at all, not just individual mutations.
+- ``external_calendar_google`` / ``external_calendar_microsoft`` in
+  ``CalendarService.authenticate`` -- the common chokepoint both connection paths
+  flow through.
+
+Unlike a pre-paid limit, an entitlement is boolean and uses
+``EntitlementService.has_entitlement``, which fails **closed** on an existing
+subscription whose entitlement row is absent or disabled, but fails **open**
+when the organization has no subscription at all (the same "we don't know"
+treatment ``get_effective_limit`` already gives that condition) -- see
+``EntitlementService.has_entitlement``'s docstring. Every test in this module
+that asserts a block was confirmed to fail when its corresponding guard was
+removed.
+"""
+
+import datetime
+
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from allauth.socialaccount.models import SocialAccount, SocialToken
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from payments.billing_constants import BillingState, Entitlement
+from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+def _organization_with_entitlement(entitlement_key: str, is_enabled: bool) -> Organization:
+    """A standalone (non-reseller) organization whose subscription carries an
+    explicit ``SubscriptionEntitlement`` row for ``entitlement_key``."""
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionEntitlement,
+        subscription=subscription,
+        entitlement_key=entitlement_key,
+        is_enabled=is_enabled,
+    )
+    return organization
+
+
+def _unlimited_organization() -> Organization:
+    """An organization on the seeded ``unlimited`` plan -- every entitlement
+    enabled. The rollout's own kill switch: this is what "no feature flag" means
+    in practice, and every enforcement phase carries a test against it."""
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    plan = BillingPlan.objects.get(slug="unlimited")
+    from payments.services.subscription_service import SubscriptionService
+
+    SubscriptionService().create_subscription_for_organization(organization, plan=plan)
+    return organization
+
+
+# ---------------------------------------------------------------------------
+# partner_api -- PublicApiSystemUserMiddleware
+# ---------------------------------------------------------------------------
+
+TYPENAME_QUERY = "{ __typename }"
+USERS_QUERY = "query { users { id } }"
+
+_EXPECTED_ERROR_KEYS = {"detail", "code", "resource", "current_usage", "limit", "remedy"}
+
+
+def _post_graphql(client, system_user, token, query):
+    from di_core.containers import container
+
+    auth_service = PublicAPIAuthService()
+    with container.public_api_auth_service.override(auth_service):
+        return client.post(
+            "/graphql/",
+            data={"query": query, "variables": {}},
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+
+
+def _make_system_user(organization: Organization, *, with_user_access: bool = False) -> tuple:
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name=f"test-integration-{organization.id}",
+        organization=organization,
+    )
+    if with_user_access:
+        # OrganizationResourceAccess (unrelated to this phase's gate) requires an
+        # explicit grant per resource. Only needed on the positive-control paths
+        # below that expect the `users` query to actually resolve.
+        baker.make(ResourceAccess, system_user=system_user, resource_name="user")
+    return system_user, token
+
+
+@pytest.mark.django_db
+class TestPartnerApiGate:
+    def test_blocks_a_trivial_query_with_a_structured_402(self):
+        """Even a document with no application-level field (``__typename``) never
+        reaches graphql-core -- the gate is transport-level, not per-resolver."""
+        organization = _organization_with_entitlement(Entitlement.PARTNER_API, is_enabled=False)
+        system_user, token = _make_system_user(organization)
+        client = APIClient()
+
+        response = _post_graphql(client, system_user, token, TYPENAME_QUERY)
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        body = response.json()
+        assert set(body.keys()) == _EXPECTED_ERROR_KEYS
+        assert body["code"] == "limit_exceeded"
+        assert body["resource"] == Entitlement.PARTNER_API
+        assert body["remedy"] == "upgrade_plan"
+
+    def test_blocks_a_real_query_with_the_same_structured_402(self):
+        organization = _organization_with_entitlement(Entitlement.PARTNER_API, is_enabled=False)
+        system_user, token = _make_system_user(organization)
+        client = APIClient()
+
+        response = _post_graphql(client, system_user, token, USERS_QUERY)
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        assert response.json()["resource"] == Entitlement.PARTNER_API
+
+    def test_missing_entitlement_row_on_a_real_subscription_also_blocks(self):
+        """No row at all (rather than an explicit ``is_enabled=False`` row) is how
+        ``SubscriptionService._sync_entitlements`` represents a revoked grant --
+        must be treated identically to an explicit denial."""
+        organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+        now = timezone.now()
+        baker.make(
+            Subscription,
+            organization=organization,
+            plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+            billing_state=BillingState.FREE,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+        )
+        system_user, token = _make_system_user(organization)
+        client = APIClient()
+
+        response = _post_graphql(client, system_user, token, TYPENAME_QUERY)
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+
+    def test_org_with_partner_api_enabled_is_not_blocked(self):
+        organization = _organization_with_entitlement(Entitlement.PARTNER_API, is_enabled=True)
+        system_user, token = _make_system_user(organization, with_user_access=True)
+        client = APIClient()
+
+        response = _post_graphql(client, system_user, token, USERS_QUERY)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "errors" not in data or not data.get("errors")
+
+    def test_unlimited_plan_org_is_never_blocked(self):
+        """The rollout's kill switch: every organization is on ``unlimited`` until
+        deliberately migrated, so this must see byte-for-byte unchanged behavior."""
+        organization = _unlimited_organization()
+        system_user, token = _make_system_user(organization, with_user_access=True)
+        client = APIClient()
+
+        response = _post_graphql(client, system_user, token, USERS_QUERY)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "errors" not in data or not data.get("errors")
+
+    def test_anonymous_requests_are_unaffected(self):
+        """No credentials presented -> no organization resolved -> the gate never
+        runs. A genuinely anonymous caller is rejected (if at all) by the normal
+        ``IsAuthenticated`` permission class, not this gate -- and never with the
+        entitlement error body."""
+        client = APIClient()
+
+        response = client.post(
+            "/graphql/",
+            data={"query": USERS_QUERY, "variables": {}},
+            format="json",
+        )
+
+        assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED
+
+
+# ---------------------------------------------------------------------------
+# external_calendar_google / external_calendar_microsoft -- CalendarService.authenticate
+# ---------------------------------------------------------------------------
+
+
+def _admin_membership(organization: Organization) -> OrganizationMembership:
+    from users.factories import UserFactory
+
+    user = UserFactory().create_user()
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=organization,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+def _google_account_with_token(user) -> SocialAccount:
+    account = baker.make(SocialAccount, user=user, provider=CalendarProvider.GOOGLE)
+    baker.make(
+        SocialToken,
+        account=account,
+        token="fake-google-access-token",
+        token_secret="fake-google-refresh-token",
+        expires_at=timezone.now() + datetime.timedelta(hours=1),
+    )
+    return account
+
+
+@pytest.mark.django_db
+class TestExternalCalendarGoogleGate:
+    def test_cannot_import_from_a_google_account_without_the_entitlement(self):
+        organization = _organization_with_entitlement(
+            Entitlement.EXTERNAL_CALENDAR_GOOGLE, is_enabled=False
+        )
+        membership = _admin_membership(organization)
+        _google_account_with_token(membership.user)
+
+        client = APIClient()
+        client.force_authenticate(user=membership.user)
+
+        response = client.post(reverse("api:Calendars-request-import"))
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        assert response.data["resource"] == Entitlement.EXTERNAL_CALENDAR_GOOGLE
+
+    def test_can_import_from_a_google_account_with_the_entitlement(self):
+        organization = _organization_with_entitlement(
+            Entitlement.EXTERNAL_CALENDAR_GOOGLE, is_enabled=True
+        )
+        membership = _admin_membership(organization)
+        _google_account_with_token(membership.user)
+
+        client = APIClient()
+        client.force_authenticate(user=membership.user)
+
+        response = client.post(reverse("api:Calendars-request-import"))
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+
+    def test_unlimited_plan_org_can_import_unchanged(self):
+        organization = _unlimited_organization()
+        membership = _admin_membership(organization)
+        _google_account_with_token(membership.user)
+
+        client = APIClient()
+        client.force_authenticate(user=membership.user)
+
+        response = client.post(reverse("api:Calendars-request-import"))
+
+        assert response.status_code == status.HTTP_202_ACCEPTED

--- a/public_api/tests/test_entitlement_gates.py
+++ b/public_api/tests/test_entitlement_gates.py
@@ -261,6 +261,15 @@ def _google_account_with_token(user) -> SocialAccount:
     return account
 
 
+# The Google adapter refuses to construct without these. Only the *positive*
+# controls below need them: the blocked case never gets as far as building an
+# adapter, which is itself the point of gating before `get_calendar_adapter_for_account`.
+_with_google_credentials = override_settings(
+    GOOGLE_CLIENT_ID="test-google-client-id",
+    GOOGLE_CLIENT_SECRET="test-google-client-secret",  # noqa: S106 - dummy value, not a credential
+)
+
+
 @pytest.mark.django_db
 class TestExternalCalendarGoogleGate:
     def test_cannot_import_from_a_google_account_without_the_entitlement(self):
@@ -278,6 +287,7 @@ class TestExternalCalendarGoogleGate:
         assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
         assert response.data["resource"] == Entitlement.EXTERNAL_CALENDAR_GOOGLE
 
+    @_with_google_credentials
     def test_can_import_from_a_google_account_with_the_entitlement(self):
         organization = _organization_with_entitlement(
             Entitlement.EXTERNAL_CALENDAR_GOOGLE, is_enabled=True
@@ -292,6 +302,7 @@ class TestExternalCalendarGoogleGate:
 
         assert response.status_code == status.HTTP_202_ACCEPTED
 
+    @_with_google_credentials
     def test_unlimited_plan_org_can_import_unchanged(self):
         organization = _unlimited_organization()
         membership = _admin_membership(organization)
@@ -456,6 +467,7 @@ class TestWriteAdapterProviderGate:
         service.authenticate(account=actor.user, organization=organization)
         return service, calendar
 
+    @_with_google_credentials
     def test_write_adapter_is_blocked_for_an_unentitled_calendar_provider(self):
         service, calendar = self._setup(microsoft_enabled=False)
 
@@ -464,6 +476,7 @@ class TestWriteAdapterProviderGate:
 
         assert exc_info.value.resource_key == Entitlement.EXTERNAL_CALENDAR_MICROSOFT
 
+    @_with_google_credentials
     @_with_ms_credentials
     def test_write_adapter_is_returned_when_the_calendar_provider_is_entitled(self):
         service, calendar = self._setup(microsoft_enabled=True)

--- a/public_api/tests/test_entitlement_gates.py
+++ b/public_api/tests/test_entitlement_gates.py
@@ -6,21 +6,27 @@ is not a bypass), applied to the three named chokepoints:
 - ``partner_api`` in ``PublicApiSystemUserMiddleware`` -- an organization without
   it cannot use the GraphQL API at all, not just individual mutations.
 - ``external_calendar_google`` / ``external_calendar_microsoft`` in
-  ``CalendarService.authenticate`` -- the common chokepoint both connection paths
-  flow through.
+  ``CalendarService.authenticate`` (the account's provider) **and** in
+  ``CalendarService._get_write_adapter_for_calendar`` (the calendar's provider,
+  which can differ -- see ``TestWriteAdapterProviderGate``).
 
 Unlike a pre-paid limit, an entitlement is boolean and uses
-``EntitlementService.has_entitlement``, which fails **closed** on an existing
-subscription whose entitlement row is absent or disabled, but fails **open**
-when the organization has no subscription at all (the same "we don't know"
-treatment ``get_effective_limit`` already gives that condition) -- see
-``EntitlementService.has_entitlement``'s docstring. Every test in this module
-that asserts a block was confirmed to fail when its corresponding guard was
-removed.
+``EntitlementService.has_entitlement``, which fails **closed** in every unknown
+case: an absent or disabled row on a real subscription, and a missing subscription
+entirely. That is deliberately *not* symmetric with ``get_effective_limit``'s
+fail-open — for a numeric ceiling "we don't know" means unlimited, which is what
+the rollout seeds anyway; for a boolean gate it would mean *granted*, handing paid
+features to organizations whose billing state is corrupt. See
+``EntitlementService.has_entitlement``'s docstring.
+
+Every test in this module that asserts a block was confirmed to fail when its
+corresponding guard was removed.
 """
 
 import datetime
+from typing import TYPE_CHECKING
 
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -33,9 +39,32 @@ from rest_framework.test import APIClient
 from calendar_integration.constants import CalendarProvider
 from organizations.models import Organization, OrganizationMembership, OrganizationRole
 from payments.billing_constants import BillingState, Entitlement
+from payments.exceptions import OverLimitError
 from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
 from public_api.models import ResourceAccess
-from public_api.services import PublicAPIAuthService
+
+
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
+if TYPE_CHECKING:
+    from di_core.containers import AppContainer
+
+
+def _container() -> "AppContainer":
+    """The wired DI container, narrowed for mypy.
+
+    Imported inside the function body on purpose: ``di_core.containers.container`` is
+    only *assigned* in ``DICoreConfig.ready()``, so a module-level ``from ... import
+    container`` binds ``None`` forever. The root ``conftest.py``'s ``di_container``
+    fixture defers the import for the same reason.
+    """
+    from di_core.containers import container
+
+    assert container is not None, "DI container is only assigned in DICoreConfig.ready()"
+    return container
 
 
 def _organization_with_entitlement(entitlement_key: str, is_enabled: bool) -> Organization:
@@ -64,10 +93,10 @@ def _unlimited_organization() -> Organization:
     """An organization on the seeded ``unlimited`` plan -- every entitlement
     enabled. The rollout's own kill switch: this is what "no feature flag" means
     in practice, and every enforcement phase carries a test against it."""
-    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
-    plan = BillingPlan.objects.get(slug="unlimited")
     from payments.services.subscription_service import SubscriptionService
 
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    plan = BillingPlan.objects.get(slug="unlimited")
     SubscriptionService().create_subscription_for_organization(organization, plan=plan)
     return organization
 
@@ -83,10 +112,8 @@ _EXPECTED_ERROR_KEYS = {"detail", "code", "resource", "current_usage", "limit", 
 
 
 def _post_graphql(client, system_user, token, query):
-    from di_core.containers import container
-
-    auth_service = PublicAPIAuthService()
-    with container.public_api_auth_service.override(auth_service):
+    auth_service = _container().public_api_auth_service()
+    with _container().public_api_auth_service.override(auth_service):
         return client.post(
             "/graphql/",
             data={"query": query, "variables": {}},
@@ -96,7 +123,7 @@ def _post_graphql(client, system_user, token, query):
 
 
 def _make_system_user(organization: Organization, *, with_user_access: bool = False) -> tuple:
-    auth_service = PublicAPIAuthService()
+    auth_service = _container().public_api_auth_service()
     system_user, token = auth_service.create_system_user(
         integration_name=f"test-integration-{organization.id}",
         organization=organization,
@@ -186,7 +213,11 @@ class TestPartnerApiGate:
         """No credentials presented -> no organization resolved -> the gate never
         runs. A genuinely anonymous caller is rejected (if at all) by the normal
         ``IsAuthenticated`` permission class, not this gate -- and never with the
-        entitlement error body."""
+        entitlement error body.
+
+        Asserts the exact status rather than ``!= 402``: ``!= 402`` also passes on a
+        500, which would hide the gate breaking the anonymous path outright.
+        """
         client = APIClient()
 
         response = client.post(
@@ -195,7 +226,9 @@ class TestPartnerApiGate:
             format="json",
         )
 
-        assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED
+        # graphql-core reports authorization failures in the `errors` array of a 200.
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["errors"]
 
 
 # ---------------------------------------------------------------------------
@@ -270,3 +303,169 @@ class TestExternalCalendarGoogleGate:
         response = client.post(reverse("api:Calendars-request-import"))
 
         assert response.status_code == status.HTTP_202_ACCEPTED
+
+
+# The Microsoft adapter refuses to construct without these. Only the *positive*
+# controls below need them: the blocked cases never get as far as building an adapter,
+# which is itself the point of gating before `get_calendar_adapter_for_account`.
+_with_ms_credentials = override_settings(
+    MS_CLIENT_ID="test-ms-client-id",
+    MS_CLIENT_SECRET="test-ms-client-secret",  # noqa: S106 - dummy value, not a credential
+)
+
+
+def _microsoft_account_with_token(user) -> SocialAccount:
+    account = baker.make(SocialAccount, user=user, provider=CalendarProvider.MICROSOFT)
+    baker.make(
+        SocialToken,
+        account=account,
+        token="fake-ms-access-token",
+        token_secret="fake-ms-refresh-token",
+        expires_at=timezone.now() + datetime.timedelta(hours=1),
+    )
+    return account
+
+
+def _organization_with_entitlements(**grants: bool) -> Organization:
+    """A standalone organization whose subscription carries an explicit
+    ``SubscriptionEntitlement`` row per keyword (``entitlement_key=is_enabled``)."""
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    for entitlement_key, is_enabled in grants.items():
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=entitlement_key,
+            is_enabled=is_enabled,
+        )
+    return organization
+
+
+@pytest.mark.django_db
+class TestExternalCalendarMicrosoftGate:
+    """The Microsoft half of ``_PROVIDER_ENTITLEMENTS``.
+
+    The phase body names both providers; only Google was exercised, so a Microsoft-only
+    regression (a typo in the mapping, a provider constant drift) would have gone
+    unnoticed.
+    """
+
+    def test_microsoft_account_is_blocked_without_the_entitlement(self):
+        from calendar_integration.services.calendar_service import CalendarService
+
+        organization = _organization_with_entitlements(
+            **{Entitlement.EXTERNAL_CALENDAR_MICROSOFT: False}
+        )
+        membership = _admin_membership(organization)
+        account = _microsoft_account_with_token(membership.user)
+
+        service = _container().calendar_service()
+        with pytest.raises(OverLimitError) as exc_info:
+            service.authenticate(account=account, organization=organization)
+
+        assert exc_info.value.resource_key == Entitlement.EXTERNAL_CALENDAR_MICROSOFT
+        assert isinstance(service, CalendarService)
+
+    @_with_ms_credentials
+    def test_microsoft_account_is_allowed_with_the_entitlement(self):
+        organization = _organization_with_entitlements(
+            **{Entitlement.EXTERNAL_CALENDAR_MICROSOFT: True}
+        )
+        membership = _admin_membership(organization)
+        account = _microsoft_account_with_token(membership.user)
+
+        service = _container().calendar_service()
+        service.authenticate(account=account, organization=organization)
+
+        assert service.organization == organization
+
+    def test_google_entitlement_does_not_unlock_microsoft(self):
+        """The two entitlements are independent — holding one must not imply the other."""
+        organization = _organization_with_entitlements(
+            **{
+                Entitlement.EXTERNAL_CALENDAR_GOOGLE: True,
+                Entitlement.EXTERNAL_CALENDAR_MICROSOFT: False,
+            }
+        )
+        membership = _admin_membership(organization)
+        account = _microsoft_account_with_token(membership.user)
+
+        service = _container().calendar_service()
+        with pytest.raises(OverLimitError) as exc_info:
+            service.authenticate(account=account, organization=organization)
+
+        assert exc_info.value.resource_key == Entitlement.EXTERNAL_CALENDAR_MICROSOFT
+
+
+@pytest.mark.django_db
+class TestWriteAdapterProviderGate:
+    """``authenticate`` is not the sole chokepoint, and this pins the gap it leaves.
+
+    ``_get_write_adapter_for_calendar`` resolves an adapter from the **calendar's**
+    provider, not the authenticated account's, via the *static*
+    ``get_calendar_adapter_for_account`` — a different code path from the instance the
+    authenticate-time gate ran against.
+
+    The bypass this closes: an organization holds ``external_calendar_google`` but not
+    ``external_calendar_microsoft``. Calendar ``C`` has ``provider=microsoft`` and is
+    owned by a user who holds a Microsoft ``SocialAccount``. The actor authenticates with
+    their **Google** account, so the authenticate gate passes — correctly, it is a Google
+    account. Every write to ``C`` then builds a Microsoft adapter for that owner:
+    unmetered, ungated Microsoft traffic.
+    """
+
+    def _setup(self, *, microsoft_enabled: bool):
+        from calendar_integration.models import Calendar, CalendarOwnership
+
+        organization = _organization_with_entitlements(
+            **{
+                Entitlement.EXTERNAL_CALENDAR_GOOGLE: True,
+                Entitlement.EXTERNAL_CALENDAR_MICROSOFT: microsoft_enabled,
+            }
+        )
+        actor = _admin_membership(organization)
+        _google_account_with_token(actor.user)
+
+        owner = _admin_membership(organization)
+        _microsoft_account_with_token(owner.user)
+
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.MICROSOFT,
+            external_id="ms-calendar-1",
+        )
+        baker.make(
+            CalendarOwnership,
+            organization=organization,
+            calendar=calendar,
+            membership_user_id=owner.user_id,
+            is_default=True,
+        )
+
+        service = _container().calendar_service()
+        # Passes: the *account* is Google and the org holds external_calendar_google.
+        service.authenticate(account=actor.user, organization=organization)
+        return service, calendar
+
+    def test_write_adapter_is_blocked_for_an_unentitled_calendar_provider(self):
+        service, calendar = self._setup(microsoft_enabled=False)
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service._get_write_adapter_for_calendar(calendar)
+
+        assert exc_info.value.resource_key == Entitlement.EXTERNAL_CALENDAR_MICROSOFT
+
+    @_with_ms_credentials
+    def test_write_adapter_is_returned_when_the_calendar_provider_is_entitled(self):
+        service, calendar = self._setup(microsoft_enabled=True)
+
+        assert service._get_write_adapter_for_calendar(calendar) is not None

--- a/public_api/tests/test_queries.py
+++ b/public_api/tests/test_queries.py
@@ -6490,3 +6490,101 @@ class TestEventIcsQuery:
         assert data["eventIcs"] is None, (
             "Event from a different org must not be visible (org filter)"
         )
+
+
+# This class builds its own Subscription rows (OneToOne with Organization); the rest of
+# the module relies on conftest's autouse `provision_default_subscription`.
+@pytest.mark.no_auto_subscription
+@pytest.mark.django_db
+@patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+class TestReturnUrlSurvivesBrandingDowngrade:
+    """Phase 6c: the ``white_label_branding`` entitlement must not gate the OAuth
+    return flow.
+
+    ``resolve_branding`` backs two very different callers: ``brandingForTenant``
+    (cosmetic) and ``validateReturnUrl`` (an auth-flow decision). Gating both would mean
+    a reseller downgrading off a *cosmetic* entitlement returns
+    ``{allowed: False, sanitized_url: None}`` for every tenant in its subtree, breaking
+    the OAuth interstitial for all of them. That is a lockout caused by a change to a
+    logo, so the two callers use different resolvers -- ``resolve_branding_for_display``
+    for presentation, plain ``resolve_branding`` for the allowlist.
+
+    Confirmed to fail when ``validate_return_url`` is pointed at the gated resolver.
+    """
+
+    def _post(self, client, query, variables):
+        return client.post(
+            "/graphql/",
+            data=json.dumps({"query": query, "variables": variables}),
+            content_type="application/json",
+        )
+
+    def _reseller_without_branding_entitlement(self, allowlist):
+        import datetime as _datetime
+
+        from django.utils import timezone as _timezone
+
+        from payments.billing_constants import BillingState, Entitlement
+        from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
+
+        reseller = baker.make(Organization, name="Downgraded", can_invite_organizations=True)
+        now = _timezone.now()
+        subscription = baker.make(
+            Subscription,
+            organization=reseller,
+            plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+            billing_state=BillingState.FREE,
+            current_period_start=now,
+            current_period_end=now + _datetime.timedelta(days=30),
+        )
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=Entitlement.WHITE_LABEL_BRANDING,
+            is_enabled=False,
+        )
+        baker.make(
+            "organizations.OrganizationBranding",
+            organization=reseller,
+            app_name="Downgraded App",
+            return_url_allowlist=allowlist,
+        )
+        return reseller
+
+    def test_return_url_still_validates_after_the_downgrade(
+        self, mock_rate_limiter, anonymous_client
+    ):
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = self._reseller_without_branding_entitlement(["https://app.example.com"])
+        child = baker.make(Organization, name="Downgraded Child", parent=reseller)
+
+        candidate = "https://app.example.com/auth/callback?code=abc"
+        response = self._post(
+            anonymous_client,
+            _VALIDATE_RETURN_URL_QUERY,
+            {"tenantId": str(child.id), "url": candidate},
+        )
+
+        data = assert_graphql_success(response)
+        assert data["validateReturnUrl"] == {"allowed": True, "sanitizedUrl": candidate}
+
+    def test_branding_itself_does_fall_back_to_the_vinta_default(
+        self, mock_rate_limiter, anonymous_client
+    ):
+        """The other half of the split: the cosmetic surface *is* gated, so the
+        downgrade is really in effect and the test above is not just measuring an
+        ungated system."""
+        mock_rate_limiter.return_value = iter([None])
+
+        reseller = self._reseller_without_branding_entitlement(["https://app.example.com"])
+
+        query = """
+            query BrandingForTenant($tenantId: ID!) {
+                brandingForTenant(tenantId: $tenantId) { appName }
+            }
+        """
+        response = self._post(anonymous_client, query, {"tenantId": str(reseller.id)})
+
+        data = assert_graphql_success(response)
+        assert data["brandingForTenant"]["appName"] != "Downgraded App"

--- a/public_api/tests/test_queries.py
+++ b/public_api/tests/test_queries.py
@@ -6587,4 +6587,6 @@ class TestReturnUrlSurvivesBrandingDowngrade:
         response = self._post(anonymous_client, query, {"tenantId": str(reseller.id)})
 
         data = assert_graphql_success(response)
-        assert data["brandingForTenant"]["appName"] != "Downgraded App"
+        from public_api.queries import _vinta_default_branding
+
+        assert data["brandingForTenant"]["appName"] == _vinta_default_branding().app_name

--- a/public_api/tests/test_system_user_limits.py
+++ b/public_api/tests/test_system_user_limits.py
@@ -1,0 +1,146 @@
+"""Phase 6c: the pre-paid limit guard on ``PublicAPIAuthService.create_system_user``.
+
+Spec use-case 2 ("an organization hits a pre-paid limit and is blocked"), applied
+to the ``public_api_system_users`` resource. Every REST, GraphQL, and admin
+creation path routes through this single function (see its docstring), so guarding
+it here guards all of them at once.
+
+The guard's predicate is derived from the counter it guards
+(``EntitlementService._count_public_api_system_users``, which counts
+``SystemUser.objects.live()`` -- ``is_active=True`` and ``deleted_at__isnull=True``):
+a freshly created row defaults to both, so there is nothing to keep in sync between
+the two.
+
+Every test in this module was confirmed to fail when the guard was removed.
+"""
+
+import datetime
+
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+
+from organizations.models import Organization
+from payments.billing_constants import BillingState, LimitedResource, LimitKind
+from payments.exceptions import OverLimitError
+from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
+from public_api.models import SystemUser
+from public_api.services import PublicAPIAuthService
+
+
+def _organization_with_limit(limit_value: int | None) -> Organization:
+    """A standalone (non-reseller) organization with a ceiling on
+    ``public_api_system_users``. ``limit_value=None`` builds an
+    ``unlimited``-shaped subscription (NULL ceiling) -- the plan's "no feature
+    flag" rollout switch -- so the guard is exercised against it as well as a
+    finite ceiling.
+    """
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=LimitedResource.PUBLIC_API_SYSTEM_USERS,
+        limit_value=limit_value,
+        kind=LimitKind.PREPAID,
+    )
+    return organization
+
+
+@pytest.fixture
+def service() -> PublicAPIAuthService:
+    # Untyped deliberately: PublicAPIAuthService's constructor params are
+    # DI-injected (Provide[...]) and resolved at call time by the wired container,
+    # which mypy cannot see -- an explicit `-> PublicAPIAuthService` return
+    # annotation would make mypy check this body and flag the zero-arg call as
+    # missing the required `audit_service` argument.
+    return PublicAPIAuthService()
+
+
+@pytest.mark.django_db
+class TestCreateSystemUserLimit:
+    def test_raises_and_creates_nothing_at_the_limit(self, service):
+        organization = _organization_with_limit(1)
+        baker.make(
+            SystemUser,
+            organization=organization,
+            integration_name="seed-integration",
+            long_lived_token_hash="seed-hash",
+        )
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.create_system_user(
+                integration_name="blocked-integration",
+                organization=organization,
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.PUBLIC_API_SYSTEM_USERS
+        assert exc_info.value.current_usage == 1
+        assert exc_info.value.limit == 1
+        assert not SystemUser.objects.filter(integration_name="blocked-integration").exists()
+
+    def test_revoked_and_deleted_system_users_free_capacity(self, service):
+        """Neither an ``is_active=False`` (revoked) nor a soft-deleted row may count
+        against the ceiling -- both feed the same ``.live()`` predicate the counter
+        uses."""
+        organization = _organization_with_limit(1)
+        baker.make(
+            SystemUser,
+            organization=organization,
+            integration_name="revoked-integration",
+            long_lived_token_hash="revoked-hash",
+            is_active=False,
+        )
+
+        system_user, token = service.create_system_user(
+            integration_name="fits-integration",
+            organization=organization,
+        )
+
+        assert system_user.pk is not None
+        assert token
+
+    @pytest.mark.parametrize("limit_value", [2, None], ids=["headroom", "unlimited"])
+    def test_succeeds_with_headroom(self, service, limit_value):
+        organization = _organization_with_limit(limit_value)
+        baker.make(
+            SystemUser,
+            organization=organization,
+            integration_name="seed-integration-2",
+            long_lived_token_hash="seed-hash-2",
+        )
+
+        system_user, token = service.create_system_user(
+            integration_name="fits-integration-2",
+            organization=organization,
+        )
+
+        assert system_user.pk is not None
+        assert token
+
+    def test_bypass_limits_creates_anyway(self, service):
+        organization = _organization_with_limit(1)
+        baker.make(
+            SystemUser,
+            organization=organization,
+            integration_name="seed-integration-3",
+            long_lived_token_hash="seed-hash-3",
+        )
+
+        system_user, token = service.create_system_user(
+            integration_name="bypassed-integration",
+            organization=organization,
+            bypass_limits=True,
+        )
+
+        assert system_user.pk is not None
+        assert token

--- a/public_api/tests/test_system_user_limits.py
+++ b/public_api/tests/test_system_user_limits.py
@@ -29,6 +29,11 @@ from public_api.models import SystemUser
 from public_api.services import PublicAPIAuthService
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 def _organization_with_limit(limit_value: int | None) -> Organization:
     """A standalone (non-reseller) organization with a ceiling on
     ``public_api_system_users``. ``limit_value=None`` builds an
@@ -58,12 +63,20 @@ def _organization_with_limit(limit_value: int | None) -> Organization:
 
 @pytest.fixture
 def service() -> PublicAPIAuthService:
-    # Untyped deliberately: PublicAPIAuthService's constructor params are
-    # DI-injected (Provide[...]) and resolved at call time by the wired container,
-    # which mypy cannot see -- an explicit `-> PublicAPIAuthService` return
-    # annotation would make mypy check this body and flag the zero-arg call as
-    # missing the required `audit_service` argument.
-    return PublicAPIAuthService()
+    """The container-built service, not a hand-constructed one.
+
+    ``PublicAPIAuthService.__init__`` takes required dependencies (``audit_service``);
+    constructing it with no arguments relies on ``@inject`` filling them at call time,
+    which mypy cannot see and reports as ``[call-arg]``. Asking the container is both
+    type-correct and the wiring production actually uses.
+
+    The import is deferred into the body because ``container`` is only *assigned* in
+    ``DICoreConfig.ready()`` -- a module-level import binds ``None`` forever.
+    """
+    from di_core.containers import container
+
+    assert container is not None, "DI container is only assigned in DICoreConfig.ready()"
+    return container.public_api_auth_service()
 
 
 @pytest.mark.django_db
@@ -86,7 +99,9 @@ class TestCreateSystemUserLimit:
         assert exc_info.value.resource_key == LimitedResource.PUBLIC_API_SYSTEM_USERS
         assert exc_info.value.current_usage == 1
         assert exc_info.value.limit == 1
-        assert not SystemUser.objects.filter(integration_name="blocked-integration").exists()
+        assert not SystemUser.objects.filter(
+            organization=organization, integration_name="blocked-integration"
+        ).exists()
 
     def test_revoked_and_deleted_system_users_free_capacity(self, service):
         """Neither an ``is_active=False`` (revoked) nor a soft-deleted row may count

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,3 +23,5 @@ filterwarnings =
     # strawberry-django 0.86 deprecates its own internal `_django_type` attribute;
     # not actionable on our side until upstream removes it. Remove this on next bump.
     ignore:_django_type is deprecated:UserWarning
+markers =
+    no_auto_subscription: opt out of conftest's autouse `provision_default_subscription`. For tests that build their own `Subscription` (the field is a OneToOneField, so a second row is an IntegrityError) or that deliberately exercise the plan-less state.

--- a/webhooks/services/webhook_service.py
+++ b/webhooks/services/webhook_service.py
@@ -1,16 +1,24 @@
 import datetime
-from typing import Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, cast
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import URLValidator
+from django.db import transaction
 
 import requests
+from dependency_injector.wiring import Provide, inject
 
 from organizations.models import Organization
+from payments.billing_constants import LimitedResource
+from payments.exceptions import OverLimitError
 from webhooks.constants import WebhookEventType, WebhookStatus
 from webhooks.models import WebhookConfiguration, WebhookEvent
 from webhooks.services.payloads import WebhookEnvelope
 from webhooks.tasks import process_webhook_event
+
+
+if TYPE_CHECKING:
+    from payments.services.entitlement_service import EntitlementService
 
 
 MAX_WEBHOOK_RETRIES = 5
@@ -23,6 +31,15 @@ class InitializedWebhook:
 
 
 class WebhookService:
+    @inject
+    def __init__(
+        self,
+        entitlement_service: Annotated[
+            "EntitlementService | None", Provide["entitlement_service"]
+        ] = None,
+    ) -> None:
+        self.entitlement_service = entitlement_service
+
     def _validate_config_fields(self, event_type: str, url: str) -> None:
         """Validate event_type and url before persisting a WebhookConfiguration.
 
@@ -43,10 +60,41 @@ class WebhookService:
         except DjangoValidationError as e:
             raise ValueError(f"Invalid url '{url}'. Must be a valid http(s) URL.") from e
 
+    @transaction.atomic()
     def create_configuration(
-        self, organization: Organization, event_type: str, url: str, headers: dict
+        self,
+        organization: Organization,
+        event_type: str,
+        url: str,
+        headers: dict,
+        bypass_limits: bool = False,
     ) -> WebhookConfiguration:
+        """Create a ``WebhookConfiguration``, guarded on the ``webhook_subscriptions``
+        pre-paid limit.
+
+        :param bypass_limits: When True, skips the ``webhook_subscriptions`` limit
+            guard below. Only management commands and one-off repair scripts should
+            pass this -- never a request-handling path.
+        :raises OverLimitError: When the organization is at its effective
+            ``webhook_subscriptions`` ceiling. Nothing is created. Checked and locked
+            (``SELECT ... FOR UPDATE`` on the billing root's subscription) inside this
+            method's own transaction, so two concurrent creates for the last unit of
+            capacity serialize on that row.
+
+            The counter this guards (``EntitlementService._count_webhook_subscriptions``)
+            counts ``WebhookConfiguration.objects.live()`` -- rows with
+            ``deleted_at__isnull=True``. A freshly created row always has
+            ``deleted_at=None``, so it is unconditionally "live" and always feeds the
+            same counter this check reads: there is no separate predicate to keep in
+            sync.
+        """
         self._validate_config_fields(event_type, url)
+        if not bypass_limits and self.entitlement_service is not None:
+            result = self.entitlement_service.check_limit(
+                organization, LimitedResource.WEBHOOK_SUBSCRIPTIONS, lock=True
+            )
+            if not result.allowed:
+                raise OverLimitError.from_check_result(result)
         return WebhookConfiguration.objects.create(
             organization=organization, event_type=event_type, url=url, headers=headers
         )

--- a/webhooks/tests/test_webhook_subscription_limits.py
+++ b/webhooks/tests/test_webhook_subscription_limits.py
@@ -26,6 +26,11 @@ from webhooks.models import WebhookConfiguration
 from webhooks.services.webhook_service import WebhookService
 
 
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
 def _organization_with_limit(limit_value: int | None) -> Organization:
     """A standalone (non-reseller) organization with a ceiling on
     ``webhook_subscriptions``. ``limit_value=None`` builds an ``unlimited``-shaped

--- a/webhooks/tests/test_webhook_subscription_limits.py
+++ b/webhooks/tests/test_webhook_subscription_limits.py
@@ -1,0 +1,143 @@
+"""Phase 6c: the pre-paid limit guard on ``WebhookService.create_configuration``.
+
+Spec use-case 2 ("an organization hits a pre-paid limit and is blocked"), applied
+to the ``webhook_subscriptions`` resource. The guard's predicate is derived from
+the counter it guards (``EntitlementService._count_webhook_subscriptions``, which
+counts ``WebhookConfiguration.objects.live()`` -- ``deleted_at__isnull=True``): a
+freshly created row always has ``deleted_at=None``, so there is nothing to keep in
+sync between the two.
+
+Every test in this module was confirmed to fail when the guard was removed.
+"""
+
+import datetime
+
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+
+from organizations.models import Organization
+from payments.billing_constants import BillingState, LimitedResource, LimitKind
+from payments.exceptions import OverLimitError
+from payments.models import BillingPlan, Subscription, SubscriptionPlanLimit
+from webhooks.constants import WebhookEventType
+from webhooks.models import WebhookConfiguration
+from webhooks.services.webhook_service import WebhookService
+
+
+def _organization_with_limit(limit_value: int | None) -> Organization:
+    """A standalone (non-reseller) organization with a ceiling on
+    ``webhook_subscriptions``. ``limit_value=None`` builds an ``unlimited``-shaped
+    subscription (NULL ceiling) -- the plan's "no feature flag" rollout switch --
+    so the guard is exercised against it as well as a finite ceiling.
+    """
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=LimitedResource.WEBHOOK_SUBSCRIPTIONS,
+        limit_value=limit_value,
+        kind=LimitKind.PREPAID,
+    )
+    return organization
+
+
+@pytest.fixture
+def service() -> WebhookService:
+    return WebhookService()
+
+
+@pytest.mark.django_db
+class TestCreateConfigurationLimit:
+    def test_raises_and_creates_nothing_at_the_limit(self, service):
+        organization = _organization_with_limit(1)
+        baker.make(
+            WebhookConfiguration,
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/seed",
+        )
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.create_configuration(
+                organization=organization,
+                event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+                url="https://example.com/blocked",
+                headers={},
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.WEBHOOK_SUBSCRIPTIONS
+        assert exc_info.value.current_usage == 1
+        assert exc_info.value.limit == 1
+        assert not WebhookConfiguration.objects.filter(
+            organization=organization, url="https://example.com/blocked"
+        ).exists()
+
+    def test_soft_deleted_configurations_free_capacity(self, service):
+        """A soft-deleted row must not count against the ceiling -- it feeds the
+        same ``.live()`` predicate the counter uses."""
+        organization = _organization_with_limit(1)
+        baker.make(
+            WebhookConfiguration,
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/deleted",
+            deleted_at=timezone.now(),
+        )
+
+        configuration = service.create_configuration(
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/fits",
+            headers={},
+        )
+
+        assert configuration.pk is not None
+
+    @pytest.mark.parametrize("limit_value", [2, None], ids=["headroom", "unlimited"])
+    def test_succeeds_with_headroom(self, service, limit_value):
+        organization = _organization_with_limit(limit_value)
+        baker.make(
+            WebhookConfiguration,
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/seed2",
+        )
+
+        configuration = service.create_configuration(
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/fits2",
+            headers={},
+        )
+
+        assert configuration.pk is not None
+
+    def test_bypass_limits_creates_anyway(self, service):
+        organization = _organization_with_limit(1)
+        baker.make(
+            WebhookConfiguration,
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/seed3",
+        )
+
+        configuration = service.create_configuration(
+            organization=organization,
+            event_type=WebhookEventType.CALENDAR_EVENT_CREATED,
+            url="https://example.com/bypassed",
+            headers={},
+            bypass_limits=True,
+        )
+
+        assert configuration.pk is not None


### PR DESCRIPTION

Phase 6c of the [billing plans and limits plan](../../../ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_IMPLEMENTATION_PLAN.md). **Stacked on [phase 6b](https://github.com/vintasoftware/vinta-schedule-api/pull/196)** — review that one first.

**This phase closes spec objective 1 for pre-paid resources.** Every `kind=prepaid` member of `LimitedResource` now has a guarded creation path with a test proving it blocks. It also adds the three boolean entitlement gates.

## The acceptance condition, machine-checked

`payments/tests/test_prepaid_resource_coverage.py` derives the prepaid set from the seeded plan's own `PlanLimit.kind` rather than a hand-typed list, and drives each probe through the **real** guarded service method:

| resource | guarded path | phase |
|---|---|---|
| `organization_members` | `OrganizationService.invite_user_to_organization` | 6a |
| `resource_calendars` | `CalendarService.create_resource_calendar` | 6b |
| `calendar_groups` | `CalendarGroupService.create_group` | 6b |
| `bundle_calendars` | `CalendarService.create_bundle_calendar` | 6b |
| `availability_windows` | `CalendarService.create_available_time` | 6b |
| `webhook_subscriptions` | `WebhookService.create_configuration` | **6c** |
| `public_api_system_users` | `PublicAPIAuthService.create_system_user` | **6c** |

`event_occurrences` is asserted as the one deliberate exclusion (`kind=postpaid`, owned by Phase 8). The registry check is bidirectional, so both an unguarded new prepaid resource and a stale probe fail loudly.

## Three review rounds. The first round's own fix was the biggest finding.

### A deliberate design decision was reversed to make tests pass — and reverted

`has_entitlement` fails **closed** by Phase 5's reviewed design: absence encodes revocation, because `_sync_entitlements` *deletes* rows for entitlements a plan lacks.

The first implementation changed the missing-subscription branch to fail **open**, after 106 test failures caused by calendar-integration fixtures that build organizations with no `Subscription`. The justification offered was symmetry with `get_effective_limit`, which fails open on the same condition.

**That symmetry is invalid.** For a numeric ceiling, "we don't know" → NULL → *unlimited*, which coincides with what the rollout actually seeds. For a **boolean** gate, "we don't know" → `True` grants **paid** features — strictly more than the `free` plan grants. And the rollout-safety argument was already satisfied: the backfill migration puts every billing root on `unlimited`, whose entitlements are all enabled. The fail-open branch contributed nothing to rollout safety and fired only when billing state was *already* broken — handing the most access to exactly those organizations. Ops deleting a `Subscription` to re-provision an org would, in that window, grant a `free` org the entire partner API.

Reverted. `payments/services/entitlement_service.py` has **zero net diff** against phase 6b. The fixtures were fixed instead — an autouse fixture provisions a subscription for test organizations, with 20 modules opting out via `@pytest.mark.no_auto_subscription` because they own their own rows or deliberately exercise the plan-less path.

### The entitlement gate was bypassable

The plan chose `authenticate` as the chokepoint "both connection paths flow through". It is not. `_get_write_adapter_for_calendar` builds a provider adapter for whoever *owns* the calendar. An org with Google enabled and Microsoft disabled could authenticate via Google, pass the gate, then write to a Microsoft calendar owned by another user — ungated Microsoft traffic.

### A previously-working admin path started 500ing

`create_system_user(organization=None)` is explicitly supported (`SystemUser.organization` is nullable, and `save_model` branches on the org-less case). The guard passed `None` into `resolve_billing_root`, producing `AttributeError` and an admin 500.

## Two `@inject` landmines found, neither billing-related

Both were invisible to the test suite, and one is a live production bug:

1. **Silent no-op under `from __future__ import annotations`.** dependency_injector cannot read `Provide[...]` out of a stringified annotation, so it emits a warning and returns the function **unpatched**. The branding guard passed every test while doing nothing.
2. **Admin autodiscovery beats DI wiring.** `SystemUserAdmin` was constructed by `@admin.register` *before* `DICoreConfig.ready()` calls `container.wire()`, so its injected service was permanently `None` — **every** admin-created system user raised `ValueError`, entirely independent of billing.

The pattern exists elsewhere in the codebase. Worth a deliberate sweep rather than fixing it where it happens to surface.

## Reviewer-facing notes

- **`_get_write_adapter_for_calendar` now raises** rather than returning `None`. Callers were traced individually: GraphQL is inside `try/except OverLimitError`, DRF maps to 402 via the global handler, and the five `if write_adapter := ...` sites run under `ATOMIC_REQUESTS` so the local write rolls back rather than diverging from the remote. The **calendar webhook service was the one caller** where skipping the remote work was intended — it now catches `OverLimitError` explicitly, because otherwise the provider gets a 500 and retries until the channel expires while the event row is never recorded.
- **`resolve_branding` was split.** The gate reached further than branding: it also backs `validate_return_url`, so a reseller downgrading off `white_label_branding` would have broken the OAuth return flow for every downstream tenant. `resolve_branding` is now ungated; `resolve_branding_for_display` carries the gate.
- **`partner_api` fails closed when DI is broken**, deliberately — a wiring failure should deny, not grant every org unrestricted API access.

## Verification

Re-run independently by the orchestrator in the container, not relayed:

- Full suite **4200 passed** (6b base 4148; +52).
- `mypy` **305 errors / 57 files** — at baseline. The first implementation regressed this to 309/60 and reported "net new: zero"; its `git stash` verification had left the new untracked test files on disk, so it measured the phase against itself. Verified here against a clean checkout of the base branch.
- `ruff` clean; `makemigrations --check` clean; `schema.yml` unchanged.
- Each guard confirmed by deleting it and watching specific tests fail, then restoring.
- 5 × `noqa: S106`, all dummy credentials in tests.

## Carried forward

- `ADVANCED_SCHEDULING` is a declared `Entitlement` with **no gate anywhere**. Out of scope here (the phase body names four gates); recorded so it is not mistaken for covered.
- `SystemUserAdmin`'s changelist raises `ImproperlyConfigured: QuerySet must be filtered by 'organization'` — a real pre-existing admin defect, unrelated to this phase.
- The `@inject` sweep described above.
- Everything from phases 5/6b (availability-counter residual, add-on expiry, nullable `SystemUser.organization`, `CalendarQuerySet.update()`'s `self._meta` bug, sync-lock chunking).