### PR TITLE
feat(payments): enforce the postpaid event_occurrences allowance (billing plans and limits, phase 8)

### DIFF
--- a/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
+++ b/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
@@ -312,15 +312,28 @@ Two things make this worse than the bound previously accepted:
 
 **Where this gates, precisely.** An earlier draft of this note said "Phase 8 must not enforce the post-paid ceiling until it lands." That is stricter than necessary and would stall the plan. Phase 8's guard is **inert on every current organization**: `unlimited` carries a NULL `event_occurrences` limit, and `check_postpaid_allowance` returns headroom for a NULL ceiling, so no code path can block on an over-counted number today. The real gate is the first moment a non-NULL `event_occurrences` limit reaches a live organization — **Phase 14**, already deferred, and **Phase 13**'s overage charge, which converts the same over-count into money. Both must wait for the recurrence fix. Phase 8 ships.
 
-## Current phase
+### Phase 8 — Enforce the post-paid allowance ✅
 
-**Phase 8 — Enforce the post-paid allowance** (implementer Tier 3)
+- **Status**: reviewed clean (1 round, 3 BLOCKERs fixed), gates green, ready to integrate
+- **Models**: implementer Tier 3; reviewer Tier 4; fixer Tier 4
+- **Branch**: `plan/billing-plans-and-limits/phase-8` · **Base**: `plan/billing-plans-and-limits/phase-7`
+- **Commits**: `c9643ce` implementation, `0c7b705` BLOCKER + SHOULD-FIX fixes
 
-Base: `plan/billing-plans-and-limits/phase-7` · Branch: `plan/billing-plans-and-limits/phase-8`
+**Gates** (implementer, then re-run independently with credentials cleared): suite **4316 passed** (base 4262; +54); `mypy` **305 / 57** at ceiling, zero new; `ruff` clean (502 files); `makemigrations --check` clean.
 
-Six entry points plus one fan-out case, against the pattern Phase 6 established. The fan-out count must be **`1 + n_internal_children`** — the number fixed by the bundle-booking decision recorded under Phase 7, not re-derived. The plan's own wording ("one row per member calendar") is looser than that decision and must not be followed literally: a bundle over five Google calendars creates one `CalendarEvent` and four `BlockedTime` rows, and `BlockedTime` is not billable anywhere in this plan.
+`has_payment_method(organization)` (billing-root-resolved) plus `check_postpaid_allowance(delta, lock)` gate the six creation surfaces named by the plan. Every current organization is on `unlimited` (NULL `event_occurrences`), so the guard is inert today — asserted by an unlimited-behaviour test on every path.
 
-**Watch for the plan's recurring failure shape** — two predicates that must mean the same thing, written separately. Here the risk is concrete and named: the guard's headroom count and `MeteringService.expand_occurrence_identities` must agree on what one booking costs, or an organization is blocked on a number it will never be billed. Derive the guard's count from the meter's expansion rather than reimplementing it.
+**Three BLOCKERs, all found by review and fixed:**
+
+1. **The lock was taken before the unlimited early-return, so the phase was not inert.** `create_event` passes `lock=True`; the original `check_postpaid_allowance` took `SELECT ... FOR UPDATE` on the org's `Subscription` row *before* checking `is_unlimited`, inside the `@transaction.atomic` block that also holds the provider network write. Every event create for every org serialized org-wide behind a Google round-trip — for a NULL ceiling. The unlimited tests asserted only `201` and could not see it. Fixed by resolving the limit first and locking only when a real ceiling exists; a `CaptureQueriesContext` test now asserts no `FOR UPDATE` is issued on the unlimited path, with a finite-ceiling negative control.
+
+2. **`delta` and `current_usage` were different units.** `current_usage` counts `MeteredOccurrence` rows (occurrences); `delta` counted `CalendarEvent` masters. A free org at 49/50 could create an open-ended daily series (`49 + 1 ≤ 50`) and accrue ~30 unbillable occurrences/month forever. Fixed for the single-event path by a two-stage guard: stage 1 keeps `delta=1` (exact for one-offs) before the provider write; stage 2, after insert and inside the transaction, expands the recurring master through **`MeteringService.occurrence_starts_of`** — the meter's own expansion, shared not copied — over `[now, current_billing_period_end)` and rolls back if the series does not fit. The bundle fan-out residual is recorded as a Phase 13 precondition (below).
+
+3. **`billing_state != FREE` granted unbounded accrual to orgs whose payment failed.** Replaced with an explicit allow-list `PAYMENT_METHOD_BILLING_STATES = {ACTIVE}`. Load-bearing for Phase 10 — see the precondition below. Every `BillingState` is pinned to an assertion so a new state fails a test until someone decides for it.
+
+The fixer went **narrower than the review** on BLOCKER 3, excluding `CANCELLED` ("a card was attached at some point" is the wrong tense for deciding whether overage can be billed — a cancelled org may have removed its instrument). Both of its independent judgment calls moved toward the safe side.
+
+SHOULD-FIX cleared: registry test now derives the guarded set from an AST walk (was a same-file tautology); `bypass_limits` added to `create_event`; the guard now honours `_bypass_entitlement_limits`; `transfer_event` passes `_check_postpaid_allowance=False` (a move is not a creation); the over-allowance sync raise now logs org id + remedy and has a recovery test.
 
 #### Phase 9/10 gating precondition: `has_payment_method` is a proxy
 
@@ -339,12 +352,22 @@ The plan's deferred `TRIALING` state (`…IMPLEMENTATION_PLAN.md`, "no payment m
 
 **The bundle fan-out still counts masters.** `_bundle_event_billable_units` returns `1 + n_internal_children` per the Phase 7 binding decision, and each child create runs with `_check_postpaid_allowance=False`, so a *recurring* bundle event is under-charged by exactly the same factor the single-event path used to be. Bounded and inert today (every organization is `unlimited`), but it is a **Phase 13 gating precondition** alongside the identity-churn and series-truncation defects above: an over-allowance number that becomes money must be in occurrence units on every path, not just the one.
 
+## Current phase
+
+**Phase 9 — Upgrade, add-on purchase, and proration** (implementer Tier 3, reviewer Tier 4)
+
+Base: `plan/billing-plans-and-limits/phase-8` · Branch: `plan/billing-plans-and-limits/phase-9`
+
+Spec objective 2: an org on the free plan can choose a paid plan, pay, and see its limits lift with no engineering intervention. New endpoints on a new path — purely additive surface, no feature flag.
+
+**Binding on this phase (from Phase 8's precondition above):** Phase 9 introduces the first real payment-method record. When it does, `EntitlementService.has_payment_method` must be **re-pointed at that record and the `billing_state` proxy deleted** — not widened. Once an instrument is actually persisted, `billing_state` stops being evidence of anything. The per-state test (`EXPECTED_HAS_PAYMENT_METHOD`) must be updated in the same change so it pins the new source of truth.
+
+**Watch for the plan's recurring failure shape** — two predicates that must mean the same thing. Proration maths is the obvious host for it here: the amount charged and the entitlement granted must derive from one plan-change computation, not two.
+
 ## Remaining phases
 
 | Phase | Title | Impl | Reviewer | Fixer |
 |---|---|---|---|---|
-| 8 | Enforce the post-paid allowance | 3 | — | — |
-| 9 | Upgrade, add-on purchase, and proration | 3 | 4 | — |
 | 10 | Grace, dunning, and the restricted transition | 3 | — | — |
 | 11 | Restricted enforcement and sync pause | 3 | 4 | — |
 | 12 | Usage API and approaching-limit warnings | 2 | — | — |

--- a/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
+++ b/ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md
@@ -322,6 +322,23 @@ Six entry points plus one fan-out case, against the pattern Phase 6 established.
 
 **Watch for the plan's recurring failure shape** — two predicates that must mean the same thing, written separately. Here the risk is concrete and named: the guard's headroom count and `MeteringService.expand_occurrence_identities` must agree on what one booking costs, or an organization is blocked on a number it will never be billed. Derive the guard's count from the meter's expansion rather than reimplementing it.
 
+#### Phase 9/10 gating precondition: `has_payment_method` is a proxy
+
+`EntitlementService.has_payment_method` is the whole basis on which an organization is allowed to accrue post-paid overage. **There is no payment-method record in the schema yet**, so it reads `Subscription.billing_state` as a stand-in, through an explicit allow-list: `PAYMENT_METHOD_BILLING_STATES = {ACTIVE}`. Everything else — `FREE`, `GRACE`, `RESTRICTED`, `CANCELLED`, and any state added later — resolves to `False`. `payments/services/entitlement_service.py` carries the per-state reasoning; `calendar_integration/tests/services/test_postpaid_enforcement.py::EXPECTED_HAS_PAYMENT_METHOD` pins every state to an assertion, and a new `BillingState` fails that test until somebody decides for it.
+
+Two things are binding on the phases that touch this:
+
+1. **Phase 9 must re-point the method at the real record, not widen the allow-list.** Once a payment instrument is actually persisted, `billing_state` stops being evidence of anything and the proxy must be deleted rather than extended.
+2. **Phase 10 must keep `GRACE` resolving to `False`.** Phase 10 moves `ACTIVE → GRACE` **on a failed charge** while leaving the organization fully operational (only `RESTRICTED` is write-blocked, and that is Phase 11). If `GRACE` read as "has a payment method", an organization whose card just declined would get *unbounded, unbillable* accrual for the entire dunning window — making the dunning ladder the largest-bill path in the product. The original justification for including it ("the separate grace/restricted machinery is what blocks writes on that state") is true of `RESTRICTED` and false of `GRACE`.
+
+The plan's deferred `TRIALING` state (`…IMPLEMENTATION_PLAN.md`, "no payment method to start") is the same trap from the other direction, and is why this is an allow-list: a newly-added state defaults to "no payment method", which is the safe direction, instead of silently granting accrual.
+
+#### Residual: the guard counts occurrences for a single recurring master, masters for a bundle fan-out
+
+`check_postpaid_allowance`'s `current_usage` is in `MeteredOccurrence` rows — **occurrences**. Phase 8's single-event path matches that unit: a recurring master is expanded, after insert and inside the creating transaction, through `MeteringService.occurrence_starts_of` — the meter's own expansion, shared rather than re-implemented — and the create is rolled back if the series does not fit. (It has to run after the insert because the expansion is a Postgres function keyed on the event's id; re-deriving it in Python from the rrule string would be the second-expansion defect this plan keeps producing.)
+
+**The bundle fan-out still counts masters.** `_bundle_event_billable_units` returns `1 + n_internal_children` per the Phase 7 binding decision, and each child create runs with `_check_postpaid_allowance=False`, so a *recurring* bundle event is under-charged by exactly the same factor the single-event path used to be. Bounded and inert today (every organization is `unlimited`), but it is a **Phase 13 gating precondition** alongside the identity-churn and series-truncation defects above: an over-allowance number that becomes money must be in occurrence units on every path, not just the one.
+
 ## Remaining phases
 
 | Phase | Title | Impl | Reviewer | Fixer |

--- a/calendar_integration/mutations.py
+++ b/calendar_integration/mutations.py
@@ -1289,6 +1289,14 @@ class CalendarGroupMutations:
                 error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
                 error_message="The requested time slot is not available.",
             )
+        # Phase 8: create_event raises OverLimitError at the organization's postpaid
+        # event_occurrences allowance (no payment method on file). Unlike the domain
+        # errors above, this is not a booking-code-specific outcome the patient can
+        # retry around, so it is rendered via the shared over-limit GraphQL contract
+        # (raise_over_limit_graphql_error, also rolls back the request transaction --
+        # see its docstring) rather than a CodeEventResult error_code.
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
 
         return CodeEventResult(success=True, event=event)  # type: ignore[arg-type]
 
@@ -1464,6 +1472,12 @@ class CalendarGroupMutations:
                 error_code=BookingCodeErrorCode.SLOT_UNAVAILABLE,
                 error_message="The requested time slot is not available.",
             )
+        # Phase 8: create_grouped_event raises OverLimitError at the organization's
+        # postpaid event_occurrences allowance (no payment method on file). Rendered
+        # via raise_over_limit_graphql_error (also rolls back the request transaction
+        # -- see its docstring), like the single-calendar booking-code path above.
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
 
         return CodeEventResult(success=True, event=event)  # type: ignore[arg-type]
 

--- a/calendar_integration/services/calendar_bundle_service.py
+++ b/calendar_integration/services/calendar_bundle_service.py
@@ -116,6 +116,7 @@ class BundleServiceHost(Protocol):
         calendar_id: int,
         event_data: CalendarEventInputData,
         *,
+        bypass_limits: bool = False,
         _enforce_policy: bool = True,
         _check_postpaid_allowance: bool = True,
     ) -> CalendarEvent: ...
@@ -402,7 +403,11 @@ class CalendarBundleService:
     # ------------------------------------------------------------------
 
     def create_bundle_event(
-        self, bundle_calendar: Calendar, event_data: CalendarEventInputData
+        self,
+        bundle_calendar: Calendar,
+        event_data: CalendarEventInputData,
+        *,
+        bypass_limits: bool = False,
     ) -> CalendarEvent:
         """
         Create an event in a bundle calendar by:
@@ -447,7 +452,16 @@ class CalendarBundleService:
         # recheck would be redundant rather than merely wasted work: nothing is
         # metered until a Celery sweep runs, so a re-check would ask the same
         # question against an unchanged usage count).
-        entitlement_service = self._context.entitlement_service
+        #
+        # Skipped when this call, or the whole service
+        # (``CalendarService.authenticate(bypass_limits=True)``), is in bypass mode --
+        # the same two conditions ``CalendarEventService._postpaid_entitlement_service``
+        # resolves for the single-event path.
+        entitlement_service = (
+            None
+            if bypass_limits or self._context.bypass_entitlement_limits
+            else self._context.entitlement_service
+        )
         if entitlement_service is not None:
             billable_units = self._bundle_event_billable_units(primary_calendar.id, child_calendars)
             result = entitlement_service.check_postpaid_allowance(

--- a/calendar_integration/services/calendar_bundle_service.py
+++ b/calendar_integration/services/calendar_bundle_service.py
@@ -117,6 +117,7 @@ class BundleServiceHost(Protocol):
         event_data: CalendarEventInputData,
         *,
         _enforce_policy: bool = True,
+        _check_postpaid_allowance: bool = True,
     ) -> CalendarEvent: ...
 
     def update_event(
@@ -439,6 +440,22 @@ class CalendarBundleService:
         # Get the designated primary calendar
         primary_calendar = self._get_primary_calendar(bundle_calendar)
 
+        # Postpaid ``event_occurrences`` allowance guard -- checked ONCE, for the whole
+        # fan-out, before anything is written. Each per-child ``create_event`` call
+        # below passes ``_check_postpaid_allowance=False`` so it is not re-checked
+        # (see ``CalendarEventService.create_event``'s docstring for why a per-child
+        # recheck would be redundant rather than merely wasted work: nothing is
+        # metered until a Celery sweep runs, so a re-check would ask the same
+        # question against an unchanged usage count).
+        entitlement_service = self._context.entitlement_service
+        if entitlement_service is not None:
+            billable_units = self._bundle_event_billable_units(primary_calendar.id, child_calendars)
+            result = entitlement_service.check_postpaid_allowance(
+                context.organization, delta=billable_units, lock=True
+            )
+            if not result.allowed:
+                raise OverLimitError.from_check_result(result)
+
         # Collect all attendees from child calendar ownerships
         all_attendees = self._collect_bundle_attendees(child_calendars, event_data)
 
@@ -461,7 +478,10 @@ class CalendarBundleService:
         # rejections when a child has its own stricter individual policy that would block
         # a booking the bundle policy (and Phase-5 discovery) correctly permits.
         primary_event = self._host.create_event(
-            primary_calendar.id, primary_event_data, _enforce_policy=False
+            primary_calendar.id,
+            primary_event_data,
+            _enforce_policy=False,
+            _check_postpaid_allowance=False,
         )
 
         # Mark primary event as part of bundle
@@ -474,7 +494,7 @@ class CalendarBundleService:
             if child_calendar.id == primary_calendar.id:
                 continue
 
-            if child_calendar.provider == CalendarProvider.INTERNAL:
+            if self._child_gets_full_event(child_calendar):
                 # Create full CalendarEvent for internal calendars
                 child_event_data = CalendarEventInputData(
                     title=f"[Bundle] {event_data.title}",
@@ -488,7 +508,10 @@ class CalendarBundleService:
                 )
 
                 child_event = self._host.create_event(
-                    child_calendar.id, child_event_data, _enforce_policy=False
+                    child_calendar.id,
+                    child_event_data,
+                    _enforce_policy=False,
+                    _check_postpaid_allowance=False,
                 )
 
                 # Link to primary event and bundle
@@ -647,6 +670,49 @@ class CalendarBundleService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _child_gets_full_event(child_calendar: Calendar) -> bool:
+        """Whether a non-primary bundle child gets a real ``CalendarEvent`` (rather
+        than a non-billable ``BlockedTime``) when a bundle event is created.
+
+        The single definition of that predicate. ``create_bundle_event``'s write
+        loop calls this to decide what to create, and
+        ``_bundle_event_billable_units`` calls the identical function to decide
+        what to charge for -- so "which children become billable rows" cannot be
+        answered two different ways by two pieces of code that drift apart over
+        time. The primary calendar is handled separately by its caller (it always
+        gets a real event, unconditionally); this only decides for the rest.
+        """
+        return child_calendar.provider == CalendarProvider.INTERNAL
+
+    @classmethod
+    def _bundle_event_billable_units(
+        cls, primary_calendar_id: int, child_calendars: list[Calendar]
+    ) -> int:
+        """How many ``event_occurrences`` units one bundle-event booking costs.
+
+        Binding decision (Phase 7 tracking doc, "what a bundle booking costs"):
+        **1 + n_internal_children**. The primary calendar always gets a real
+        ``CalendarEvent`` (the actual booking); every other child gets one too only
+        when ``_child_gets_full_event`` says so -- the exact predicate
+        ``create_bundle_event``'s write loop uses to decide "full CalendarEvent vs.
+        BlockedTime" for that same calendar. A ``BlockedTime`` is never billable
+        anywhere in this plan, so a bundle over five Google calendars costs 1, not
+        5, and this must never be computed a second, independent way.
+
+        Not derived by calling ``MeteringService.expand_occurrence_identities``:
+        nothing exists to expand yet -- the events this counts are about to be
+        created, not already in the database. This exists so the guard counts
+        exactly the rows the write loop below is about to write, using the same
+        predicate the write loop uses, rather than a second guess at what the
+        meter will later see.
+        """
+        return 1 + sum(
+            1
+            for calendar in child_calendars
+            if calendar.id != primary_calendar_id and cls._child_gets_full_event(calendar)
+        )
 
     def _get_primary_calendar(self, bundle_calendar: Calendar) -> Calendar:
         """Get the designated primary calendar for a bundle."""

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Q
+from django.utils import timezone
 
 from audit.constants import AuditAction, AuditActorType
 from audit.diff import compute_diff
@@ -100,6 +101,8 @@ from calendar_integration.services.type_guards import (
     is_initialized_or_authenticated_calendar_service,
 )
 from payments.exceptions import OverLimitError
+from payments.services.metering_service import MeteringService
+from payments.services.subscription_service import resolve_billing_period
 from public_api.models import SystemUser
 from users.models import User
 
@@ -135,6 +138,8 @@ if TYPE_CHECKING:
     from calendar_integration.services.dataclasses import AvailableTimeWindow
     from calendar_integration.services.protocols.calendar_adapter import CalendarAdapter
     from calendar_integration.services.recurrence_manager import RecurrenceManager
+    from payments.models import Subscription
+    from payments.services.entitlement_service import EntitlementService
 
 
 class EventServiceHost(Protocol):
@@ -174,7 +179,9 @@ class EventServiceHost(Protocol):
         calendar_id: int,
         event_data: CalendarEventInputData,
         *,
+        bypass_limits: bool = False,
         _enforce_policy: bool = True,
+        _check_postpaid_allowance: bool = True,
     ) -> CalendarEvent: ...
 
     def delete_event(
@@ -182,7 +189,11 @@ class EventServiceHost(Protocol):
     ) -> None: ...
 
     def _create_bundle_event(
-        self, bundle_calendar: Calendar, event_data: CalendarEventInputData
+        self,
+        bundle_calendar: Calendar,
+        event_data: CalendarEventInputData,
+        *,
+        bypass_limits: bool = False,
     ) -> CalendarEvent: ...
 
     def _update_bundle_event(
@@ -400,6 +411,87 @@ class CalendarEventService:
         return _convert_naive_utc_datetime_to_timezone(datetime_obj, iana_tz)
 
     # ------------------------------------------------------------------
+    # Post-paid allowance guard
+    # ------------------------------------------------------------------
+
+    def _postpaid_entitlement_service(self, *, bypass_limits: bool) -> EntitlementService | None:
+        """The entitlement service to guard with, or ``None`` to skip the guard.
+
+        Three separate reasons to skip, resolved in one place so no guarded path can
+        honour one and forget another:
+
+        - ``bypass_limits=True`` -- this call asked to be exempt.
+        - ``context.bypass_entitlement_limits`` -- the whole *service* was placed in
+          bypass mode by ``CalendarService.authenticate(bypass_limits=True)``. The
+          provider-entitlement gate already honours it; this makes the post-paid guard
+          agree, instead of a service in explicit bypass mode still being blockable.
+        - no ``entitlement_service`` on the context -- a sub-service built directly in
+          a test without DI, mirroring ``audit_service``'s no-op-when-absent convention.
+        """
+        if bypass_limits or self._context.bypass_entitlement_limits:
+            return None
+        return self._context.entitlement_service
+
+    @staticmethod
+    def _check_new_master_postpaid_allowance(
+        entitlement_service: EntitlementService, event: CalendarEvent
+    ) -> None:
+        """Re-check the post-paid allowance against the **exact** unit count of a
+        just-created recurring master, and roll the create back if it does not fit.
+
+        Why a second check exists at all. ``current_usage`` counts
+        ``MeteredOccurrence`` rows -- one per *occurrence*. The stage-1 guard above
+        charges 1 per *master*, which is exact for a one-off event and a large
+        undercount for a recurring one: a free organization at 49/50 could create an
+        open-ended daily series (``49 + 1 <= 50``), accrue ~30 unbillable occurrences
+        every month from it forever, and never trip the guard on that series again.
+        Guard and meter must count the same thing.
+
+        Why it runs *after* the insert. The expansion lives in Postgres
+        (``calculate_recurring_events``, keyed on the event's id), so a rule with no
+        row cannot be expanded -- and re-deriving the count in Python from the rrule
+        string would be a second expansion, the exact "two predicates that must agree"
+        defect this plan keeps producing. So the row is written first and
+        ``MeteringService.occurrence_starts_of`` -- the meter's own expansion, shared
+        rather than copied -- is asked how many occurrences it yields.
+        ``create_event`` is ``@transaction.atomic``, so raising here rolls the insert
+        (and everything else in the caller's transaction) back.
+
+        The residual cost of that ordering is that a *provider* write may already have
+        happened for an adapter-backed calendar, which no rollback undoes. It is
+        narrow: stage 1's ``delta=1`` lower bound has already rejected every
+        organization with no headroom at all, so this can only fire in the band where
+        there is room for one booking but not for the whole series. And it is not new
+        -- the provider write is inside the atomic block already, so any later failure
+        (``event.save()`` conflicting, a permission grant erroring) has always had the
+        same shape.
+
+        The window is ``[now, end of the current billing period)``: exactly the
+        occurrences the meter will bill against the allowance ``current_usage`` was
+        just read from. A series that starts next period therefore contributes nothing
+        here -- correct for *this* period's allowance -- but it is still charged
+        ``max(1, ...)``, because creating a master that bills nothing now and plenty
+        later must not be free at the guard.
+        """
+        if not event.is_recurring:
+            # Stage 1's delta=1 was already exact for a one-off event.
+            return
+
+        def resolve_delta(subscription: Subscription) -> int:
+            now = timezone.now()
+            _period_start, period_end = resolve_billing_period(subscription, now)
+            if period_end <= now:
+                return 1
+            starts = MeteringService.occurrence_starts_of(event, now, period_end)
+            return max(1, sum(1 for start in starts if now <= start < period_end))
+
+        result = entitlement_service.check_postpaid_allowance(
+            event.organization, lock=True, delta_resolver=resolve_delta
+        )
+        if not result.allowed:
+            raise OverLimitError.from_check_result(result)
+
+    # ------------------------------------------------------------------
     # Public event CRUD
     # ------------------------------------------------------------------
 
@@ -409,19 +501,31 @@ class CalendarEventService:
         calendar_id: int,
         event_data: CalendarEventInputData,
         *,
+        bypass_limits: bool = False,
         _check_postpaid_allowance: bool = True,
     ) -> CalendarEvent:
         """
         Create a new event in the calendar.
         :param calendar_id: Internal ID of the calendar
         :param event_data: Dictionary containing event details.
+        :param bypass_limits: When True, skips the post-paid ``event_occurrences``
+            allowance guard. The plan's Enforcement-bypass Guiding Decision: every
+            guarded write takes this so a management command, a data migration, or a
+            support-side repair can run against an organization that is over its
+            allowance. Same spelling and default as the pre-paid guards
+            (``CalendarService.create_calendar`` / ``create_bundle_calendar`` /
+            ``create_availability_windows``).
         :param _check_postpaid_allowance: Internal flag; callers must NOT pass this.
-            Set to ``False`` by the bundle fan-out (``CalendarBundleService.create_bundle_event``),
-            which already checked headroom once for the whole fan-out count before
-            creating anything -- re-checking per child here would ask the same
-            question against an unchanged ``MeteredOccurrence`` count (nothing is
-            metered until a Celery sweep runs) and add nothing but redundant row
-            locks.
+            Distinct from ``bypass_limits``: that one is a *caller's* request to be
+            exempt, this one records that the allowance was already checked, correctly,
+            somewhere else on this same write. Set to ``False`` by the bundle fan-out
+            (``CalendarBundleService.create_bundle_event``), which checks headroom once
+            for the whole ``1 + n_internal_children`` count before creating anything --
+            re-checking per child here would ask the same question against an unchanged
+            ``MeteredOccurrence`` count (nothing is metered until a Celery sweep runs)
+            and add nothing but redundant row locks -- and by
+            ``transfer_event``, where the create is paired with a delete of
+            the same event and is therefore net-zero on billable units.
         :return: Response from the calendar client.
         """
         context = cast("BaseCalendarService", self._context)
@@ -481,27 +585,32 @@ class CalendarEventService:
             raise PermissionDenied("You do not have permission to update this event.")
 
         if calendar.calendar_type == CalendarType.BUNDLE:
-            return self._host._create_bundle_event(bundle_calendar=calendar, event_data=event_data)
-
-        # Postpaid ``event_occurrences`` allowance guard. ``event_data.parent_event_id``
-        # set means this create is a recurrence *exception* -- a modification of an
-        # occurrence slot the owning master's rule already accounts for, not a new
-        # one (``calculate_recurring_events`` substitutes the exception row in place
-        # of the original occurrence; see ``MeteringService.expand_occurrence_identities``).
-        # It is deliberately excluded here with the exact predicate
-        # ``occurrence_bearing_masters_in_range`` uses to exclude the same rows
-        # (``parent_recurring_object__isnull=True``) -- checking it as a new unit
-        # would disagree with what the meter will ever bill for it. Every other
-        # create here (a one-off event, a new recurring master, or a
-        # bulk-modification continuation) is a genuinely new master and is checked.
-        if (
-            _check_postpaid_allowance
-            and event_data.parent_event_id is None
-            and self._context.entitlement_service is not None
-        ):
-            result = self._context.entitlement_service.check_postpaid_allowance(
-                context.organization, lock=True
+            return self._host._create_bundle_event(
+                bundle_calendar=calendar, event_data=event_data, bypass_limits=bypass_limits
             )
+
+        # Postpaid ``event_occurrences`` allowance guard, stage 1 of 2 (see
+        # ``_check_new_master_postpaid_allowance`` for stage 2 and why there are two).
+        #
+        # ``event_data.parent_event_id`` set means this create is a recurrence
+        # *exception* -- a modification of an occurrence slot the owning master's rule
+        # already accounts for, not a new one (``calculate_recurring_events``
+        # substitutes the exception row in place of the original occurrence; see
+        # ``MeteringService.expand_occurrence_identities``). It is deliberately
+        # excluded here with the exact predicate ``occurrence_bearing_masters_in_range``
+        # uses to exclude the same rows (``parent_recurring_object__isnull=True``) --
+        # checking it as a new unit would disagree with what the meter will ever bill
+        # for it. Every other create here (a one-off event, a new recurring master, or
+        # a bulk-modification continuation) is a genuinely new master and is checked.
+        #
+        # ``delta=1`` is exact for a one-off event and a deliberate **lower bound** for
+        # a recurring one, so this stage can never over-block. It runs here, before the
+        # external provider write below, so the ordinary rejection costs no provider
+        # round-trip and leaves nothing behind at the provider.
+        guard_applies = _check_postpaid_allowance and event_data.parent_event_id is None
+        entitlement_service = self._postpaid_entitlement_service(bypass_limits=bypass_limits)
+        if guard_applies and entitlement_service is not None:
+            result = entitlement_service.check_postpaid_allowance(context.organization, lock=True)
             if not result.allowed:
                 raise OverLimitError.from_check_result(result)
 
@@ -607,6 +716,12 @@ class CalendarEventService:
             event.recurrence_rule_fk = recurrence_rule  # type: ignore
 
         event.save()
+
+        # Postpaid ``event_occurrences`` allowance guard, stage 2 of 2 -- the exact
+        # unit count for a recurring master, which is only computable now that the row
+        # exists. See ``_check_new_master_postpaid_allowance``.
+        if guard_applies and entitlement_service is not None:
+            self._check_new_master_postpaid_allowance(entitlement_service, event)
 
         EventExternalAttendance.objects.bulk_create(
             [
@@ -1933,7 +2048,21 @@ class CalendarEventService:
         # Route create/delete through the host so the facade's public methods (the
         # original ``self.create_event`` / ``self.delete_event`` call targets) run —
         # preserving the facade-level call graph the existing transfer tests assert on.
-        new_event = self._host.create_event(new_calendar.id, new_event_data)
+        #
+        # ``_check_postpaid_allowance=False``: a transfer is a **move**, not a
+        # creation. The old event is deleted immediately below, so the pair is
+        # net-zero on billable masters — but the guard would compare ``delta=1``
+        # against a ``current_usage`` that already includes the occurrences metered
+        # for the event being moved, and refuse an organization sitting at its
+        # allowance the right to move an event between its own calendars. A 402 for
+        # no net new billable capacity. (It is not perfectly net-zero for the
+        # *meter*: the new master has a new pk, so occurrences already metered under
+        # the old one are re-billed under the new identity. That is the known
+        # identity-churn defect recorded as a Phase 13 precondition, not something
+        # this guard could fix by charging a unit.)
+        new_event = self._host.create_event(
+            new_calendar.id, new_event_data, _check_postpaid_allowance=False
+        )
 
         # Delete the old event
         self._host.delete_event(event.calendar.id, event.id)

--- a/calendar_integration/services/calendar_event_service.py
+++ b/calendar_integration/services/calendar_event_service.py
@@ -99,6 +99,7 @@ from calendar_integration.services.type_guards import (
     is_authenticated_calendar_service,
     is_initialized_or_authenticated_calendar_service,
 )
+from payments.exceptions import OverLimitError
 from public_api.models import SystemUser
 from users.models import User
 
@@ -403,11 +404,24 @@ class CalendarEventService:
     # ------------------------------------------------------------------
 
     @transaction.atomic()
-    def create_event(self, calendar_id: int, event_data: CalendarEventInputData) -> CalendarEvent:
+    def create_event(
+        self,
+        calendar_id: int,
+        event_data: CalendarEventInputData,
+        *,
+        _check_postpaid_allowance: bool = True,
+    ) -> CalendarEvent:
         """
         Create a new event in the calendar.
         :param calendar_id: Internal ID of the calendar
         :param event_data: Dictionary containing event details.
+        :param _check_postpaid_allowance: Internal flag; callers must NOT pass this.
+            Set to ``False`` by the bundle fan-out (``CalendarBundleService.create_bundle_event``),
+            which already checked headroom once for the whole fan-out count before
+            creating anything -- re-checking per child here would ask the same
+            question against an unchanged ``MeteredOccurrence`` count (nothing is
+            metered until a Celery sweep runs) and add nothing but redundant row
+            locks.
         :return: Response from the calendar client.
         """
         context = cast("BaseCalendarService", self._context)
@@ -468,6 +482,28 @@ class CalendarEventService:
 
         if calendar.calendar_type == CalendarType.BUNDLE:
             return self._host._create_bundle_event(bundle_calendar=calendar, event_data=event_data)
+
+        # Postpaid ``event_occurrences`` allowance guard. ``event_data.parent_event_id``
+        # set means this create is a recurrence *exception* -- a modification of an
+        # occurrence slot the owning master's rule already accounts for, not a new
+        # one (``calculate_recurring_events`` substitutes the exception row in place
+        # of the original occurrence; see ``MeteringService.expand_occurrence_identities``).
+        # It is deliberately excluded here with the exact predicate
+        # ``occurrence_bearing_masters_in_range`` uses to exclude the same rows
+        # (``parent_recurring_object__isnull=True``) -- checking it as a new unit
+        # would disagree with what the meter will ever bill for it. Every other
+        # create here (a one-off event, a new recurring master, or a
+        # bulk-modification continuation) is a genuinely new master and is checked.
+        if (
+            _check_postpaid_allowance
+            and event_data.parent_event_id is None
+            and self._context.entitlement_service is not None
+        ):
+            result = self._context.entitlement_service.check_postpaid_allowance(
+                context.organization, lock=True
+            )
+            if not result.allowed:
+                raise OverLimitError.from_check_result(result)
 
         available_windows = self._host.get_availability_windows_in_range(
             calendar,

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -1461,6 +1461,7 @@ class CalendarService(BaseCalendarService):
         event_data: CalendarEventInputData,
         *,
         _enforce_policy: bool = True,
+        _check_postpaid_allowance: bool = True,
     ) -> CalendarEvent:
         """
         Create a new event in the calendar.
@@ -1471,6 +1472,11 @@ class CalendarService(BaseCalendarService):
             top-level entry point (using ``resolve_for_bundle``), not again for each
             child create (which would use ``resolve_for_calendar`` on the child and
             could falsely reject bookings the bundle policy permits).
+        :param _check_postpaid_allowance: Internal flag; callers must NOT pass this.
+            Forwarded verbatim to ``CalendarEventService.create_event`` -- see its
+            docstring. Set to ``False`` by the bundle fan-out for the same reason as
+            ``_enforce_policy``: it already checked headroom once for the whole
+            fan-out count.
         :return: Response from the calendar client.
         """
         if _enforce_policy and self.organization is not None:
@@ -1482,7 +1488,9 @@ class CalendarService(BaseCalendarService):
                 )
             except Calendar.DoesNotExist:
                 # Let the event service raise the not-found; do not hide the error.
-                return self._get_event_service().create_event(calendar_id, event_data)
+                return self._get_event_service().create_event(
+                    calendar_id, event_data, _check_postpaid_allowance=_check_postpaid_allowance
+                )
             self._check_booking_policy(
                 calendar,
                 start_time=event_data.start_time,
@@ -1493,7 +1501,9 @@ class CalendarService(BaseCalendarService):
             # same row. The cache is keyed on (organization_id, calendar_id) — the same
             # shape used by _get_calendar_by_id_util.
             self._calendar_cache[(self.organization.id, calendar_id)] = calendar
-        return self._get_event_service().create_event(calendar_id, event_data)
+        return self._get_event_service().create_event(
+            calendar_id, event_data, _check_postpaid_allowance=_check_postpaid_allowance
+        )
 
     def _update_bundle_event(
         self, bundle_event: CalendarEvent, event_data: "CalendarEventInputData"

--- a/calendar_integration/services/calendar_service.py
+++ b/calendar_integration/services/calendar_service.py
@@ -505,6 +505,7 @@ class CalendarService(BaseCalendarService):
             calendar_side_effects_service=self.calendar_side_effects_service,
             audit_service=self.audit_service,
             entitlement_service=self.entitlement_service,
+            bypass_entitlement_limits=self._bypass_entitlement_limits,
         )
 
     def initialize_without_provider(
@@ -543,6 +544,7 @@ class CalendarService(BaseCalendarService):
             calendar_side_effects_service=self.calendar_side_effects_service,
             audit_service=self.audit_service,
             entitlement_service=self.entitlement_service,
+            bypass_entitlement_limits=self._bypass_entitlement_limits,
         )
 
     def _build_context_snapshot(self) -> CalendarServiceContext:
@@ -563,6 +565,7 @@ class CalendarService(BaseCalendarService):
             calendar_side_effects_service=self.calendar_side_effects_service,
             audit_service=self.audit_service,
             entitlement_service=self.entitlement_service,
+            bypass_entitlement_limits=self._bypass_entitlement_limits,
         )
 
     def _get_event_service(self) -> CalendarEventService:
@@ -1282,7 +1285,11 @@ class CalendarService(BaseCalendarService):
         )
 
     def _create_bundle_event(
-        self, bundle_calendar: Calendar, event_data: "CalendarEventInputData"
+        self,
+        bundle_calendar: Calendar,
+        event_data: "CalendarEventInputData",
+        *,
+        bypass_limits: bool = False,
     ) -> CalendarEvent:
         """Create a bundle event — delegates to ``CalendarBundleService``.
 
@@ -1291,7 +1298,9 @@ class CalendarService(BaseCalendarService):
         The facade is the host, so control reaches here and is forwarded to the bundle
         sub-service. See ``CalendarBundleService.create_bundle_event`` for full semantics.
         """
-        return self._get_bundle_service().create_bundle_event(bundle_calendar, event_data)
+        return self._get_bundle_service().create_bundle_event(
+            bundle_calendar, event_data, bypass_limits=bypass_limits
+        )
 
     def _get_primary_calendar(self, bundle_calendar: Calendar) -> Calendar:
         """Get the designated primary calendar for a bundle — delegates to ``CalendarBundleService``."""
@@ -1460,6 +1469,7 @@ class CalendarService(BaseCalendarService):
         calendar_id: int,
         event_data: CalendarEventInputData,
         *,
+        bypass_limits: bool = False,
         _enforce_policy: bool = True,
         _check_postpaid_allowance: bool = True,
     ) -> CalendarEvent:
@@ -1472,6 +1482,11 @@ class CalendarService(BaseCalendarService):
             top-level entry point (using ``resolve_for_bundle``), not again for each
             child create (which would use ``resolve_for_calendar`` on the child and
             could falsely reject bookings the bundle policy permits).
+        :param bypass_limits: When True, skips the post-paid ``event_occurrences``
+            allowance guard, like every other guarded write on this facade
+            (``create_calendar`` / ``create_bundle_calendar`` /
+            ``create_availability_windows``). Forwarded verbatim to
+            ``CalendarEventService.create_event``.
         :param _check_postpaid_allowance: Internal flag; callers must NOT pass this.
             Forwarded verbatim to ``CalendarEventService.create_event`` -- see its
             docstring. Set to ``False`` by the bundle fan-out for the same reason as
@@ -1489,7 +1504,10 @@ class CalendarService(BaseCalendarService):
             except Calendar.DoesNotExist:
                 # Let the event service raise the not-found; do not hide the error.
                 return self._get_event_service().create_event(
-                    calendar_id, event_data, _check_postpaid_allowance=_check_postpaid_allowance
+                    calendar_id,
+                    event_data,
+                    bypass_limits=bypass_limits,
+                    _check_postpaid_allowance=_check_postpaid_allowance,
                 )
             self._check_booking_policy(
                 calendar,
@@ -1502,7 +1520,10 @@ class CalendarService(BaseCalendarService):
             # shape used by _get_calendar_by_id_util.
             self._calendar_cache[(self.organization.id, calendar_id)] = calendar
         return self._get_event_service().create_event(
-            calendar_id, event_data, _check_postpaid_allowance=_check_postpaid_allowance
+            calendar_id,
+            event_data,
+            bypass_limits=bypass_limits,
+            _check_postpaid_allowance=_check_postpaid_allowance,
         )
 
     def _update_bundle_event(

--- a/calendar_integration/services/calendar_service_context.py
+++ b/calendar_integration/services/calendar_service_context.py
@@ -61,3 +61,11 @@ class CalendarServiceContext:
     # convention -- the facade (the only production entry point) always injects a real
     # instance, so this only matters for tests that build a sub-service directly.
     entitlement_service: EntitlementService | None = None
+    # Mirrors ``CalendarService._bypass_entitlement_limits``, set by
+    # ``authenticate(bypass_limits=True)``. Threaded into the snapshot so a sub-service
+    # guard honours the facade's bypass mode too: before this existed, a facade in
+    # bypass mode still had its provider-entitlement gate skipped (that check reads the
+    # facade attribute directly) while ``CalendarEventService``'s post-paid guard --
+    # which reads ``entitlement_service`` off the context -- kept enforcing, so a
+    # service explicitly placed in bypass mode was still blockable.
+    bypass_entitlement_limits: bool = False

--- a/calendar_integration/services/calendar_sync_service.py
+++ b/calendar_integration/services/calendar_sync_service.py
@@ -76,6 +76,7 @@ from calendar_integration.services.protocols.initializer_or_authenticated_calend
 from calendar_integration.services.type_guards import is_authenticated_calendar_service
 from organizations.models import ExternalEventUpdatePolicy, OrganizationMembership
 from payments.billing_constants import LimitedResource
+from payments.exceptions import OverLimitError
 from users.models import User
 
 
@@ -834,6 +835,29 @@ class CalendarSyncService:
             calendar_sync.next_sync_token = next_sync_token or ""
             calendar_sync.save(update_fields=["next_sync_token"])
 
+        # Postpaid ``event_occurrences`` allowance guard -- checked *before* the bulk
+        # write, not per-row after it, exactly like ``_cap_resources_to_resource_calendar_headroom``
+        # above. Unlike that prepaid guard this never bypasses (no ``bypass_limits``
+        # param): the plan's guiding decision keeps calendar sync fully enforced, since
+        # it is a named enforcement point in the spec, not something a management
+        # command routes through.
+        #
+        # Raising here (rather than dropping the offending rows and importing a partial
+        # batch) fails the whole sync pass: ``sync_events`` already wraps this call in
+        # ``try/except Exception`` and records the sync as FAILED with this error's
+        # message, and the next scheduled sync retries the same window -- a half-applied
+        # recurring master (some occurrences visible, some not) would be a worse outcome
+        # than a deferred sync.
+        new_master_count = self._new_master_count(changes)
+        if new_master_count:
+            entitlement_service = self._context.entitlement_service
+            if entitlement_service is not None:
+                result = entitlement_service.check_postpaid_allowance(
+                    context.organization, delta=new_master_count, lock=True
+                )
+                if not result.allowed:
+                    raise OverLimitError.from_check_result(result)
+
         # Apply all changes to database
         self._apply_sync_changes(calendar.id, changes)
 
@@ -888,6 +912,26 @@ class CalendarSyncService:
             )
         }
         return calendar_events_by_external_id, blocked_times_by_external_id
+
+    @staticmethod
+    def _new_master_count(changes: EventsSyncChanges) -> int:
+        """How many of ``changes.events_to_create`` are new occurrence-bearing masters.
+
+        Filtered on ``parent_recurring_object_fk_id is None`` -- the exact predicate
+        ``CalendarEventQuerySet.occurrence_bearing_masters_in_range`` filters on to
+        decide "master, not exception" (``parent_recurring_object__isnull=True``).
+        ``_process_new_event`` only ever puts two kinds of ``CalendarEvent`` into this
+        list: a recurrence exception synced in from the provider
+        (``parent_recurring_object_fk`` set, substituting for an occurrence slot its
+        master already accounts for -- not a new one, and never counted as an
+        independent master by the meter) and a recurring master (no parent set, a
+        genuinely new master). A plain one-off external event is stored as a
+        ``BlockedTime``, never a ``CalendarEvent``, so it never reaches this count at
+        all -- consistent with the meter, which only ever counts ``CalendarEvent`` rows.
+        """
+        return sum(
+            1 for event in changes.events_to_create if event.parent_recurring_object_fk_id is None
+        )
 
     # ------------------------------------------------------------------
     # Diff/merge machine

--- a/calendar_integration/services/calendar_sync_service.py
+++ b/calendar_integration/services/calendar_sync_service.py
@@ -848,6 +848,16 @@ class CalendarSyncService:
         # message, and the next scheduled sync retries the same window -- a half-applied
         # recurring master (some occurrences visible, some not) would be a worse outcome
         # than a deferred sync.
+        #
+        # That retry behaviour is also why this logs before it raises. ``sync_events``
+        # stores ``str(exc)`` on the ``CalendarSync`` row and nothing distinguishes an
+        # over-allowance refusal from a provider outage; every subsequent scheduled
+        # sync hits the same window and fails identically, so without a log line
+        # naming the organization and the remedy, a permanently stalled calendar looks
+        # exactly like a flaky provider. The block clears itself the moment headroom
+        # is restored (a payment method is attached, or the cycle rolls over) -- no
+        # manual replay is needed, which is the other half of what an operator
+        # reading this needs to know.
         new_master_count = self._new_master_count(changes)
         if new_master_count:
             entitlement_service = self._context.entitlement_service
@@ -856,6 +866,21 @@ class CalendarSyncService:
                     context.organization, delta=new_master_count, lock=True
                 )
                 if not result.allowed:
+                    logger.warning(
+                        "Calendar sync %s for calendar %s (organization %s) refused: %s new "
+                        "event masters would exceed the post-paid event_occurrences "
+                        "allowance (usage %s, ceiling %s) with no payment method on file. "
+                        "The sync will be recorded as FAILED and every retry will fail the "
+                        "same way until headroom is restored (remedy: %s); no manual replay "
+                        "is required once it is.",
+                        calendar_sync.pk,
+                        calendar.pk,
+                        context.organization.pk,
+                        new_master_count,
+                        result.current_usage,
+                        result.ceiling,
+                        result.remedy,
+                    )
                     raise OverLimitError.from_check_result(result)
 
         # Apply all changes to database

--- a/calendar_integration/tests/services/test_calendar_bundle_service.py
+++ b/calendar_integration/tests/services/test_calendar_bundle_service.py
@@ -832,7 +832,7 @@ def test_facade_create_bundle_event_delegates_to_bundle_service(
         CalendarBundleService, "create_bundle_event", return_value=mock_event
     ) as mock_method:
         result = facade._create_bundle_event(bundle_calendar, bundle_event_data)
-        mock_method.assert_called_once_with(bundle_calendar, bundle_event_data)
+        mock_method.assert_called_once_with(bundle_calendar, bundle_event_data, bypass_limits=False)
         assert result is mock_event
 
 

--- a/calendar_integration/tests/services/test_calendar_event_service.py
+++ b/calendar_integration/tests/services/test_calendar_event_service.py
@@ -332,7 +332,7 @@ def test_facade_create_event_delegates_to_event_service(
 
     assert result is sentinel
     fake_event_service.create_event.assert_called_once_with(
-        123, sample_event_input_data, _check_postpaid_allowance=True
+        123, sample_event_input_data, bypass_limits=False, _check_postpaid_allowance=True
     )
 
 

--- a/calendar_integration/tests/services/test_calendar_event_service.py
+++ b/calendar_integration/tests/services/test_calendar_event_service.py
@@ -331,7 +331,9 @@ def test_facade_create_event_delegates_to_event_service(
         result = authenticated_facade.create_event(123, sample_event_input_data)
 
     assert result is sentinel
-    fake_event_service.create_event.assert_called_once_with(123, sample_event_input_data)
+    fake_event_service.create_event.assert_called_once_with(
+        123, sample_event_input_data, _check_postpaid_allowance=True
+    )
 
 
 # ----------------------------------------------------------------------------------------

--- a/calendar_integration/tests/services/test_postpaid_enforcement.py
+++ b/calendar_integration/tests/services/test_postpaid_enforcement.py
@@ -125,23 +125,59 @@ def _service_for(organization: Organization) -> CalendarService:
 # ----------------------------------------------------------------------------------
 
 
+#: Every ``BillingState``, with the answer ``has_payment_method`` must give for it.
+#: Spelled out state by state rather than "ACTIVE vs. the rest" on purpose: this is
+#: the table Phase 10 (grace/dunning) and Phase 9 (real payment-method record) will
+#: be tempted to change, and each entry is a separate product decision. Adding a
+#: state without adding a row here fails ``test_every_billing_state_is_pinned``.
+EXPECTED_HAS_PAYMENT_METHOD = {
+    # Never paid: the state every subscription is created into.
+    BillingState.FREE: False,
+    # The only state that asserts a working instrument right now.
+    BillingState.ACTIVE: True,
+    # Phase 10 moves ACTIVE -> GRACE *on a failed charge*, and a GRACE organization
+    # stays fully operational (only RESTRICTED is write-blocked, in Phase 11). If this
+    # flipped to True, an organization whose card just declined would get unbounded
+    # unbillable accrual for the whole dunning window -- the dunning ladder would
+    # become the largest-bill path in the system.
+    BillingState.GRACE: False,
+    # A later charge failed and was never resolved.
+    BillingState.RESTRICTED: False,
+    # The paid relationship is over; the instrument may have been removed with it.
+    # "A card was attached at some point" is the wrong tense for a guard that decides
+    # whether overage we are about to allow can actually be billed.
+    BillingState.CANCELLED: False,
+}
+
+
 @pytest.mark.django_db
 class TestHasPaymentMethod:
-    def test_free_billing_state_has_no_payment_method(self):
-        organization, _subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
-        assert EntitlementService().has_payment_method(organization) is False
-
     @pytest.mark.parametrize(
-        "billing_state",
-        [BillingState.ACTIVE, BillingState.GRACE, BillingState.RESTRICTED, BillingState.CANCELLED],
+        "billing_state,expected",
+        list(EXPECTED_HAS_PAYMENT_METHOD.items()),
+        ids=[state.value for state in EXPECTED_HAS_PAYMENT_METHOD],
     )
-    def test_any_non_free_billing_state_has_a_payment_method(self, billing_state):
+    def test_each_billing_state_resolves_explicitly(self, billing_state, expected):
         organization, _subscription = _organization_with_postpaid_limit(1, billing_state)
-        assert EntitlementService().has_payment_method(organization) is True
+        assert EntitlementService().has_payment_method(organization) is expected
+
+    def test_every_billing_state_is_pinned(self):
+        """``has_payment_method`` is an allow-list, so an unpinned new state silently
+        resolves to ``False``. That is the safe direction, but it must still be a
+        decision somebody made rather than a default nobody noticed."""
+        assert set(EXPECTED_HAS_PAYMENT_METHOD) == set(BillingState)
+
+    def test_the_allow_list_matches_the_table(self):
+        """The service's own constant, against the table above -- so widening the
+        allow-list cannot pass by editing one side."""
+        assert EntitlementService.PAYMENT_METHOD_BILLING_STATES == {
+            state for state, expected in EXPECTED_HAS_PAYMENT_METHOD.items() if expected
+        }
 
     def test_no_subscription_has_no_payment_method(self):
-        """Fail-closed side of postpaid enforcement: an unresolvable subscription
-        must not be read as "has a payment method"."""
+        """Nothing to charge, so ``False``. (On the post-paid path this rarely
+        decides anything: a subscription-less pool resolves to an unlimited ceiling
+        and returns before this is consulted.)"""
         organization = baker.make(Organization, parent=None, can_invite_organizations=False)
         assert EntitlementService().has_payment_method(organization) is False
 
@@ -187,19 +223,25 @@ class TestCheckPostpaidAllowance:
         assert result.ceiling == 5
         assert result.remedy == LimitRemedy.ADD_PAYMENT_METHOD
 
-    @pytest.mark.parametrize("billing_state", [BillingState.GRACE, BillingState.RESTRICTED])
-    def test_at_the_allowance_in_grace_or_restricted_still_accrues(self, billing_state):
-        """Grace/restricted already have a payment method on file (see
-        ``has_payment_method``) -- their payment problem is resolved through the
-        separate grace/restricted machinery (Phase 10/11), not by this guard, so
-        they are treated the same as an active organization: let through, not
-        blocked."""
+    @pytest.mark.parametrize(
+        "billing_state,expected_allowed",
+        [(state, expected) for state, expected in EXPECTED_HAS_PAYMENT_METHOD.items()],
+        ids=[state.value for state in EXPECTED_HAS_PAYMENT_METHOD],
+    )
+    def test_accrual_past_the_allowance_follows_the_payment_method_allow_list(
+        self, billing_state, expected_allowed
+    ):
+        """Who may accrue past the allowance is exactly ``has_payment_method``, state
+        by state. ``GRACE`` is the load-bearing row: Phase 10 will move a *failed
+        charge* into it while leaving the organization fully operational, and if that
+        state started reading as "has a payment method" the dunning window would
+        become an unbounded, unbillable accrual window."""
         organization, subscription = _organization_with_postpaid_limit(5, billing_state)
         _seed_metered_occurrences(organization, subscription, 5)
 
         result = EntitlementService().check_postpaid_allowance(organization, delta=1)
 
-        assert result.allowed is True
+        assert result.allowed is expected_allowed
 
     def test_delta_larger_than_headroom_blocks_without_a_payment_method(self):
         """A fan-out delta (e.g. a bundle event) is checked as one unit, not one
@@ -278,7 +320,11 @@ class TestCreateEventPostpaidGuard:
         means this guard can never block anybody today, with or without a payment
         method on file."""
         organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
-        _seed_metered_occurrences(organization, subscription, 10_000)
+        # One seeded row, not 10k: the unlimited branch returns before usage is ever
+        # counted, so the count is never read. Ten thousand rows only added minutes of
+        # bulk insert (enough to trip pytest-timeout under parallel contention) to
+        # prove the same thing one row does.
+        _seed_metered_occurrences(organization, subscription, 1)
         calendar = _bookable_calendar(organization)
         service = _service_for(organization)
         start = subscription.current_period_start + datetime.timedelta(days=1)

--- a/calendar_integration/tests/services/test_postpaid_enforcement.py
+++ b/calendar_integration/tests/services/test_postpaid_enforcement.py
@@ -1,0 +1,334 @@
+"""Phase 8: the post-paid ``event_occurrences`` allowance guard.
+
+Spec use-case 4 (enforcement half): an organization **with** a payment method
+accrues past its included allowance and is never interrupted; one **without** a
+payment method is blocked at the allowance.
+
+These tests drive the real guarded path (``CalendarService.create_event`` /
+``EntitlementService.check_postpaid_allowance`` / ``has_payment_method``) rather
+than asserting on a hand-built queryset -- a guard's own test would otherwise pass
+whether or not the invariant holds.
+"""
+
+import datetime
+from decimal import Decimal
+
+from django.utils import timezone
+
+import pytest
+from model_bakery import baker
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import Calendar, CalendarEvent
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import CalendarEventInputData
+from organizations.models import Organization
+from payments.billing_constants import BillingState, LimitedResource, LimitKind, LimitRemedy
+from payments.exceptions import OverLimitError
+from payments.models import BillingPlan, MeteredOccurrence, Subscription, SubscriptionPlanLimit
+from payments.services.entitlement_service import EntitlementService
+
+
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
+def _organization_with_postpaid_limit(
+    limit_value: int | None, billing_state: str = BillingState.FREE
+) -> tuple[Organization, Subscription]:
+    """A standalone (non-reseller) organization with a ceiling on ``event_occurrences``.
+
+    ``limit_value=None`` builds an ``unlimited``-shaped subscription (NULL ceiling) --
+    every organization's actual state for the whole rollout, and the property this
+    phase's tests must prove is inert.
+    """
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=billing_state,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=LimitedResource.EVENT_OCCURRENCES,
+        limit_value=limit_value,
+        kind=LimitKind.POSTPAID,
+    )
+    return organization, subscription
+
+
+def _seed_metered_occurrences(organization: Organization, subscription: Subscription, count: int):
+    """Write ``count`` already-metered occurrences into the subscription's current
+    billing period -- what ``_count_event_occurrences`` reads back as usage."""
+    MeteredOccurrence.objects.bulk_create(
+        [
+            MeteredOccurrence(
+                organization=organization,
+                subscription=subscription,
+                event_id=900000 + i,
+                occurrence_start=subscription.current_period_start + datetime.timedelta(hours=i),
+                billing_period_start=subscription.current_period_start,
+                is_within_allowance=True,
+                unit_price=Decimal("0"),
+            )
+            for i in range(count)
+        ]
+    )
+
+
+def _bookable_calendar(organization: Organization) -> Calendar:
+    """A calendar any unauthenticated caller may book on, with no adapter round-trip.
+
+    ``accepts_public_scheduling=True`` grants the booking permission check
+    unconditionally (mirrors the codeless public-scheduling flows elsewhere), and
+    ``manage_available_windows=False`` (the model default) makes the whole range
+    bookable with no ``AvailableTime`` rows to seed. ``provider=INTERNAL`` (the
+    model default) means no entitlement gate and no external adapter is resolved.
+    """
+    return baker.make(
+        Calendar,
+        organization=organization,
+        calendar_type=CalendarType.PERSONAL,
+        provider=CalendarProvider.INTERNAL,
+        accepts_public_scheduling=True,
+        manage_available_windows=False,
+    )
+
+
+def _event_input(start: datetime.datetime, minutes: int = 60) -> CalendarEventInputData:
+    return CalendarEventInputData(
+        title="Postpaid event",
+        description="",
+        start_time=start,
+        end_time=start + datetime.timedelta(minutes=minutes),
+        timezone="UTC",
+        attendances=[],
+        external_attendances=[],
+        resource_allocations=[],
+    )
+
+
+def _service_for(organization: Organization) -> CalendarService:
+    service = CalendarService()
+    service.initialize_without_provider(organization=organization)
+    return service
+
+
+# ----------------------------------------------------------------------------------
+# EntitlementService.has_payment_method / check_postpaid_allowance -- direct unit tests
+# ----------------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestHasPaymentMethod:
+    def test_free_billing_state_has_no_payment_method(self):
+        organization, _subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        assert EntitlementService().has_payment_method(organization) is False
+
+    @pytest.mark.parametrize(
+        "billing_state",
+        [BillingState.ACTIVE, BillingState.GRACE, BillingState.RESTRICTED, BillingState.CANCELLED],
+    )
+    def test_any_non_free_billing_state_has_a_payment_method(self, billing_state):
+        organization, _subscription = _organization_with_postpaid_limit(1, billing_state)
+        assert EntitlementService().has_payment_method(organization) is True
+
+    def test_no_subscription_has_no_payment_method(self):
+        """Fail-closed side of postpaid enforcement: an unresolvable subscription
+        must not be read as "has a payment method"."""
+        organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+        assert EntitlementService().has_payment_method(organization) is False
+
+
+@pytest.mark.django_db
+class TestCheckPostpaidAllowance:
+    def test_unlimited_never_counts_usage_or_blocks(self):
+        organization, _subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        service = EntitlementService()
+
+        result = service.check_postpaid_allowance(organization, delta=1000)
+
+        assert result.allowed is True
+        assert result.current_usage is None
+        assert result.ceiling is None
+
+    def test_under_the_allowance_is_allowed_without_a_payment_method(self):
+        organization, subscription = _organization_with_postpaid_limit(5, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 3)
+
+        result = EntitlementService().check_postpaid_allowance(organization, delta=1)
+
+        assert result.allowed is True
+        assert result.current_usage == 3
+        assert result.ceiling == 5
+
+    def test_at_the_allowance_with_a_payment_method_accrues(self):
+        organization, subscription = _organization_with_postpaid_limit(5, BillingState.ACTIVE)
+        _seed_metered_occurrences(organization, subscription, 5)
+
+        result = EntitlementService().check_postpaid_allowance(organization, delta=1)
+
+        assert result.allowed is True
+
+    def test_at_the_allowance_without_a_payment_method_blocks(self):
+        organization, subscription = _organization_with_postpaid_limit(5, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 5)
+
+        result = EntitlementService().check_postpaid_allowance(organization, delta=1)
+
+        assert result.allowed is False
+        assert result.current_usage == 5
+        assert result.ceiling == 5
+        assert result.remedy == LimitRemedy.ADD_PAYMENT_METHOD
+
+    @pytest.mark.parametrize("billing_state", [BillingState.GRACE, BillingState.RESTRICTED])
+    def test_at_the_allowance_in_grace_or_restricted_still_accrues(self, billing_state):
+        """Grace/restricted already have a payment method on file (see
+        ``has_payment_method``) -- their payment problem is resolved through the
+        separate grace/restricted machinery (Phase 10/11), not by this guard, so
+        they are treated the same as an active organization: let through, not
+        blocked."""
+        organization, subscription = _organization_with_postpaid_limit(5, billing_state)
+        _seed_metered_occurrences(organization, subscription, 5)
+
+        result = EntitlementService().check_postpaid_allowance(organization, delta=1)
+
+        assert result.allowed is True
+
+    def test_delta_larger_than_headroom_blocks_without_a_payment_method(self):
+        """A fan-out delta (e.g. a bundle event) is checked as one unit, not one
+        check per row -- a delta that alone exceeds headroom must block even though
+        a delta of 1 would not have."""
+        organization, subscription = _organization_with_postpaid_limit(5, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 3)
+
+        result = EntitlementService().check_postpaid_allowance(organization, delta=3)
+
+        assert result.allowed is False
+
+
+# ----------------------------------------------------------------------------------
+# CalendarService.create_event -- the guarded creation path
+# ----------------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateEventPostpaidGuard:
+    def test_with_payment_method_creation_past_the_allowance_succeeds_and_accrues(self):
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.ACTIVE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        calendar = _bookable_calendar(organization)
+        service = _service_for(organization)
+
+        # Anchored to the subscription's own period (not a hand-picked calendar date)
+        # so metering below resolves to the same billing period the seeded usage sits
+        # in, regardless of when the suite runs.
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        event = service.create_event(calendar.id, _event_input(start))
+
+        assert event.pk is not None
+        assert CalendarEvent.objects.filter(pk=event.pk).exists()
+
+        # "Accrues" is proven, not assumed: metering this event now must record it
+        # as overage (outside the 1-occurrence allowance), not silently for free.
+        from di_core.containers import container
+
+        result = container.metering_service().meter_occurrences_for_period(
+            subscription,
+            window_start=event.start_time - datetime.timedelta(minutes=1),
+            window_end=event.end_time + datetime.timedelta(minutes=1),
+        )
+        assert result.occurrences_recorded == 1
+        recorded = MeteredOccurrence.objects.get(organization=organization, event_id=event.pk)
+        assert recorded.is_within_allowance is False
+
+    def test_without_payment_method_at_the_allowance_blocks(self):
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        calendar = _bookable_calendar(organization)
+        service = _service_for(organization)
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.create_event(calendar.id, _event_input(start))
+
+        assert exc_info.value.resource_key == LimitedResource.EVENT_OCCURRENCES
+        assert exc_info.value.remedy == LimitRemedy.ADD_PAYMENT_METHOD
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+
+    def test_without_payment_method_under_the_allowance_succeeds(self):
+        organization, subscription = _organization_with_postpaid_limit(5, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 2)
+        calendar = _bookable_calendar(organization)
+        service = _service_for(organization)
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+
+        event = service.create_event(calendar.id, _event_input(start))
+
+        assert event.pk is not None
+
+    def test_unlimited_plan_is_unchanged_behavior(self):
+        """The rollout's inertness guarantee: the ``unlimited`` plan's NULL ceiling
+        means this guard can never block anybody today, with or without a payment
+        method on file."""
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 10_000)
+        calendar = _bookable_calendar(organization)
+        service = _service_for(organization)
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+
+        event = service.create_event(calendar.id, _event_input(start))
+
+        assert event.pk is not None
+
+    def test_recurrence_exception_is_not_charged_a_second_unit(self):
+        """A modified occurrence substitutes for a slot its master's rule already
+        accounts for -- it must not independently consume headroom, or the guard
+        would disagree with ``MeteringService.expand_occurrence_identities`` about
+        what one booking costs (it never counts an exception as its own master).
+
+        The master is seeded directly via the ORM (not through ``create_event``):
+        the only thing this test drives through the guarded path is the exception
+        create, and ``CalendarEvent.external_id`` is globally unique, so two calls
+        through the un-adapted ``create_event`` path (which both stamp
+        ``external_id=""``) would collide with each other regardless of billing.
+        """
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        calendar = _bookable_calendar(organization)
+        service = _service_for(organization)
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+
+        master = CalendarEvent.objects.create(
+            calendar_fk=calendar,
+            organization=organization,
+            title="Master",
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=start + datetime.timedelta(hours=1),
+            timezone="UTC",
+            external_id="postpaid-exception-master",
+        )
+        # At the allowance now (the seeded "usage" unit is what would prove blocking
+        # if the exception path incorrectly re-ran the guard): the check here is
+        # that a create against the same organization -- one that is an exception
+        # of `master` -- does not consume a unit at all.
+        _seed_metered_occurrences(organization, subscription, 1)
+
+        exception_input = CalendarEventInputData(
+            title="Rescheduled",
+            description="",
+            start_time=start + datetime.timedelta(days=1),
+            end_time=start + datetime.timedelta(days=1, hours=1),
+            timezone="UTC",
+            parent_event_id=master.id,
+            is_recurring_exception=True,
+        )
+
+        exception_event = service.create_event(calendar.id, exception_input)
+
+        assert exception_event.pk is not None

--- a/calendar_integration/tests/test_event_creation_surfaces.py
+++ b/calendar_integration/tests/test_event_creation_surfaces.py
@@ -18,11 +18,16 @@ a bundle event over five ``INTERNAL`` children costs 5 units of headroom, one ov
 five Google children costs 1 -- because a ``BlockedTime`` is never billable.
 """
 
+import ast
 import base64
 import datetime
+import pathlib
 from unittest.mock import Mock, patch
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from django.utils import timezone
 
 import pytest
 from allauth.socialaccount.models import SocialAccount, SocialToken
@@ -67,7 +72,6 @@ from payments.models import (
 )
 from public_api.constants import PublicAPIResources
 from public_api.models import ResourceAccess
-from public_api.services import PublicAPIAuthService
 from users.models import Profile, User
 
 
@@ -118,18 +122,57 @@ def _organization_with_postpaid_limit(
 
 
 def _seed_metered_occurrences(organization: Organization, subscription: Subscription, count: int):
+    """``count`` already-metered occurrences in the subscription's current billing
+    period -- what ``_count_event_occurrences`` reads back as usage.
+
+    Each row points at a **real** ``CalendarEvent``. An earlier version invented
+    ``event_id=800000 + i`` for rows whose events did not exist; that only survived
+    because Django declares FK constraints ``DEFERRABLE INITIALLY DEFERRED`` and a
+    test transaction is rolled back rather than committed, so the check never ran. A
+    fixture that depends on never committing is a fixture that breaks the first time
+    somebody writes a ``transactional_db`` test against it.
+    """
+    seed_calendar = baker.make(
+        Calendar,
+        organization=organization,
+        provider=CalendarProvider.INTERNAL,
+        external_id=f"usage-seed-cal-{organization.pk}",
+    )
+    period_start = subscription.current_period_start
+    events = CalendarEvent.objects.bulk_create(
+        [
+            CalendarEvent(
+                organization=organization,
+                calendar_fk=seed_calendar,
+                title=f"Seeded usage {i}",
+                description="",
+                start_time_tz_unaware=(period_start + datetime.timedelta(hours=i)).replace(
+                    tzinfo=None
+                ),
+                end_time_tz_unaware=(
+                    period_start + datetime.timedelta(hours=i, minutes=30)
+                ).replace(tzinfo=None),
+                timezone="UTC",
+                # `CalendarEvent.external_id` is globally unique and an un-adapted
+                # create stamps `""`, so the seeds must not also use `""` or the very
+                # first real create in the test collides with them.
+                external_id=f"usage-seed-{organization.pk}-{i}",
+            )
+            for i in range(count)
+        ]
+    )
     MeteredOccurrence.objects.bulk_create(
         [
             MeteredOccurrence(
                 organization=organization,
                 subscription=subscription,
-                event_id=800000 + i,
-                occurrence_start=subscription.current_period_start + datetime.timedelta(hours=i),
-                billing_period_start=subscription.current_period_start,
+                event_id=event.pk,
+                occurrence_start=period_start + datetime.timedelta(hours=i),
+                billing_period_start=period_start,
                 is_within_allowance=True,
                 unit_price=0,
             )
-            for i in range(count)
+            for i, event in enumerate(events)
         ]
     )
 
@@ -245,7 +288,7 @@ class TestRestSurface:
 
     def test_unlimited_plan_is_unchanged(self, mock_google_adapter):
         organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
-        _seed_metered_occurrences(organization, subscription, 10_000)
+        _seed_metered_occurrences(organization, subscription, 1)
         calendar = baker.make(
             Calendar,
             organization=organization,
@@ -351,7 +394,7 @@ class TestTokenSurface:
 
     def test_unlimited_plan_is_unchanged(self):
         organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
-        _seed_metered_occurrences(organization, subscription, 10_000)
+        _seed_metered_occurrences(organization, subscription, 1)
         calendar = baker.make(
             Calendar,
             organization=organization,
@@ -390,7 +433,15 @@ mutation ScheduleEvent($input: ScheduleEventInput!) {
 def _scoped_system_user(
     organization: Organization, membership: OrganizationMembership
 ) -> tuple[object, str]:
-    auth_service = PublicAPIAuthService()
+    # Built through the container rather than `PublicAPIAuthService()`: its
+    # `audit_service` is a required constructor argument, satisfied by DI at runtime
+    # but not by a bare call (which mypy correctly rejects). Imported inside the
+    # function because `di_core.containers.container` is None until app startup wires
+    # it -- a module-level `from ... import container` would capture the None.
+    from di_core.containers import container
+
+    assert container is not None
+    auth_service = container.public_api_auth_service()
     system_user, token = auth_service.create_system_user(
         integration_name=f"sched-surface-{organization.pk}",
         organization=organization,
@@ -468,7 +519,7 @@ class TestPublicApiScheduleEventSurface:
     def test_unlimited_plan_is_unchanged(self, mock_rate_limiter):
         mock_rate_limiter.return_value = iter([None])
         organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
-        _seed_metered_occurrences(organization, subscription, 10_000)
+        _seed_metered_occurrences(organization, subscription, 1)
         _owner, membership, calendar = _owner_with_calendar(organization)
         system_user, token = _scoped_system_user(organization, membership)
 
@@ -581,7 +632,7 @@ class TestBookingCodeEventSurface:
     def test_unlimited_plan_is_unchanged(self, mock_rate_limiter):
         mock_rate_limiter.return_value = iter([None])
         organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
-        _seed_metered_occurrences(organization, subscription, 10_000)
+        _seed_metered_occurrences(organization, subscription, 1)
         calendar = baker.make(
             Calendar,
             organization=organization,
@@ -714,7 +765,7 @@ class TestBookingCodeGroupEventSurface:
     def test_unlimited_plan_is_unchanged(self, mock_rate_limiter):
         mock_rate_limiter.return_value = iter([None])
         organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
-        _seed_metered_occurrences(organization, subscription, 10_000)
+        _seed_metered_occurrences(organization, subscription, 1)
         group, slot, calendar = _group_with_one_slot(organization)
         _token, code = _group_booking_code(organization, group)
 
@@ -826,7 +877,7 @@ class TestBulkSyncWriterSurface:
 
     def test_unlimited_plan_is_unchanged(self):
         organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
-        _seed_metered_occurrences(organization, subscription, 10_000)
+        _seed_metered_occurrences(organization, subscription, 1)
         sync_service, calendar = _sync_setup(organization)
 
         from calendar_integration.models import CalendarSync
@@ -1065,32 +1116,668 @@ class TestBundleEventFanOutHeadroom:
 
 
 # ----------------------------------------------------------------------------------
-# Coverage registry: every named surface has a probe here
+# Inertness, observed rather than inferred
 # ----------------------------------------------------------------------------------
 
-GUARDED_SURFACES = {
-    "rest": TestRestSurface,
-    "token": TestTokenSurface,
-    "public_api_schedule_event": TestPublicApiScheduleEventSurface,
-    "booking_code_single_event": TestBookingCodeEventSurface,
-    "booking_code_group_event": TestBookingCodeGroupEventSurface,
-    "bulk_sync_writer": TestBulkSyncWriterSurface,
+
+@pytest.mark.django_db
+class TestUnlimitedPlanTakesNoLock:
+    """The ``test_unlimited_plan_is_unchanged`` probes above assert a 201/success,
+    which is necessary but blind to *how* the guard reached it.
+
+    An earlier revision of ``check_postpaid_allowance`` took ``SELECT ... FOR UPDATE``
+    on the billing root's ``Subscription`` row **before** resolving the limit, so every
+    event creation for every organization -- all of which are on ``unlimited`` for this
+    whole rollout -- took an organization-wide row lock, inside ``create_event``'s
+    transaction, held across the external provider round-trip. Two users booking
+    different calendars of the same organization serialized on it. Every one of those
+    tests still passed, because the request still returned 201.
+
+    So this asserts the property directly: on the unlimited path the guard issues no
+    row lock at all. A future change cannot silently put one back.
+    """
+
+    def test_no_row_lock_is_taken_on_the_unlimited_path(self):
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            accepts_public_scheduling=True,
+            manage_available_windows=False,
+            external_id=f"nolock-cal-{organization.pk}",
+        )
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        with CaptureQueriesContext(connection) as captured:
+            facade.create_event(
+                calendar.id,
+                CalendarEventInputData(
+                    title="Unlimited, unlocked",
+                    description="",
+                    start_time=start,
+                    end_time=start + datetime.timedelta(hours=1),
+                    timezone="UTC",
+                    attendances=[],
+                    external_attendances=[],
+                    resource_allocations=[],
+                ),
+            )
+
+        locking = [
+            query["sql"]
+            for query in captured.captured_queries
+            if "FOR UPDATE" in query["sql"].upper()
+            and "PAYMENTS_SUBSCRIPTION" in query["sql"].upper()
+        ]
+        assert not locking, (
+            "check_postpaid_allowance took SELECT ... FOR UPDATE on payments_subscription "
+            "for an organization with a NULL event_occurrences ceiling. Every organization "
+            "is on `unlimited` for this rollout and create_event is @transaction.atomic "
+            "around a provider round-trip, so this serializes every booking in the "
+            f"organization on one row for a ceiling that cannot block anybody: {locking}"
+        )
+
+    def test_a_finite_ceiling_still_takes_the_lock(self):
+        """The negative control: the lock is *deferred* until a real ceiling exists,
+        not deleted. Without this, "take no lock" would pass by removing the guard's
+        concurrency protection entirely."""
+        organization, subscription = _organization_with_postpaid_limit(50, BillingState.ACTIVE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.INTERNAL,
+            calendar_type=CalendarType.PERSONAL,
+            accepts_public_scheduling=True,
+            manage_available_windows=False,
+            external_id=f"lock-cal-{organization.pk}",
+        )
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        with CaptureQueriesContext(connection) as captured:
+            facade.create_event(
+                calendar.id,
+                CalendarEventInputData(
+                    title="Finite ceiling, locked",
+                    description="",
+                    start_time=start,
+                    end_time=start + datetime.timedelta(hours=1),
+                    timezone="UTC",
+                    attendances=[],
+                    external_attendances=[],
+                    resource_allocations=[],
+                ),
+            )
+
+        assert any(
+            "FOR UPDATE" in query["sql"].upper() and "PAYMENTS_SUBSCRIPTION" in query["sql"].upper()
+            for query in captured.captured_queries
+        )
+
+
+# ----------------------------------------------------------------------------------
+# Recurring masters: the guard must charge occurrences, not masters
+# ----------------------------------------------------------------------------------
+
+
+def _bookable_calendar(organization: Organization, slug: str) -> Calendar:
+    return baker.make(
+        Calendar,
+        organization=organization,
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        accepts_public_scheduling=True,
+        manage_available_windows=False,
+        external_id=f"{slug}-{organization.pk}",
+    )
+
+
+@pytest.mark.django_db
+class TestRecurringMasterCostsItsOccurrences:
+    """``current_usage`` counts ``MeteredOccurrence`` rows -- one per *occurrence*.
+    A recurring master is one row in ``CalendarEvent`` but ~30 occurrences a month in
+    the meter, so a guard that charges 1 per master lets an organization one unit
+    below its ceiling create an open-ended daily series and accrue unbillable usage
+    forever, never tripping the guard on that series again.
+
+    The delta comes from ``MeteringService.occurrence_starts_of`` -- the meter's own
+    expansion, called rather than re-implemented.
+    """
+
+    def test_a_daily_series_costs_its_occurrences_not_one(self):
+        organization, subscription = _organization_with_postpaid_limit(10, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 9)
+        calendar = _bookable_calendar(organization, "recurring-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        # 9 used of 10: a *single* event would fit (9 + 1 <= 10). A daily series of 5
+        # does not (9 + 5 > 10), and the old master-counting guard would have allowed it.
+        start = timezone.now() + datetime.timedelta(days=1)
+        with pytest.raises(OverLimitError) as exc_info:
+            facade.create_event(
+                calendar.id,
+                CalendarEventInputData(
+                    title="Daily standup",
+                    description="",
+                    start_time=start,
+                    end_time=start + datetime.timedelta(minutes=30),
+                    timezone="UTC",
+                    recurrence_rule="RRULE:FREQ=DAILY;COUNT=5",
+                    attendances=[],
+                    external_attendances=[],
+                    resource_allocations=[],
+                ),
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.EVENT_OCCURRENCES
+        assert exc_info.value.remedy == LimitRemedy.ADD_PAYMENT_METHOD
+        # Stage 2 runs after the insert and rolls it back; nothing survives.
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+
+    def test_a_single_event_of_the_same_shape_still_fits(self):
+        """The control for the test above: with 9 of 10 used, one booking is allowed.
+        Without this, the block above could just be an over-eager guard."""
+        organization, subscription = _organization_with_postpaid_limit(10, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 9)
+        calendar = _bookable_calendar(organization, "single-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = timezone.now() + datetime.timedelta(days=1)
+        event = facade.create_event(
+            calendar.id,
+            CalendarEventInputData(
+                title="One booking",
+                description="",
+                start_time=start,
+                end_time=start + datetime.timedelta(minutes=30),
+                timezone="UTC",
+                attendances=[],
+                external_attendances=[],
+                resource_allocations=[],
+            ),
+        )
+
+        assert event.pk is not None
+
+    def test_a_series_that_fits_is_created(self):
+        organization, subscription = _organization_with_postpaid_limit(10, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 4)
+        calendar = _bookable_calendar(organization, "fits-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = timezone.now() + datetime.timedelta(days=1)
+        event = facade.create_event(
+            calendar.id,
+            CalendarEventInputData(
+                title="Daily standup that fits",
+                description="",
+                start_time=start,
+                end_time=start + datetime.timedelta(minutes=30),
+                timezone="UTC",
+                recurrence_rule="RRULE:FREQ=DAILY;COUNT=5",
+                attendances=[],
+                external_attendances=[],
+                resource_allocations=[],
+            ),
+        )
+
+        assert event.pk is not None
+        assert event.is_recurring
+
+    def test_create_recurring_event_shortcut_is_guarded_the_same_way(self):
+        """``create_recurring_event`` is a thin shortcut over ``create_event``; it must
+        not be a way around the occurrence-counting guard."""
+        organization, subscription = _organization_with_postpaid_limit(10, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 9)
+        calendar = _bookable_calendar(organization, "shortcut-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = timezone.now() + datetime.timedelta(days=1)
+        with pytest.raises(OverLimitError):
+            facade.create_recurring_event(
+                calendar_id=calendar.id,
+                title="Daily standup",
+                description="",
+                start_time=start,
+                end_time=start + datetime.timedelta(minutes=30),
+                timezone="UTC",
+                recurrence_rule="RRULE:FREQ=DAILY;COUNT=5",
+            )
+
+    def test_the_unlimited_plan_is_unchanged_for_a_series(self):
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        calendar = _bookable_calendar(organization, "unlimited-recurring-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = timezone.now() + datetime.timedelta(days=1)
+        with CaptureQueriesContext(connection) as captured:
+            event = facade.create_event(
+                calendar.id,
+                CalendarEventInputData(
+                    title="Unlimited daily standup",
+                    description="",
+                    start_time=start,
+                    end_time=start + datetime.timedelta(minutes=30),
+                    timezone="UTC",
+                    recurrence_rule="RRULE:FREQ=DAILY;COUNT=5",
+                    attendances=[],
+                    external_attendances=[],
+                    resource_allocations=[],
+                ),
+            )
+
+        assert event.pk is not None
+        # The expansion is behind the unlimited early-return, so an unlimited
+        # organization does not pay for it -- nor for a row lock.
+        assert not [
+            query["sql"]
+            for query in captured.captured_queries
+            if "FOR UPDATE" in query["sql"].upper()
+            and "PAYMENTS_SUBSCRIPTION" in query["sql"].upper()
+        ]
+
+
+# ----------------------------------------------------------------------------------
+# Internal re-entries into create_event, and the bypass switch
+# ----------------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestInternalCreateEventReentries:
+    def test_bulk_modification_continuation_is_guarded(self):
+        """Splitting a series creates a *continuation* master through ``create_event``.
+        It is a genuinely new master the meter enumerates in its own right, so it is
+        checked -- and, being recurring, checked for its occurrences."""
+        organization, subscription = _organization_with_postpaid_limit(20, BillingState.FREE)
+        calendar = _bookable_calendar(organization, "bulkmod-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        # Microsecond-free: `OccurrenceValidator.validate_modification_date` compares
+        # the split date against `dateutil.rrule` output, which truncates microseconds,
+        # so a `now()`-derived start would never match its own second occurrence.
+        start = (timezone.now() + datetime.timedelta(days=1)).replace(microsecond=0)
+        parent = facade.create_event(
+            calendar.id,
+            CalendarEventInputData(
+                title="Weekly sync",
+                description="",
+                start_time=start,
+                end_time=start + datetime.timedelta(minutes=30),
+                timezone="UTC",
+                recurrence_rule="RRULE:FREQ=WEEKLY;COUNT=5",
+                attendances=[],
+                external_attendances=[],
+                resource_allocations=[],
+            ),
+        )
+
+        # Fill the allowance to the brim before splitting, so the continuation's own
+        # create is the thing that has to fail.
+        _seed_metered_occurrences(organization, subscription, 20)
+
+        # The split first *updates* the parent (to truncate it), which runs the
+        # ordinary permission-token check -- unrelated to the guard under test and
+        # needing a full event-token fixture to satisfy. Mocked open; the guard and
+        # every write stay real.
+        with (
+            patch.object(CalendarPermissionService, "can_perform_update", return_value=True),
+            pytest.raises(OverLimitError) as exc_info,
+        ):
+            facade.create_recurring_event_bulk_modification(
+                parent_event=parent,
+                modification_start_date=parent.start_time + datetime.timedelta(weeks=1),
+                modified_title="Weekly sync (moved)",
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.EVENT_OCCURRENCES
+
+    def test_transfer_between_calendars_is_not_charged(self):
+        """A transfer is a **move**: ``transfer_event`` creates the event on
+        the target calendar and deletes it from the source, so it is net-zero on
+        billable masters. Charging it would compare ``delta=1`` against a usage count
+        that already includes the moved event's own occurrences and hand an
+        organization at its allowance a 402 for no net new billable capacity."""
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        source = _bookable_calendar(organization, "transfer-src")
+        target = _bookable_calendar(organization, "transfer-dst")
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        event = baker.make(
+            CalendarEvent,
+            organization=organization,
+            calendar_fk=source,
+            title="Movable",
+            description="",
+            start_time_tz_unaware=start.replace(tzinfo=None),
+            end_time_tz_unaware=(start + datetime.timedelta(hours=1)).replace(tzinfo=None),
+            timezone="UTC",
+            external_id="transfer-external-id",
+        )
+
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+        # `transfer_event` requires an authenticated service (it reads the
+        # source event back off the provider). Everything below the guard is real.
+        adapter = Mock()
+        adapter.get_event.return_value = CalendarEventAdapterOutputData(
+            calendar_external_id=source.external_id,
+            external_id=event.external_id,
+            title="Movable",
+            description="",
+            start_time=start,
+            end_time=start + datetime.timedelta(hours=1),
+            timezone="UTC",
+            attendees=[],
+            resources=[],
+            original_payload={},
+        )
+        adapter.create_event.return_value = CalendarEventAdapterOutputData(
+            calendar_external_id=target.external_id,
+            external_id="transferred-external-id",
+            title="Movable",
+            description="",
+            start_time=start,
+            end_time=start + datetime.timedelta(hours=1),
+            timezone="UTC",
+            attendees=[],
+            resources=[],
+            original_payload={},
+        )
+        facade.account = Mock(name="fake-social-account")
+        facade.calendar_adapter = adapter
+
+        # At the allowance (1 of 1) with no payment method: a *creation* would be
+        # blocked here (that is what TestRestSurface asserts). A move must not be.
+        #
+        # The transfer's second half (`delete_event` on the source) runs the ordinary
+        # permission-token update check, which has nothing to do with the post-paid
+        # guard under test and would need a full event-token fixture to satisfy. It is
+        # mocked open; the guard, both creates, and every DB write stay real.
+        with patch.object(CalendarPermissionService, "can_perform_update", return_value=True):
+            moved = facade.transfer_event(event, target)
+
+        assert moved.pk is not None
+        assert moved.calendar_fk_id == target.id
+        assert not CalendarEvent.objects.filter(pk=event.pk).exists()
+
+    def test_bypass_limits_skips_the_guard(self):
+        """The plan's Enforcement-bypass Guiding Decision: every guarded write takes
+        ``bypass_limits`` so a management command or a support repair can run against
+        an organization that is over its allowance."""
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        calendar = _bookable_calendar(organization, "bypass-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        event_data = CalendarEventInputData(
+            title="Bypassed",
+            description="",
+            start_time=start,
+            end_time=start + datetime.timedelta(hours=1),
+            timezone="UTC",
+            attendances=[],
+            external_attendances=[],
+            resource_allocations=[],
+        )
+
+        # Control: without the bypass this exact call is blocked.
+        with pytest.raises(OverLimitError):
+            facade.create_event(calendar.id, event_data)
+
+        event = facade.create_event(calendar.id, event_data, bypass_limits=True)
+        assert event.pk is not None
+
+    def test_a_service_in_bypass_mode_skips_the_guard(self):
+        """``CalendarService.authenticate(bypass_limits=True)`` puts the whole service
+        in bypass mode. The provider-entitlement gate honours it; so must this guard,
+        or a service explicitly placed in bypass mode is still post-paid-blocked."""
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        calendar = _bookable_calendar(organization, "bypassmode-cal")
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+        facade._bypass_entitlement_limits = True
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        event = facade.create_event(
+            calendar.id,
+            CalendarEventInputData(
+                title="Bypass mode",
+                description="",
+                start_time=start,
+                end_time=start + datetime.timedelta(hours=1),
+                timezone="UTC",
+                attendances=[],
+                external_attendances=[],
+                resource_allocations=[],
+            ),
+        )
+
+        assert event.pk is not None
+
+
+@pytest.mark.django_db
+class TestSyncRecoversOnceHeadroomIsRestored:
+    """An over-allowance sync is refused, recorded as ``FAILED``, and retried on the
+    next scheduled pass. Nothing in the ``CalendarSync`` row distinguishes that from a
+    provider outage, so the refusal is logged with the organization and the remedy --
+    and, critically, it must **self-heal**: once headroom exists, the very next sync
+    over the same window must succeed with no manual replay."""
+
+    def test_the_same_sync_succeeds_once_headroom_exists(self):
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        sync_service, calendar = _sync_setup(organization)
+
+        from calendar_integration.models import CalendarSync
+
+        calendar_sync = CalendarSync.objects.create(
+            organization=organization,
+            calendar=calendar,
+            start_datetime=datetime.datetime.now(datetime.UTC),
+            end_datetime=datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30),
+            should_update_events=False,
+        )
+        sync_service._context.calendar_adapter.get_events.return_value = {
+            "events": [_recurring_master_adapter_event("sync-recovers")],
+            "next_sync_token": None,
+        }
+
+        sync_service.sync_events(calendar_sync)
+        calendar_sync.refresh_from_db()
+        assert calendar_sync.status == "failed"
+
+        # Headroom restored (here by attaching a payment method -- the remedy the
+        # refusal reports). No replay, no manual intervention: just the next pass.
+        subscription.billing_state = BillingState.ACTIVE
+        subscription.save(update_fields=["billing_state"])
+
+        sync_service.sync_events(calendar_sync)
+        calendar_sync.refresh_from_db()
+        assert calendar_sync.status == "success"
+        assert CalendarEvent.objects.filter(calendar=calendar, external_id="sync-recovers").exists()
+
+
+# ----------------------------------------------------------------------------------
+# Coverage registry: every module that reaches the guard has a probe here
+# ----------------------------------------------------------------------------------
+
+#: Repository root, for the source walk below.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+#: The three modules that *implement* the guarded write chain rather than consume it,
+#: excluded from the derived set below. Each has a reason, not a convenience:
+#:
+#: - ``calendar_event_service.py`` holds the guard itself, and its internal
+#:   re-entries into ``create_event`` (``create_recurring_event``, the
+#:   bulk-modification continuation, ``transfer_event``) are covered by
+#:   ``TestInternalCreateEventReentries`` below rather than by a "surface" probe.
+#: - ``calendar_service.py`` is the facade that forwards to it.
+#: - ``calendar_bundle_service.py`` is the fan-out, covered by
+#:   ``TestBundleEventFanOutHeadroom``.
+_GUARD_IMPLEMENTATION_MODULES = {
+    "calendar_integration/services/calendar_event_service.py",
+    "calendar_integration/services/calendar_service.py",
+    "calendar_integration/services/calendar_bundle_service.py",
+}
+
+#: Call names that mean "this module can trip the post-paid guard": the two service
+#: entry points that route into ``CalendarEventService.create_event``, and a direct
+#: call to the guard for a writer (the sync path) that does not go through it.
+_GUARD_REACHING_CALLS = {"create_event", "create_recurring_event", "check_postpaid_allowance"}
+
+#: Receivers whose ``create_event`` is the *provider* adapter's (a Google/Microsoft
+#: API write), not this service's. ``ExternalEventChangeRequestService`` calls
+#: ``write_adapter.create_event`` to re-create an event on the provider after an
+#: undone deletion -- no local ``CalendarEvent`` is created and nothing is metered,
+#: so it is not a guarded surface.
+_ADAPTER_RECEIVER_MARKERS = ("adapter", "client")
+
+
+def _receiver_name(node: ast.Attribute) -> str:
+    """The identifier the guarded call is made *on* (``x.y.create_event`` -> ``y``)."""
+    value = node.value
+    if isinstance(value, ast.Attribute):
+        return value.attr
+    if isinstance(value, ast.Name):
+        return value.id
+    return ""
+
+
+#: Every module the walk below is expected to find, mapped to the test class(es) that
+#: drive it. The **keys are asserted against the source tree**, in both directions --
+#: this is the difference between this test and the hand-written literal it replaced,
+#: which compared a dict in this file against a list in this file and would therefore
+#: have passed unchanged when a seventh entry point appeared.
+GUARDED_SURFACES: dict[str, tuple[type, ...]] = {
+    # REST (`CalendarEventViewSet`) and the token REST surface share one serializer,
+    # which is the module that actually issues the create.
+    "calendar_integration/serializers.py": (TestRestSurface, TestTokenSurface),
+    # `createCalendarEventWithCode` (direct) and `createCalendarGroupEventWithCode`
+    # (via `calendar_group_service`, below).
+    "calendar_integration/mutations.py": (
+        TestBookingCodeEventSurface,
+        TestBookingCodeGroupEventSurface,
+    ),
+    "public_api/mutations.py": (TestPublicApiScheduleEventSurface,),
+    "calendar_integration/services/calendar_group_service.py": (TestBookingCodeGroupEventSurface,),
+    "calendar_integration/services/calendar_sync_service.py": (TestBulkSyncWriterSurface,),
 }
 
 
-def test_every_named_surface_has_a_blocked_and_unlimited_probe():
-    """The plan names exactly six ``CalendarEvent`` creation entry points. A
-    surface class registered here without both a blocked-at-the-allowance and an
-    unlimited-plan test method would defeat the point of this file."""
-    assert set(GUARDED_SURFACES) == {
-        "rest",
-        "token",
-        "public_api_schedule_event",
-        "booking_code_single_event",
-        "booking_code_group_event",
-        "bulk_sync_writer",
-    }
-    for name, test_class in GUARDED_SURFACES.items():
-        method_names = {m for m in dir(test_class) if m.startswith("test_")}
-        assert any("blocked" in m for m in method_names), f"{name} has no blocked-path test"
-        assert any("unlimited" in m for m in method_names), f"{name} has no unlimited-plan test"
+def _modules_reaching_the_guard() -> set[str]:
+    """Every module in the tree that can trip the post-paid guard, read out of the
+    source with ``ast`` rather than listed by hand.
+
+    Tests, migrations, factories, and the calendar *adapters* (whose own
+    ``create_event`` talks to Google/Microsoft, not to this service) are excluded, as
+    are the three guard-implementation modules above.
+
+    Scoped to this project's own **first-party Django app packages** (resolved from
+    ``django.apps``, kept to those living under the repo), not a blind ``rglob`` of the
+    repo root. Two reasons, one correctness and one operational: a blind walk would
+    read non-source trees like ``mediafiles`` / ``templates`` / a nested
+    ``.claude/worktrees`` checkout of this same repo -- making the result depend on
+    what else is on disk -- and parsing every one of them is slow enough to trip this
+    test's ``pytest-timeout`` under parallel load. Walking only the app packages is
+    both the correct set and an order of magnitude less work.
+    """
+    from django.apps import apps
+
+    app_dirs: list[pathlib.Path] = []
+    for config in apps.get_app_configs():
+        app_path = pathlib.Path(config.path).resolve()
+        try:
+            app_path.relative_to(_REPO_ROOT)
+        except ValueError:
+            continue  # third-party app installed outside the repo
+        app_dirs.append(app_path)
+
+    found: set[str] = set()
+    for app_dir in app_dirs:
+        for path in app_dir.rglob("*.py"):
+            parts = path.relative_to(_REPO_ROOT).parts
+            relative = path.relative_to(_REPO_ROOT).as_posix()
+            if (
+                any(part.startswith(".") for part in parts)
+                or "tests" in parts
+                or "migrations" in parts
+                or "calendar_adapters" in parts
+                or path.name == "factories.py"
+                or relative in _GUARD_IMPLEMENTATION_MODULES
+            ):
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - not our source
+                continue
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in _GUARD_REACHING_CALLS
+                    and not any(
+                        marker in _receiver_name(node.func) for marker in _ADAPTER_RECEIVER_MARKERS
+                    )
+                ):
+                    found.add(relative)
+                    break
+    return found
+
+
+def test_every_module_reaching_the_guard_has_a_probe():
+    """Derived from the source tree, and asserted both ways.
+
+    A seventh entry point -- a new viewset, a new mutation, a new service that calls
+    ``create_event`` -- appears in ``discovered`` the moment it is written and fails
+    here until somebody registers a probe for it. And a registration left behind for
+    a module that no longer creates events fails the other assertion, so the registry
+    cannot rot in the direction of *claiming* coverage it no longer has.
+    """
+    discovered = _modules_reaching_the_guard()
+
+    unprobed = discovered - GUARDED_SURFACES.keys()
+    assert not unprobed, (
+        f"These modules reach CalendarEventService.create_event (or the post-paid guard "
+        f"directly) but have no probe in this file: {sorted(unprobed)}. Add one, or add "
+        "the module to _GUARD_IMPLEMENTATION_MODULES with a reason if it implements the "
+        "guarded chain rather than consuming it."
+    )
+
+    stale = GUARDED_SURFACES.keys() - discovered
+    assert not stale, (
+        f"GUARDED_SURFACES registers {sorted(stale)}, which no longer reach the guard. "
+        "Remove the registration, or fix the call path if the surface was meant to stay "
+        "guarded -- otherwise this file reports coverage of a path nothing routes through."
+    )
+
+
+def test_every_registered_surface_has_a_blocked_and_unlimited_probe():
+    """A registered probe class that lost its blocked-path or unlimited-path test
+    would leave the module above nominally covered and actually unchecked."""
+    for module, test_classes in GUARDED_SURFACES.items():
+        for test_class in test_classes:
+            method_names = {m for m in dir(test_class) if m.startswith("test_")}
+            assert any("blocked" in m for m in method_names), (
+                f"{module} -> {test_class.__name__} has no blocked-path test"
+            )
+            assert any("unlimited" in m for m in method_names), (
+                f"{module} -> {test_class.__name__} has no unlimited-plan test"
+            )

--- a/calendar_integration/tests/test_event_creation_surfaces.py
+++ b/calendar_integration/tests/test_event_creation_surfaces.py
@@ -1,0 +1,1096 @@
+"""Phase 8: the postpaid ``event_occurrences`` guard, driven through every real
+entry point that reaches ``CalendarEventService.create_event``.
+
+The Guiding Decision behind this phase names six distinct entry points: REST
+(``calendar_integration/views.py`` -- ``CalendarEventViewSet``), the token surface
+(``calendar_integration/token_views.py``), and three GraphQL mutations
+(``public_api/mutations.py``'s ``scheduleEvent``, and
+``calendar_integration/mutations.py``'s ``createCalendarEventWithCode`` /
+``createCalendarGroupEventWithCode``), plus the bulk sync writer
+(``calendar_integration/services/calendar_sync_service.py``). Guarding a viewset
+would leave the sync path unmetered, so the enforcement layer is the service --
+these tests exist to prove every *surface* still reaches it and renders the
+resulting ``OverLimitError`` correctly rather than a raw 500 or a silent success.
+
+Also covers the fan-out case Phase 7's tracking doc names as the plan's own
+recurring failure shape (guard and meter disagreeing on what one booking costs):
+a bundle event over five ``INTERNAL`` children costs 5 units of headroom, one over
+five Google children costs 1 -- because a ``BlockedTime`` is never billable.
+"""
+
+import base64
+import datetime
+from unittest.mock import Mock, patch
+
+from django.urls import reverse
+
+import pytest
+from allauth.socialaccount.models import SocialAccount, SocialToken
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    Calendar,
+    CalendarEvent,
+    CalendarManagementToken,
+    CalendarManagementTokenPermission,
+    EventManagementPermissions,
+)
+from calendar_integration.services.calendar_permission_service import (
+    DEFAULT_CALENDAR_OWNER_PERMISSIONS,
+    CalendarPermissionService,
+)
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.calendar_sync_service import CalendarSyncService
+from calendar_integration.services.dataclasses import (
+    CalendarEventAdapterOutputData,
+    CalendarEventInputData,
+)
+from common.utils.authentication_utils import generate_long_lived_token, hash_long_lived_token
+from organizations.models import Organization, OrganizationMembership
+from payments.billing_constants import (
+    BillingState,
+    Entitlement,
+    LimitedResource,
+    LimitKind,
+    LimitRemedy,
+)
+from payments.exceptions import OverLimitError
+from payments.models import (
+    BillingPlan,
+    MeteredOccurrence,
+    Subscription,
+    SubscriptionEntitlement,
+    SubscriptionPlanLimit,
+)
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+from users.models import Profile, User
+
+
+# This module builds its own Subscription rows (OneToOne with Organization), so it
+# opts out of conftest's autouse `provision_default_subscription`.
+pytestmark = pytest.mark.no_auto_subscription
+
+
+def _organization_with_postpaid_limit(
+    limit_value: int | None, billing_state: str = BillingState.FREE
+) -> tuple[Organization, Subscription]:
+    """A standalone (non-reseller) organization with a ceiling on ``event_occurrences``.
+
+    ``limit_value=None`` builds an ``unlimited``-shaped subscription -- every
+    organization's actual state for the whole rollout, and the property every
+    surface below must prove is inert.
+
+    Every ``Entitlement`` is granted so the ``partner_api`` gate (public GraphQL)
+    and the ``external_calendar_google`` / ``external_calendar_microsoft`` gates
+    (any Google/Microsoft-provider calendar) never mask the postpaid guard under
+    test -- this file is about ``event_occurrences``, not those other gates.
+    """
+    organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+    now = datetime.datetime.now(datetime.UTC)
+    subscription = baker.make(
+        Subscription,
+        organization=organization,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=billing_state,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionPlanLimit,
+        subscription=subscription,
+        resource_key=LimitedResource.EVENT_OCCURRENCES,
+        limit_value=limit_value,
+        kind=LimitKind.POSTPAID,
+    )
+    for entitlement_key in Entitlement.values:
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=entitlement_key,
+            is_enabled=True,
+        )
+    return organization, subscription
+
+
+def _seed_metered_occurrences(organization: Organization, subscription: Subscription, count: int):
+    MeteredOccurrence.objects.bulk_create(
+        [
+            MeteredOccurrence(
+                organization=organization,
+                subscription=subscription,
+                event_id=800000 + i,
+                occurrence_start=subscription.current_period_start + datetime.timedelta(hours=i),
+                billing_period_start=subscription.current_period_start,
+                is_within_allowance=True,
+                unit_price=0,
+            )
+            for i in range(count)
+        ]
+    )
+
+
+def _at_the_allowance_no_payment_method(limit_value: int = 1) -> tuple[Organization, Subscription]:
+    """An organization sitting exactly at its ``event_occurrences`` allowance with no
+    payment method on file -- the one state every surface below must block on."""
+    organization, subscription = _organization_with_postpaid_limit(limit_value, BillingState.FREE)
+    _seed_metered_occurrences(organization, subscription, limit_value)
+    return organization, subscription
+
+
+# ----------------------------------------------------------------------------------
+# 1. REST -- calendar_integration/views.py CalendarEventViewSet.perform_create
+# ----------------------------------------------------------------------------------
+
+
+def _google_backed_owner(
+    organization: Organization, calendar: Calendar
+) -> tuple[User, SocialAccount]:
+    """A User with a real Google SocialAccount/SocialToken, membership, ownership,
+    and a calendar-level ``CalendarManagementToken`` for ``calendar`` -- the
+    minimum a *real* (non-DI-mocked) User-driven ``create_event`` needs.
+    ``CalendarService.authenticate`` resolves an adapter from the account
+    regardless of the target calendar's own provider, and
+    ``CalendarPermissionService.initialize_with_user`` requires an existing
+    calendar-level token to resolve permissions from (mirrors
+    ``test_calendar_event_service.py``'s ``calendar_owner_token`` fixture).
+    """
+    from calendar_integration.models import CalendarManagementToken, CalendarOwnership
+
+    user = User.objects.create_user(email=f"rest-{organization.pk}@example.com", password="x")
+    Profile.objects.create(user=user)
+    OrganizationMembership.objects.create(user=user, organization=organization, is_active=True)
+    social_account = SocialAccount.objects.create(
+        user=user, provider=CalendarProvider.GOOGLE, uid=f"uid-{organization.pk}"
+    )
+    SocialToken.objects.create(
+        account=social_account,
+        token="access-token",
+        token_secret="refresh-token",
+        expires_at=datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1),
+    )
+    CalendarOwnership.objects.create(
+        calendar=calendar, membership_user_id=user.id, organization=organization
+    )
+    token = CalendarManagementToken.objects.create(
+        calendar_fk=calendar, membership_user_id=user.id, organization=organization
+    )
+    for permission in DEFAULT_CALENDAR_OWNER_PERMISSIONS:
+        CalendarManagementTokenPermission.objects.create(
+            token_fk=token, permission=permission, organization=organization
+        )
+    return user, social_account
+
+
+@pytest.fixture
+def mock_google_adapter():
+    with patch(
+        "calendar_integration.services.calendar_adapters.google_calendar_adapter.GoogleCalendarAdapter"
+    ) as mock_adapter_class:
+        mock_adapter = Mock()
+        mock_adapter.provider = CalendarProvider.GOOGLE
+        del mock_adapter.resolve_expression
+        del mock_adapter.get_source_expressions
+        mock_adapter_class.return_value = mock_adapter
+        mock_adapter_class.from_service_account_credentials.return_value = mock_adapter
+        yield mock_adapter
+
+
+def _rest_payload(calendar: Calendar, organization: Organization) -> dict:
+    start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+    return {
+        "organization": organization.id,
+        "calendar": calendar.id,
+        "title": "REST Surface Event",
+        "description": "",
+        "start_time": start.isoformat(),
+        "end_time": (start + datetime.timedelta(hours=1)).isoformat(),
+        "timezone": "UTC",
+        "resource_allocations": [],
+        "attendances": [],
+        "external_attendances": [],
+    }
+
+
+@pytest.mark.django_db
+class TestRestSurface:
+    def test_blocked_at_the_allowance_returns_402(self, mock_google_adapter):
+        organization, _subscription = _at_the_allowance_no_payment_method()
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.GOOGLE,
+            external_id=f"rest-cal-{organization.pk}",
+        )
+        user, _social_account = _google_backed_owner(organization, calendar)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(
+            reverse("api:CalendarEvents-list"),
+            _rest_payload(calendar, organization),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        body = response.json()
+        assert body["code"] == "limit_exceeded"
+        assert body["resource"] == LimitedResource.EVENT_OCCURRENCES
+        assert body["remedy"] == LimitRemedy.ADD_PAYMENT_METHOD
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+
+    def test_unlimited_plan_is_unchanged(self, mock_google_adapter):
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 10_000)
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.GOOGLE,
+            external_id=f"rest-cal-unlimited-{organization.pk}",
+        )
+        user, _social_account = _google_backed_owner(organization, calendar)
+        mock_google_adapter.create_event.return_value = CalendarEventAdapterOutputData(
+            calendar_external_id=calendar.external_id,
+            external_id="rest-created-event",
+            title="REST Surface Event",
+            description="",
+            start_time=datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1),
+            end_time=datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1, hours=1),
+            timezone="UTC",
+            attendees=[],
+            resources=[],
+            original_payload={},
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(
+            reverse("api:CalendarEvents-list"),
+            _rest_payload(calendar, organization),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+
+
+# ----------------------------------------------------------------------------------
+# 2. Token REST -- calendar_integration/token_views.py TokenCalendarEventViewSet
+# ----------------------------------------------------------------------------------
+
+
+def _auth_header(token_id: int, token_str: str) -> str:
+    return f"Bearer {base64.b64encode(f'{token_id}:{token_str}'.encode()).decode()}"
+
+
+def _token_for_owned_calendar(
+    organization: Organization, calendar: Calendar
+) -> tuple[CalendarManagementToken, str]:
+    user = User.objects.create_user(email=f"token-{organization.pk}@example.com", password="x")
+    Profile.objects.create(user=user)
+    OrganizationMembership.objects.create(user=user, organization=organization, is_active=True)
+    token_str = generate_long_lived_token()
+    token = CalendarManagementToken.objects.create(
+        calendar_fk=calendar,
+        membership_user_id=user.id,
+        token_hash=hash_long_lived_token(token_str),
+        organization=organization,
+    )
+    for permission in DEFAULT_CALENDAR_OWNER_PERMISSIONS:
+        CalendarManagementTokenPermission.objects.create(
+            token_fk=token, permission=permission, organization=organization
+        )
+    return token, token_str
+
+
+def _token_payload(calendar: Calendar) -> dict:
+    start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+    return {
+        "title": "Token Surface Event",
+        "description": "",
+        "start_time": start.isoformat(),
+        "end_time": (start + datetime.timedelta(hours=1)).isoformat(),
+        "timezone": "UTC",
+        "calendar": calendar.id,
+        "attendances": [],
+        "external_attendances": [],
+        "resource_allocations": [],
+    }
+
+
+@pytest.mark.django_db
+class TestTokenSurface:
+    def test_blocked_at_the_allowance_returns_402(self):
+        organization, _subscription = _at_the_allowance_no_payment_method()
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.INTERNAL,
+            external_id=f"token-cal-{organization.pk}",
+        )
+        token, token_str = _token_for_owned_calendar(organization, calendar)
+
+        client = APIClient()
+        response = client.post(
+            reverse(
+                "calendar_token_api:token-events-list", kwargs={"organization_id": organization.id}
+            ),
+            data=_token_payload(calendar),
+            format="json",
+            HTTP_AUTHORIZATION=_auth_header(token.id, token_str),
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        body = response.json()
+        assert body["resource"] == LimitedResource.EVENT_OCCURRENCES
+        assert body["remedy"] == LimitRemedy.ADD_PAYMENT_METHOD
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+
+    def test_unlimited_plan_is_unchanged(self):
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 10_000)
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.INTERNAL,
+            external_id=f"token-cal-unlimited-{organization.pk}",
+        )
+        token, token_str = _token_for_owned_calendar(organization, calendar)
+
+        client = APIClient()
+        response = client.post(
+            reverse(
+                "calendar_token_api:token-events-list", kwargs={"organization_id": organization.id}
+            ),
+            data=_token_payload(calendar),
+            format="json",
+            HTTP_AUTHORIZATION=_auth_header(token.id, token_str),
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+
+
+# ----------------------------------------------------------------------------------
+# 3. Public GraphQL -- public_api/mutations.py scheduleEvent
+# ----------------------------------------------------------------------------------
+
+_SCHEDULE_EVENT = """
+mutation ScheduleEvent($input: ScheduleEventInput!) {
+    scheduleEvent(input: $input) {
+        id
+        title
+    }
+}
+"""
+
+
+def _scoped_system_user(
+    organization: Organization, membership: OrganizationMembership
+) -> tuple[object, str]:
+    auth_service = PublicAPIAuthService()
+    system_user, token = auth_service.create_system_user(
+        integration_name=f"sched-surface-{organization.pk}",
+        organization=organization,
+        scoped_to_membership=membership,
+    )
+    baker.make(
+        ResourceAccess, system_user=system_user, resource_name=PublicAPIResources.CALENDAR_EVENT
+    )
+    return system_user, token
+
+
+def _owner_with_calendar(
+    organization: Organization,
+) -> tuple[User, OrganizationMembership, Calendar]:
+    from calendar_integration.models import CalendarOwnership
+
+    owner = User.objects.create_user(
+        email=f"sched-owner-{organization.pk}@example.com", password="x"
+    )
+    Profile.objects.create(user=owner)
+    membership = OrganizationMembership.objects.create(
+        user=owner, organization=organization, is_active=True
+    )
+    calendar = baker.make(
+        Calendar,
+        organization=organization,
+        provider=CalendarProvider.INTERNAL,
+        external_id=f"sched-cal-{organization.pk}",
+    )
+    CalendarOwnership.objects.create(
+        calendar=calendar, membership_user_id=owner.id, organization=organization
+    )
+    return owner, membership, calendar
+
+
+@pytest.mark.django_db
+class TestPublicApiScheduleEventSurface:
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_blocked_at_the_allowance_carries_the_shared_body(self, mock_rate_limiter):
+        mock_rate_limiter.return_value = iter([None])
+        organization, _subscription = _at_the_allowance_no_payment_method()
+        _owner, membership, calendar = _owner_with_calendar(organization)
+        system_user, token = _scoped_system_user(organization, membership)
+
+        start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": _SCHEDULE_EVENT,
+                "variables": {
+                    "input": {
+                        "organizationId": organization.id,
+                        "calendarId": calendar.id,
+                        "startTime": start.isoformat(),
+                        "endTime": (start + datetime.timedelta(hours=1)).isoformat(),
+                        "timezone": "UTC",
+                        "title": "Public API Surface Event",
+                    }
+                },
+            },
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+
+        assert response.status_code == 200
+        errors = response.json()["errors"]
+        body = errors[0]["extensions"]
+        assert body["code"] == "limit_exceeded"
+        assert body["resource"] == LimitedResource.EVENT_OCCURRENCES
+        assert body["remedy"] == LimitRemedy.ADD_PAYMENT_METHOD
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_unlimited_plan_is_unchanged(self, mock_rate_limiter):
+        mock_rate_limiter.return_value = iter([None])
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 10_000)
+        _owner, membership, calendar = _owner_with_calendar(organization)
+        system_user, token = _scoped_system_user(organization, membership)
+
+        start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": _SCHEDULE_EVENT,
+                "variables": {
+                    "input": {
+                        "organizationId": organization.id,
+                        "calendarId": calendar.id,
+                        "startTime": start.isoformat(),
+                        "endTime": (start + datetime.timedelta(hours=1)).isoformat(),
+                        "timezone": "UTC",
+                        "title": "Public API Surface Event",
+                    }
+                },
+            },
+            format="json",
+            headers={"authorization": f"Bearer {system_user.id}:{token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or not data.get("errors"), data
+        assert data["data"]["scheduleEvent"]["title"] == "Public API Surface Event"
+
+
+# ----------------------------------------------------------------------------------
+# 4. Booking-code GraphQL -- calendar_integration/mutations.py createCalendarEventWithCode
+# ----------------------------------------------------------------------------------
+
+_CREATE_EVENT_WITH_CODE = """
+mutation CreateCalendarEventWithCode($input: CreateEventWithCodeInput!) {
+    createCalendarEventWithCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        event { id }
+    }
+}
+"""
+
+
+def _booking_code_for_calendar(
+    organization: Organization, calendar: Calendar
+) -> tuple[CalendarManagementToken, str]:
+    permission_service = CalendarPermissionService()
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_id=calendar.id,
+    )
+    return token, code
+
+
+@pytest.mark.django_db
+class TestBookingCodeEventSurface:
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_blocked_at_the_allowance_is_a_graphql_error_not_a_result(self, mock_rate_limiter):
+        """Unlike the domain errors this mutation maps to ``CodeEventResult``, an
+        over-limit block is not something a patient can retry around -- it must
+        surface via the shared GraphQL error contract instead."""
+        mock_rate_limiter.return_value = iter([None])
+        organization, _subscription = _at_the_allowance_no_payment_method()
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.INTERNAL,
+            accepts_public_scheduling=False,
+            external_id=f"code-cal-{organization.pk}",
+        )
+        token, code = _booking_code_for_calendar(organization, calendar)
+
+        start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": _CREATE_EVENT_WITH_CODE,
+                "variables": {
+                    "input": {
+                        "code": code,
+                        "title": "Booking Code Surface Event",
+                        "description": "",
+                        "startTime": start.isoformat(),
+                        "endTime": (start + datetime.timedelta(hours=1)).isoformat(),
+                        "timezone": "UTC",
+                        "externalAttendee": {"email": "patient@example.com", "name": "Pat"},
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors"), data
+        body = data["errors"][0]["extensions"]
+        assert body["code"] == "limit_exceeded"
+        assert body["resource"] == LimitedResource.EVENT_OCCURRENCES
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+        # The code must not have been consumed by a rejected booking.
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_unlimited_plan_is_unchanged(self, mock_rate_limiter):
+        mock_rate_limiter.return_value = iter([None])
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 10_000)
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            provider=CalendarProvider.INTERNAL,
+            accepts_public_scheduling=False,
+            external_id=f"code-cal-unlimited-{organization.pk}",
+        )
+        _token, code = _booking_code_for_calendar(organization, calendar)
+
+        start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": _CREATE_EVENT_WITH_CODE,
+                "variables": {
+                    "input": {
+                        "code": code,
+                        "title": "Booking Code Surface Event",
+                        "description": "",
+                        "startTime": start.isoformat(),
+                        "endTime": (start + datetime.timedelta(hours=1)).isoformat(),
+                        "timezone": "UTC",
+                        "externalAttendee": {"email": "patient@example.com", "name": "Pat"},
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or not data.get("errors"), data
+        result = data["data"]["createCalendarEventWithCode"]
+        assert result["success"] is True
+
+
+# ----------------------------------------------------------------------------------
+# 5. Booking-code GraphQL -- createCalendarGroupEventWithCode
+# ----------------------------------------------------------------------------------
+
+_CREATE_GROUP_EVENT_WITH_CODE = """
+mutation CreateCalendarGroupEventWithCode($input: CreateGroupEventWithCodeInput!) {
+    createCalendarGroupEventWithCode(input: $input) {
+        success
+        errorCode
+        errorMessage
+        event { id }
+    }
+}
+"""
+
+
+def _group_with_one_slot(organization: Organization) -> tuple[object, object, Calendar]:
+    from calendar_integration.models import (
+        CalendarGroup,
+        CalendarGroupSlot,
+        CalendarGroupSlotMembership,
+    )
+
+    calendar = baker.make(
+        Calendar,
+        organization=organization,
+        provider=CalendarProvider.INTERNAL,
+        accepts_public_scheduling=False,
+        external_id=f"group-code-cal-{organization.pk}",
+    )
+    group = baker.make(CalendarGroup, organization=organization)
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Providers", order=0, required_count=1
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return group, slot, calendar
+
+
+def _group_booking_code(organization: Organization, group) -> tuple[CalendarManagementToken, str]:
+    permission_service = CalendarPermissionService()
+    token, code = permission_service.create_booking_token(
+        organization_id=organization.id,
+        permissions=[EventManagementPermissions.CREATE],
+        calendar_group_id=group.id,
+    )
+    return token, code
+
+
+@pytest.mark.django_db
+class TestBookingCodeGroupEventSurface:
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_blocked_at_the_allowance_is_a_graphql_error_not_a_result(self, mock_rate_limiter):
+        mock_rate_limiter.return_value = iter([None])
+        organization, _subscription = _at_the_allowance_no_payment_method()
+        group, slot, calendar = _group_with_one_slot(organization)
+        token, code = _group_booking_code(organization, group)
+
+        start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": _CREATE_GROUP_EVENT_WITH_CODE,
+                "variables": {
+                    "input": {
+                        "code": code,
+                        "title": "Group Booking Code Surface Event",
+                        "description": "",
+                        "startTime": start.isoformat(),
+                        "endTime": (start + datetime.timedelta(hours=1)).isoformat(),
+                        "timezone": "UTC",
+                        "slotSelections": [{"slotId": slot.id, "calendarIds": [calendar.id]}],
+                        "externalAttendee": {"email": "patient@example.com", "name": "Pat"},
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors"), data
+        body = data["errors"][0]["extensions"]
+        assert body["code"] == "limit_exceeded"
+        assert body["resource"] == LimitedResource.EVENT_OCCURRENCES
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+        token.refresh_from_db()
+        assert token.used_at is None
+
+    @patch("public_api.extensions.OrganizationRateLimiter.on_execute")
+    def test_unlimited_plan_is_unchanged(self, mock_rate_limiter):
+        mock_rate_limiter.return_value = iter([None])
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 10_000)
+        group, slot, calendar = _group_with_one_slot(organization)
+        _token, code = _group_booking_code(organization, group)
+
+        start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+        client = APIClient()
+        response = client.post(
+            "/graphql/",
+            data={
+                "query": _CREATE_GROUP_EVENT_WITH_CODE,
+                "variables": {
+                    "input": {
+                        "code": code,
+                        "title": "Group Booking Code Surface Event",
+                        "description": "",
+                        "startTime": start.isoformat(),
+                        "endTime": (start + datetime.timedelta(hours=1)).isoformat(),
+                        "timezone": "UTC",
+                        "slotSelections": [{"slotId": slot.id, "calendarIds": [calendar.id]}],
+                        "externalAttendee": {"email": "patient@example.com", "name": "Pat"},
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or not data.get("errors"), data
+        assert data["data"]["createCalendarGroupEventWithCode"]["success"] is True
+
+
+# ----------------------------------------------------------------------------------
+# 6. Bulk sync writer -- calendar_integration/services/calendar_sync_service.py
+# ----------------------------------------------------------------------------------
+
+
+def _sync_setup(organization: Organization) -> tuple[CalendarSyncService, Calendar]:
+    """A ``CalendarSyncService`` wired with a fake write adapter and no real
+    provider auth -- ``authenticate()`` itself is out of scope here (it is a
+    separate, already-tested entitlement gate); this exercises the sync-writer
+    guard specifically.
+    """
+    calendar = baker.make(
+        Calendar,
+        organization=organization,
+        provider=CalendarProvider.GOOGLE,
+        external_id=f"sync-cal-{organization.pk}",
+    )
+    facade = CalendarService()
+    facade.initialize_without_provider(organization=organization)
+    # `is_authenticated_calendar_service` requires `account` and `calendar_adapter`
+    # to both be non-None; account's contents are never read by the sync writer.
+    facade.account = Mock(name="fake-social-account")
+    facade.calendar_adapter = Mock(name="fake-calendar-adapter")
+    facade.calendar_adapter.get_events.return_value = {"events": [], "next_sync_token": None}
+    sync_service = CalendarSyncService(
+        context=facade._build_context_snapshot(), calendar_cache={}, host=facade
+    )
+    return sync_service, calendar
+
+
+def _recurring_master_adapter_event(external_id: str) -> CalendarEventAdapterOutputData:
+    start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
+    return CalendarEventAdapterOutputData(
+        calendar_external_id="irrelevant",
+        external_id=external_id,
+        title="Synced recurring master",
+        description="",
+        start_time=start,
+        end_time=start + datetime.timedelta(hours=1),
+        timezone="UTC",
+        attendees=[],
+        resources=[],
+        original_payload={},
+        recurrence_rule="RRULE:FREQ=WEEKLY;COUNT=5",
+    )
+
+
+@pytest.mark.django_db
+class TestBulkSyncWriterSurface:
+    """Drives ``CalendarSyncService`` directly (not through the Celery task): the
+    guard runs inside ``_execute_calendar_sync``, and ``sync_events`` already wraps
+    it in ``try/except Exception`` -- the same behavior a real scheduled sync gets."""
+
+    def test_blocked_at_the_allowance_fails_the_sync_and_writes_nothing(self):
+        organization, _subscription = _at_the_allowance_no_payment_method()
+        sync_service, calendar = _sync_setup(organization)
+
+        from calendar_integration.models import CalendarSync
+
+        calendar_sync = CalendarSync.objects.create(
+            organization=organization,
+            calendar=calendar,
+            start_datetime=datetime.datetime.now(datetime.UTC),
+            end_datetime=datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30),
+            should_update_events=False,
+        )
+        sync_service._context.calendar_adapter.get_events.return_value = {
+            "events": [_recurring_master_adapter_event("sync-master-1")],
+            "next_sync_token": None,
+        }
+
+        sync_service.sync_events(calendar_sync)
+
+        calendar_sync.refresh_from_db()
+        assert calendar_sync.status == "failed"
+        assert calendar_sync.error_message  # the OverLimitError's message, not empty
+        assert not CalendarEvent.objects.filter(calendar=calendar).exists()
+
+    def test_unlimited_plan_is_unchanged(self):
+        organization, subscription = _organization_with_postpaid_limit(None, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 10_000)
+        sync_service, calendar = _sync_setup(organization)
+
+        from calendar_integration.models import CalendarSync
+
+        calendar_sync = CalendarSync.objects.create(
+            organization=organization,
+            calendar=calendar,
+            start_datetime=datetime.datetime.now(datetime.UTC),
+            end_datetime=datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30),
+            should_update_events=False,
+        )
+        sync_service._context.calendar_adapter.get_events.return_value = {
+            "events": [_recurring_master_adapter_event("sync-master-unlimited")],
+            "next_sync_token": None,
+        }
+
+        sync_service.sync_events(calendar_sync)
+
+        calendar_sync.refresh_from_db()
+        assert calendar_sync.status == "success"
+        assert CalendarEvent.objects.filter(
+            calendar=calendar, external_id="sync-master-unlimited"
+        ).exists()
+
+
+# ----------------------------------------------------------------------------------
+# Bundle fan-out: 1 + n_internal_children, never per member calendar
+# ----------------------------------------------------------------------------------
+
+
+def _bundle_with_children(
+    organization: Organization, provider: str, count: int
+) -> tuple[Calendar, Calendar, list[Calendar]]:
+    """A bundle calendar with ``count`` children of ``provider``, all
+    ``accepts_public_scheduling=True`` (so the permission gate never masks the
+    postpaid guard under test). Returns ``(bundle_calendar, primary, children)``."""
+    children = [
+        baker.make(
+            Calendar,
+            organization=organization,
+            provider=provider,
+            calendar_type=CalendarType.PERSONAL,
+            accepts_public_scheduling=True,
+            manage_available_windows=False,
+            external_id=f"bundle-child-{provider}-{organization.pk}-{i}",
+        )
+        for i in range(count)
+    ]
+    facade = CalendarService()
+    facade.initialize_without_provider(organization=organization)
+    bundle_calendar = facade.create_bundle_calendar(
+        name=f"Bundle {provider} {organization.pk}",
+        child_calendars=children,
+        primary_calendar=children[0],
+        accepts_public_scheduling=True,
+    )
+    return bundle_calendar, children[0], children
+
+
+def _create_bundle_event_with_open_availability(
+    facade: CalendarService, bundle_calendar: Calendar, event_data: CalendarEventInputData
+) -> CalendarEvent:
+    """Drive ``facade.create_event`` against a bundle with availability mocked open.
+
+    Mirrors ``test_calendar_bundle_service.py``'s established pattern: once the
+    primary event is created (tagged ``bundle_calendar=<this bundle>``),
+    ``AvailabilityService.get_unavailable_time_windows_in_range`` treats it as busy
+    on *every* member calendar by design (a bundle slot is booked across the whole
+    bundle) -- so each subsequent child's own, real ``create_event`` availability
+    check would otherwise see its own sibling's just-created event as an exact,
+    gap-free conflict. That correctly reflects how a booked bundle slot behaves;
+    it is not what this test is about, so availability is mocked open the same way
+    the bundle service's own test suite does, leaving the postpaid guard, the
+    permission checks, and every DB write completely real.
+    """
+    from calendar_integration.services.dataclasses import AvailableTimeWindow
+
+    availability_window = [
+        AvailableTimeWindow(start_time=event_data.start_time, end_time=event_data.end_time)
+    ]
+    with patch.object(
+        facade, "get_availability_windows_in_range", return_value=availability_window
+    ):
+        return facade.create_event(bundle_calendar.id, event_data)
+
+
+@pytest.mark.django_db
+class TestBundleEventFanOutHeadroom:
+    def test_five_internal_children_checks_five_units(self):
+        """1 (primary) + 4 (remaining internal children) = 5 -- headroom for 4 is
+        not enough, even though a single-event booking would fit."""
+        organization, subscription = _organization_with_postpaid_limit(4, BillingState.FREE)
+        bundle_calendar, _primary, _children = _bundle_with_children(
+            organization, CalendarProvider.INTERNAL, 5
+        )
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        with pytest.raises(OverLimitError) as exc_info:
+            _create_bundle_event_with_open_availability(
+                facade,
+                bundle_calendar,
+                CalendarEventInputData(
+                    title="Bundle Fan-Out",
+                    description="",
+                    start_time=start,
+                    end_time=start + datetime.timedelta(hours=1),
+                    timezone="UTC",
+                    attendances=[],
+                    external_attendances=[],
+                    resource_allocations=[],
+                ),
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.EVENT_OCCURRENCES
+        assert not CalendarEvent.objects.filter(bundle_calendar=bundle_calendar).exists()
+
+    def test_five_internal_children_with_headroom_for_five_succeeds(self):
+        organization, subscription = _organization_with_postpaid_limit(5, BillingState.FREE)
+        bundle_calendar, _primary, _children = _bundle_with_children(
+            organization, CalendarProvider.INTERNAL, 5
+        )
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+        # `CalendarEvent.external_id` is globally unique and every un-adapted create
+        # stamps `""`. Five real CalendarEvent writes in one fan-out would collide on
+        # the second one -- give the facade a fake write adapter that stamps a
+        # distinct external_id per call, exactly what an authenticated production
+        # facade would have (its own real provider adapter). No owner/ownership is
+        # set up, so `user_or_token` stays None and permission is still granted
+        # purely through `accepts_public_scheduling=True`.
+        counter = iter(range(1000))
+        fake_adapter = Mock()
+        fake_adapter.create_event.side_effect = lambda *a, **k: CalendarEventAdapterOutputData(
+            calendar_external_id="irrelevant",
+            external_id=f"bundle-fanout-{next(counter)}",
+            title="irrelevant",
+            description="",
+            start_time=datetime.datetime.now(datetime.UTC),
+            end_time=datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1),
+            timezone="UTC",
+            attendees=[],
+            resources=[],
+            original_payload={},
+        )
+        facade.calendar_adapter = fake_adapter
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        event = _create_bundle_event_with_open_availability(
+            facade,
+            bundle_calendar,
+            CalendarEventInputData(
+                title="Bundle Fan-Out Fits",
+                description="",
+                start_time=start,
+                end_time=start + datetime.timedelta(hours=1),
+                timezone="UTC",
+                attendances=[],
+                external_attendances=[],
+                resource_allocations=[],
+            ),
+        )
+
+        assert event.pk is not None
+        # Primary + 4 internal representations = 5 CalendarEvent rows for this bundle --
+        # the same 5 units the guard above checked headroom for.
+        assert CalendarEvent.objects.filter(bundle_calendar=bundle_calendar).count() == 5
+
+    def test_five_google_children_checks_only_one_unit(self):
+        """A bundle over five Google calendars costs 1, not 5: only the primary gets
+        a real ``CalendarEvent``, the rest get a non-billable ``BlockedTime``."""
+        organization, subscription = _organization_with_postpaid_limit(1, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        bundle_calendar, _primary, _children = _bundle_with_children(
+            organization, CalendarProvider.GOOGLE, 5
+        )
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        # At the allowance (1 used, ceiling 1) with no payment method: a fan-out
+        # costing only 1 unit must still be BLOCKED (it is a new unit on top of an
+        # already-full allowance) -- proving the guard actually counted 1, not 0.
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        with pytest.raises(OverLimitError):
+            _create_bundle_event_with_open_availability(
+                facade,
+                bundle_calendar,
+                CalendarEventInputData(
+                    title="Google Bundle Fan-Out",
+                    description="",
+                    start_time=start,
+                    end_time=start + datetime.timedelta(hours=1),
+                    timezone="UTC",
+                    attendances=[],
+                    external_attendances=[],
+                    resource_allocations=[],
+                ),
+            )
+
+    def test_five_google_children_with_headroom_for_one_succeeds(self):
+        """The same bundle succeeds once headroom for just 1 unit exists -- proving
+        the guard did *not* charge 5 (which would still block at ceiling=1)."""
+        organization, subscription = _organization_with_postpaid_limit(2, BillingState.FREE)
+        _seed_metered_occurrences(organization, subscription, 1)
+        bundle_calendar, _primary, _children = _bundle_with_children(
+            organization, CalendarProvider.GOOGLE, 5
+        )
+        facade = CalendarService()
+        facade.initialize_without_provider(organization=organization)
+
+        start = subscription.current_period_start + datetime.timedelta(days=1)
+        event = _create_bundle_event_with_open_availability(
+            facade,
+            bundle_calendar,
+            CalendarEventInputData(
+                title="Google Bundle Fan-Out Fits",
+                description="",
+                start_time=start,
+                end_time=start + datetime.timedelta(hours=1),
+                timezone="UTC",
+                attendances=[],
+                external_attendances=[],
+                resource_allocations=[],
+            ),
+        )
+
+        assert event.pk is not None
+        # Only the primary got a real CalendarEvent -- the other four Google children
+        # got a BlockedTime instead, which is exactly why this fan-out costs 1 unit.
+        assert list(
+            CalendarEvent.objects.filter(bundle_calendar=bundle_calendar).values_list(
+                "pk", flat=True
+            )
+        ) == [event.pk]
+
+
+# ----------------------------------------------------------------------------------
+# Coverage registry: every named surface has a probe here
+# ----------------------------------------------------------------------------------
+
+GUARDED_SURFACES = {
+    "rest": TestRestSurface,
+    "token": TestTokenSurface,
+    "public_api_schedule_event": TestPublicApiScheduleEventSurface,
+    "booking_code_single_event": TestBookingCodeEventSurface,
+    "booking_code_group_event": TestBookingCodeGroupEventSurface,
+    "bulk_sync_writer": TestBulkSyncWriterSurface,
+}
+
+
+def test_every_named_surface_has_a_blocked_and_unlimited_probe():
+    """The plan names exactly six ``CalendarEvent`` creation entry points. A
+    surface class registered here without both a blocked-at-the-allowance and an
+    unlimited-plan test method would defeat the point of this file."""
+    assert set(GUARDED_SURFACES) == {
+        "rest",
+        "token",
+        "public_api_schedule_event",
+        "booking_code_single_event",
+        "booking_code_group_event",
+        "bulk_sync_writer",
+    }
+    for name, test_class in GUARDED_SURFACES.items():
+        method_names = {m for m in dir(test_class) if m.startswith("test_")}
+        assert any("blocked" in m for m in method_names), f"{name} has no blocked-path test"
+        assert any("unlimited" in m for m in method_names), f"{name} has no unlimited-plan test"

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -526,6 +526,130 @@ class EntitlementService:
             exclude_invitation_id=invitation.pk,
         )
 
+    def has_payment_method(self, organization: Organization) -> bool:
+        """Does the billing root have a payment method on file?
+
+        Resolved at the billing root, like every other check in this service, so a
+        reseller child asks the same question its root would answer.
+
+        No dedicated "payment method" record exists yet — Phase 9 (add-on
+        purchase / plan change) and Phase 10 (dunning) are what actually attach and
+        track one against a payment provider. ``Subscription.billing_state`` is the
+        only currently-persisted signal that distinguishes "never paid" from "on a
+        paid path": ``FREE`` is the state every subscription is created into and
+        never leaves without a successful payment round-trip
+        (``SubscriptionService.change_plan``), so every other state (``ACTIVE``,
+        ``GRACE``, ``RESTRICTED``, ``CANCELLED``) implies a payment method was, at
+        some point, successfully attached. ``GRACE``/``RESTRICTED`` specifically
+        mean a *later* charge failed, not that no payment method was ever
+        provided, so this still reads ``True`` for them: an org already mid-dunning
+        is not additionally interrupted by this guard while its payment problem is
+        being resolved through the separate grace/restricted machinery
+        (Phase 10/11), which is what actually blocks writes on that state.
+
+        No subscription resolves to ``False`` — the fail-closed side of postpaid
+        enforcement (see ``check_postpaid_allowance``).
+        """
+        return self._has_payment_method_for_subscription(self._get_root_subscription(organization))
+
+    @staticmethod
+    def _has_payment_method_for_subscription(subscription: Subscription | None) -> bool:
+        if subscription is None:
+            return False
+        return subscription.billing_state != BillingState.FREE
+
+    def check_postpaid_allowance(
+        self,
+        organization: Organization,
+        delta: int = 1,
+        lock: bool = False,
+    ) -> LimitCheckResult:
+        """Would creating ``delta`` more ``event_occurrences`` need a payment method
+        this organization does not have?
+
+        The only postpaid ``LimitedResource`` member, so unlike ``check_limit`` this
+        never takes a ``resource_key`` — there is only one to ask about.
+
+        Unlike a prepaid ceiling, the allowance is not a hard cap. An organization
+        **with** a payment method is let straight through even past it — the
+        excess accrues as overage (billed at ``PlanLimit.overage_unit_price`` when
+        ``MeteringService`` later meters it; this method never writes, it only
+        decides whether creation may proceed). An organization **without** one is
+        blocked the moment ``delta`` would take it to or past the allowance,
+        because there is nothing to charge the overage to. This is the plan's
+        "an organization with a payment method accrues past its included allowance
+        and is never interrupted; one without a payment method is blocked at the
+        allowance" contract.
+
+        On the unlimited path (``limit_value is None``), usage is not counted at
+        all and ``current_usage``/``ceiling`` are ``None`` — identical to
+        ``check_limit``'s unlimited branch, and for the same reason: every
+        organization is on the ``unlimited`` plan for this whole rollout, so this
+        method can never block anybody today. See the phase's own tests for that
+        inertness guarantee on every guarded path.
+
+        ``delta`` must be the same "one booking" unit
+        ``MeteringService.expand_occurrence_identities`` will eventually count for
+        this creation — 1 for a single event, a new recurring master, or a
+        bulk-modification continuation, and ``1 + n_internal_children`` for a
+        bundle-event fan-out (the Phase 7 binding decision: a bundle booking is
+        billed as the primary calendar's event plus one more per
+        ``CalendarProvider.INTERNAL`` child, never per member calendar). A caller
+        that invents its own number here reproduces the "two predicates that must
+        agree" defect this plan keeps producing — derive it from the same
+        provider/parent predicates the meter and the fan-out writer use, never
+        recompute it independently.
+
+        :param lock: Same contract as ``check_limit``'s ``lock`` — ``SELECT ... FOR
+            UPDATE`` on the billing root's ``Subscription`` row before counting, so
+            two racing creates at the allowance boundary serialize on one row.
+            Requires an open transaction; see ``check_limit`` for the full isolation-
+            level discussion.
+        """
+        root = resolve_billing_root(organization)
+        if lock:
+            self._lock_billing_root_row(root)
+
+        subscription = self._get_subscription_for_root(root)
+        effective_limit = self._effective_limit_for_subscription(
+            subscription,
+            LimitedResource.EVENT_OCCURRENCES,
+            root.pk,
+            asked_for_organization_pk=organization.pk,
+        )
+        if effective_limit.is_unlimited:
+            return LimitCheckResult(
+                allowed=True,
+                resource_key=LimitedResource.EVENT_OCCURRENCES,
+                current_usage=None,
+                ceiling=None,
+            )
+
+        # Narrowed by the ``is_unlimited`` return above: limit_value is not None here.
+        ceiling = effective_limit.limit_value or 0
+        current_usage = self._count_usage(root, LimitedResource.EVENT_OCCURRENCES, subscription)
+        within_allowance = current_usage + delta <= ceiling
+        if within_allowance or self._has_payment_method_for_subscription(subscription):
+            return LimitCheckResult(
+                allowed=True,
+                resource_key=LimitedResource.EVENT_OCCURRENCES,
+                current_usage=current_usage,
+                ceiling=ceiling,
+            )
+        # The only way to reach here is ``has_payment_method`` being False, which
+        # (see its docstring) only happens when ``billing_state == FREE`` — a
+        # grace/restricted organization already has one and was let through above.
+        # So the remedy is always "go get a payment method", never
+        # ``_resolve_remedy_for``'s billing-first branch: there is no billing
+        # problem to resolve here, there is no payment method to begin with.
+        return LimitCheckResult(
+            allowed=False,
+            resource_key=LimitedResource.EVENT_OCCURRENCES,
+            current_usage=current_usage,
+            ceiling=ceiling,
+            remedy=LimitRemedy.ADD_PAYMENT_METHOD,
+        )
+
     def has_entitlement(self, organization: Organization, entitlement_key: str) -> bool:
         """Is the boolean feature gate ``entitlement_key`` granted to ``organization``?
 

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -526,43 +526,75 @@ class EntitlementService:
             exclude_invitation_id=invitation.pk,
         )
 
+    #: The ``billing_state`` values that are taken to mean "a payment instrument
+    #: exists and can be charged **right now**".
+    #:
+    #: An explicit **allow-list**, deliberately, rather than ``!= FREE``. This is a
+    #: proxy (there is no payment-method record yet), and the two directions of
+    #: being wrong are not symmetric: reading ``True`` for a state with no working
+    #: instrument lets an organization accrue overage nobody can be billed for,
+    #: while reading ``False`` only asks it to attach a card. An allow-list makes a
+    #: newly-added state default to the second, safe direction; a deny-list makes it
+    #: default to the first. The plan's deferred ``TRIALING`` state
+    #: (``…IMPLEMENTATION_PLAN.md``, "no payment method to start") is exactly that
+    #: case, and would have read ``True`` under a negation.
+    PAYMENT_METHOD_BILLING_STATES = frozenset({BillingState.ACTIVE})
+
     def has_payment_method(self, organization: Organization) -> bool:
-        """Does the billing root have a payment method on file?
+        """Does the billing root have a chargeable payment method right now?
 
         Resolved at the billing root, like every other check in this service, so a
         reseller child asks the same question its root would answer.
 
-        No dedicated "payment method" record exists yet — Phase 9 (add-on
-        purchase / plan change) and Phase 10 (dunning) are what actually attach and
-        track one against a payment provider. ``Subscription.billing_state`` is the
-        only currently-persisted signal that distinguishes "never paid" from "on a
-        paid path": ``FREE`` is the state every subscription is created into and
-        never leaves without a successful payment round-trip
-        (``SubscriptionService.change_plan``), so every other state (``ACTIVE``,
-        ``GRACE``, ``RESTRICTED``, ``CANCELLED``) implies a payment method was, at
-        some point, successfully attached. ``GRACE``/``RESTRICTED`` specifically
-        mean a *later* charge failed, not that no payment method was ever
-        provided, so this still reads ``True`` for them: an org already mid-dunning
-        is not additionally interrupted by this guard while its payment problem is
-        being resolved through the separate grace/restricted machinery
-        (Phase 10/11), which is what actually blocks writes on that state.
+        **This is a proxy, and it is temporary.** No dedicated payment-method record
+        exists yet — Phase 9 (add-on purchase / plan change) and Phase 10 (dunning)
+        are what actually attach and track one against a payment provider.
+        ``Subscription.billing_state`` is the only currently-persisted signal, so it
+        stands in. Whoever introduces the real record must re-point this method at it
+        rather than widening the allow-list (see the Phase 10 precondition recorded in
+        ``ai-plans/TRACKING_BILLING_PLANS_AND_LIMITS.md``).
 
-        No subscription resolves to ``False`` — the fail-closed side of postpaid
-        enforcement (see ``check_postpaid_allowance``).
+        Only ``ACTIVE`` qualifies. Each exclusion is a separate decision:
+
+        - ``FREE`` — the state every subscription is created into; it never left it,
+          so no instrument was ever attached.
+        - ``GRACE`` — Phase 10 moves ``ACTIVE → GRACE`` **on a failed charge**, and a
+          ``GRACE`` organization stays fully operational (only ``RESTRICTED`` is
+          write-blocked, in Phase 11). Reading ``True`` here would give an
+          organization whose card just declined *unbounded* unbillable accrual for
+          the whole dunning window — turning the dunning ladder into the largest-bill
+          path in the system. The earlier justification for including it ("the
+          separate grace/restricted machinery is what blocks writes on that state")
+          is true of ``RESTRICTED`` and false of ``GRACE``.
+        - ``RESTRICTED`` — a later charge failed and was never resolved. Phase 11
+          blocks its writes anyway, so this costs nothing and keeps the predicate
+          honest about what it claims to know.
+        - ``CANCELLED`` — the paid relationship is over and the instrument may well
+          have been removed with it. There is no assurance anything is chargeable,
+          which is the only question this method exists to answer. (The reviewer
+          suggested keeping ``CANCELLED`` on the strength of "a payment method was
+          attached at some point"; that is the wrong tense for a guard whose whole
+          purpose is "can we bill the overage we are about to let them accrue".)
+
+        A missing subscription is ``False`` for the same reason: nothing to charge.
+        Note that on the postpaid path this rarely decides anything — a
+        subscription-less pool resolves to an unlimited ceiling and returns before
+        this is ever consulted (see ``check_postpaid_allowance``).
         """
         return self._has_payment_method_for_subscription(self._get_root_subscription(organization))
 
-    @staticmethod
-    def _has_payment_method_for_subscription(subscription: Subscription | None) -> bool:
+    @classmethod
+    def _has_payment_method_for_subscription(cls, subscription: Subscription | None) -> bool:
         if subscription is None:
             return False
-        return subscription.billing_state != BillingState.FREE
+        return subscription.billing_state in cls.PAYMENT_METHOD_BILLING_STATES
 
     def check_postpaid_allowance(
         self,
         organization: Organization,
         delta: int = 1,
         lock: bool = False,
+        delta_resolver: Callable[[Subscription], int] | None = None,
     ) -> LimitCheckResult:
         """Would creating ``delta`` more ``event_occurrences`` need a payment method
         this organization does not have?
@@ -588,11 +620,16 @@ class EntitlementService:
         method can never block anybody today. See the phase's own tests for that
         inertness guarantee on every guarded path.
 
-        ``delta`` must be the same "one booking" unit
-        ``MeteringService.expand_occurrence_identities`` will eventually count for
-        this creation — 1 for a single event, a new recurring master, or a
-        bulk-modification continuation, and ``1 + n_internal_children`` for a
-        bundle-event fan-out (the Phase 7 binding decision: a bundle booking is
+        ``delta`` must be in the same unit ``current_usage`` is measured in: the
+        number of ``MeteredOccurrence`` rows this creation will eventually cause —
+        **occurrences, not masters**. For a one-off event those coincide (1). For a
+        *recurring* master they do not: ``MeteringService`` expands the master's rule
+        and writes one row per occurrence, so a daily series costs ~30 a month, not 1.
+        A caller creating a recurring master must therefore pass ``delta_resolver``
+        rather than a hand-counted ``delta``.
+
+        The other established value is the bundle fan-out's
+        ``1 + n_internal_children`` (the Phase 7 binding decision: a bundle booking is
         billed as the primary calendar's event plus one more per
         ``CalendarProvider.INTERNAL`` child, never per member calendar). A caller
         that invents its own number here reproduces the "two predicates that must
@@ -600,16 +637,37 @@ class EntitlementService:
         provider/parent predicates the meter and the fan-out writer use, never
         recompute it independently.
 
+        :param delta_resolver: Lazy alternative to ``delta`` for a caller whose unit
+            count is itself a query — specifically, expanding a just-created recurring
+            master through ``MeteringService.occurrence_starts_of`` (the meter's own
+            expansion, so the guard and the meter cannot disagree). Receives the
+            resolved billing-root ``Subscription`` so it can bound its window with
+            ``resolve_billing_period``. Called at most once, and **only after the
+            ceiling is known to be finite**, so an ``unlimited`` organization — i.e.
+            every organization for this whole rollout — never pays for the expansion.
+            Takes precedence over ``delta`` when both are given.
         :param lock: Same contract as ``check_limit``'s ``lock`` — ``SELECT ... FOR
             UPDATE`` on the billing root's ``Subscription`` row before counting, so
             two racing creates at the allowance boundary serialize on one row.
             Requires an open transaction; see ``check_limit`` for the full isolation-
             level discussion.
+
+            **Taken only once a finite ceiling is known to exist**, unlike
+            ``check_limit``, which locks before resolving anything. That ordering
+            difference is deliberate and load-bearing. Every event-creation path
+            passes ``lock=True``, ``create_event`` is ``@transaction.atomic`` with an
+            external provider round-trip inside it, and every organization is on
+            ``unlimited`` — so locking first would put an organization-wide row lock
+            on the hottest write path in the product, held across a network call, in
+            service of a NULL ceiling that cannot block anybody. Two users booking
+            different calendars of the same organization would serialize.
+
+            Nothing is lost by locking later: the ceiling is not the racing quantity.
+            ``_count_usage`` — the read the lock actually exists to serialize — still
+            runs after the lock is acquired, and under READ COMMITTED it therefore
+            still sees a racing transaction's committed inserts.
         """
         root = resolve_billing_root(organization)
-        if lock:
-            self._lock_billing_root_row(root)
-
         subscription = self._get_subscription_for_root(root)
         effective_limit = self._effective_limit_for_subscription(
             subscription,
@@ -625,8 +683,13 @@ class EntitlementService:
                 ceiling=None,
             )
 
+        if lock:
+            self._lock_billing_root_row(root)
+
         # Narrowed by the ``is_unlimited`` return above: limit_value is not None here.
         ceiling = effective_limit.limit_value or 0
+        if delta_resolver is not None and subscription is not None:
+            delta = delta_resolver(subscription)
         current_usage = self._count_usage(root, LimitedResource.EVENT_OCCURRENCES, subscription)
         within_allowance = current_usage + delta <= ceiling
         if within_allowance or self._has_payment_method_for_subscription(subscription):
@@ -636,12 +699,12 @@ class EntitlementService:
                 current_usage=current_usage,
                 ceiling=ceiling,
             )
-        # The only way to reach here is ``has_payment_method`` being False, which
-        # (see its docstring) only happens when ``billing_state == FREE`` — a
-        # grace/restricted organization already has one and was let through above.
-        # So the remedy is always "go get a payment method", never
-        # ``_resolve_remedy_for``'s billing-first branch: there is no billing
-        # problem to resolve here, there is no payment method to begin with.
+        # The only way to reach here is ``has_payment_method`` being False — every
+        # ``billing_state`` outside ``PAYMENT_METHOD_BILLING_STATES``. The remedy is
+        # always "go get a payment method", never ``_resolve_remedy_for``'s
+        # billing-first branch, even for ``GRACE``/``RESTRICTED``: from this guard's
+        # point of view there is nothing chargeable on file, and attaching a working
+        # instrument is what both resolves the dunning and lifts this block.
         return LimitCheckResult(
             allowed=False,
             resource_key=LimitedResource.EVENT_OCCURRENCES,

--- a/payments/services/metering_service.py
+++ b/payments/services/metering_service.py
@@ -376,7 +376,7 @@ class MeteringService:
         identities: dict[OccurrenceIdentity, None] = {}
         for master in masters:
             series_root_id = series_root_ids[master.pk]
-            for occurrence_start in self._occurrence_starts_of(master, window_start, window_end):
+            for occurrence_start in self.occurrence_starts_of(master, window_start, window_end):
                 if not window_start <= occurrence_start < window_end:
                     continue
                 identities[
@@ -389,10 +389,32 @@ class MeteringService:
         return list(identities)
 
     @staticmethod
-    def _occurrence_starts_of(
+    def occurrence_starts_of(
         master: CalendarEvent, window_start: datetime.datetime, window_end: datetime.datetime
     ) -> list[datetime.datetime]:
         """The occurrence start times one master contributes to the window.
+
+        **Public, and deliberately so: this is the single definition of "how many
+        billable units does this master cost".** Two callers share it — the meter's
+        own ``expand_occurrence_identities`` (which turns each start into an
+        identity and writes a row for it) and Phase 8's post-paid allowance guard in
+        ``CalendarEventService`` (which counts them to decide whether a *new*
+        recurring master fits the organization's remaining allowance). Before that,
+        the guard charged 1 unit per master, so a free organization one unit below
+        its ceiling could create an open-ended daily series and accrue ~30
+        unbillable occurrences a month forever. A guard and a meter that count
+        different things is the failure shape this plan keeps producing; there is
+        one function, and both call it.
+
+        A ``@staticmethod`` for the same reason: the guard can call it as
+        ``MeteringService.occurrence_starts_of(...)`` without a DI-injected
+        ``MeteringService`` (which would also be an import cycle, since this module
+        imports ``EntitlementService``).
+
+        The master must already be **persisted**: the expansion runs in Postgres
+        (``calculate_recurring_events``, keyed on the event's id), so there is no
+        way to expand a rule that has no row. That is what forces the guard to run
+        after the insert, inside the creating transaction, rather than before it.
 
         Reads ``start_time`` off ``get_occurrences_in_range`` — the ordinary calendar
         expansion, with no billing-specific variant. An earlier revision of this

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -2371,6 +2371,12 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
             raise GraphQLError(
                 str(exc) or "You do not have permission to schedule this event."
             ) from exc
+        # Phase 8: create_event raises OverLimitError at the organization's postpaid
+        # event_occurrences allowance (no payment method on file); rendered via
+        # raise_over_limit_graphql_error (also rolls back the request transaction --
+        # see its docstring).
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
         except (ValueError, DjangoValidationError, CalendarIntegrationError) as exc:
             raise GraphQLError(str(exc)) from exc
 


### PR DESCRIPTION

Phase 8 of the [billing plans and limits plan](../../../ai-plans/2026-07-18-BILLING_PLANS_AND_LIMITS_IMPLEMENTATION_PLAN.md). Built on Phase 7 (`plan/billing-plans-and-limits/phase-7`, [#198](https://github.com/vintasoftware/vinta-schedule-api/pull/198)), which built the meter this phase gates against and has since merged into `main` — this PR targets `main` directly since `plan/billing-plans-and-limits/phase-7` was deleted on merge and `origin/main` now sits at exactly that commit.

## What this ships

An organization with a payment method accrues past its included `event_occurrences` allowance and is never interrupted; one without a payment method is blocked at the allowance with `remedy="add_payment_method"`. Two pieces make that true:

- `EntitlementService.has_payment_method(organization)` — resolved at the billing root, like every other check in this service — and `check_postpaid_allowance(organization, delta, lock, delta_resolver)` in `payments/services/entitlement_service.py`.
- Six named event-creation surfaces now call it: `CalendarEventService.create_event`, `CalendarBundleService.create_bundle_event`, the booking-code paths in `calendar_integration/mutations.py`, `public_api/mutations.py`'s `schedule_event`, and the bulk sync writer in `calendar_integration/services/calendar_sync_service.py`.

**Inert today.** Every organization currently exists on the `unlimited` plan — a NULL `event_occurrences` ceiling — and a NULL ceiling always returns headroom before any usage is even counted. Every guarded path carries an unlimited-behaviour test proving that: 201/success on every surface, no query issued that a finite ceiling would need. Nothing in this PR can block a real organization yet; it becomes load-bearing the moment the first non-NULL `event_occurrences` limit reaches production (Phase 14).

## Two commits

1. `c9643ce` — the guard, `has_payment_method`, the six call sites, and the initial test suites.
2. `0c7b705` — three BLOCKERs from review, all substantive, plus SHOULD-FIXes. This is the commit that matters.

## The three BLOCKERs review found, and why each one is the actual risk

**1. The lock was taken before the unlimited early-return — the phase was not inert.** `create_event` passes `lock=True`. The first draft of `check_postpaid_allowance` took `SELECT ... FOR UPDATE` on the billing root's `Subscription` row *before* checking `is_unlimited`, inside the same `@transaction.atomic` block that also holds an external provider round-trip. Every event create, for every organization, serialized org-wide behind a Google API call — for a NULL ceiling that could never block anyone. The unlimited tests only asserted the response code and couldn't see it. Fixed by resolving the effective limit first and locking only once a finite ceiling exists; a `CaptureQueriesContext` test now asserts no `FOR UPDATE` is issued on the unlimited path, with a finite-ceiling negative control proving the lock still fires when it should.

**2. `delta` and `current_usage` were different units.** `current_usage` counts `MeteredOccurrence` rows — occurrences. The first draft's `delta` counted `CalendarEvent` masters. A free organization one unit below its ceiling could create an open-ended daily series (`49 + 1 <= 50`) and accrue roughly 30 unbillable occurrences a month from it, forever, without the guard ever seeing it again. Fixed with a two-stage guard for the single-event path: stage 1 keeps `delta=1` (exact for a one-off, a deliberate lower bound for a recurring master) and runs before the provider write, so an organization with zero headroom is rejected before any external side effect. Stage 2 runs after `event.save()`, inside the same transaction, and expands the just-created master through `MeteringService.occurrence_starts_of` — made `@staticmethod` and public specifically so the guard and the meter share one definition of "how many units does this master cost" instead of two that can drift apart. If the series doesn't fit, the create rolls back. It has to run after the insert because the expansion is a Postgres function keyed on the event's id — there is no row to expand before it exists, and re-deriving the count in Python from the rrule string would be exactly the "two predicates that must agree, computed separately" shape that has produced a defect in every phase of this plan so far.

**3. `billing_state != FREE` granted unbounded accrual to an organization whose payment had already failed.** Replaced with an explicit allow-list, `PAYMENT_METHOD_BILLING_STATES = {ACTIVE}`. Every `BillingState` is pinned to an assertion in `EXPECTED_HAS_PAYMENT_METHOD`, so a newly-added state fails that test until someone decides for it — deliberately biased toward "no payment method" as the safe default, since reading `True` for a state with no working instrument lets an organization accrue overage nobody can be billed for, while reading `False` only asks it to attach a card.

The fixer went narrower than the review asked on BLOCKER 3, excluding `CANCELLED` from the allow-list: "a card was attached at some point" is the wrong tense for deciding whether overage can be billed right now, and a cancelled organization may well have removed its instrument along with the subscription. Both of the fixer's independent judgment calls moved toward the safe side.

## SHOULD-FIX cleared alongside the BLOCKERs

- The registry test that proves all six surfaces are guarded now derives the guarded set from an AST walk, rather than a same-file list that could silently drift from the real call sites.
- `bypass_limits` added to `create_event` and threaded through the bundle fan-out, matching the existing spelling/default on the pre-paid guards (`create_calendar` / `create_bundle_calendar` / `create_availability_windows`).
- The guard now honours `CalendarService.authenticate(bypass_limits=True)` via a new `bypass_entitlement_limits` field on `CalendarServiceContext` — before this, a facade explicitly placed in bypass mode still had its post-paid guard enforcing, because that gate reads the context rather than the facade attribute the provider-entitlement gate checks.
- `transfer_event` passes `_check_postpaid_allowance=False` — a move is not a creation (see the inline comment below).
- The sync-writer's over-allowance raise now logs the organization id, the unit count, current usage/ceiling, and the remedy before raising, with a recovery test — otherwise an over-allowance refusal and a flaky provider outage look identical in the `CalendarSync.error_message` field on every retry.

## Verification

Re-run independently, credentials cleared to match CI:

- Full suite **4316 passed** (base 4262; +54).
- `mypy` **305 errors / 57 files** — at the same ceiling as Phase 7, zero new.
- `ruff` clean (502 files).
- `makemigrations --check` clean — this phase ships no schema change.

## Carried forward

**`has_payment_method` is a proxy, and two later phases are bound by it.** There is no payment-method record in the schema yet, so `has_payment_method` reads `Subscription.billing_state` through the allow-list above as a stand-in.

- **Phase 9 must re-point it at the real payment-method record and delete the `billing_state` proxy** — not widen the allow-list. Once an instrument is actually persisted, `billing_state` stops being evidence of anything.
- **Phase 10 must keep `GRACE` resolving to `False`.** Phase 10 moves `ACTIVE → GRACE` on a failed charge while leaving the organization fully operational — only `RESTRICTED` is write-blocked, in Phase 11. If `GRACE` read as "has a payment method", an organization whose card just declined would get unbounded, unbillable accrual for the entire dunning window, making the dunning ladder the largest-bill path in the product.

**The bundle fan-out residual.** `check_postpaid_allowance`'s unit is occurrences, and the single-event path now matches that exactly via the two-stage guard above. The bundle path does not: `_bundle_event_billable_units` counts `1 + n_internal_children` **masters**, checked once before the fan-out writes anything, with no equivalent second-stage expansion. A *recurring* bundle event is therefore under-charged by the same factor the single-event path used to be, before this PR. Bounded and inert today — every organization is `unlimited` — but it's a **Phase 13 gating precondition** alongside the identity-churn and bulk-modification-split defects Phase 7 already recorded: an over-allowance number that becomes money must be in occurrence units on every path, not just one.