### PR TITLE
feat: widen branding write gate to parentless entitled organizations (Phase 3 — auth branding)

### DIFF
--- a/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
+++ b/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
@@ -56,7 +56,7 @@ Command translation (container → host):
 | 1 | Self-serve organization slug | 3 | ✅ done — [PR #206](https://github.com/vintasoftware/vinta-schedule-api/pull/206) | plan/organization-auth-branding/phase-1 |
 | 2a | Swap allowlist → single redirect | 2 | ✅ done — [PR #207](https://github.com/vintasoftware/vinta-schedule-api/pull/207) | plan/organization-auth-branding/phase-2a |
 | 2b | Logo upload and delivery | 3 | ✅ done — [PR #208](https://github.com/vintasoftware/vinta-schedule-api/pull/208) | plan/organization-auth-branding/phase-2b |
-| 3 | Widen write gate | 3 | ⏳ pending | plan/organization-auth-branding/phase-3 |
+| 3 | Widen write gate | 3 | ✅ done — [PR #209](https://github.com/vintasoftware/vinta-schedule-api/pull/209) | plan/organization-auth-branding/phase-3 |
 | 4 | Audit + capability field | 2 | ⏳ pending | plan/organization-auth-branding/phase-4 |
 | 5 | Resolve branding (parentless) | 3 | ⏳ pending | plan/organization-auth-branding/phase-5 |
 | 6 | Invitation reply-to | 2 | ⏳ pending | plan/organization-auth-branding/phase-6 |
@@ -97,9 +97,19 @@ Command translation (container → host):
 - Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, **full suite 4754 passed**. schema.yml regenerated (schema-auth.yml unchanged).
 - Carry-forward: `resolve_branding_for_display` now accepts `Organization | None`. `build_logo_delivery_url` keyed by branding ROOT (reseller) org. `BrandingLogoURLField.get_attribute` DRF override (single-instance only; would N+1 in a list). Slug-less root resolves logo_url to `/branding/logo/default/`.
 
+### Phase 3 — Widen write gate ✅
+- **Branch**: `plan/organization-auth-branding/phase-3` (base: phase-2b) · **PR**: [#209](https://github.com/vintasoftware/vinta-schedule-api/pull/209)
+- **Implementer**: sonnet (T3) · **Reviewer**: opus (T4) · **Fixer**: sonnet (T2)
+- `evaluate_branding_write_gate(org)` → `BrandingWriteGateReason` (OK/HAS_PARENT/NOT_ENTITLED/NO_SLUG). Distinguishable refusals per surface. REST: 3 PermissionDenied subclasses (`organizations/exceptions.py`); PUT/PATCH full gate; **GET uses two-condition read gate** (NO_SLUG admitted) so slug-less eligible orgs load the page. GraphQL `updateBranding` swaps `assert_org_can_invite` for the gate; `UpdateBrandingInput.slug` optional → sets slug+branding in ONE `transaction.atomic()` call (atomic rollback verified vs graphql-core's HTTP-200 swallow). Admin form `clean` refuses parented org.
+- Two-condition logo-signing helper (Phase 2b) kept separate — logo upload does NOT require a slug.
+- No migration (no model change). Reseller fixtures now need a slug (asserted).
+- **Tier-4 review lead finding (fixed)**: GET was over-gated on slug → would 403 slug-less eligible orgs and pre-break Phase 4's `can_manage_branding` contract; fixed to two-condition read gate. Also fixed: friendly error (not IntegrityError 500) on GraphQL slug-collision race via nested savepoint. Verified holding: no gate bypass on any write surface, atomicity, no reason leak.
+- Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors (+ fixed a latent User|None narrowing at 2 touched sites), **full suite 4778 passed**. schema.yml regenerated (only 403 descriptions changed).
+- Carry-forward: `can_manage_branding` (Phase 4) = parentless+entitled (NO slug) — must equal GET-reachability. Out-of-scope flagged: pre-existing `S3DirectWidget`/admin-form required-when-blank + re-render crash (worked around in tests).
+
 ## Current phase
 
-Phase 3 — Widen the write gate to parentless entitled organizations.
+Phase 4 — Audit branding writes and expose the capability field.
 
 ## Deferred phases
 

--- a/organizations/admin.py
+++ b/organizations/admin.py
@@ -196,10 +196,58 @@ class OrganizationAdmin(admin.ModelAdmin):
         subscription_service.create_subscription_for_organization(obj)
 
 
+class OrganizationBrandingAdminForm(forms.ModelForm):
+    """Refuses to save branding for an organization that has a parent.
+
+    Admin is not an escape hatch: "no branding for organizations inside a
+    hierarchy" (see the plan's Non-goals) holds for staff too, mirroring here
+    what the other two write surfaces (``OrganizationBrandingView``,
+    ``update_branding``) enforce via ``organizations.permissions.
+    evaluate_branding_write_gate``. Deliberately checks ONLY the parent
+    condition, not entitlement or slug: those are self-serve/billing states an
+    operator may legitimately need to seed branding ahead of (e.g. before the
+    organization's own admin has picked a slug), whereas the parent rule is a
+    hard structural boundary with no legitimate admin override.
+    """
+
+    class Meta:
+        model = OrganizationBranding
+        fields = (
+            "organization",
+            "app_name",
+            "logo",
+            "primary_color",
+            "secondary_color",
+            "support_email",
+            "redirect_url",
+        )
+
+    def clean(self) -> dict[str, Any] | None:
+        cleaned_data = super().clean()
+        organization = None if cleaned_data is None else cleaned_data.get("organization")
+        if organization is not None and organization.parent_id is not None:
+            raise forms.ValidationError(
+                {
+                    "organization": (
+                        "This organization has a parent organization and cannot have "
+                        "its own branding. Branding for organizations inside a "
+                        "hierarchy is controlled by the reseller organization above them."
+                    )
+                }
+            )
+        return cleaned_data
+
+
 @admin.register(OrganizationBranding)
 class OrganizationBrandingAdmin(admin.ModelAdmin):
-    """Admin interface for OrganizationBranding."""
+    """Admin interface for OrganizationBranding.
 
+    ``form`` refuses to save branding for an organization that has a parent
+    (``OrganizationBrandingAdminForm.clean``) -- the parent-present rule holds
+    for staff too, not just the REST/GraphQL write surfaces.
+    """
+
+    form = OrganizationBrandingAdminForm
     list_display = ("id", "organization", "app_name", "support_email", "created_at", "updated_at")
     list_filter = ("created_at", "updated_at")
     search_fields = ("organization__name", "app_name", "support_email")

--- a/organizations/exceptions.py
+++ b/organizations/exceptions.py
@@ -1,4 +1,4 @@
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 
 class DuplicateInvitationError(ValidationError):
@@ -26,6 +26,42 @@ class InvitationNotFoundError(ValidationError):
 class UserAlreadyHasMembershipError(ValidationError):
     default_detail = "User is already a member of this organization."
     default_code = "user_already_has_membership"
+
+
+class OrganizationHasParentBrandingError(PermissionDenied):
+    """Raised by the branding write gate (``organizations.permissions.
+    evaluate_branding_write_gate``) when the acting organization has a parent.
+
+    Permanent refusal (spec Use-case 5): branding within a hierarchy belongs to
+    the reseller alone, on every write surface, no matter which entry point the
+    request came through. Distinguished from the other two gate refusals so a
+    caller never mistakes this for a fixable billing/onboarding state.
+    """
+
+    default_detail = (
+        "This organization has a parent organization and cannot manage its own "
+        "branding. Branding for organizations inside a hierarchy is controlled "
+        "by the reseller organization above them."
+    )
+    default_code = "branding_organization_has_parent"
+
+
+class BrandingEntitlementRequiredError(PermissionDenied):
+    """Raised by the branding write gate when the acting organization does not
+    hold the ``white_label_branding`` entitlement -- a billing state, fixable
+    by upgrading, unlike ``OrganizationHasParentBrandingError``."""
+
+    default_detail = "This organization's plan does not include white-label branding."
+    default_code = "branding_entitlement_required"
+
+
+class OrganizationSlugRequiredForBrandingError(PermissionDenied):
+    """Raised by the branding write gate when the acting organization is
+    otherwise eligible but has not picked a public slug yet -- the "one step
+    away" refusal (spec: "Eligible org with no public identifier yet")."""
+
+    default_detail = "Pick a public slug for this organization before configuring branding."
+    default_code = "branding_slug_required"
 
 
 class BrandingLogoUploadRejectedError(Exception):

--- a/organizations/permissions.py
+++ b/organizations/permissions.py
@@ -1,3 +1,4 @@
+import enum
 from typing import TYPE_CHECKING, Annotated
 
 from dependency_injector.wiring import Provide, inject
@@ -22,20 +23,14 @@ if TYPE_CHECKING:
 
 
 @inject
-def is_branding_eligible_organization(
-    organization: Organization | None,
+def _organization_holds_white_label_branding(
+    organization: Organization,
     entitlement_service: Annotated[EntitlementService, Provide["entitlement_service"]] = None,  # type: ignore[assignment]
 ) -> bool:
-    """Shared branding-eligibility gate: ``organization`` has no parent AND holds
-    the ``white_label_branding`` entitlement.
-
-    Two conditions today (Organization Auth-Area Branding plan, Phase 2b) --
-    this is the gate's first caller (the ``branding_logos`` S3Direct destination's
-    ``auth`` callable, via ``user_administers_branding_eligible_organization``
-    below, and the GraphQL logo-signing mutation). Phase 3 extends this into the
-    full write gate by adding a third condition (the organization ends the write
-    with a ``slug`` set). Written as an early-return chain rather than a single
-    boolean expression so that extension is a one-line addition, not a rewrite.
+    """The entitlement half of the branding gate, factored out so both
+    ``is_branding_eligible_organization`` (two-condition, below) and
+    ``evaluate_branding_write_gate`` (three-condition, further below) share one
+    entitlement check rather than each re-deriving it.
 
     ``entitlement_service`` is DI-injected via ``@inject``/``Provide`` (the
     established pattern -- see ``audit/services.py``,
@@ -47,14 +42,84 @@ def is_branding_eligible_organization(
     before app startup completes): an unresolvable entitlement service denies
     rather than admits.
     """
-    if organization is None or organization.parent_id is not None:
-        return False
-
     if entitlement_service is None:
         return False
     return has_entitlement_cached(
         entitlement_service, organization, Entitlement.WHITE_LABEL_BRANDING
     )
+
+
+def is_branding_eligible_organization(organization: Organization | None) -> bool:
+    """Shared branding-eligibility gate: ``organization`` has no parent AND holds
+    the ``white_label_branding`` entitlement.
+
+    Two conditions -- this is the ``branding_logos`` S3Direct destination's
+    ``auth`` callable (via ``user_administers_branding_eligible_organization``
+    below) and the GraphQL logo-signing mutation's gate (Organization
+    Auth-Area Branding plan, Phase 2b). Phase 3 introduces a THIRD condition
+    (the organization ends the write with a ``slug`` set) but does **not** fold
+    it in here -- see ``evaluate_branding_write_gate`` below, which composes on
+    top of this function rather than replacing it. Requiring a slug before an
+    admin can upload a logo would order the branding form around an
+    implementation detail (the Write gate guiding decision), so the
+    logo-signing surface deliberately keeps using this two-condition helper.
+    """
+    if organization is None or organization.parent_id is not None:
+        return False
+    return _organization_holds_white_label_branding(organization)
+
+
+class BrandingWriteGateReason(enum.Enum):
+    """Distinguishable outcome of ``evaluate_branding_write_gate``.
+
+    ``OK`` means the write is admitted; every other member names exactly the
+    one condition that failed, so each of the three write surfaces
+    (``OrganizationBrandingView``, ``update_branding``,
+    ``OrganizationBrandingAdmin``) can render its own error idiom without
+    re-deriving *why* the gate refused:
+
+    - ``HAS_PARENT`` -- permanent. Branding within a hierarchy belongs to the
+      reseller alone (spec Use-case 5); no message for this reason should read
+      as fixable by the organization itself.
+    - ``NOT_ENTITLED`` -- a billing state. The organization's plan does not
+      include white-label branding; fixable by upgrading.
+    - ``NO_SLUG`` -- one step away. The organization is otherwise eligible but
+      has not picked a public slug yet (spec: "Eligible org with no public
+      identifier yet" -- branding settings stay offered, refused with a
+      message that reads as "pick a slug first", not hidden outright).
+    """
+
+    OK = "ok"
+    HAS_PARENT = "has_parent"
+    NOT_ENTITLED = "not_entitled"
+    NO_SLUG = "no_slug"
+
+
+def evaluate_branding_write_gate(organization: Organization | None) -> BrandingWriteGateReason:
+    """Full three-condition branding **write** gate (Organization Auth-Area
+    Branding plan, Phase 3): the acting organization must be parentless, hold
+    the ``white_label_branding`` entitlement, AND end the write with a
+    ``slug`` set. Replaces ``is_reseller()`` on every write surface.
+
+    Composes on top of, rather than duplicating, the two-condition
+    ``is_branding_eligible_organization`` above by sharing
+    ``_organization_holds_white_label_branding`` -- see that function's
+    docstring for why the logo-signing surface stays on the two-condition
+    helper instead of this one.
+
+    Checked in this order -- parent, then entitlement, then slug -- so the
+    permanent case is never masked by a fixable one, and the billing case is
+    never masked by the one-step-away case (an organization that lost the
+    entitlement and never picked a slug is told about the entitlement first;
+    picking a slug would not admit it either way).
+    """
+    if organization is None or organization.parent_id is not None:
+        return BrandingWriteGateReason.HAS_PARENT
+    if not _organization_holds_white_label_branding(organization):
+        return BrandingWriteGateReason.NOT_ENTITLED
+    if not organization.slug:
+        return BrandingWriteGateReason.NO_SLUG
+    return BrandingWriteGateReason.OK
 
 
 def user_administers_branding_eligible_organization(user: "User | None") -> bool:

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -23,6 +23,11 @@ from organizations.models import (
     resolve_branding_for_display,
 )
 from organizations.notification_contexts import organization_invitation_context
+from organizations.permissions import (
+    BrandingWriteGateReason,
+    evaluate_branding_write_gate,
+    is_branding_eligible_organization,
+)
 from organizations.redirect_url_validation import validate_redirect_url
 from payments.billing_constants import BillingState, Entitlement
 from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
@@ -335,6 +340,87 @@ def _org_with_entitlement(entitlement_key: str, is_enabled: bool, **org_kwargs) 
         is_enabled=is_enabled,
     )
     return org
+
+
+@pytest.mark.django_db
+class TestEvaluateBrandingWriteGate:
+    """``organizations.permissions.evaluate_branding_write_gate`` -- the full
+    three-condition write gate (Organization Auth-Area Branding plan, Phase 3):
+    parentless AND entitled AND slug-set. Composes on top of the two-condition
+    ``is_branding_eligible_organization`` (Phase 2b), which stays the
+    logo-signing surface's gate -- see ``test_two_condition_helper_stays_free_
+    of_the_slug_condition`` below for that split pinned as a regression test.
+    """
+
+    def test_admits_a_parentless_entitled_slugged_organization(self):
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None, slug="eligible-org"
+        )
+
+        assert evaluate_branding_write_gate(org) is BrandingWriteGateReason.OK
+
+    def test_refuses_an_organization_with_a_parent(self):
+        parent_org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None, slug="parent-org"
+        )
+        # No subscription needed on the child: the gate short-circuits on
+        # `parent_id is not None` before ever checking entitlement or slug.
+        child_org = baker.make(Organization, parent=parent_org, slug="child-org")
+
+        assert evaluate_branding_write_gate(child_org) is BrandingWriteGateReason.HAS_PARENT
+
+    def test_refuses_an_unentitled_organization(self):
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=False, parent=None, slug="free-plan-org"
+        )
+
+        assert evaluate_branding_write_gate(org) is BrandingWriteGateReason.NOT_ENTITLED
+
+    def test_refuses_an_organization_with_no_slug(self):
+        org = _org_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None)
+        assert org.slug is None
+
+        assert evaluate_branding_write_gate(org) is BrandingWriteGateReason.NO_SLUG
+
+    def test_the_three_refusals_are_distinguishable(self):
+        """Each failure mode produces its own reason, not a bare False -- this is
+        the whole point of the enum-returning gate over a boolean helper."""
+        parent_org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None, slug="parent-org-2"
+        )
+        child_org = baker.make(Organization, parent=parent_org)
+        unentitled_org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=False, parent=None, slug="unentitled-org"
+        )
+        no_slug_org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None
+        )
+
+        reasons = {
+            evaluate_branding_write_gate(child_org),
+            evaluate_branding_write_gate(unentitled_org),
+            evaluate_branding_write_gate(no_slug_org),
+        }
+
+        assert reasons == {
+            BrandingWriteGateReason.HAS_PARENT,
+            BrandingWriteGateReason.NOT_ENTITLED,
+            BrandingWriteGateReason.NO_SLUG,
+        }
+
+    def test_two_condition_helper_stays_free_of_the_slug_condition(self):
+        """The logo-signing surface's gate (`is_branding_eligible_organization`)
+        must still admit a slug-less eligible organization -- requiring a slug
+        before an admin can upload a logo would order the branding form around
+        an implementation detail (Write gate guiding decision). Pins the split
+        between the two-condition and three-condition gates as a regression
+        test: a future change that folds the slug condition into
+        `is_branding_eligible_organization` would flip this assertion."""
+        org = _org_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None)
+        assert org.slug is None
+
+        assert is_branding_eligible_organization(org) is True
+        assert evaluate_branding_write_gate(org) is BrandingWriteGateReason.NO_SLUG
 
 
 @pytest.mark.django_db

--- a/organizations/tests/test_branding_rest.py
+++ b/organizations/tests/test_branding_rest.py
@@ -849,10 +849,15 @@ class TestBrandingLogoKeyPrefixIsEnforcedOnWrite:
 @pytest.mark.django_db
 class TestBrandingWriteGateAllMethods:
     """The shared write gate (``organizations.permissions.
-    evaluate_branding_write_gate``) guards GET, PUT, AND PATCH uniformly on
-    ``OrganizationBrandingView`` -- Phase 3 replaces the reseller-only
-    ``_check_reseller_status`` with this three-condition gate on all three
-    HTTP methods (see the class docstring on ``OrganizationBrandingView``)."""
+    evaluate_branding_write_gate``) guards PUT and PATCH on
+    ``OrganizationBrandingView`` with its full three-condition check -- Phase 3
+    replaces the reseller-only ``_check_reseller_status`` with it (see the
+    class docstring on ``OrganizationBrandingView``). GET uses the narrower
+    two-condition eligibility gate (``_check_branding_read_gate``): it still
+    refuses on parent-present and not-entitled, but -- unlike PUT/PATCH --
+    admits a slug-less-but-otherwise-eligible org (see
+    ``test_no_slug_eligible_org_get_is_allowed_but_put_and_patch_are_refused``
+    below)."""
 
     def test_eligible_non_reseller_admin_completes_get_put_and_patch(
         self, client, user, eligible_org, eligible_org_admin
@@ -935,6 +940,58 @@ class TestBrandingWriteGateAllMethods:
         assert "slug" in str(response.json()).lower()
         assert not OrganizationBranding.objects.filter(organization=no_slug_org).exists()
 
+    def test_no_slug_eligible_org_get_is_allowed_but_put_and_patch_are_refused(
+        self, client, user, no_slug_org, no_slug_org_admin
+    ):
+        """Capability signal guiding decision (Organization Auth-Area
+        Branding plan): a parentless + entitled + slug-less org must still
+        SEE the branding page -- GET is admitted by the narrower
+        two-condition eligibility gate -- even though writing is refused
+        ("pick a slug first") until it does. Matches the spec's "Eligible org
+        with no public identifier yet" edge case: settings still offered,
+        saving refused. Mirrors the slugged-reseller no-row case
+        (``TestResellerNowRequiresASlug.test_reseller_with_a_slug_still_passes_the_gate``):
+        404, not 403, when no branding row exists yet; 200 once one does."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(no_slug_org.id))
+
+        # No branding row yet: GET admits the request (the eligibility gate
+        # passed) and falls through to the ordinary "no row" 404 -- not 403.
+        get_response = client.get(BRANDING_URL)
+        assert_response_status_code(get_response, status.HTTP_404_NOT_FOUND)
+
+        # PUT/PATCH still refuse with the "pick a slug first" reason.
+        payload = {
+            "app_name": "NoSlugApp",
+            "logo_url": "",
+            "primary_color": "",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+        put_response = client.put(BRANDING_URL, data=payload, format="json")
+        assert_response_status_code(put_response, status.HTTP_403_FORBIDDEN)
+        assert "slug" in str(put_response.json()).lower()
+
+        patch_response = client.patch(BRANDING_URL, data={"app_name": "x"}, format="json")
+        assert_response_status_code(patch_response, status.HTTP_403_FORBIDDEN)
+        assert "slug" in str(patch_response.json()).lower()
+
+        # Now with a branding row present, GET succeeds with 200.
+        baker.make(
+            OrganizationBranding,
+            organization=no_slug_org,
+            app_name="NoSlugAppExisting",
+            logo="",
+            primary_color="",
+            secondary_color="",
+            support_email="",
+            redirect_url="",
+        )
+        get_response_with_row = client.get(BRANDING_URL)
+        assert_response_status_code(get_response_with_row, status.HTTP_200_OK)
+        assert get_response_with_row.json()["app_name"] == "NoSlugAppExisting"
+
     def test_non_admin_member_of_an_eligible_org_still_gets_403(
         self, client, eligible_org, eligible_org_member
     ):
@@ -976,14 +1033,29 @@ class TestBrandingWriteGateAllMethods:
     ):
         """The has-a-parent and no-slug 403 bodies differ -- not a generic
         "forbidden" message both times -- so a caller (or a reviewer reading
-        the response) can tell which write-gate condition failed."""
+        the response) can tell which write-gate condition failed.
+
+        Probed via PUT: the no-slug condition is a write-gate-only refusal
+        (GET uses the narrower two-condition eligibility gate and admits a
+        slug-less-but-otherwise-eligible org -- see
+        ``test_no_slug_eligible_org_get_is_allowed_but_put_and_patch_are_refused``),
+        so GET would not reproduce the no-slug 403 body here."""
         client.force_authenticate(user)
 
+        payload = {
+            "app_name": "x",
+            "logo_url": "",
+            "primary_color": "",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+
         client.credentials(HTTP_X_ORGANIZATION_ID=str(parented_org.id))
-        parented_detail = client.get(BRANDING_URL).json()
+        parented_detail = client.put(BRANDING_URL, data=payload, format="json").json()
 
         client.credentials(HTTP_X_ORGANIZATION_ID=str(no_slug_org.id))
-        no_slug_detail = client.get(BRANDING_URL).json()
+        no_slug_detail = client.put(BRANDING_URL, data=payload, format="json").json()
 
         assert parented_detail != no_slug_detail
         assert "parent" in str(parented_detail).lower()
@@ -1004,6 +1076,10 @@ class TestResellerNowRequiresASlug:
     side effect of ``reseller_org`` now carrying a slug."""
 
     def test_reseller_without_a_slug_is_now_refused(self, client, user, reseller_org_without_slug):
+        """The no-slug refusal is a **write** gate condition (see
+        ``OrganizationBrandingView._check_branding_read_gate`` -- GET uses the
+        narrower two-condition eligibility gate and does not refuse for a
+        missing slug), so probe it via PUT."""
         baker.make(
             OrganizationMembership,
             user=user,
@@ -1014,7 +1090,15 @@ class TestResellerNowRequiresASlug:
         client.force_authenticate(user)
         client.credentials(HTTP_X_ORGANIZATION_ID=str(reseller_org_without_slug.id))
 
-        response = client.get(BRANDING_URL)
+        payload = {
+            "app_name": "NoSlugApp",
+            "logo_url": "",
+            "primary_color": "",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+        response = client.put(BRANDING_URL, data=payload, format="json")
         assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
         assert "slug" in str(response.json()).lower()
 

--- a/organizations/tests/test_branding_rest.py
+++ b/organizations/tests/test_branding_rest.py
@@ -1,6 +1,8 @@
+import datetime
 import json
 
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 import pytest
 from model_bakery import baker
@@ -13,9 +15,37 @@ from organizations.models import (
     OrganizationMembership,
     OrganizationRole,
 )
+from payments.billing_constants import BillingState, Entitlement
+from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
 
 
 User = get_user_model()
+
+
+def _make_unentitled_org(**org_kwargs) -> Organization:
+    """A parentless organization whose subscription explicitly lacks
+    ``white_label_branding`` -- the free-plan write-gate refusal. Callers must
+    mark the test ``@pytest.mark.no_auto_subscription``: the suite's autouse
+    fixture would otherwise grant every baker-made ``Organization`` the
+    (all-entitlements-on) "unlimited" plan, making this state unreachable."""
+    org = baker.make(Organization, **org_kwargs)
+    now = timezone.now()
+    subscription = baker.make(
+        Subscription,
+        organization=org,
+        plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+        billing_state=BillingState.FREE,
+        current_period_start=now,
+        current_period_end=now + datetime.timedelta(days=30),
+    )
+    baker.make(
+        SubscriptionEntitlement,
+        subscription=subscription,
+        entitlement_key=Entitlement.WHITE_LABEL_BRANDING,
+        is_enabled=False,
+    )
+    return org
+
 
 BRANDING_URL = "/branding/"
 
@@ -52,14 +82,42 @@ def user():
 
 @pytest.fixture
 def reseller_org():
-    """Create a reseller organization."""
+    """A reseller organization -- parentless (default) and entitled via the
+    suite's autouse default subscription. Phase 3 widens the write gate with a
+    THIRD condition (slug-set) on top of the pre-existing parentless+entitled
+    pair, and a reseller is not exempt from it -- this fixture carries a slug
+    so the pre-Phase-3 test bodies below keep passing. See
+    ``TestResellerNowRequiresASlug`` for the explicit regression coverage of
+    that behavior change."""
+    return baker.make(Organization, can_invite_organizations=True, slug="acme-reseller")
+
+
+@pytest.fixture
+def reseller_org_without_slug():
+    """Same as ``reseller_org`` but deliberately unslugged."""
     return baker.make(Organization, can_invite_organizations=True)
 
 
 @pytest.fixture
-def non_reseller_org():
-    """Create a non-reseller organization."""
-    return baker.make(Organization, can_invite_organizations=False)
+def eligible_org():
+    """A plain (non-reseller), parentless organization that is entitled (the
+    suite's autouse default subscription) and has a slug -- the population
+    Phase 3 widens the write gate to admit (spec Use-case 1's actor)."""
+    return baker.make(Organization, can_invite_organizations=False, slug="eligible-org")
+
+
+@pytest.fixture
+def no_slug_org():
+    """Parentless and entitled, but no slug -- the "one step away" refusal
+    (spec: "Eligible org with no public identifier yet")."""
+    return baker.make(Organization, can_invite_organizations=False, parent=None)
+
+
+@pytest.fixture
+def parented_org(eligible_org):
+    """An organization with a parent -- refused on every write surface
+    regardless of its own entitlement/slug state (spec Use-case 5)."""
+    return baker.make(Organization, parent=eligible_org, slug="child-org")
 
 
 @pytest.fixture
@@ -75,12 +133,50 @@ def reseller_org_admin(user, reseller_org):
 
 
 @pytest.fixture
-def non_reseller_org_admin(user, non_reseller_org):
-    """Create an admin membership for the user in a non-reseller org."""
+def eligible_org_admin(user, eligible_org):
+    """Create an admin membership for the user in the eligible (non-reseller) org."""
     return baker.make(
         OrganizationMembership,
         user=user,
-        organization=non_reseller_org,
+        organization=eligible_org,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def eligible_org_member(eligible_org):
+    """A non-admin member of the eligible org."""
+    member = baker.make(User)
+    baker.make(
+        OrganizationMembership,
+        user=member,
+        organization=eligible_org,
+        role=OrganizationRole.MEMBER,
+        is_active=True,
+    )
+    return member
+
+
+@pytest.fixture
+def no_slug_org_admin(user, no_slug_org):
+    """Create an admin membership for the user in the no-slug org."""
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=no_slug_org,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def parented_org_admin(user, parented_org):
+    """Create an admin membership for the user in the parented org."""
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=parented_org,
         role=OrganizationRole.ADMIN,
         is_active=True,
     )
@@ -381,10 +477,16 @@ class TestOrganizationBrandingViewSet:
         response = client.put(BRANDING_URL, data=payload, format="json")
         assert_response_status_code(response, status.HTTP_201_CREATED)
 
-    def test_non_reseller_org_returns_403(self, client, user, non_reseller_org_admin):
-        """Non-reseller org admin gets 403."""
+    def test_non_reseller_org_without_a_slug_returns_403_for_the_slug_reason(
+        self, client, user, no_slug_org, no_slug_org_admin
+    ):
+        """A plain (non-reseller) organization is no longer refused for lacking
+        reseller status -- see ``TestBrandingWriteGateAllMethods`` for the full
+        "eligible non-reseller org succeeds" coverage that is the point of this
+        phase. It IS still refused here, but for the slug condition -- the
+        response body must name the slug, not reseller status."""
         client.force_authenticate(user)
-        client.credentials(HTTP_X_ORGANIZATION_ID=str(non_reseller_org_admin.organization_id))
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(no_slug_org.id))
 
         payload = {
             "app_name": "MyScheduler",
@@ -397,6 +499,8 @@ class TestOrganizationBrandingViewSet:
 
         response = client.put(BRANDING_URL, data=payload, format="json")
         assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        assert "slug" in str(response.json()).lower()
+        assert "reseller" not in str(response.json()).lower()
 
     def test_non_admin_member_returns_403(self, client, reseller_org, reseller_org_member):
         """Non-admin member of reseller org gets 403."""
@@ -566,8 +670,12 @@ class TestOrganizationBrandingViewSet:
         membership (reseller_a) for every request, silently ignoring the header.
         """
         user = baker.make(User)
-        reseller_a = baker.make(Organization, can_invite_organizations=True)
-        reseller_b = baker.make(Organization, can_invite_organizations=True)
+        reseller_a = baker.make(
+            Organization, can_invite_organizations=True, slug="reseller-a-multi"
+        )
+        reseller_b = baker.make(
+            Organization, can_invite_organizations=True, slug="reseller-b-multi"
+        )
 
         # Create memberships: reseller_a first so it is the "oldest".
         baker.make(
@@ -646,8 +754,12 @@ class TestOrganizationBrandingViewSet:
     def test_multi_org_absent_header_returns_400(self, client):
         """Multi-org admin omitting X-Organization-Id gets 400 (not a silent fallback)."""
         user = baker.make(User)
-        reseller_a = baker.make(Organization, can_invite_organizations=True)
-        reseller_b = baker.make(Organization, can_invite_organizations=True)
+        reseller_a = baker.make(
+            Organization, can_invite_organizations=True, slug="reseller-a-multi-2"
+        )
+        reseller_b = baker.make(
+            Organization, can_invite_organizations=True, slug="reseller-b-multi-2"
+        )
 
         baker.make(
             OrganizationMembership,
@@ -732,3 +844,188 @@ class TestBrandingLogoKeyPrefixIsEnforcedOnWrite:
 
         response = client.put(BRANDING_URL, data=payload, format="json")
         assert_response_status_code(response, status.HTTP_201_CREATED)
+
+
+@pytest.mark.django_db
+class TestBrandingWriteGateAllMethods:
+    """The shared write gate (``organizations.permissions.
+    evaluate_branding_write_gate``) guards GET, PUT, AND PATCH uniformly on
+    ``OrganizationBrandingView`` -- Phase 3 replaces the reseller-only
+    ``_check_reseller_status`` with this three-condition gate on all three
+    HTTP methods (see the class docstring on ``OrganizationBrandingView``)."""
+
+    def test_eligible_non_reseller_admin_completes_get_put_and_patch(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        """The headline behavior change of this phase: a plain, parentless,
+        entitled, slugged organization -- not a reseller -- can now manage its
+        own branding through every method this endpoint exposes."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        put_payload = {
+            "app_name": "EligibleApp",
+            "logo_url": "",
+            "primary_color": "#112233",
+            "secondary_color": "#445566",
+            "support_email": "support@example.com",
+            "redirect_url": "https://example.com/return",
+        }
+        put_response = client.put(BRANDING_URL, data=put_payload, format="json")
+        assert_response_status_code(put_response, status.HTTP_201_CREATED)
+        assert put_response.json()["app_name"] == "EligibleApp"
+
+        get_response = client.get(BRANDING_URL)
+        assert_response_status_code(get_response, status.HTTP_200_OK)
+        assert get_response.json()["app_name"] == "EligibleApp"
+
+        patch_response = client.patch(
+            BRANDING_URL, data={"app_name": "EligibleAppRenamed"}, format="json"
+        )
+        assert_response_status_code(patch_response, status.HTTP_200_OK)
+        assert patch_response.json()["app_name"] == "EligibleAppRenamed"
+
+    def test_admin_of_a_parented_org_gets_403_on_get_put_and_patch(
+        self, client, user, parented_org, parented_org_admin
+    ):
+        """Use-case 5: refused by the backend on every method, not merely
+        hidden in the interface -- and nothing is persisted."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(parented_org.id))
+
+        payload = {
+            "app_name": "ShouldNotSave",
+            "logo_url": "",
+            "primary_color": "",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+        put_response = client.put(BRANDING_URL, data=payload, format="json")
+        assert_response_status_code(put_response, status.HTTP_403_FORBIDDEN)
+        assert "parent" in str(put_response.json()).lower()
+
+        get_response = client.get(BRANDING_URL)
+        assert_response_status_code(get_response, status.HTTP_403_FORBIDDEN)
+
+        patch_response = client.patch(BRANDING_URL, data={"app_name": "x"}, format="json")
+        assert_response_status_code(patch_response, status.HTTP_403_FORBIDDEN)
+
+        assert not OrganizationBranding.objects.filter(organization=parented_org).exists()
+
+    def test_no_slug_org_gets_403_with_the_pick_a_slug_reason(
+        self, client, user, no_slug_org, no_slug_org_admin
+    ):
+        """Spec edge case: "Eligible org with no public identifier yet" --
+        refused with a reason distinct from the other two (named "slug", not
+        "parent" or "plan")."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(no_slug_org.id))
+
+        payload = {
+            "app_name": "NoSlugApp",
+            "logo_url": "",
+            "primary_color": "",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+        response = client.put(BRANDING_URL, data=payload, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        assert "slug" in str(response.json()).lower()
+        assert not OrganizationBranding.objects.filter(organization=no_slug_org).exists()
+
+    def test_non_admin_member_of_an_eligible_org_still_gets_403(
+        self, client, eligible_org, eligible_org_member
+    ):
+        """The write gate widens WHICH organizations are eligible; it does not
+        loosen the admin-only requirement within an eligible organization."""
+        client.force_authenticate(eligible_org_member)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.get(BRANDING_URL)
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    @pytest.mark.no_auto_subscription
+    def test_free_plan_org_gets_403(self, client, user):
+        """Parentless and slugged, but not entitled -- the billing-state refusal."""
+        org = _make_unentitled_org(parent=None, slug="free-plan-org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(org.id))
+
+        response = client.get(BRANDING_URL)
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        detail = str(response.json()).lower()
+        assert "plan" in detail or "entitle" in detail
+
+    def test_the_three_refusal_reasons_are_distinguishable(
+        self,
+        client,
+        user,
+        parented_org,
+        parented_org_admin,
+        no_slug_org,
+        no_slug_org_admin,
+    ):
+        """The has-a-parent and no-slug 403 bodies differ -- not a generic
+        "forbidden" message both times -- so a caller (or a reviewer reading
+        the response) can tell which write-gate condition failed."""
+        client.force_authenticate(user)
+
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(parented_org.id))
+        parented_detail = client.get(BRANDING_URL).json()
+
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(no_slug_org.id))
+        no_slug_detail = client.get(BRANDING_URL).json()
+
+        assert parented_detail != no_slug_detail
+        assert "parent" in str(parented_detail).lower()
+        assert "slug" in str(no_slug_detail).lower()
+        assert "slug" not in str(parented_detail).lower()
+        assert "parent" not in str(no_slug_detail).lower()
+
+
+@pytest.mark.django_db
+class TestResellerNowRequiresASlug:
+    """Phase 3 widens the write gate with a THIRD condition (slug-set) on top
+    of the pre-existing parentless+entitled pair. A reseller organization is
+    parentless in every fixture this suite has, and (via the autouse default
+    subscription) entitled by default -- so before this phase a reseller
+    always passed the old ``is_reseller()`` gate. It does NOT get a pass on
+    the new slug condition: this is a deliberate behavior change for reseller
+    fixtures, asserted explicitly here rather than left to be discovered as a
+    side effect of ``reseller_org`` now carrying a slug."""
+
+    def test_reseller_without_a_slug_is_now_refused(self, client, user, reseller_org_without_slug):
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=reseller_org_without_slug,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(reseller_org_without_slug.id))
+
+        response = client.get(BRANDING_URL)
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+        assert "slug" in str(response.json()).lower()
+
+    def test_reseller_with_a_slug_still_passes_the_gate(
+        self, client, user, reseller_org, reseller_org_admin
+    ):
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(reseller_org.id))
+
+        # No branding configured yet: 404 (not 403) proves the gate itself
+        # admitted the request -- IsOrganizationAdmin + the write gate both
+        # passed, and the endpoint fell through to the "no row yet" branch.
+        response = client.get(BRANDING_URL)
+        assert_response_status_code(response, status.HTTP_404_NOT_FOUND)

--- a/organizations/tests/test_organization_admin.py
+++ b/organizations/tests/test_organization_admin.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 import pytest
 from model_bakery import baker
 
-from organizations.models import Organization
+from organizations.models import Organization, OrganizationBranding
 from payments.models import Subscription
 from payments.services.subscription_service import SubscriptionService
 
@@ -322,3 +322,98 @@ class TestOrganizationAdminSlugValidation:
         assert response.status_code == 302
         organization.refresh_from_db()
         assert organization.slug is None
+
+
+@pytest.mark.django_db
+class TestOrganizationBrandingAdminParentGuard:
+    """``OrganizationBrandingAdmin`` refuses to save branding for an
+    organization that has a parent -- admin is not an escape hatch for the
+    write gate's permanent refusal (Organization Auth-Area Branding plan,
+    Phase 3). Only the parent condition is enforced in admin; entitlement and
+    slug are self-serve/billing states an operator may legitimately need to
+    seed branding ahead of."""
+
+    def test_saving_branding_for_a_parented_organization_fails_validation(self, admin_client):
+        parent = baker.make(Organization, name="Branding Parent", parent=None)
+        child = baker.make(Organization, name="Branding Child", parent=parent)
+
+        add_url = reverse("admin:organizations_organizationbranding_add")
+        response = admin_client.post(
+            add_url,
+            data={
+                "organization": child.pk,
+                "app_name": "ShouldNotSave",
+                # Left empty deliberately: the S3Direct widget's re-render on a
+                # validation-error response cannot handle a bound non-empty
+                # string value (a pre-existing quirk of
+                # s3direct_overrides.form_widgets.S3DirectWidget.render,
+                # unrelated to this phase) -- an empty value renders fine.
+                "logo": "",
+                "primary_color": "",
+                "secondary_color": "",
+                "support_email": "",
+                "redirect_url": "",
+            },
+        )
+
+        # A validation error re-renders the form (200), it does not redirect.
+        assert response.status_code == 200
+        form = response.context["adminform"].form
+        assert "organization" in form.errors
+        assert "parent" in form.errors["organization"][0].lower()
+        assert not OrganizationBranding.objects.filter(organization=child).exists()
+
+    def test_saving_branding_for_a_parentless_organization_succeeds(self, admin_client):
+        organization = baker.make(Organization, name="Branding Root", parent=None)
+
+        add_url = reverse("admin:organizations_organizationbranding_add")
+        response = admin_client.post(
+            add_url,
+            data={
+                "organization": organization.pk,
+                "app_name": "AllowedApp",
+                "logo": "uploads/branding_logos/admin-test-logo.png",
+                "primary_color": "",
+                "secondary_color": "",
+                "support_email": "",
+                "redirect_url": "",
+            },
+        )
+
+        assert response.status_code == 302
+        branding = OrganizationBranding.objects.get(organization=organization)
+        assert branding.app_name == "AllowedApp"
+
+    def test_editing_existing_branding_for_a_parented_organization_still_fails(self, admin_client):
+        """A branding row that predates a reparenting (spec: "A standalone
+        organization later gains a parent") cannot be re-saved through admin
+        either -- the guard runs on every save, not only on create."""
+        parent = baker.make(Organization, name="Later Parent", parent=None)
+        organization = baker.make(Organization, name="Later Child", parent=None)
+        branding = baker.make(
+            OrganizationBranding,
+            organization=organization,
+            app_name="Original",
+        )
+        organization.parent = parent
+        organization.save(update_fields=["parent"])
+
+        change_url = reverse("admin:organizations_organizationbranding_change", args=[branding.pk])
+        response = admin_client.post(
+            change_url,
+            data={
+                "organization": organization.pk,
+                "app_name": "Renamed",
+                # See the comment on the create-path test above: empty avoids
+                # the S3Direct widget's re-render crash on a bound value.
+                "logo": "",
+                "primary_color": "",
+                "secondary_color": "",
+                "support_email": "",
+                "redirect_url": "",
+            },
+        )
+
+        assert response.status_code == 200
+        branding.refresh_from_db()
+        assert branding.app_name == "Original"

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import Annotated
+from typing import Annotated, ClassVar
 
 from django.db import transaction
 from django.http import FileResponse
@@ -41,10 +41,13 @@ from organizations.branding_logo import (
     guess_logo_content_type,
 )
 from organizations.exceptions import (
+    BrandingEntitlementRequiredError,
     DuplicateInvitationError,
     InvalidInvitationTokenError,
     InvitationNotFoundError,
     NoServiceAccountConfiguredError,
+    OrganizationHasParentBrandingError,
+    OrganizationSlugRequiredForBrandingError,
     UserAlreadyHasMembershipError,
 )
 from organizations.filtersets import (
@@ -61,9 +64,11 @@ from organizations.models import (
     resolve_branding_for_display,
 )
 from organizations.permissions import (
+    BrandingWriteGateReason,
     IsOrganizationAdmin,
     OrganizationInvitationPermission,
     OrganizationManagementPermission,
+    evaluate_branding_write_gate,
 )
 from organizations.serializers import (
     AcceptInvitationSerializer,
@@ -977,11 +982,24 @@ class AcceptInvitationView(generics.CreateAPIView):
 
 @extend_schema(tags=["Branding"])
 class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
-    """Admin-only REST endpoint for managing a reseller organization's branding.
+    """Admin-only REST endpoint for managing a parentless, entitled, slugged
+    organization's branding.
 
-    Reseller-admin gate: the acting org must itself be a reseller
-    (can_invite_organizations=True; a non-reseller returns 403) AND the caller
-    must be an org admin (IsOrganizationAdmin permission).
+    Write gate (Organization Auth-Area Branding plan, Phase 3): the acting org
+    must be parentless, hold the ``white_label_branding`` entitlement, AND
+    have a slug set (``organizations.permissions.evaluate_branding_write_gate``),
+    AND the caller must be an org admin (``IsOrganizationAdmin`` permission).
+    Replaces the earlier reseller-only gate (``is_reseller()``) -- any paying,
+    parentless, slugged organization can now manage its own branding, not just
+    resellers. The gate guards all three HTTP methods (GET/PUT/PATCH)
+    uniformly -- this endpoint has no read path that bypasses it. A missing
+    slug refuses with a distinct 403 body reading as "pick a slug first" (this
+    endpoint never sets a slug itself -- see the organization endpoint,
+    Phase 1). Each of the three failure conditions raises its own
+    ``PermissionDenied`` subclass (``organizations.exceptions``) so the
+    response body -- not just the 403 status -- distinguishes the permanent
+    refusal (has a parent) from the billing state (not entitled) from the
+    one-step-away case (no slug).
 
     Operations: retrieve (GET) + upsert (PUT/PATCH) the **acting org's own**
     branding. The endpoint operates on the request's organization only — it
@@ -1005,11 +1023,23 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
     permission_classes = (IsOrganizationAdmin,)
     serializer_class = OrganizationBrandingSerializer
 
-    def _check_reseller_status(self):
-        """Verify the acting org is a reseller. Raise 403 if not."""
+    _GATE_EXCEPTIONS: ClassVar[dict[BrandingWriteGateReason, type[PermissionDenied]]] = {
+        BrandingWriteGateReason.HAS_PARENT: OrganizationHasParentBrandingError,
+        BrandingWriteGateReason.NOT_ENTITLED: BrandingEntitlementRequiredError,
+        BrandingWriteGateReason.NO_SLUG: OrganizationSlugRequiredForBrandingError,
+    }
+
+    def _check_branding_write_gate(self):
+        """Verify the acting org passes the full write gate (parentless,
+        entitled, slug-set). Raises the matching ``PermissionDenied`` subclass
+        on the first failed condition; a no-op when the gate admits the org."""
         membership = get_active_organization_membership(self.request.user)
-        if membership is None or not membership.organization.is_reseller():
-            raise PermissionDenied("Only reseller organizations may manage branding.")
+        if membership is None:
+            raise PermissionDenied("No active organization membership.")
+        reason = evaluate_branding_write_gate(membership.organization)
+        if reason is BrandingWriteGateReason.OK:
+            return
+        raise self._GATE_EXCEPTIONS[reason]()
 
     def _get_branding_or_404(self):
         """Get the acting org's branding, or raise 404 if not set."""
@@ -1026,13 +1056,15 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         summary="Retrieve the acting organization's branding",
         responses={
             200: OrganizationBrandingSerializer,
-            403: OpenApiResponse(description="Not a reseller or not an admin"),
+            403: OpenApiResponse(
+                description="Organization has a parent, lacks the entitlement, or has no slug; or not an admin"
+            ),
             404: OpenApiResponse(description="Branding not yet configured"),
         },
     )
     def get(self, request, *args, **kwargs):
         """GET /branding/ — retrieve the acting org's branding."""
-        self._check_reseller_status()
+        self._check_branding_write_gate()
         instance = self._get_branding_or_404()
         serializer = OrganizationBrandingSerializer(instance, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -1044,12 +1076,14 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
             201: OrganizationBrandingSerializer,
             200: OrganizationBrandingSerializer,
             400: OpenApiResponse(description="Invalid input (color format, URL validation)"),
-            403: OpenApiResponse(description="Not a reseller or not an admin"),
+            403: OpenApiResponse(
+                description="Organization has a parent, lacks the entitlement, or has no slug; or not an admin"
+            ),
         },
     )
     def put(self, request, *args, **kwargs):
         """PUT /branding/ — create or replace the acting org's branding."""
-        self._check_reseller_status()
+        self._check_branding_write_gate()
         membership = get_active_organization_membership(request.user)
         if membership is None:
             raise PermissionDenied("No active organization membership.")
@@ -1075,13 +1109,15 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         responses={
             200: OrganizationBrandingSerializer,
             400: OpenApiResponse(description="Invalid input (color format, URL validation)"),
-            403: OpenApiResponse(description="Not a reseller or not an admin"),
+            403: OpenApiResponse(
+                description="Organization has a parent, lacks the entitlement, or has no slug; or not an admin"
+            ),
             404: OpenApiResponse(description="Branding not yet configured"),
         },
     )
     def patch(self, request, *args, **kwargs):
         """PATCH /branding/ — update the acting org's branding (partial)."""
-        self._check_reseller_status()
+        self._check_branding_write_gate()
         instance = self._get_branding_or_404()
 
         serializer = OrganizationBrandingSerializer(

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -985,21 +985,30 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
     """Admin-only REST endpoint for managing a parentless, entitled, slugged
     organization's branding.
 
-    Write gate (Organization Auth-Area Branding plan, Phase 3): the acting org
-    must be parentless, hold the ``white_label_branding`` entitlement, AND
-    have a slug set (``organizations.permissions.evaluate_branding_write_gate``),
-    AND the caller must be an org admin (``IsOrganizationAdmin`` permission).
+    Write gate (Organization Auth-Area Branding plan, Phase 3): PUT/PATCH
+    require the acting org to be parentless, hold the ``white_label_branding``
+    entitlement, AND have a slug set
+    (``organizations.permissions.evaluate_branding_write_gate``), AND the
+    caller must be an org admin (``IsOrganizationAdmin`` permission).
     Replaces the earlier reseller-only gate (``is_reseller()``) -- any paying,
     parentless, slugged organization can now manage its own branding, not just
-    resellers. The gate guards all three HTTP methods (GET/PUT/PATCH)
-    uniformly -- this endpoint has no read path that bypasses it. A missing
-    slug refuses with a distinct 403 body reading as "pick a slug first" (this
-    endpoint never sets a slug itself -- see the organization endpoint,
-    Phase 1). Each of the three failure conditions raises its own
+    resellers. Each of the three failure conditions raises its own
     ``PermissionDenied`` subclass (``organizations.exceptions``) so the
     response body -- not just the 403 status -- distinguishes the permanent
     refusal (has a parent) from the billing state (not entitled) from the
     one-step-away case (no slug).
+
+    GET uses the narrower two-condition **eligibility** gate
+    (``organizations.permissions.is_branding_eligible_organization`` --
+    parentless AND entitled, via ``_check_branding_read_gate``): a slug-less
+    but otherwise eligible org still gets to *see* the branding page (its
+    normal 404-no-row-yet / 200-with-a-row behavior), so the "pick a slug
+    first" refusal only ever surfaces on a write. This matches the plan's
+    Capability signal guiding decision and keeps this endpoint's read path
+    consistent with the ``can_manage_branding`` contract a slug-less eligible
+    org's SPA would otherwise render into a page that immediately 403s.
+    GET still refuses with the same parent/entitlement 403 bodies as the
+    write gate.
 
     Operations: retrieve (GET) + upsert (PUT/PATCH) the **acting org's own**
     branding. The endpoint operates on the request's organization only — it
@@ -1029,15 +1038,41 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         BrandingWriteGateReason.NO_SLUG: OrganizationSlugRequiredForBrandingError,
     }
 
-    def _check_branding_write_gate(self):
+    def _check_branding_write_gate(self) -> None:
         """Verify the acting org passes the full write gate (parentless,
         entitled, slug-set). Raises the matching ``PermissionDenied`` subclass
         on the first failed condition; a no-op when the gate admits the org."""
-        membership = get_active_organization_membership(self.request.user)
+        user = self.request.user
+        # Narrows AbstractBaseUser | AnonymousUser -> AbstractBaseUser for mypy
+        # (matches the pattern in ServiceAccountViewSet.get_queryset above);
+        # IsOrganizationAdmin already blocks anonymous callers before this runs.
+        if not user.is_authenticated:
+            raise PermissionDenied("No active organization membership.")
+        membership = get_active_organization_membership(user)
         if membership is None:
             raise PermissionDenied("No active organization membership.")
         reason = evaluate_branding_write_gate(membership.organization)
         if reason is BrandingWriteGateReason.OK:
+            return
+        raise self._GATE_EXCEPTIONS[reason]()
+
+    def _check_branding_read_gate(self) -> None:
+        """Verify the acting org passes the two-condition branding
+        **eligibility** gate (parentless, entitled) used for GET.
+
+        Reuses ``evaluate_branding_write_gate`` to derive the failure reason
+        so the parent/entitlement 403 bodies stay byte-for-byte identical to
+        the write gate's, but treats ``NO_SLUG`` as admitted here -- a
+        slug-less eligible org must still be able to see the branding page
+        (see the class docstring). A no-op when the gate admits the org."""
+        user = self.request.user
+        if not user.is_authenticated:
+            raise PermissionDenied("No active organization membership.")
+        membership = get_active_organization_membership(user)
+        if membership is None:
+            raise PermissionDenied("No active organization membership.")
+        reason = evaluate_branding_write_gate(membership.organization)
+        if reason in (BrandingWriteGateReason.OK, BrandingWriteGateReason.NO_SLUG):
             return
         raise self._GATE_EXCEPTIONS[reason]()
 
@@ -1057,14 +1092,20 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         responses={
             200: OrganizationBrandingSerializer,
             403: OpenApiResponse(
-                description="Organization has a parent, lacks the entitlement, or has no slug; or not an admin"
+                description="Organization has a parent or lacks the entitlement; or not an admin. "
+                "A slug-less-but-otherwise-eligible org is NOT refused here -- see 404."
             ),
             404: OpenApiResponse(description="Branding not yet configured"),
         },
     )
     def get(self, request, *args, **kwargs):
-        """GET /branding/ — retrieve the acting org's branding."""
-        self._check_branding_write_gate()
+        """GET /branding/ — retrieve the acting org's branding.
+
+        Uses the two-condition eligibility gate, not the full write gate: a
+        slug-less-but-otherwise-eligible org is admitted here (and falls
+        through to the normal 404-no-row-yet / 200-with-a-row branch below)
+        -- see ``_check_branding_read_gate``."""
+        self._check_branding_read_gate()
         instance = self._get_branding_or_404()
         serializer = OrganizationBrandingSerializer(instance, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -57,9 +57,14 @@ from organizations.exceptions import (
     UserAlreadyHasMembershipError,
 )
 from organizations.models import Organization, OrganizationBranding, OrganizationMembership
-from organizations.permissions import is_branding_eligible_organization
+from organizations.permissions import (
+    BrandingWriteGateReason,
+    evaluate_branding_write_gate,
+    is_branding_eligible_organization,
+)
 from organizations.redirect_url_validation import validate_redirect_url
 from organizations.services import OrganizationService
+from organizations.slug_validation import validate_organization_slug
 from payments.exceptions import OverLimitError
 from payments.services.subscription_service import SubscriptionService
 from public_api.capabilities import assert_org_can_invite, assert_target_in_subtree
@@ -108,6 +113,50 @@ HEX_COLOR_PATTERN = re.compile(r"^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$")
 # Mirrors CalendarEvent.title's max_length so an over-long title is rejected with a clean
 # GraphQL error rather than surfacing as a DB-level error after work has begun.
 EVENT_TITLE_MAX_LENGTH = 255
+
+# One message per ``organizations.permissions.BrandingWriteGateReason`` failure --
+# this surface's translation of the shared write gate into its own error idiom
+# (GraphQLError), matching the plan's Shared gate helper guiding decision. Kept
+# distinct in wording from the REST 403 bodies (organizations.exceptions) and the
+# admin form error (organizations.admin) so each surface reads naturally, while
+# preserving the same three-way distinguishability.
+_BRANDING_GATE_MESSAGES: dict[BrandingWriteGateReason, str] = {
+    BrandingWriteGateReason.HAS_PARENT: (
+        "This organization has a parent organization and cannot manage its own "
+        "branding. Branding for organizations inside a hierarchy is controlled by "
+        "the reseller organization above them."
+    ),
+    BrandingWriteGateReason.NOT_ENTITLED: (
+        "This organization's plan does not include white-label branding."
+    ),
+    BrandingWriteGateReason.NO_SLUG: (
+        "Pick a public slug for this organization before configuring branding. "
+        "Supply `slug` on this mutation, or set one via the organization endpoint first."
+    ),
+}
+
+
+def _apply_input_slug(organization: Organization, slug: str) -> None:
+    """Validate ``slug`` with the shared organization-slug rules, check
+    uniqueness excluding ``organization`` itself, and persist it immediately.
+
+    Called from ``update_branding`` when ``UpdateBrandingInput.slug`` is
+    supplied, BEFORE the write gate's slug condition is evaluated -- see that
+    mutation's docstring. The caller wraps this call in ``transaction.atomic()``:
+    an invalid or colliding slug raises ``GraphQLError`` here, and because that
+    propagates out of the atomic block, the slug write (and anything else the
+    block did) is rolled back rather than partially applied.
+    """
+    try:
+        validate_organization_slug(slug)
+    except DjangoValidationError as e:
+        raise GraphQLError("; ".join(e.messages)) from e
+
+    if Organization.objects.filter(slug=slug).exclude(pk=organization.pk).exists():
+        raise GraphQLError(f"An organization with the slug '{slug}' already exists.")
+
+    organization.slug = slug
+    organization.save(update_fields=["slug"])
 
 
 @dataclass
@@ -1245,17 +1294,32 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         input: UpdateBrandingInput,  # noqa: A002
     ) -> UpdateBrandingResult:
         """
-        Update or create branding for the acting (reseller) organization.
+        Update or create branding for the acting organization.
 
         The mutation:
-        1. Checks that the acting org has can_invite_organizations (via assert_org_can_invite).
-        2. Validates app_name: non-empty and max 120 characters.
-        3. Validates primary_color and secondary_color format (#RRGGBB or #RRGGBBAA).
-        4. Validates redirect_url: HTTPS scheme, no wildcard, no path-prefix pattern
+        1. When ``input.slug`` is supplied, validates it with the shared
+           organization-slug rules and a uniqueness check (excluding the acting
+           org itself) and applies it to the acting org BEFORE step 2 -- see
+           ``UpdateBrandingInput.slug``'s docstring and ``_apply_input_slug``.
+        2. Evaluates the shared branding write gate -- parentless, entitled,
+           slug-set (``organizations.permissions.evaluate_branding_write_gate``).
+           Replaces the old ``can_invite_organizations``-only check
+           (``assert_org_can_invite``): a reseller is not exempt from any of
+           the three conditions. Raises a distinguishable ``GraphQLError`` per
+           failed condition.
+        3. Validates app_name: non-empty and max 120 characters.
+        4. Validates primary_color and secondary_color format (#RRGGBB or #RRGGBBAA).
+        5. Validates redirect_url: HTTPS scheme, no wildcard, no path-prefix pattern
            (organizations.redirect_url_validation, shared with the REST serializer).
-        5. Upserts OrganizationBranding on the acting org only (always keyed to acting_org).
-        6. Returns the upserted branding row (without internal fields like support_email/
+        6. Upserts OrganizationBranding on the acting org only (always keyed to acting_org).
+        7. Returns the upserted branding row (without internal fields like support_email/
            redirect_url).
+
+        Steps 1 through 6 run inside one ``transaction.atomic()`` block: a
+        rejected slug, a failed gate, or any field-validation failure rolls
+        back everything this call did -- including the slug write -- rather
+        than partially applying (see the plan's Slug is a precondition for
+        branding guiding decision).
 
         The token's OrganizationResourceAccess must include the BRANDING resource.
         """
@@ -1263,59 +1327,67 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         if not acting_org:
             raise GraphQLError("Organization not found")
 
-        # Gate: check the org can invite before proceeding
-        assert_org_can_invite(acting_org)
+        with transaction.atomic():
+            # Slug application happens BEFORE the gate is evaluated so a
+            # partner-API caller can satisfy the gate's slug precondition and
+            # set branding in one call.
+            if input.slug:
+                _apply_input_slug(acting_org, input.slug)
 
-        # Validate app_name: must be non-empty and at most 120 characters
-        if input.app_name:
-            if not input.app_name.strip():
-                raise GraphQLError("app_name must not be empty or whitespace-only.")
-            if len(input.app_name) > 120:
-                raise GraphQLError("app_name must be 120 characters or fewer.")
+            gate_reason = evaluate_branding_write_gate(acting_org)
+            if gate_reason is not BrandingWriteGateReason.OK:
+                raise GraphQLError(_BRANDING_GATE_MESSAGES[gate_reason])
 
-        # Validate color format: #RRGGBB or #RRGGBBAA (6 or 8 hex chars after #)
-        if input.primary_color and not HEX_COLOR_PATTERN.match(input.primary_color):
-            raise GraphQLError(
-                f"Invalid primary_color format: '{input.primary_color}'. "
-                "Expected #RRGGBB or #RRGGBBAA."
+            # Validate app_name: must be non-empty and at most 120 characters
+            if input.app_name:
+                if not input.app_name.strip():
+                    raise GraphQLError("app_name must not be empty or whitespace-only.")
+                if len(input.app_name) > 120:
+                    raise GraphQLError("app_name must be 120 characters or fewer.")
+
+            # Validate color format: #RRGGBB or #RRGGBBAA (6 or 8 hex chars after #)
+            if input.primary_color and not HEX_COLOR_PATTERN.match(input.primary_color):
+                raise GraphQLError(
+                    f"Invalid primary_color format: '{input.primary_color}'. "
+                    "Expected #RRGGBB or #RRGGBBAA."
+                )
+
+            if input.secondary_color and not HEX_COLOR_PATTERN.match(input.secondary_color):
+                raise GraphQLError(
+                    f"Invalid secondary_color format: '{input.secondary_color}'. "
+                    "Expected #RRGGBB or #RRGGBBAA."
+                )
+
+            # Validate redirect_url: HTTPS scheme, no wildcard, no path-prefix pattern.
+            # Shared with the REST serializer's validate_redirect_url.
+            try:
+                validate_redirect_url(input.redirect_url)
+            except DjangoValidationError as e:
+                raise GraphQLError("; ".join(e.messages)) from e
+
+            # `logo_url` is write-only here despite the name: normalize a bare key or a
+            # full signed/public URL down to the bare S3 key -- the persisted value,
+            # never a URL. See organizations.branding_logo.normalize_uploaded_logo_key.
+            # Raises BrandingLogoUploadRejectedError if the normalized key falls
+            # outside the branding_logos upload prefix (e.g. a key from another
+            # destination in the shared media bucket) -- see BRANDING_LOGO_KEY_PREFIX.
+            try:
+                logo_key = normalize_uploaded_logo_key(input.logo_url)
+            except BrandingLogoUploadRejectedError as e:
+                raise GraphQLError(str(e)) from e
+
+            # Upsert branding on the acting org (always acts on acting org, never another org)
+            branding, _ = OrganizationBranding.objects.update_or_create(
+                organization=acting_org,
+                defaults={
+                    "app_name": input.app_name,
+                    "logo": logo_key,
+                    "primary_color": input.primary_color,
+                    "secondary_color": input.secondary_color,
+                    "support_email": input.support_email,
+                    "redirect_url": input.redirect_url,
+                },
             )
-
-        if input.secondary_color and not HEX_COLOR_PATTERN.match(input.secondary_color):
-            raise GraphQLError(
-                f"Invalid secondary_color format: '{input.secondary_color}'. "
-                "Expected #RRGGBB or #RRGGBBAA."
-            )
-
-        # Validate redirect_url: HTTPS scheme, no wildcard, no path-prefix pattern.
-        # Shared with the REST serializer's validate_redirect_url.
-        try:
-            validate_redirect_url(input.redirect_url)
-        except DjangoValidationError as e:
-            raise GraphQLError("; ".join(e.messages)) from e
-
-        # `logo_url` is write-only here despite the name: normalize a bare key or a
-        # full signed/public URL down to the bare S3 key -- the persisted value,
-        # never a URL. See organizations.branding_logo.normalize_uploaded_logo_key.
-        # Raises BrandingLogoUploadRejectedError if the normalized key falls
-        # outside the branding_logos upload prefix (e.g. a key from another
-        # destination in the shared media bucket) -- see BRANDING_LOGO_KEY_PREFIX.
-        try:
-            logo_key = normalize_uploaded_logo_key(input.logo_url)
-        except BrandingLogoUploadRejectedError as e:
-            raise GraphQLError(str(e)) from e
-
-        # Upsert branding on the acting org (always acts on acting org, never another org)
-        branding, _ = OrganizationBranding.objects.update_or_create(
-            organization=acting_org,
-            defaults={
-                "app_name": input.app_name,
-                "logo": logo_key,
-                "primary_color": input.primary_color,
-                "secondary_color": input.secondary_color,
-                "support_email": input.support_email,
-                "redirect_url": input.redirect_url,
-            },
-        )
 
         # Return the branding without internal fields (no support_email, no redirect_url).
         # logo_url is always the logo delivery route's URL, keyed by the acting org's

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -146,6 +146,15 @@ def _apply_input_slug(organization: Organization, slug: str) -> None:
     an invalid or colliding slug raises ``GraphQLError`` here, and because that
     propagates out of the atomic block, the slug write (and anything else the
     block did) is rolled back rather than partially applied.
+
+    The uniqueness pre-check above is a TOCTOU race: a concurrent caller could
+    claim the same slug between the ``exists()`` check and this function's own
+    ``save()``. The ``save()`` call is wrapped in its own nested
+    ``transaction.atomic()`` (a savepoint) so a resulting ``IntegrityError`` can
+    be caught and converted to the same friendly ``GraphQLError`` without
+    poisoning the caller's outer atomic block -- an uncaught ``IntegrityError``
+    marks the enclosing transaction/savepoint for rollback, so catching it
+    anywhere outside its own savepoint would leave the outer block unusable.
     """
     try:
         validate_organization_slug(slug)
@@ -156,7 +165,11 @@ def _apply_input_slug(organization: Organization, slug: str) -> None:
         raise GraphQLError(f"An organization with the slug '{slug}' already exists.")
 
     organization.slug = slug
-    organization.save(update_fields=["slug"])
+    try:
+        with transaction.atomic():
+            organization.save(update_fields=["slug"])
+    except IntegrityError as e:
+        raise GraphQLError(f"An organization with the slug '{slug}' already exists.") from e
 
 
 @dataclass

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -1556,14 +1556,20 @@ class TestUpdateBranding:
         assert "branding_logos" in str(data["errors"])
         assert not OrganizationBranding.objects.filter(organization=reseller_org).exists()
 
-    def test_update_branding_fails_flag_off(self):
-        """Test that updateBranding fails when acting org has flag off."""
+    def test_update_branding_succeeds_for_a_non_reseller_organization(self):
+        """The headline behavior change of this phase: a plain (non-reseller),
+        parentless, entitled, slugged organization can now save branding
+        through `updateBranding` -- it is no longer refused for lacking
+        `can_invite_organizations`."""
         from di_core.containers import container
 
-        # Create a non-reseller org
-        non_reseller_org = baker.make(Organization, name="Non-Reseller")
+        non_reseller_org = baker.make(
+            Organization,
+            name="Non-Reseller",
+            can_invite_organizations=False,
+            slug="plain-org-succeeds",
+        )
 
-        # Create a system user with BRANDING resource access
         auth_service = PublicAPIAuthService()
         system_user, token = auth_service.create_system_user(
             integration_name="branding_integration", organization=non_reseller_org
@@ -1594,16 +1600,113 @@ class TestUpdateBranding:
 
         assert response.status_code == 200
         data = response.json()
+        assert "errors" not in data or not data["errors"], data
+        assert data["data"]["updateBranding"]["branding"]["appName"] == "MyApp"
+
+    def test_update_branding_fails_for_an_organization_with_a_parent(self):
+        """Use-case 5: refused by the backend regardless of the org's own
+        entitlement/slug state, because it has a parent."""
+        from di_core.containers import container
+
+        parent_org = baker.make(
+            Organization, name="Parent", can_invite_organizations=False, parent=None
+        )
+        child_org = baker.make(
+            Organization,
+            name="Child",
+            can_invite_organizations=False,
+            parent=parent_org,
+            slug="child-org-branding",
+        )
+
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="branding_integration", organization=child_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
+
+        mutation = """
+        mutation UpdateBranding($input: UpdateBrandingInput!) {
+            updateBranding(input: $input) {
+                branding {
+                    id
+                    appName
+                }
+            }
+        }
+        """
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {"input": {"appName": "MyApp"}},
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
         assert "errors" in data
         assert len(data["errors"]) > 0
-        assert "does not have permission" in str(data["errors"]).lower()
+        assert "parent" in str(data["errors"]).lower()
+        assert not OrganizationBranding.objects.filter(organization=child_org).exists()
+
+    @pytest.mark.no_auto_subscription
+    def test_update_branding_fails_for_an_unentitled_organization(self):
+        """Parentless and (once given one) slugged, but not entitled -- the
+        billing-state refusal, distinct in wording from the parent refusal."""
+        from di_core.containers import container
+
+        org = _make_unentitled_organization(
+            name="Free Plan Org", parent=None, slug="free-plan-branding-org"
+        )
+
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="branding_integration", organization=org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
+
+        mutation = """
+        mutation UpdateBranding($input: UpdateBrandingInput!) {
+            updateBranding(input: $input) {
+                branding {
+                    id
+                    appName
+                }
+            }
+        }
+        """
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": mutation,
+                    "variables": {"input": {"appName": "MyApp"}},
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        errors = str(data["errors"]).lower()
+        assert "plan" in errors or "entitle" in errors
+        assert "parent" not in errors
 
     def test_update_branding_fails_no_scope(self):
         """Test that updateBranding fails without BRANDING scope."""
         from di_core.containers import container
 
         # Create a reseller org
-        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        reseller_org = baker.make(
+            Organization, name="Reseller", can_invite_organizations=True, slug="branding-no-scope"
+        )
 
         # Create a system user without BRANDING resource access
         auth_service = PublicAPIAuthService()
@@ -1644,7 +1747,12 @@ class TestUpdateBranding:
         """Test that invalid color format is rejected."""
         from di_core.containers import container
 
-        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        reseller_org = baker.make(
+            Organization,
+            name="Reseller",
+            can_invite_organizations=True,
+            slug="branding-invalid-color",
+        )
 
         auth_service = PublicAPIAuthService()
         system_user, token = auth_service.create_system_user(
@@ -1687,7 +1795,12 @@ class TestUpdateBranding:
         """Test that a non-HTTPS redirect_url is rejected."""
         from di_core.containers import container
 
-        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        reseller_org = baker.make(
+            Organization,
+            name="Reseller",
+            can_invite_organizations=True,
+            slug="branding-non-https-redirect",
+        )
 
         auth_service = PublicAPIAuthService()
         system_user, token = auth_service.create_system_user(
@@ -1730,7 +1843,12 @@ class TestUpdateBranding:
         """Test that a redirect_url containing a wildcard character is rejected."""
         from di_core.containers import container
 
-        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        reseller_org = baker.make(
+            Organization,
+            name="Reseller",
+            can_invite_organizations=True,
+            slug="branding-wildcard-redirect",
+        )
 
         auth_service = PublicAPIAuthService()
         system_user, token = auth_service.create_system_user(
@@ -1783,7 +1901,12 @@ class TestUpdateBranding:
         """Hostless, scheme-confused, and CRLF redirect_url are rejected and not persisted."""
         from di_core.containers import container
 
-        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        reseller_org = baker.make(
+            Organization,
+            name="Reseller",
+            can_invite_organizations=True,
+            slug="branding-malformed-redirect",
+        )
 
         auth_service = PublicAPIAuthService()
         system_user, token = auth_service.create_system_user(
@@ -1827,7 +1950,9 @@ class TestUpdateBranding:
         """Test that multiple updates to the same org create only one branding row."""
         from di_core.containers import container
 
-        reseller_org = baker.make(Organization, name="Reseller", can_invite_organizations=True)
+        reseller_org = baker.make(
+            Organization, name="Reseller", can_invite_organizations=True, slug="branding-upsert"
+        )
 
         auth_service = PublicAPIAuthService()
         system_user, token = auth_service.create_system_user(
@@ -1911,8 +2036,12 @@ class TestUpdateBranding:
         from organizations.models import OrganizationBranding
 
         # Create two independent reseller organizations
-        reseller_a = baker.make(Organization, name="Reseller A", can_invite_organizations=True)
-        reseller_b = baker.make(Organization, name="Reseller B", can_invite_organizations=True)
+        reseller_a = baker.make(
+            Organization, name="Reseller A", can_invite_organizations=True, slug="reseller-a-iso"
+        )
+        reseller_b = baker.make(
+            Organization, name="Reseller B", can_invite_organizations=True, slug="reseller-b-iso"
+        )
 
         # System user + token for Reseller A
         auth_service_a = PublicAPIAuthService()
@@ -2018,6 +2147,209 @@ class TestUpdateBranding:
         assert OrganizationBranding.objects.filter(organization=reseller_a).count() == 1
         # Verify there is exactly one branding row for B
         assert OrganizationBranding.objects.filter(organization=reseller_b).count() == 1
+
+
+UPDATE_BRANDING_WITH_SLUG_MUTATION = """
+mutation UpdateBranding($input: UpdateBrandingInput!) {
+    updateBranding(input: $input) {
+        branding {
+            id
+            appName
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestUpdateBrandingSlugInOneCall:
+    """``UpdateBrandingInput.slug`` -- a partner-API caller can satisfy the
+    write gate's slug precondition and set branding in a single
+    ``updateBranding`` call (Organization Auth-Area Branding plan, Phase 3).
+    Both the slug write and the branding upsert land in one
+    ``transaction.atomic()`` block: a rejected slug, or a later
+    field-validation failure, must not leave a partial write behind."""
+
+    def setup_method(self):
+        self.client = APIClient()
+
+    def _org_with_branding_scope(self, **org_kwargs):
+        org = baker.make(Organization, can_invite_organizations=False, parent=None, **org_kwargs)
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="branding_integration", organization=org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
+        return org, auth_service, system_user, token
+
+    def test_supplying_a_valid_slug_alongside_branding_sets_both(self):
+        """A no-slug org can satisfy the gate's slug precondition and save
+        branding in the same call."""
+        from di_core.containers import container
+
+        org, auth_service, system_user, token = self._org_with_branding_scope()
+        assert org.slug is None
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": UPDATE_BRANDING_WITH_SLUG_MUTATION,
+                    "variables": {
+                        "input": {
+                            "appName": "OneCallApp",
+                            "slug": "one-call-org",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or not data["errors"], data
+        assert data["data"]["updateBranding"]["branding"]["appName"] == "OneCallApp"
+
+        org.refresh_from_db()
+        assert org.slug == "one-call-org"
+        assert OrganizationBranding.objects.get(organization=org).app_name == "OneCallApp"
+
+    def test_omitting_slug_relies_on_the_organizations_stored_slug(self):
+        """When `slug` is omitted (`None`), the organization's already-stored
+        slug must satisfy the gate on its own -- unaffected by this input."""
+        from di_core.containers import container
+
+        org, auth_service, system_user, token = self._org_with_branding_scope(
+            slug="already-slugged-org"
+        )
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": UPDATE_BRANDING_WITH_SLUG_MUTATION,
+                    "variables": {"input": {"appName": "StillWorksApp"}},
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or not data["errors"], data
+        org.refresh_from_db()
+        assert org.slug == "already-slugged-org"
+
+    def test_invalid_slug_rejects_the_whole_call_and_leaves_the_org_without_one(self):
+        """An invalid slug (fails the shared format rule) rejects the entire
+        call before the gate or the branding upsert ever runs -- the
+        organization's slug stays unset and no branding row is created."""
+        from di_core.containers import container
+
+        org, auth_service, system_user, token = self._org_with_branding_scope()
+        assert org.slug is None
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": UPDATE_BRANDING_WITH_SLUG_MUTATION,
+                    "variables": {
+                        "input": {
+                            "appName": "ShouldNotPersist",
+                            "slug": "Not_Valid_Slug!",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert data["errors"]
+
+        org.refresh_from_db()
+        assert org.slug is None
+        assert not OrganizationBranding.objects.filter(organization=org).exists()
+
+    def test_colliding_slug_rejects_without_partially_applying(self):
+        """A slug already claimed by another organization rejects the whole
+        call -- the acting org's slug is unchanged and no branding is written,
+        rather than a 500 from the unique index or a partial write."""
+        from di_core.containers import container
+
+        baker.make(Organization, parent=None, slug="already-taken-slug")
+        org, auth_service, system_user, token = self._org_with_branding_scope()
+        assert org.slug is None
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": UPDATE_BRANDING_WITH_SLUG_MUTATION,
+                    "variables": {
+                        "input": {
+                            "appName": "ShouldNotPersist",
+                            "slug": "already-taken-slug",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert "already exists" in str(data["errors"]).lower()
+
+        org.refresh_from_db()
+        assert org.slug is None
+        assert not OrganizationBranding.objects.filter(organization=org).exists()
+
+    def test_valid_slug_rolls_back_when_a_later_validation_fails(self):
+        """Transaction check: the slug write and the branding upsert are one
+        atomic unit. A syntactically valid, non-colliding slug is applied
+        first, but a later field-validation failure (invalid primary_color)
+        must roll back the slug write too -- nothing from this call is
+        left behind, not even the slug that validated cleanly on its own."""
+        from di_core.containers import container
+
+        org, auth_service, system_user, token = self._org_with_branding_scope()
+        assert org.slug is None
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": UPDATE_BRANDING_WITH_SLUG_MUTATION,
+                    "variables": {
+                        "input": {
+                            "appName": "ShouldNotPersist",
+                            "slug": "would-have-been-valid",
+                            "primaryColor": "not-a-color",
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert "invalid primary_color" in str(data["errors"]).lower()
+
+        org.refresh_from_db()
+        assert org.slug is None, (
+            "The slug write must roll back with the rest of the transaction, "
+            "even though the slug itself was valid and would-have-been unique."
+        )
+        assert not OrganizationBranding.objects.filter(organization=org).exists()
+        assert not Organization.objects.filter(slug="would-have-been-valid").exists()
 
 
 CREATE_BRANDING_LOGO_UPLOAD_MUTATION = """

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -25,6 +25,7 @@ from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
 from public_api.constants import PublicAPIResources
 from public_api.models import ResourceAccess
 from public_api.mutations import (
+    _apply_input_slug,
     _get_org_and_init_calendar_service,
     get_calendar_mutation_dependencies,
 )
@@ -2309,6 +2310,26 @@ class TestUpdateBrandingSlugInOneCall:
         org.refresh_from_db()
         assert org.slug is None
         assert not OrganizationBranding.objects.filter(organization=org).exists()
+
+    def test_slug_collision_surfacing_as_integrity_error_is_a_friendly_graphql_error(self):
+        """Simulates the TOCTOU race the pre-check cannot fully close: the
+        ``exists()`` uniqueness check reports no collision (as it would for a
+        concurrent claim landing between the check and the write), but the
+        DB-level unique index still fires on ``save()``. The resulting
+        ``IntegrityError`` must surface as the same friendly "already exists"
+        ``GraphQLError`` -- not a raw 500 -- and must not poison the caller's
+        transaction (verified here by asserting the org's slug is unchanged
+        afterwards, i.e. the save's own savepoint rolled back cleanly)."""
+        baker.make(Organization, parent=None, slug="race-slug")
+        org = baker.make(Organization, parent=None)
+
+        with patch("public_api.mutations.Organization.objects.filter") as mock_filter:
+            mock_filter.return_value.exclude.return_value.exists.return_value = False
+            with pytest.raises(GraphQLError, match="already exists"):
+                _apply_input_slug(org, "race-slug")
+
+        org.refresh_from_db()
+        assert org.slug is None
 
     def test_valid_slug_rolls_back_when_a_later_validation_fails(self):
         """Transaction check: the slug write and the branding upsert are one

--- a/public_api/types.py
+++ b/public_api/types.py
@@ -116,16 +116,32 @@ class CreateSystemUserTokenResult:
 
 @strawberry.input
 class UpdateBrandingInput:
-    """Input for updating reseller branding.
+    """Input for updating an organization's branding.
 
-    Updates branding on the acting org (must be a reseller). Always upserts
-    (creates if missing, updates if exists). Cannot target another org's tree.
+    Updates branding on the acting org. Always upserts (creates if missing,
+    updates if exists). Cannot target another org's tree. The acting org must
+    pass the shared branding write gate (parentless, entitled, slug-set --
+    ``organizations.permissions.evaluate_branding_write_gate``); a reseller is
+    not exempt from any of those three conditions.
 
     ``logo_url`` is write-only despite the name (kept for symmetry with the REST
     serializer's field): it accepts the S3 key returned by
     ``createBrandingLogoUpload`` (a bare key or a full signed/public URL, either
     way normalized to a key before it is stored). Reads never echo this value
     back — ``BrandingResult.logo_url`` is always the logo delivery route's URL.
+
+    ``slug``: optional. When supplied, it is validated with the same shared
+    rules the organization REST endpoint uses (``organizations.slug_validation
+    .validate_organization_slug``, plus a uniqueness check excluding the acting
+    org itself) and applied to the acting organization BEFORE the write gate's
+    slug condition is evaluated -- so a partner-API caller can satisfy the
+    slug precondition and set branding in a single call, rather than needing a
+    separate organization-update mutation that does not exist on this surface.
+    When omitted (``None``), the acting organization's already-stored slug
+    must satisfy the gate on its own. The slug write and the branding upsert
+    land in one transaction: an invalid or colliding slug, or a
+    field-validation failure anywhere else in this input, rejects the whole
+    call and leaves the organization's slug unchanged.
     """
 
     app_name: str
@@ -134,6 +150,7 @@ class UpdateBrandingInput:
     secondary_color: str = ""
     support_email: str = ""
     redirect_url: str = ""
+    slug: str | None = None
 
 
 @strawberry.type

--- a/schema.yml
+++ b/schema.yml
@@ -3572,7 +3572,8 @@ paths:
                 $ref: '#/components/schemas/OrganizationBranding'
           description: ''
         '403':
-          description: Not a reseller or not an admin
+          description: Organization has a parent, lacks the entitlement, or has no
+            slug; or not an admin
         '404':
           description: Branding not yet configured
     put:
@@ -3623,7 +3624,8 @@ paths:
         '400':
           description: Invalid input (color format, URL validation)
         '403':
-          description: Not a reseller or not an admin
+          description: Organization has a parent, lacks the entitlement, or has no
+            slug; or not an admin
     patch:
       operationId: branding_partial_update
       description: PATCH /branding/ — update the acting org's branding (partial).
@@ -3665,7 +3667,8 @@ paths:
         '400':
           description: Invalid input (color format, URL validation)
         '403':
-          description: Not a reseller or not an admin
+          description: Organization has a parent, lacks the entitlement, or has no
+            slug; or not an admin
         '404':
           description: Branding not yet configured
   /branding/logo/{org_slug}/:


### PR DESCRIPTION
## Phase 3 — Widen the write gate to parentless entitled organizations

Fourth phase of the [Organization Auth-Area Branding plan](../blob/main/ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md). This is the **authorization boundary** for the whole feature: any admin of a paying organization with no parent can save branding; an admin of an organization with a parent is refused by the backend on every surface. Replaces the reseller-only gate.

> **Stacked on [#208](https://github.com/vintasoftware/vinta-schedule-api/pull/208) (Phase 2b).** Review this diff against that branch.

### The gate
`evaluate_branding_write_gate(org)` → `BrandingWriteGateReason` (`OK | HAS_PARENT | NOT_ENTITLED | NO_SLUG`), three conditions: parentless **and** entitled (`white_label_branding`) **and** slug set. Each surface maps the reason to its own idiom with a **distinguishable refusal** — permanent (parent) vs billing state (entitlement) vs one-step-away (slug):
- **REST** (`OrganizationBrandingView`) — three `PermissionDenied` subclasses. **PUT/PATCH** use the full gate. **GET** uses the two-condition read gate (parentless + entitled) so a slug-less eligible org can still load its branding page and see the "pick a slug first" prompt — the no-slug refusal belongs on the write, not the read (keeps the Phase 4 `can_manage_branding` contract intact).
- **GraphQL** (`updateBranding`) — swaps `assert_org_can_invite` for the gate; `UpdateBrandingInput` gains an optional `slug` so a partner-API caller sets slug + branding in **one atomic call** (invalid/colliding slug rejects the whole call, leaving nothing persisted).
- **Admin** — form `clean` refuses a parented organization (staff are not an escape hatch).

The two-condition logo-signing helper from Phase 2b is kept separate (uploading a logo must not require a slug).

### Tests
Gate unit tests (admit parentless+entitled+slugged; distinct reason for each of the three refusals); REST method matrix (eligible admin completes GET/PUT/PATCH; parented → 403 on all; no-slug → 403 pick-a-slug on writes but GET allowed; non-admin → 403; free plan → 403; reseller now needs a slug, asserted); GraphQL one-call slug+branding (success sets both; invalid/colliding slug rolls back both — atomicity verified against graphql-core's HTTP-200-swallow behavior); admin parent guard. Full suite: **4778 passed**.

### Review notes (Tier 4 / opus)
- **Lead finding (fixed):** GET was originally gated on the full three-condition gate, which would 403 a slug-less eligible org and pre-break the Phase 4 capability contract. Fixed to the two-condition read gate; parent/entitlement 403s preserved byte-for-byte; no-slug refusal tests moved to PUT/PATCH.
- **Fixed:** the GraphQL one-call slug write now returns a friendly error (not a raw `IntegrityError` 500) on a slug-collision race, via a nested savepoint.
- Verified and holding: no gate bypass on any of the three write surfaces; GraphQL slug+branding write is genuinely atomic; refusal reasons don't leak cross-tenant info; reseller resolution unaffected.

### Out of scope (flagged for follow-up)
A pre-existing `S3DirectWidget`/`formfield` issue in the admin branding form (required-when-blank; a re-render crash on validation error) — worked around in tests, not introduced here. And a latent `User | AnonymousUser` vs `User | None` typing pattern across view handlers (only the two sites touched here were corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2)_