### PR TITLE
feat: audit branding writes and expose can_manage_branding (Phase 4 — auth branding)

### DIFF
--- a/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
+++ b/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
@@ -57,7 +57,7 @@ Command translation (container → host):
 | 2a | Swap allowlist → single redirect | 2 | ✅ done — [PR #207](https://github.com/vintasoftware/vinta-schedule-api/pull/207) | plan/organization-auth-branding/phase-2a |
 | 2b | Logo upload and delivery | 3 | ✅ done — [PR #208](https://github.com/vintasoftware/vinta-schedule-api/pull/208) | plan/organization-auth-branding/phase-2b |
 | 3 | Widen write gate | 3 | ✅ done — [PR #209](https://github.com/vintasoftware/vinta-schedule-api/pull/209) | plan/organization-auth-branding/phase-3 |
-| 4 | Audit + capability field | 2 | ⏳ pending | plan/organization-auth-branding/phase-4 |
+| 4 | Audit + capability field | 2 | ✅ done — [PR #210](https://github.com/vintasoftware/vinta-schedule-api/pull/210) | plan/organization-auth-branding/phase-4 |
 | 5 | Resolve branding (parentless) | 3 | ⏳ pending | plan/organization-auth-branding/phase-5 |
 | 6 | Invitation reply-to | 2 | ⏳ pending | plan/organization-auth-branding/phase-6 |
 | 7 | Post-auth destination server-side | 3 | ⏳ pending | plan/organization-auth-branding/phase-7 |
@@ -107,9 +107,18 @@ Command translation (container → host):
 - Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors (+ fixed a latent User|None narrowing at 2 touched sites), **full suite 4778 passed**. schema.yml regenerated (only 403 descriptions changed).
 - Carry-forward: `can_manage_branding` (Phase 4) = parentless+entitled (NO slug) — must equal GET-reachability. Out-of-scope flagged: pre-existing `S3DirectWidget`/admin-form required-when-blank + re-render crash (worked around in tests).
 
+### Phase 4 — Audit + capability field ✅
+- **Branch**: `plan/organization-auth-branding/phase-4` (base: phase-3) · **PR**: [#210](https://github.com/vintasoftware/vinta-schedule-api/pull/210)
+- **Implementer**: sonnet (T2) · **Reviewer**: sonnet (T3) · **Fixer**: sonnet (T2)
+- Audit on branding create (no diff) + update (diff of changed fields) via `AuditService.record` on REST PUT/PATCH + GraphQL `updateBranding`; actor `actor_from_membership` (REST) / `actor_from_system_user` (partner API); refused writes record nothing (audit call unreachable + `on_commit` defer). Shared `branding_diff_state()` helper (6 fields; logo→key).
+- `can_manage_branding` read-only on `CurrentMembershipSerializer` + `MyMembershipSerializer` = `is_branding_eligible_organization` (parentless+entitled, NO slug) → equals GET-reachability. No migration.
+- **Review (no BLOCKER)**: fixed N+1 on `/organizations/mine/` (new `EntitlementService.has_entitlement_for_organizations` bulk helper + `_MyMembershipListSerializer` batching; query-count test proves no linear scaling); hoisted late audit imports (no cycle).
+- Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, **full suite 4800 passed**. schema.yml regenerated.
+- Carry-forward: bulk helpers `EntitlementService.has_entitlement_for_organizations` + `is_branding_eligible_organizations` now exist. 3 redundant local `AuditService` imports remain in unrelated booking-policy mutations (out-of-scope cleanup).
+
 ## Current phase
 
-Phase 4 — Audit branding writes and expose the capability field.
+Phase 5 — Resolve branding for parentless organizations.
 
 ## Deferred phases
 

--- a/organizations/branding_logo.py
+++ b/organizations/branding_logo.py
@@ -25,7 +25,7 @@ from organizations.exceptions import BrandingLogoUploadRejectedError
 
 
 if TYPE_CHECKING:
-    from organizations.models import Organization
+    from organizations.models import Organization, OrganizationBranding
 
 
 # Reserved slug (also listed in `organizations.slug_validation._RESERVED_ROUTE_SLUGS`,
@@ -263,4 +263,43 @@ def sign_branding_logo_upload(
         "bucket": dest.get("bucket") or getattr(settings, "AWS_STORAGE_BUCKET_NAME", None),
         "endpoint": dest.get("endpoint") or getattr(settings, "AWS_S3_ENDPOINT_URL", None),
         "acl": dest.get("acl") or "public-read",
+    }
+
+
+def branding_diff_state(branding: OrganizationBranding | None) -> dict[str, str]:
+    """Field-level snapshot of an ``OrganizationBranding`` row for audit diffs
+    (Organization Auth-Area Branding plan, Phase 4).
+
+    Shared by both write surfaces -- ``organizations.views.OrganizationBrandingView``
+    (REST) and ``public_api.mutations.Mutation.update_branding`` (GraphQL) -- so
+    they feed ``audit.diff.compute_diff`` identically-shaped before/after states
+    rather than each re-deriving the field list.
+
+    ``logo`` is captured as its stored key (``FieldFile.name``, normalized to
+    ``""`` when unset) rather than the ``FieldFile`` object itself, so equality
+    comparison in ``compute_diff`` behaves like every other plain string field.
+
+    Returns an all-empty state (never ``None``) when ``branding`` is ``None`` --
+    the "before" side of a create, where there is no prior row to diff against.
+    Callers creating a fresh row should skip diffing entirely (an audit CREATE
+    record carries no diff) rather than feed this into ``compute_diff`` against
+    an all-empty "before", which would misrepresent a creation as an update of
+    every field from empty.
+    """
+    if branding is None:
+        return {
+            "app_name": "",
+            "logo": "",
+            "primary_color": "",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+    return {
+        "app_name": branding.app_name,
+        "logo": branding.logo.name or "",
+        "primary_color": branding.primary_color,
+        "secondary_color": branding.secondary_color,
+        "support_email": branding.support_email,
+        "redirect_url": branding.redirect_url,
     }

--- a/organizations/permissions.py
+++ b/organizations/permissions.py
@@ -1,4 +1,5 @@
 import enum
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated
 
 from dependency_injector.wiring import Provide, inject
@@ -49,6 +50,28 @@ def _organization_holds_white_label_branding(
     )
 
 
+@inject
+def _organizations_hold_white_label_branding(
+    organizations: Sequence[Organization],
+    entitlement_service: Annotated[EntitlementService, Provide["entitlement_service"]] = None,  # type: ignore[assignment]
+) -> dict[int, bool]:
+    """Bulk sibling of ``_organization_holds_white_label_branding``, backing
+    ``is_branding_eligible_organizations``. Same ``@inject``/``Provide``
+    fail-closed pattern: an unresolvable entitlement service denies every
+    organization in the batch rather than admitting any of it.
+
+    Deliberately does not go through ``has_entitlement_cached`` — the point of
+    this function is to answer for the whole batch in two queries, which
+    already beats what the per-organization request memo achieves for a batch
+    of distinct organizations.
+    """
+    if entitlement_service is None or not organizations:
+        return {}
+    return entitlement_service.has_entitlement_for_organizations(
+        organizations, Entitlement.WHITE_LABEL_BRANDING
+    )
+
+
 def is_branding_eligible_organization(organization: Organization | None) -> bool:
     """Shared branding-eligibility gate: ``organization`` has no parent AND holds
     the ``white_label_branding`` entitlement.
@@ -67,6 +90,33 @@ def is_branding_eligible_organization(organization: Organization | None) -> bool
     if organization is None or organization.parent_id is not None:
         return False
     return _organization_holds_white_label_branding(organization)
+
+
+def is_branding_eligible_organizations(organizations: Sequence[Organization]) -> dict[int, bool]:
+    """Bulk sibling of ``is_branding_eligible_organization``: the same
+    parentless-and-entitled check for many organizations, in two queries total
+    instead of two per organization.
+
+    Built for ``MyMembershipSerializer.get_can_manage_branding``, which
+    computes this per membership row on ``GET /organizations/mine/`` — one call
+    to ``is_branding_eligible_organization`` per row would pay a subscription
+    fetch plus entitlement-row fetch per distinct organization the caller
+    belongs to. Organizations with a parent are excluded from the entitlement
+    batch (same short-circuit as the single-organization function above) since
+    their answer is always ``False`` without needing an entitlement lookup at
+    all. See ``EntitlementService.has_entitlement_for_organizations`` for what
+    the batching itself looks like.
+
+    Returns ``{organization.pk: bool}`` for every organization passed in.
+    """
+    parentless = [organization for organization in organizations if organization.parent_id is None]
+    entitled_by_pk = _organizations_hold_white_label_branding(parentless)
+    return {
+        organization.pk: (
+            organization.parent_id is None and entitled_by_pk.get(organization.pk, False)
+        )
+        for organization in organizations
+    }
 
 
 class BrandingWriteGateReason(enum.Enum):

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -17,7 +17,10 @@ from organizations.models import (
     OrganizationMembership,
     OrganizationRole,
 )
-from organizations.permissions import is_branding_eligible_organization
+from organizations.permissions import (
+    is_branding_eligible_organization,
+    is_branding_eligible_organizations,
+)
 from organizations.redirect_url_validation import (
     validate_redirect_url as validate_redirect_url_rule,
 )
@@ -341,6 +344,31 @@ class OrganizationBriefSerializer(serializers.ModelSerializer):
         read_only_fields = ("id", "name", "slug")
 
 
+class _MyMembershipListSerializer(serializers.ListSerializer):
+    """Batches ``can_manage_branding`` for the whole membership list up front.
+
+    ``GET /organizations/mine/`` lists every active membership for the caller,
+    which can span N distinct organizations. Left to
+    ``MyMembershipSerializer.get_can_manage_branding`` calling
+    ``is_branding_eligible_organization`` per row, that would be N entitlement
+    lookups (see ``EntitlementService.has_entitlement_for_organizations`` for
+    what each one costs). This resolves the whole batch with
+    ``is_branding_eligible_organizations`` once, in two queries total, and
+    stashes the result on the shared serializer context so each child's
+    ``get_can_manage_branding`` reads from it instead of asking individually.
+    """
+
+    def to_representation(self, data):
+        iterable = data.all() if hasattr(data, "all") else data
+        memberships = list(iterable)
+        self.context["_can_manage_branding_by_organization_pk"] = (
+            is_branding_eligible_organizations(
+                [membership.organization for membership in memberships]
+            )
+        )
+        return super().to_representation(memberships)
+
+
 class MyMembershipSerializer(serializers.ModelSerializer):
     """Read-only serializer for the caller's active organization memberships.
 
@@ -357,6 +385,7 @@ class MyMembershipSerializer(serializers.ModelSerializer):
         model = OrganizationMembership
         fields = ("organization", "role", "can_manage_branding")
         read_only_fields = ("organization", "role", "can_manage_branding")
+        list_serializer_class = _MyMembershipListSerializer
 
     def get_can_manage_branding(self, obj: OrganizationMembership) -> bool:
         """Whether this membership's organization is branding-eligible
@@ -367,7 +396,18 @@ class MyMembershipSerializer(serializers.ModelSerializer):
         admin's, matching the read gate's own admin-agnostic eligibility
         check -- role-based write authorization is enforced separately by
         ``IsOrganizationAdmin`` on the branding endpoints themselves.
+
+        Reads from the batch ``_MyMembershipListSerializer`` precomputes on the
+        shared context when serializing a list (the ``many=True`` path this
+        serializer is actually used on). Falls back to the single-organization
+        ``is_branding_eligible_organization`` call when there is no such batch
+        in context (e.g. this serializer instantiated directly against one
+        membership), which is exactly what the batch entry would have computed
+        for that one organization anyway.
         """
+        batch = self.context.get("_can_manage_branding_by_organization_pk")
+        if batch is not None:
+            return batch.get(obj.organization_id, False)
         return is_branding_eligible_organization(obj.organization)
 
 

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -17,6 +17,7 @@ from organizations.models import (
     OrganizationMembership,
     OrganizationRole,
 )
+from organizations.permissions import is_branding_eligible_organization
 from organizations.redirect_url_validation import (
     validate_redirect_url as validate_redirect_url_rule,
 )
@@ -297,15 +298,31 @@ class CurrentMembershipSerializer(serializers.ModelSerializer):
     """
 
     organization = serializers.SerializerMethodField()
+    can_manage_branding = serializers.SerializerMethodField()
 
     class Meta:
         model = OrganizationMembership
-        fields = ("role", "organization")
-        read_only_fields = ("role", "organization")
+        fields = ("role", "organization", "can_manage_branding")
+        read_only_fields = ("role", "organization", "can_manage_branding")
 
     def get_organization(self, obj: OrganizationMembership) -> dict:
         """Serialize the related organization using OrganizationSerializer."""
         return OrganizationSerializer(obj.organization, context=self.context).data  # type: ignore[call-arg]
+
+    def get_can_manage_branding(self, obj: OrganizationMembership) -> bool:
+        """Whether the membership's organization is branding-eligible.
+
+        Computed as parentless-and-entitled -- deliberately excludes the slug
+        condition (Organization Auth-Area Branding plan, Phase 4 Capability
+        signal guiding decision), so an organization missing only a slug still
+        sees the branding page instead of it being silently absent. Shares
+        ``organizations.permissions.is_branding_eligible_organization`` rather
+        than restating the two-condition check, so this tracks the same gate
+        that governs ``GET /branding/`` (see
+        ``OrganizationBrandingView._check_branding_read_gate``) rather than
+        the three-condition write gate.
+        """
+        return is_branding_eligible_organization(obj.organization)
 
 
 class OrganizationBriefSerializer(serializers.ModelSerializer):
@@ -328,16 +345,30 @@ class MyMembershipSerializer(serializers.ModelSerializer):
     """Read-only serializer for the caller's active organization memberships.
 
     Used by ``GET /organizations/mine/`` to power the frontend org switcher.
-    Returns a list of ``{organization: {id, name}, role}`` entries — one per
-    active membership — without requiring the ``X-Organization-Id`` header.
+    Returns a list of ``{organization: {id, name}, role, can_manage_branding}``
+    entries — one per active membership — without requiring the
+    ``X-Organization-Id`` header.
     """
 
     organization = OrganizationBriefSerializer(read_only=True)
+    can_manage_branding = serializers.SerializerMethodField()
 
     class Meta:
         model = OrganizationMembership
-        fields = ("organization", "role")
-        read_only_fields = ("organization", "role")
+        fields = ("organization", "role", "can_manage_branding")
+        read_only_fields = ("organization", "role", "can_manage_branding")
+
+    def get_can_manage_branding(self, obj: OrganizationMembership) -> bool:
+        """Whether this membership's organization is branding-eligible
+        (parentless-and-entitled, excluding the slug condition) -- see
+        ``CurrentMembershipSerializer.get_can_manage_branding`` for the full
+        rationale. Computed per-membership (not per-role): a non-admin
+        member's entry reports the same organization-level capability as an
+        admin's, matching the read gate's own admin-agnostic eligibility
+        check -- role-based write authorization is enforced separately by
+        ``IsOrganizationAdmin`` on the branding endpoints themselves.
+        """
+        return is_branding_eligible_organization(obj.organization)
 
 
 class OrganizationMembershipSerializer(serializers.ModelSerializer):

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -29,6 +29,7 @@ from organizations.permissions import (
     is_branding_eligible_organization,
 )
 from organizations.redirect_url_validation import validate_redirect_url
+from organizations.serializers import CurrentMembershipSerializer, MyMembershipSerializer
 from payments.billing_constants import BillingState, Entitlement
 from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
 from users.factories import UserFactory
@@ -421,6 +422,108 @@ class TestEvaluateBrandingWriteGate:
 
         assert is_branding_eligible_organization(org) is True
         assert evaluate_branding_write_gate(org) is BrandingWriteGateReason.NO_SLUG
+
+
+@pytest.mark.django_db
+class TestCanManageBrandingCapabilityField:
+    """``can_manage_branding`` on ``CurrentMembershipSerializer`` and
+    ``MyMembershipSerializer`` (Organization Auth-Area Branding plan, Phase 4
+    Capability signal guiding decision).
+
+    Must track ``is_branding_eligible_organization`` (the two-condition,
+    parentless-and-entitled gate) exactly -- NOT ``evaluate_branding_write_gate``
+    (the three-condition write gate). The key regression this pins: a
+    parentless, entitled organization with NO slug still reports
+    ``can_manage_branding is True`` -- folding the slug condition in would hide
+    the branding page from exactly the admins who are one step away from using
+    it (spec: "Eligible org with no public identifier yet").
+    """
+
+    def _membership(self, organization: Organization, role: str = OrganizationRole.ADMIN):
+        user = baker.make(User)
+        return baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=organization,
+            role=role,
+            is_active=True,
+        )
+
+    def test_true_for_a_parentless_entitled_organization(self):
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None, slug="eligible-org"
+        )
+        membership = self._membership(org)
+
+        assert CurrentMembershipSerializer(membership).data["can_manage_branding"] is True
+        assert MyMembershipSerializer(membership).data["can_manage_branding"] is True
+
+    def test_true_for_a_parentless_entitled_organization_with_no_slug(self):
+        """The key case: NOT including the slug condition. Pins the split against
+        `evaluate_branding_write_gate`, which would return NO_SLUG (falsy) for
+        this exact organization."""
+        org = _org_with_entitlement(Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None)
+        assert org.slug is None
+        membership = self._membership(org)
+
+        assert CurrentMembershipSerializer(membership).data["can_manage_branding"] is True
+        assert MyMembershipSerializer(membership).data["can_manage_branding"] is True
+        # ... and pin the split explicitly: the three-condition gate refuses here.
+        assert evaluate_branding_write_gate(org) is BrandingWriteGateReason.NO_SLUG
+
+    def test_false_for_a_parented_organization(self):
+        parent_org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None, slug="parent-org-cap"
+        )
+        child_org = baker.make(Organization, parent=parent_org, slug="child-org-cap")
+        membership = self._membership(child_org)
+
+        assert CurrentMembershipSerializer(membership).data["can_manage_branding"] is False
+        assert MyMembershipSerializer(membership).data["can_manage_branding"] is False
+
+    def test_false_for_an_unentitled_organization(self):
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=False, parent=None, slug="free-plan-cap"
+        )
+        membership = self._membership(org)
+
+        assert CurrentMembershipSerializer(membership).data["can_manage_branding"] is False
+        assert MyMembershipSerializer(membership).data["can_manage_branding"] is False
+
+    def test_non_admin_membership_reports_the_same_org_level_capability(self):
+        """`can_manage_branding` is an organization-level fact, not a per-role
+        one -- a non-admin member's entry reports it identically to an admin's.
+        Write authorization (who may actually POST/PATCH) is a separate,
+        role-based check (`IsOrganizationAdmin`) on the branding endpoints
+        themselves."""
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None, slug="member-org-cap"
+        )
+        admin_membership = self._membership(org, role=OrganizationRole.ADMIN)
+        member_membership = self._membership(org, role=OrganizationRole.MEMBER)
+
+        assert (
+            CurrentMembershipSerializer(admin_membership).data["can_manage_branding"]
+            is CurrentMembershipSerializer(member_membership).data["can_manage_branding"]
+            is True
+        )
+
+    def test_tracks_the_shared_helper_rather_than_duplicating_it(self):
+        """Every case above is also directly pinned against
+        `is_branding_eligible_organization` itself, so a change to the shared
+        helper's semantics is guaranteed to move this field too."""
+        eligible = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=True, parent=None
+        )
+        ineligible = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING, is_enabled=False, parent=None
+        )
+
+        for org in (eligible, ineligible):
+            membership = self._membership(org)
+            expected = is_branding_eligible_organization(org)
+            assert CurrentMembershipSerializer(membership).data["can_manage_branding"] == expected
+            assert MyMembershipSerializer(membership).data["can_manage_branding"] == expected
 
 
 @pytest.mark.django_db

--- a/organizations/tests/test_branding_audit.py
+++ b/organizations/tests/test_branding_audit.py
@@ -1,0 +1,223 @@
+"""Audit-emission tests for the ``OrganizationBrandingView`` REST write paths
+(Organization Auth-Area Branding plan, Phase 4).
+
+Mirrors ``organizations/tests/test_audit.py``'s approach for ``OrganizationService``
+and ``public_api/tests/test_booking_policy_graphql.py``'s ``test_create_audited`` /
+``test_update_audited`` for the GraphQL surface: patch
+``audit.services.persist_audit_record``, drive the real endpoint through
+``django_capture_on_commit_callbacks(execute=True)``, and inspect the serialized
+payload(s) the enqueue call received.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from organizations.models import (
+    Organization,
+    OrganizationBranding,
+    OrganizationMembership,
+    OrganizationRole,
+)
+from users.factories import UserFactory
+
+
+BRANDING_URL = "/branding/"
+
+
+def _payloads(mock_task) -> list[dict]:
+    return [call.args[0] for call in mock_task.delay.call_args_list]
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def eligible_org():
+    """A parentless, entitled (autouse default subscription), slugged organization
+    -- admits both the write gate and this endpoint's admin permission once an
+    ADMIN membership is attached."""
+    return baker.make(Organization, can_invite_organizations=False, slug="audit-eligible-org")
+
+
+@pytest.fixture
+def admin_user(eligible_org):
+    user = UserFactory().create_user(email="brand-admin@example.com")
+    baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=eligible_org,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+    return user
+
+
+@pytest.mark.django_db
+class TestOrganizationBrandingViewAudit:
+    def _authed_client(self, client, user, organization) -> APIClient:
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(organization.id))
+        return client
+
+    def test_put_create_records_one_create_entry(
+        self, client, admin_user, eligible_org, django_capture_on_commit_callbacks
+    ):
+        """A first-time PUT (no existing row) writes exactly one CREATE audit
+        entry naming the acting organization and the admin's membership as
+        actor, with no diff."""
+        self._authed_client(client, admin_user, eligible_org)
+        payload = {
+            "app_name": "AuditApp",
+            "logo_url": "",
+            "primary_color": "#FF0000",
+            "secondary_color": "#00FF00",
+            "support_email": "support@example.com",
+            "redirect_url": "https://example.com/return",
+        }
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.put(BRANDING_URL, data=payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        payloads = _payloads(mock_task)
+        assert len(payloads) == 1
+        record = payloads[0]
+        assert record["organization_id"] == eligible_org.id
+        assert record["action"] == "create"
+        assert record["subject"]["subject_type"] == "organizations.OrganizationBranding"
+        assert record["actor"]["actor_type"] == "membership"
+        assert record["actor"]["actor_id"] == admin_user.id
+        assert record["actor"]["actor_role"] == OrganizationRole.ADMIN
+        assert record["diff"] is None
+
+    def test_put_over_existing_row_records_update_with_diff_of_changed_fields_only(
+        self, client, admin_user, eligible_org, django_capture_on_commit_callbacks
+    ):
+        """A PUT that replaces an existing row writes an UPDATE entry whose
+        diff names only the fields that actually changed -- an unchanged field
+        (``support_email`` here) is absent from the diff."""
+        baker.make(
+            OrganizationBranding,
+            organization=eligible_org,
+            app_name="Before",
+            primary_color="#111111",
+            secondary_color="#222222",
+            support_email="same@example.com",
+            redirect_url="https://example.com/before",
+        )
+        self._authed_client(client, admin_user, eligible_org)
+        payload = {
+            "app_name": "After",
+            "logo_url": "",
+            "primary_color": "#333333",
+            "secondary_color": "#222222",
+            "support_email": "same@example.com",
+            "redirect_url": "https://example.com/before",
+        }
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.put(BRANDING_URL, data=payload, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        payloads = _payloads(mock_task)
+        assert len(payloads) == 1
+        record = payloads[0]
+        assert record["action"] == "update"
+        diff = record["diff"]
+        assert diff is not None
+        assert set(diff.keys()) == {"app_name", "primary_color"}
+        assert diff["app_name"] == {"old": "Before", "new": "After"}
+        assert diff["primary_color"] == {"old": "#111111", "new": "#333333"}
+
+    def test_patch_records_update_with_diff_of_changed_fields_only(
+        self, client, admin_user, eligible_org, django_capture_on_commit_callbacks
+    ):
+        baker.make(
+            OrganizationBranding,
+            organization=eligible_org,
+            app_name="Same",
+            primary_color="#111111",
+            secondary_color="#222222",
+            support_email="same@example.com",
+            redirect_url="https://example.com/before",
+        )
+        self._authed_client(client, admin_user, eligible_org)
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.patch(
+                    BRANDING_URL, data={"secondary_color": "#444444"}, format="json"
+                )
+
+        assert response.status_code == status.HTTP_200_OK
+        payloads = _payloads(mock_task)
+        assert len(payloads) == 1
+        record = payloads[0]
+        assert record["action"] == "update"
+        diff = record["diff"]
+        assert diff is not None
+        assert set(diff.keys()) == {"secondary_color"}
+        assert diff["secondary_color"] == {"old": "#222222", "new": "#444444"}
+
+    def test_refused_write_records_nothing(self, client, django_capture_on_commit_callbacks):
+        """A write refused by the branding gate (here: an organization with a
+        parent) records NO audit entry -- the gate raises before the write, so
+        the audit call is never reached."""
+        parent_org = baker.make(Organization, can_invite_organizations=False, slug="audit-parent")
+        child_org = baker.make(Organization, parent=parent_org, slug="audit-child")
+        user = UserFactory().create_user(email="child-admin@example.com")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=child_org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        self._authed_client(client, user, child_org)
+        payload = {
+            "app_name": "ShouldNotPersist",
+            "logo_url": "",
+            "primary_color": "",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.put(BRANDING_URL, data=payload, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not mock_task.delay.called
+        assert not OrganizationBranding.objects.filter(organization=child_org).exists()
+
+    def test_refused_write_via_validation_error_records_nothing(
+        self, client, admin_user, eligible_org, django_capture_on_commit_callbacks
+    ):
+        """A write that passes the gate but fails serializer validation (an
+        invalid color format here) also records nothing -- the validation
+        error raises before the upsert."""
+        self._authed_client(client, admin_user, eligible_org)
+        payload = {
+            "app_name": "Invalid",
+            "logo_url": "",
+            "primary_color": "not-a-color",
+            "secondary_color": "",
+            "support_email": "",
+            "redirect_url": "",
+        }
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                response = client.put(BRANDING_URL, data=payload, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not mock_task.delay.called

--- a/organizations/tests/test_branding_rest.py
+++ b/organizations/tests/test_branding_rest.py
@@ -2,6 +2,8 @@ import datetime
 import json
 
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
@@ -1220,3 +1222,43 @@ class TestCanManageBrandingOnMembershipPayload:
         current_response = client.get(self._current_url())
         assert_response_status_code(current_response, status.HTTP_200_OK)
         assert current_response.json()["can_manage_branding"] is True
+
+    def test_mine_endpoint_entitlement_queries_do_not_scale_with_membership_count(self):
+        """Reviewer finding: the N+1-shaped entitlement lookup on
+        ``GET /organizations/mine/`` -- ``MyMembershipSerializer.get_can_manage_branding``
+        used to call ``is_branding_eligible_organization`` once per membership
+        row, so the number of subscription/entitlement queries scaled linearly
+        with the caller's distinct-org membership count. Batched via
+        ``is_branding_eligible_organizations`` /
+        ``EntitlementService.has_entitlement_for_organizations``: the number of
+        ``payments_subscription`` queries the endpoint issues must stay the
+        same regardless of how many organizations the caller belongs to."""
+
+        def _subscription_query_count(organization_count: int) -> int:
+            caller = baker.make(User)
+            for index in range(organization_count):
+                org = baker.make(
+                    Organization,
+                    can_invite_organizations=False,
+                    slug=f"batch-org-{organization_count}-{index}",
+                )
+                baker.make(
+                    OrganizationMembership,
+                    user=caller,
+                    organization=org,
+                    role=OrganizationRole.ADMIN,
+                    is_active=True,
+                )
+            local_client = APIClient()
+            local_client.force_authenticate(caller)
+            with CaptureQueriesContext(connection) as captured:
+                response = local_client.get(self._mine_url())
+            assert_response_status_code(response, status.HTTP_200_OK)
+            assert len(response.json()) == organization_count
+            return sum(
+                1 for query in captured.captured_queries if "payments_subscription" in query["sql"]
+            )
+
+        small_batch_query_count = _subscription_query_count(2)
+        large_batch_query_count = _subscription_query_count(5)
+        assert small_batch_query_count == large_batch_query_count

--- a/organizations/tests/test_branding_rest.py
+++ b/organizations/tests/test_branding_rest.py
@@ -2,6 +2,7 @@ import datetime
 import json
 
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 from django.utils import timezone
 
 import pytest
@@ -1113,3 +1114,109 @@ class TestResellerNowRequiresASlug:
         # passed, and the endpoint fell through to the "no row yet" branch.
         response = client.get(BRANDING_URL)
         assert_response_status_code(response, status.HTTP_404_NOT_FOUND)
+
+
+@pytest.mark.django_db
+class TestCanManageBrandingOnMembershipPayload:
+    """``can_manage_branding`` on the membership payloads the SPA already
+    fetches (``GET /organizations/current/`` and ``GET /organizations/mine/``)
+    -- Organization Auth-Area Branding plan, Phase 4 Capability signal.
+
+    Covers all four write-gate cases named in the phase spec, plus the
+    no-slug-but-eligible case that is the whole point of the field (it must
+    read ``True`` there, unlike the write gate itself)."""
+
+    def _current_url(self):
+        return reverse("api:Organizations-current")
+
+    def _mine_url(self):
+        return reverse("api:Organizations-mine")
+
+    def test_eligible_org_reports_true(self, client, user, eligible_org, eligible_org_admin):
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        current_response = client.get(self._current_url())
+        assert_response_status_code(current_response, status.HTTP_200_OK)
+        assert current_response.json()["can_manage_branding"] is True
+
+        mine_response = client.get(self._mine_url())
+        assert_response_status_code(mine_response, status.HTTP_200_OK)
+        [entry] = mine_response.json()
+        assert entry["can_manage_branding"] is True
+
+    def test_eligible_org_with_no_slug_still_reports_true(self, client, user, no_slug_org):
+        """The key case: an org one write-gate step away (missing only a slug)
+        must still report `can_manage_branding=True` -- see the plan's
+        Capability signal guiding decision. Distinguishes this field from the
+        write gate, which would refuse this exact organization."""
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=no_slug_org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(no_slug_org.id))
+
+        current_response = client.get(self._current_url())
+        assert_response_status_code(current_response, status.HTTP_200_OK)
+        assert current_response.json()["can_manage_branding"] is True
+
+    def test_parented_org_reports_false(self, client, user, parented_org):
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=parented_org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(parented_org.id))
+
+        current_response = client.get(self._current_url())
+        assert_response_status_code(current_response, status.HTTP_200_OK)
+        assert current_response.json()["can_manage_branding"] is False
+
+        mine_response = client.get(self._mine_url())
+        assert_response_status_code(mine_response, status.HTTP_200_OK)
+        [entry] = mine_response.json()
+        assert entry["can_manage_branding"] is False
+
+    @pytest.mark.no_auto_subscription
+    def test_free_plan_org_reports_false(self, client, user):
+        free_org = _make_unentitled_org(parent=None, slug="free-cap-org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=free_org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(free_org.id))
+
+        current_response = client.get(self._current_url())
+        assert_response_status_code(current_response, status.HTTP_200_OK)
+        assert current_response.json()["can_manage_branding"] is False
+
+        mine_response = client.get(self._mine_url())
+        assert_response_status_code(mine_response, status.HTTP_200_OK)
+        [entry] = mine_response.json()
+        assert entry["can_manage_branding"] is False
+
+    def test_non_admin_member_of_an_eligible_org_still_reports_true(
+        self, client, eligible_org, eligible_org_member
+    ):
+        """A non-admin member's payload reports the same organization-level
+        capability as an admin's -- `can_manage_branding` is not gated by the
+        caller's own role, only by the organization's eligibility. Write
+        authorization stays role-gated separately, on the branding endpoints
+        themselves (`IsOrganizationAdmin`)."""
+        client.force_authenticate(eligible_org_member)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        current_response = client.get(self._current_url())
+        assert_response_status_code(current_response, status.HTTP_200_OK)
+        assert current_response.json()["can_manage_branding"] is True

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -21,6 +21,9 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from audit.constants import AuditAction
+from audit.diff import compute_diff
+from audit.services import AuditService
 from calendar_integration.models import GoogleCalendarServiceAccount
 from calendar_integration.serializers import CalendarSyncRequestSerializer
 from common.media_storage_backend import MediaStorage
@@ -37,6 +40,7 @@ from organizations.branding_logo import (
     DEFAULT_LOGO_ETAG_IDENTITY,
     DEFAULT_LOGO_SLUG_SENTINEL,
     LOGO_CACHE_MAX_AGE_SECONDS,
+    branding_diff_state,
     compute_logo_etag,
     guess_logo_content_type,
 )
@@ -1032,6 +1036,16 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
     permission_classes = (IsOrganizationAdmin,)
     serializer_class = OrganizationBrandingSerializer
 
+    @inject
+    def __init__(
+        self,
+        *args,
+        audit_service: Annotated[AuditService, Provide["audit_service"]],
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.audit_service = audit_service
+
     _GATE_EXCEPTIONS: ClassVar[dict[BrandingWriteGateReason, type[PermissionDenied]]] = {
         BrandingWriteGateReason.HAS_PARENT: OrganizationHasParentBrandingError,
         BrandingWriteGateReason.NOT_ENTITLED: BrandingEntitlementRequiredError,
@@ -1123,7 +1137,15 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         },
     )
     def put(self, request, *args, **kwargs):
-        """PUT /branding/ — create or replace the acting org's branding."""
+        """PUT /branding/ — create or replace the acting org's branding.
+
+        Audited (Organization Auth-Area Branding plan, Phase 4): a refused write
+        (gate failure or serializer validation error) raises before this method
+        reaches the upsert, so nothing is ever recorded for a refused write. A
+        first-time upsert records a CREATE with no diff; an upsert that replaces
+        an existing row records an UPDATE with a diff naming only the fields that
+        actually changed, using the before-state captured BEFORE the write.
+        """
         self._check_branding_write_gate()
         membership = get_active_organization_membership(request.user)
         if membership is None:
@@ -1132,11 +1154,18 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         serializer = OrganizationBrandingSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
 
+        existing = OrganizationBranding.objects.filter(
+            organization_id=membership.organization_id
+        ).first()
+        before = branding_diff_state(existing) if existing is not None else None
+
         # Create or update (upsert) the branding row for the acting org
         instance, created = OrganizationBranding.objects.update_or_create(
             organization_id=membership.organization_id,
             defaults=serializer.validated_data,
         )
+
+        self._record_branding_audit(membership, instance, created=created, before=before)
 
         status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response(
@@ -1157,9 +1186,18 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         },
     )
     def patch(self, request, *args, **kwargs):
-        """PATCH /branding/ — update the acting org's branding (partial)."""
+        """PATCH /branding/ — update the acting org's branding (partial).
+
+        Audited (Organization Auth-Area Branding plan, Phase 4): a refused write
+        (gate failure, 404-not-configured, or serializer validation error) raises
+        before this method reaches ``serializer.save()``, so nothing is ever
+        recorded for a refused write. Always an UPDATE (PATCH never creates —
+        see ``_get_branding_or_404``); the before-state is captured BEFORE
+        ``serializer.save()`` mutates ``instance`` in place.
+        """
         self._check_branding_write_gate()
         instance = self._get_branding_or_404()
+        before = branding_diff_state(instance)
 
         serializer = OrganizationBrandingSerializer(
             instance, data=request.data, partial=True, context={"request": request}
@@ -1167,7 +1205,46 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise PermissionDenied("No active organization membership.")
+        self._record_branding_audit(membership, instance, created=False, before=before)
+
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def _record_branding_audit(
+        self,
+        membership: OrganizationMembership,
+        instance: OrganizationBranding,
+        *,
+        created: bool,
+        before: dict[str, str] | None,
+    ) -> None:
+        """Emit the ``AuditService`` CREATE/UPDATE record for a successful
+        branding write. Actor is the acting admin's membership (mirrors
+        ``OrganizationService.create_organization``'s actor derivation for an
+        org-level write). ``UPDATE`` carries a diff naming only the fields that
+        changed; ``CREATE`` carries none."""
+        actor = self.audit_service.actor_from_membership(membership)
+        subject = self.audit_service.subject_from_instance(instance, label=instance.app_name)
+        if created:
+            self.audit_service.record(
+                organization_id=membership.organization_id,
+                action=AuditAction.CREATE,
+                actor=actor,
+                subject=subject,
+            )
+            return
+
+        after = branding_diff_state(instance)
+        diff = compute_diff(before or {}, after)
+        self.audit_service.record(
+            organization_id=membership.organization_id,
+            action=AuditAction.UPDATE,
+            actor=actor,
+            subject=subject,
+            diff=diff,
+        )
 
 
 @extend_schema(tags=["Branding"])

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -35,7 +35,12 @@ from payments.billing_constants import (
     LimitRemedy,
 )
 from payments.exceptions import InapplicableInvitationExclusionError, OverLimitError
-from payments.models import MeteredOccurrence, PaymentMethod, Subscription
+from payments.models import (
+    MeteredOccurrence,
+    PaymentMethod,
+    Subscription,
+    SubscriptionEntitlement,
+)
 from payments.services.billing_dataclasses import EffectiveLimit, LimitCheckResult
 from payments.services.subscription_service import (
     current_billing_period_start,
@@ -827,6 +832,62 @@ class EntitlementService:
             return False
         entitlement = subscription.entitlements.filter(entitlement_key=entitlement_key).first()
         return entitlement is not None and entitlement.is_enabled
+
+    def has_entitlement_for_organizations(
+        self, organizations: Sequence[Organization], entitlement_key: str
+    ) -> dict[int, bool]:
+        """Bulk ``has_entitlement``: the same fail-closed boolean gate for many
+        organizations, in two queries total instead of two per organization.
+
+        Built for list endpoints that compute a per-row entitlement-derived field
+        (e.g. ``MyMembershipSerializer.get_can_manage_branding`` across a
+        caller's memberships) — calling ``has_entitlement`` once per row would
+        pay a full subscription fetch plus entitlement-row fetch per distinct
+        organization.
+
+        Billing-root resolution stays per-organization (``resolve_billing_root``,
+        unchanged): it is a ``parent``-chain walk, not something that batches
+        into a single query, and it costs nothing extra for a parentless
+        organization (the common case for callers that already filtered to
+        roots, like ``is_branding_eligible_organization``) — only a genuinely
+        nested chain triggers a query. What this method batches is the
+        subscription fetch and the entitlement-row fetch, which
+        ``has_entitlement`` otherwise repeats per organization.
+
+        Returns ``{organization.pk: bool}`` for every organization passed in.
+        An organization whose billing root has no resolvable subscription reads
+        ``False`` (same fail-closed behavior as ``has_entitlement``), but unlike
+        ``has_entitlement`` this does not log a warning per organization — doing
+        so would make a list endpoint log once per row for a state that is
+        normal at this call site, not the broken-invariant signal the warning
+        is meant to be on the single-organization path.
+        """
+        roots_by_organization_pk = {
+            organization.pk: resolve_billing_root(organization) for organization in organizations
+        }
+        root_ids = {root.pk for root in roots_by_organization_pk.values()}
+        if not root_ids:
+            return {}
+        subscription_by_root_id = {
+            subscription.organization_id: subscription
+            for subscription in Subscription.objects.filter(organization_id__in=root_ids)
+        }
+        granted_subscription_ids = set(
+            SubscriptionEntitlement.objects.filter(
+                subscription_id__in=[
+                    subscription.pk for subscription in subscription_by_root_id.values()
+                ],
+                entitlement_key=entitlement_key,
+                is_enabled=True,
+            ).values_list("subscription_id", flat=True)
+        )
+        result: dict[int, bool] = {}
+        for organization_pk, root in roots_by_organization_pk.items():
+            subscription = subscription_by_root_id.get(root.pk)
+            result[organization_pk] = (
+                subscription is not None and subscription.pk in granted_subscription_ids
+            )
+        return result
 
     def _resolve_remedy_for(
         self, subscription: Subscription | None, effective_limit: EffectiveLimit

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -47,6 +47,7 @@ from calendar_integration.services.dataclasses import (
     ResourceAllocationInputData,
 )
 from organizations.branding_logo import (
+    branding_diff_state,
     build_logo_delivery_url,
     normalize_uploaded_logo_key,
     sign_branding_logo_upload,
@@ -100,6 +101,7 @@ if TYPE_CHECKING:
 
 
 if TYPE_CHECKING:
+    from audit.services import AuditService
     from calendar_integration.services.booking_policy_permission_service import (
         BookingPolicyPermissionService,
     )
@@ -262,6 +264,21 @@ def get_booking_policy_permission_service(
     if booking_policy_permission_service is None:
         raise GraphQLError("Missing required dependency: booking_policy_permission_service")
     return booking_policy_permission_service
+
+
+@inject
+def get_audit_service(
+    audit_service: Annotated["AuditService | None", Provide["audit_service"]] = None,
+) -> "AuditService":
+    """Resolve the AuditService from the DI container.
+
+    Used by mutations that write directly (no dedicated service layer holding
+    its own injected ``audit_service``) -- e.g. ``update_branding`` -- mirroring
+    ``get_booking_policy_mutation_dependencies``'s resolve-or-raise shape.
+    """
+    if audit_service is None:
+        raise GraphQLError("Missing required dependency: audit_service")
+    return audit_service
 
 
 def _get_org_and_init_calendar_service(
@@ -1334,11 +1351,31 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         than partially applying (see the plan's Slug is a precondition for
         branding guiding decision).
 
+        Audited (Organization Auth-Area Branding plan, Phase 4): every raise
+        above (slug rejection, gate failure, field validation) happens before
+        the upsert and rolls back the whole atomic block, so a refused write
+        never reaches the audit call below -- nothing is recorded for it. A
+        first-time upsert records a CREATE with no diff; an upsert that
+        replaces an existing row records an UPDATE with a diff naming only the
+        fields that changed, using the before-state captured BEFORE the
+        transaction starts. Actor is the token's system user
+        (``AuditService.actor_from_system_user``), matching the actor
+        derivation already used by the BookingPolicy partner-API mutations.
+
         The token's OrganizationResourceAccess must include the BRANDING resource.
         """
+        from audit.constants import AuditAction
+        from audit.diff import compute_diff
+        from audit.services import AuditService
+
         acting_org = info.context.request.public_api_organization
         if not acting_org:
             raise GraphQLError("Organization not found")
+
+        existing_branding = OrganizationBranding.objects.filter(organization=acting_org).first()
+        before_state = (
+            branding_diff_state(existing_branding) if existing_branding is not None else None
+        )
 
         with transaction.atomic():
             # Slug application happens BEFORE the gate is evaluated so a
@@ -1390,7 +1427,7 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                 raise GraphQLError(str(e)) from e
 
             # Upsert branding on the acting org (always acts on acting org, never another org)
-            branding, _ = OrganizationBranding.objects.update_or_create(
+            branding, created = OrganizationBranding.objects.update_or_create(
                 organization=acting_org,
                 defaults={
                     "app_name": input.app_name,
@@ -1400,6 +1437,27 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
                     "support_email": input.support_email,
                     "redirect_url": input.redirect_url,
                 },
+            )
+
+        audit_service = get_audit_service()
+        actor = AuditService.actor_from_system_user(info.context.request.public_api_system_user)
+        subject = audit_service.subject_from_instance(branding, label=branding.app_name)
+        if created:
+            audit_service.record(
+                organization_id=acting_org.id,
+                action=AuditAction.CREATE,
+                actor=actor,
+                subject=subject,
+            )
+        else:
+            after_state = branding_diff_state(branding)
+            diff = compute_diff(before_state or {}, after_state)
+            audit_service.record(
+                organization_id=acting_org.id,
+                action=AuditAction.UPDATE,
+                actor=actor,
+                subject=subject,
+                diff=diff,
             )
 
         # Return the branding without internal fields (no support_email, no redirect_url).

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -14,6 +14,9 @@ import strawberry
 from dependency_injector.wiring import Provide, inject
 from graphql import GraphQLError
 
+from audit.constants import AuditAction
+from audit.diff import compute_diff
+from audit.services import AuditService
 from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import (
     BookingPolicyViolationError,
@@ -101,7 +104,6 @@ if TYPE_CHECKING:
 
 
 if TYPE_CHECKING:
-    from audit.services import AuditService
     from calendar_integration.services.booking_policy_permission_service import (
         BookingPolicyPermissionService,
     )
@@ -1364,10 +1366,6 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
 
         The token's OrganizationResourceAccess must include the BRANDING resource.
         """
-        from audit.constants import AuditAction
-        from audit.diff import compute_diff
-        from audit.services import AuditService
-
         acting_org = info.context.request.public_api_organization
         if not acting_org:
             raise GraphQLError("Organization not found")

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -1424,6 +1424,18 @@ class TestCreateSystemUserTokenMutation:
         assert "subtree" in str(data["errors"]).lower()
 
 
+UPDATE_BRANDING_MUTATION = """
+mutation UpdateBranding($input: UpdateBrandingInput!) {
+    updateBranding(input: $input) {
+        branding {
+            id
+            appName
+        }
+    }
+}
+"""
+
+
 @pytest.mark.django_db
 class TestUpdateBranding:
     """Test updateBranding mutation."""
@@ -2148,6 +2160,155 @@ class TestUpdateBranding:
         assert OrganizationBranding.objects.filter(organization=reseller_a).count() == 1
         # Verify there is exactly one branding row for B
         assert OrganizationBranding.objects.filter(organization=reseller_b).count() == 1
+
+    def test_update_branding_create_records_one_create_entry(
+        self, django_capture_on_commit_callbacks
+    ):
+        """A first-time updateBranding call (no existing row) writes exactly
+        one CREATE audit entry, actor is the token's system user, no diff
+        (Organization Auth-Area Branding plan, Phase 4)."""
+        from di_core.containers import container
+
+        org = baker.make(
+            Organization, name="Audit Org", can_invite_organizations=False, slug="audit-gql-org"
+        )
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="branding_audit_integration", organization=org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                with container.public_api_auth_service.override(auth_service):
+                    response = self.client.post(
+                        "/graphql/",
+                        data={
+                            "query": UPDATE_BRANDING_MUTATION,
+                            "variables": {"input": {"appName": "AuditApp"}},
+                        },
+                        format="json",
+                        headers={"authorization": f"Bearer {system_user.id}:{token}"},
+                    )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or not data["errors"], data
+
+        payloads = [call.args[0] for call in mock_task.delay.call_args_list]
+        assert len(payloads) == 1
+        record = payloads[0]
+        assert record["organization_id"] == org.id
+        assert record["action"] == "create"
+        assert record["subject"]["subject_type"] == "organizations.OrganizationBranding"
+        assert record["actor"]["actor_type"] == "system_user"
+        assert record["actor"]["actor_id"] == system_user.id
+        assert record["diff"] is None
+
+    def test_update_branding_update_records_diff_of_changed_fields_only(
+        self, django_capture_on_commit_callbacks
+    ):
+        """A subsequent updateBranding call over an existing row writes an
+        UPDATE audit entry whose diff names only the fields that actually
+        changed."""
+        from di_core.containers import container
+
+        org = baker.make(
+            Organization,
+            name="Audit Org 2",
+            can_invite_organizations=False,
+            slug="audit-gql-org-2",
+        )
+        baker.make(
+            OrganizationBranding,
+            organization=org,
+            app_name="Before",
+            primary_color="#111111",
+            secondary_color="#222222",
+            support_email="same@example.com",
+            redirect_url="https://example.com/before",
+        )
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="branding_audit_integration_2", organization=org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                with container.public_api_auth_service.override(auth_service):
+                    response = self.client.post(
+                        "/graphql/",
+                        data={
+                            "query": UPDATE_BRANDING_MUTATION,
+                            "variables": {
+                                "input": {
+                                    "appName": "After",
+                                    "primaryColor": "#111111",
+                                    "secondaryColor": "#222222",
+                                    "supportEmail": "same@example.com",
+                                    "redirectUrl": "https://example.com/before",
+                                }
+                            },
+                        },
+                        format="json",
+                        headers={"authorization": f"Bearer {system_user.id}:{token}"},
+                    )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or not data["errors"], data
+
+        payloads = [call.args[0] for call in mock_task.delay.call_args_list]
+        assert len(payloads) == 1
+        record = payloads[0]
+        assert record["action"] == "update"
+        diff = record["diff"]
+        assert diff is not None
+        assert set(diff.keys()) == {"app_name"}
+        assert diff["app_name"] == {"old": "Before", "new": "After"}
+
+    def test_update_branding_refused_write_records_nothing(
+        self, django_capture_on_commit_callbacks
+    ):
+        """A write refused by the write gate (here: a parented organization)
+        records NO audit entry."""
+        from di_core.containers import container
+
+        parent_org = baker.make(
+            Organization, name="Audit Parent", can_invite_organizations=False, parent=None
+        )
+        child_org = baker.make(
+            Organization,
+            name="Audit Child",
+            can_invite_organizations=False,
+            parent=parent_org,
+            slug="audit-child-org",
+        )
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="branding_audit_refused", organization=child_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
+
+        with patch("audit.services.persist_audit_record") as mock_task:
+            with django_capture_on_commit_callbacks(execute=True):
+                with container.public_api_auth_service.override(auth_service):
+                    response = self.client.post(
+                        "/graphql/",
+                        data={
+                            "query": UPDATE_BRANDING_MUTATION,
+                            "variables": {"input": {"appName": "ShouldNotPersist"}},
+                        },
+                        format="json",
+                        headers={"authorization": f"Bearer {system_user.id}:{token}"},
+                    )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert not mock_task.delay.called
+        assert not OrganizationBranding.objects.filter(organization=child_org).exists()
 
 
 UPDATE_BRANDING_WITH_SLUG_MUTATION = """

--- a/schema.yml
+++ b/schema.yml
@@ -3546,7 +3546,13 @@ paths:
   /branding/:
     get:
       operationId: branding_retrieve
-      description: GET /branding/ — retrieve the acting org's branding.
+      description: |-
+        GET /branding/ — retrieve the acting org's branding.
+
+        Uses the two-condition eligibility gate, not the full write gate: a
+        slug-less-but-otherwise-eligible org is admitted here (and falls
+        through to the normal 404-no-row-yet / 200-with-a-row branch below)
+        -- see ``_check_branding_read_gate``.
       summary: Retrieve the acting organization's branding
       parameters:
       - in: header
@@ -3572,13 +3578,22 @@ paths:
                 $ref: '#/components/schemas/OrganizationBranding'
           description: ''
         '403':
-          description: Organization has a parent, lacks the entitlement, or has no
-            slug; or not an admin
+          description: Organization has a parent or lacks the entitlement; or not
+            an admin. A slug-less-but-otherwise-eligible org is NOT refused here --
+            see 404.
         '404':
           description: Branding not yet configured
     put:
       operationId: branding_update
-      description: PUT /branding/ — create or replace the acting org's branding.
+      description: |-
+        PUT /branding/ — create or replace the acting org's branding.
+
+        Audited (Organization Auth-Area Branding plan, Phase 4): a refused write
+        (gate failure or serializer validation error) raises before this method
+        reaches the upsert, so nothing is ever recorded for a refused write. A
+        first-time upsert records a CREATE with no diff; an upsert that replaces
+        an existing row records an UPDATE with a diff naming only the fields that
+        actually changed, using the before-state captured BEFORE the write.
       summary: Create or replace the acting organization's branding
       parameters:
       - in: header
@@ -3628,7 +3643,15 @@ paths:
             slug; or not an admin
     patch:
       operationId: branding_partial_update
-      description: PATCH /branding/ — update the acting org's branding (partial).
+      description: |-
+        PATCH /branding/ — update the acting org's branding (partial).
+
+        Audited (Organization Auth-Area Branding plan, Phase 4): a refused write
+        (gate failure, 404-not-configured, or serializer validation error) raises
+        before this method reaches ``serializer.save()``, so nothing is ever
+        recorded for a refused write. Always an UPDATE (PATCH never creates —
+        see ``_get_branding_or_404``); the before-state is captured BEFORE
+        ``serializer.save()`` mutates ``instance`` in place.
       summary: Update the acting organization's branding (partial)
       parameters:
       - in: header
@@ -14555,7 +14578,23 @@ components:
           additionalProperties: {}
           description: Serialize the related organization using OrganizationSerializer.
           readOnly: true
+        can_manage_branding:
+          type: boolean
+          description: |-
+            Whether the membership's organization is branding-eligible.
+
+            Computed as parentless-and-entitled -- deliberately excludes the slug
+            condition (Organization Auth-Area Branding plan, Phase 4 Capability
+            signal guiding decision), so an organization missing only a slug still
+            sees the branding page instead of it being silently absent. Shares
+            ``organizations.permissions.is_branding_eligible_organization`` rather
+            than restating the two-condition check, so this tracks the same gate
+            that governs ``GET /branding/`` (see
+            ``OrganizationBrandingView._check_branding_read_gate``) rather than
+            the three-condition write gate.
+          readOnly: true
       required:
+      - can_manage_branding
       - organization
       - role
     DocumentTypeEnum:
@@ -14891,8 +14930,9 @@ components:
         Read-only serializer for the caller's active organization memberships.
 
         Used by ``GET /organizations/mine/`` to power the frontend org switcher.
-        Returns a list of ``{organization: {id, name}, role}`` entries — one per
-        active membership — without requiring the ``X-Organization-Id`` header.
+        Returns a list of ``{organization: {id, name}, role, can_manage_branding}``
+        entries — one per active membership — without requiring the
+        ``X-Organization-Id`` header.
       properties:
         organization:
           allOf:
@@ -14907,7 +14947,20 @@ components:
 
             * `member` - Member
             * `admin` - Admin
+        can_manage_branding:
+          type: boolean
+          description: |-
+            Whether this membership's organization is branding-eligible
+            (parentless-and-entitled, excluding the slug condition) -- see
+            ``CurrentMembershipSerializer.get_can_manage_branding`` for the full
+            rationale. Computed per-membership (not per-role): a non-admin
+            member's entry reports the same organization-level capability as an
+            admin's, matching the read gate's own admin-agnostic eligibility
+            check -- role-based write authorization is enforced separately by
+            ``IsOrganizationAdmin`` on the branding endpoints themselves.
+          readOnly: true
       required:
+      - can_manage_branding
       - organization
       - role
     Notification:


### PR DESCRIPTION
## Phase 4 — Audit branding writes and expose the capability field

Fifth phase of the [Organization Auth-Area Branding plan](../blob/main/ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md). Every branding write is recorded with a diff, and the dashboard can tell whether to show the branding page without probing.

> **Stacked on [#209](https://github.com/vintasoftware/vinta-schedule-api/pull/209) (Phase 3).** Review this diff against that branch.

### What's in it
- **Audit** — `OrganizationBrandingView` (PUT/PATCH) and GraphQL `updateBranding` record branding **create** (no diff) and **update** (diff of changed fields only) through `AuditService.record`, actor derived per surface (`actor_from_membership` for REST, `actor_from_system_user` for the partner API), subject = the branding row. A refused write (gate or validation failure) records **nothing** — the audit call is unreachable when the write doesn't happen, and the GraphQL path defers via `transaction.on_commit` so a rolled-back atomic block never enqueues.
- **`can_manage_branding`** — read-only field on `CurrentMembershipSerializer` and `MyMembershipSerializer`, computed as **parentless-and-entitled** via the shared `is_branding_eligible_organization` helper. Deliberately **excludes the slug condition** so it exactly equals Phase 3's GET read-gate reachability: a slug-less parentless entitled org gets `true`, so the SPA renders the branding page and shows the "pick a slug first" prompt rather than hiding a page from the admins one step away.
- Shared `branding_diff_state()` snapshot helper (all six mutable fields; `logo` normalized to its stored key). No migration (audit uses the existing model; the field is computed).

### Tests
`can_manage_branding` true only for parentless+entitled (incl. slug-less), false for parented/free; audit create + update-diff (PUT and PATCH) name only changed fields; refused writes record nothing on both surfaces; membership payload carries the field across all gate cases. Full suite: **4800 passed**.

### Review notes (Tier 3 / sonnet)
No BLOCKER. Verified holding: audit diff ordering (PATCH before-state captured strictly before mutation), refused-write-records-nothing on both surfaces, `can_manage_branding` == the two-condition helper == GET-reachability, correct actor + org on each record. Two SHOULD-FIXes fixed:
- **N+1 on `GET /organizations/mine/`** — the per-row entitlement lookup is now batched via a new `EntitlementService.has_entitlement_for_organizations` bulk helper + a `ListSerializer` that resolves eligibility once for the whole list; a query-count test asserts entitlement queries don't scale with membership count (parented orgs short-circuit before any entitlement query).
- **Late imports** in `mutations.py` hoisted to module top (confirmed no import cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2)_