### PR TITLE
feat: route branded invitation replies to the organization support address (Phase 6 — auth branding)

### DIFF
--- a/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
+++ b/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
@@ -59,7 +59,7 @@ Command translation (container → host):
 | 3 | Widen write gate | 3 | ✅ done — [PR #209](https://github.com/vintasoftware/vinta-schedule-api/pull/209) | plan/organization-auth-branding/phase-3 |
 | 4 | Audit + capability field | 2 | ✅ done — [PR #210](https://github.com/vintasoftware/vinta-schedule-api/pull/210) | plan/organization-auth-branding/phase-4 |
 | 5 | Resolve branding (parentless) | 3 | ✅ done — [PR #211](https://github.com/vintasoftware/vinta-schedule-api/pull/211) | plan/organization-auth-branding/phase-5 |
-| 6 | Invitation reply-to | 2 | ⏳ pending | plan/organization-auth-branding/phase-6 |
+| 6 | Invitation reply-to | 2 | ✅ done — [PR #212](https://github.com/vintasoftware/vinta-schedule-api/pull/212) | plan/organization-auth-branding/phase-6 |
 | 7 | Post-auth destination server-side | 3 | ⏳ pending | plan/organization-auth-branding/phase-7 |
 | 8 | Branded login by slug | 2 | ⏳ pending | plan/organization-auth-branding/phase-8 |
 | 9 | Client handoff (SPA) | 1 | ⏳ pending | plan/organization-auth-branding/phase-9 |
@@ -124,9 +124,16 @@ Command translation (container → host):
 - **⚠️ ACCEPTED TRADE-OFF (supersedes plan L57/L325 "same path / not an existence oracle" claim)**: widening the root reopens a **1-query timing divergence** on the unauthenticated logo route + brandingForTenant — a real parentless org runs one entitlement query an unknown slug doesn't. Response **body/status/headers stay byte-identical**; only server-side query-count/timing differs → timing-only, not reliably weaponizable over the network. Hard close (phantom query on every anon cache-miss) not worth it; a child already pays a parent-walk query, so found≠not-found in query count is unavoidable once branding widens past resellers. **Accepted; not fixed.** The Phase 2b oracle test now asserts "exactly one expected extra query" (still catches N+1 regressions).
 - Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, **full suite 4818 passed**. schema.yml regenerated (incl. a benign Phase-4 `can_manage_branding` docstring hunk that Phase 4 never regenerated).
 
+### Phase 6 — Invitation reply-to ✅
+- **Branch**: `plan/organization-auth-branding/phase-6` (base: phase-5) · **PR**: [#212](https://github.com/vintasoftware/vinta-schedule-api/pull/212)
+- **Implementer**: sonnet (T2) · **Reviewer**: sonnet (T3) · **Fixer**: sonnet (T2)
+- New `ReplyToDjangoEmailNotificationAdapter` (subclasses vintasend stock adapter; DI-wired in `di_core/containers.py`) — reply-to concept did NOT exist in the send path, this is the plumbing. `organization_invitation_context` exposes resolved `support_email` (widened root, entitlement-gated) as `reply_to`. From provably unchanged (`NOTIFICATION_DEFAULT_FROM_EMAIL`); no reply-to verification (Open Q1 out of scope). No migration.
+- **Review (no BLOCKER)**: fixed scope creep — first pass stamped `Reply-To: <from>` on EVERY email through the shared adapter (dunning/usage-warning/password-reset/calendar); narrowed to only-branded-invitations (`reply_to` set only when context supplies it; else `[]`, byte-identical to today). Drift-guard comment names reviewed base version `vintasend-django==1.2.1`.
+- Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, **full suite 4826 passed**. No schema change.
+
 ## Current phase
 
-Phase 6 — Route invitation replies to the organization.
+Phase 7 — Resolve the post-authentication destination server-side.
 
 ## Deferred phases
 

--- a/di_core/containers.py
+++ b/di_core/containers.py
@@ -1,8 +1,5 @@
 from dependency_injector import containers, providers
 from vintasend.services.notification_service import NotificationService
-from vintasend_django.services.notification_adapters.django_email import (
-    DjangoEmailNotificationAdapter,
-)
 from vintasend_django.services.notification_backends.django_db_notification_backend import (
     DjangoDbNotificationBackend,
 )
@@ -25,6 +22,9 @@ from calendar_integration.services.external_event_change_request_service import 
     ExternalEventChangeRequestService,
 )
 from legal.services import ConsentService
+from notifications.notification_adapters.django_email import (
+    ReplyToDjangoEmailNotificationAdapter,
+)
 from notifications.notification_adapters.django_in_app import DjangoInAppNotificationAdapter
 from notifications.notification_template_renderers.django_in_app_renderer import (
     DjangoTemplatedInAppRenderer,
@@ -138,13 +138,13 @@ class AppContainer(containers.DeclarativeContainer):
 
     notification_service = providers.Singleton(
         NotificationService[
-            DjangoEmailNotificationAdapter[
+            ReplyToDjangoEmailNotificationAdapter[
                 DjangoDbNotificationBackend, DjangoTemplatedEmailRenderer
             ],
             DjangoDbNotificationBackend,
         ],
         notification_adapters=[
-            DjangoEmailNotificationAdapter(
+            ReplyToDjangoEmailNotificationAdapter(
                 DjangoTemplatedEmailRenderer(),
                 DjangoDbNotificationBackend(),
             ),

--- a/notifications/notification_adapters/django_email.py
+++ b/notifications/notification_adapters/django_email.py
@@ -39,10 +39,8 @@ class ReplyToDjangoEmailNotificationAdapter[
     per-organization.
 
     When the context has no ``reply_to`` key (or its value is falsy, e.g. an
-    unbranded/unentitled organization's blank support email), the reply-to falls
-    back to that same From address, so every outbound email always carries an
-    explicit Reply-To that lands back on us by default -- identical, in effect, to
-    the base adapter's un-set Reply-To.
+    unbranded/unentitled organization's blank support email), no Reply-To header is
+    set at all -- identical to the base adapter's behavior, which never sends one.
     """
 
     def send(
@@ -54,10 +52,20 @@ class ReplyToDjangoEmailNotificationAdapter[
         """
         Send the notification to the user through email, with reply-to support.
 
+        Reviewed against vintasend-django==1.2.1's
+        ``DjangoEmailNotificationAdapter.send()``. That base method has no seam to
+        hook into (no pre/post-build extension point for ``EmailMessage`` kwargs),
+        so this override duplicates it verbatim and adds a single conditional
+        ``reply_to`` line. ``pyproject.toml`` pins ``vintasend-django>=1.2.1,<2``,
+        so a minor bump could change the base ``send()`` without this override
+        picking up the change -- re-diff this method against the installed base
+        adapter's ``send()`` whenever that pin moves.
+
         :param notification: The notification to send (regular or one-off).
         :param context: The context to render the notification templates. An
             optional ``reply_to`` string key, when present and truthy, becomes the
-            outbound message's reply-to address.
+            outbound message's reply-to address; otherwise no Reply-To header is
+            set at all.
         :param headers: Extra raw email headers, forwarded unchanged to
             ``EmailMessage`` (matches the base adapter's signature).
         """
@@ -77,7 +85,7 @@ class ReplyToDjangoEmailNotificationAdapter[
         template = self.template_renderer.render(notification, context_with_base_url)
 
         from_email = notification_settings.NOTIFICATION_DEFAULT_FROM_EMAIL
-        reply_to_address = context.get("reply_to") or from_email
+        reply_to_address = context.get("reply_to")
 
         email = EmailMessage(
             subject=template.subject.strip(),
@@ -86,7 +94,7 @@ class ReplyToDjangoEmailNotificationAdapter[
             to=to,
             bcc=bcc,
             headers=headers,
-            reply_to=[reply_to_address],
+            reply_to=[reply_to_address] if reply_to_address else None,
         )
         email.content_subtype = "html"
 

--- a/notifications/notification_adapters/django_email.py
+++ b/notifications/notification_adapters/django_email.py
@@ -1,0 +1,96 @@
+from typing import TYPE_CHECKING
+
+from django.core.mail import EmailMessage
+
+from vintasend.app_settings import NotificationSettings
+from vintasend.services.notification_backends.base import BaseNotificationBackend
+from vintasend.services.notification_template_renderers.base_templated_email_renderer import (
+    BaseTemplatedEmailRenderer,
+)
+from vintasend_django.services.notification_adapters.django_email import (
+    DjangoEmailNotificationAdapter,
+)
+
+
+if TYPE_CHECKING:
+    from vintasend.services.dataclasses import Notification, OneOffNotification
+    from vintasend.services.notification_service import NotificationContextDict
+
+
+class ReplyToDjangoEmailNotificationAdapter[
+    B: BaseNotificationBackend,
+    T: BaseTemplatedEmailRenderer,
+](DjangoEmailNotificationAdapter[B, T]):
+    """
+    Email adapter that honors a per-notification reply-to address.
+
+    Extends ``vintasend_django``'s stock email adapter, which has no reply-to
+    concept at all -- it always sends with no ``Reply-To`` header, so replies fall
+    back to whatever mail client behavior applies to the From address. This adapter
+    reads an optional ``reply_to`` string out of the rendered notification context
+    (set by the registered context function, e.g.
+    ``organizations.notification_contexts.organization_invitation_context``) and
+    sets it as the outbound message's reply-to.
+
+    The From address is untouched in every case, branded or not: it is always
+    ``NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL``, exactly like the
+    base adapter. Per the Organization Auth-Area Branding plan's Non-goals, there is
+    no custom sender and no sending-domain verification -- only the reply-to is
+    per-organization.
+
+    When the context has no ``reply_to`` key (or its value is falsy, e.g. an
+    unbranded/unentitled organization's blank support email), the reply-to falls
+    back to that same From address, so every outbound email always carries an
+    explicit Reply-To that lands back on us by default -- identical, in effect, to
+    the base adapter's un-set Reply-To.
+    """
+
+    def send(
+        self,
+        notification: "Notification | OneOffNotification",
+        context: "NotificationContextDict",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        """
+        Send the notification to the user through email, with reply-to support.
+
+        :param notification: The notification to send (regular or one-off).
+        :param context: The context to render the notification templates. An
+            optional ``reply_to`` string key, when present and truthy, becomes the
+            outbound message's reply-to address.
+        :param headers: Extra raw email headers, forwarded unchanged to
+            ``EmailMessage`` (matches the base adapter's signature).
+        """
+        notification_settings = NotificationSettings()
+
+        recipient_info = self._get_recipient_info(notification)
+
+        to = [recipient_info["email"]]
+        bcc = [email for email in notification_settings.NOTIFICATION_DEFAULT_BCC_EMAILS] or []
+
+        context_with_base_url: NotificationContextDict = context.copy()
+        context_with_base_url["base_url"] = (
+            f"{notification_settings.NOTIFICATION_DEFAULT_BASE_URL_PROTOCOL}://"
+            f"{notification_settings.NOTIFICATION_DEFAULT_BASE_URL_DOMAIN}"
+        )
+
+        template = self.template_renderer.render(notification, context_with_base_url)
+
+        from_email = notification_settings.NOTIFICATION_DEFAULT_FROM_EMAIL
+        reply_to_address = context.get("reply_to") or from_email
+
+        email = EmailMessage(
+            subject=template.subject.strip(),
+            body=template.body,
+            from_email=from_email,
+            to=to,
+            bcc=bcc,
+            headers=headers,
+            reply_to=[reply_to_address],
+        )
+        email.content_subtype = "html"
+
+        # Attach files if any
+        self._attach_files(email, notification)
+
+        email.send()

--- a/notifications/tests/test_email_adapter.py
+++ b/notifications/tests/test_email_adapter.py
@@ -86,26 +86,26 @@ class TestReplyToDjangoEmailNotificationAdapter:
         assert sent.reply_to == ["support@brandco.example"]
         assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
 
-    def test_send_falls_back_to_from_address_when_context_has_no_reply_to(
+    def test_send_sets_no_reply_to_when_context_has_no_reply_to(
         self, adapter: ReplyToDjangoEmailNotificationAdapter
     ) -> None:
         """No ``reply_to`` key in the context -- e.g. an unbranded or unentitled
-        organization -- falls back to the From address, exactly as if there were no
-        reply-to concept at all."""
+        organization, or any non-invitation notification that never sets one --
+        sends with no Reply-To header at all, exactly like the base adapter."""
         notification = _one_off_notification()
         context = NotificationContextDict({"test_subject": "hello", "test_body": "world"})
 
         adapter.send(notification, context)
 
         sent = mail.outbox[0]
-        assert sent.reply_to == [sent.from_email]
+        assert sent.reply_to == []
         assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
 
-    def test_send_falls_back_when_reply_to_is_blank(
+    def test_send_sets_no_reply_to_when_reply_to_is_blank(
         self, adapter: ReplyToDjangoEmailNotificationAdapter
     ) -> None:
         """A present-but-blank ``reply_to`` (an entitled organization with no support
-        email set) is falsy -- also falls back to the From address."""
+        email set) is falsy -- also sends with no Reply-To header."""
         notification = _one_off_notification()
         context = NotificationContextDict(
             {"test_subject": "hello", "test_body": "world", "reply_to": ""}
@@ -114,4 +114,4 @@ class TestReplyToDjangoEmailNotificationAdapter:
         adapter.send(notification, context)
 
         sent = mail.outbox[0]
-        assert sent.reply_to == [sent.from_email]
+        assert sent.reply_to == []

--- a/notifications/tests/test_email_adapter.py
+++ b/notifications/tests/test_email_adapter.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for ReplyToDjangoEmailNotificationAdapter.
+
+Organization Auth-Area Branding plan, Phase 6: the invitation reply-to plumbing. The
+vintasend/vintasend_django email adapter has no reply-to concept at all -- it always
+sends with no ``Reply-To`` header. ``ReplyToDjangoEmailNotificationAdapter`` extends it
+to honor an optional ``reply_to`` string in the rendered notification context, while
+leaving the From address exactly as the base adapter sets it in every case.
+"""
+
+from django.core import mail
+
+import pytest
+from vintasend.app_settings import NotificationSettings
+from vintasend.constants import NotificationStatus, NotificationTypes
+from vintasend.services.dataclasses import NotificationContextDict, OneOffNotification
+from vintasend_django.services.notification_backends.django_db_notification_backend import (
+    DjangoDbNotificationBackend,
+)
+from vintasend_django.services.notification_template_renderers.django_templated_email_renderer import (
+    DjangoTemplatedEmailRenderer,
+)
+
+from notifications.notification_adapters.django_email import (
+    ReplyToDjangoEmailNotificationAdapter,
+)
+
+
+# Shipped with vintasend_django precisely for adapter-level tests like this one --
+# minimal, generic templates with no organization/branding-specific context requirements.
+_TEST_BODY_TEMPLATE = "vintasend_django/emails/test/test_templated_email_body.html"
+_TEST_SUBJECT_TEMPLATE = "vintasend_django/emails/test/test_templated_email_subject.txt"
+_TEST_PREHEADER_TEMPLATE = "vintasend_django/emails/test/test_templated_email_preheader.html"
+
+
+def _one_off_notification() -> OneOffNotification:
+    return OneOffNotification(
+        id=1,
+        email_or_phone="invitee@example.com",
+        first_name="Jane",
+        last_name="Doe",
+        notification_type=NotificationTypes.EMAIL.value,
+        title="Test notification",
+        body_template=_TEST_BODY_TEMPLATE,
+        context_name="unused",
+        context_kwargs={},
+        send_after=None,
+        subject_template=_TEST_SUBJECT_TEMPLATE,
+        preheader_template=_TEST_PREHEADER_TEMPLATE,
+        status=NotificationStatus.PENDING_SEND.value,
+    )
+
+
+@pytest.mark.django_db
+class TestReplyToDjangoEmailNotificationAdapter:
+    @pytest.fixture()
+    def adapter(self) -> ReplyToDjangoEmailNotificationAdapter:
+        return ReplyToDjangoEmailNotificationAdapter(
+            DjangoTemplatedEmailRenderer(),
+            DjangoDbNotificationBackend(),
+        )
+
+    def test_notification_type_is_email(
+        self, adapter: ReplyToDjangoEmailNotificationAdapter
+    ) -> None:
+        assert adapter.notification_type == NotificationTypes.EMAIL
+
+    def test_send_honors_reply_to_from_context(
+        self, adapter: ReplyToDjangoEmailNotificationAdapter
+    ) -> None:
+        """A context carrying a truthy ``reply_to`` sets it as the message's reply-to,
+        while the From address stays the configured default -- unchanged."""
+        notification = _one_off_notification()
+        context = NotificationContextDict(
+            {
+                "test_subject": "hello",
+                "test_body": "world",
+                "reply_to": "support@brandco.example",
+            }
+        )
+
+        adapter.send(notification, context)
+
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sent.reply_to == ["support@brandco.example"]
+        assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
+
+    def test_send_falls_back_to_from_address_when_context_has_no_reply_to(
+        self, adapter: ReplyToDjangoEmailNotificationAdapter
+    ) -> None:
+        """No ``reply_to`` key in the context -- e.g. an unbranded or unentitled
+        organization -- falls back to the From address, exactly as if there were no
+        reply-to concept at all."""
+        notification = _one_off_notification()
+        context = NotificationContextDict({"test_subject": "hello", "test_body": "world"})
+
+        adapter.send(notification, context)
+
+        sent = mail.outbox[0]
+        assert sent.reply_to == [sent.from_email]
+        assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
+
+    def test_send_falls_back_when_reply_to_is_blank(
+        self, adapter: ReplyToDjangoEmailNotificationAdapter
+    ) -> None:
+        """A present-but-blank ``reply_to`` (an entitled organization with no support
+        email set) is falsy -- also falls back to the From address."""
+        notification = _one_off_notification()
+        context = NotificationContextDict(
+            {"test_subject": "hello", "test_body": "world", "reply_to": ""}
+        )
+
+        adapter.send(notification, context)
+
+        sent = mail.outbox[0]
+        assert sent.reply_to == [sent.from_email]

--- a/organizations/notification_contexts.py
+++ b/organizations/notification_contexts.py
@@ -63,6 +63,8 @@ def organization_invitation_context(
     # branding row (or no entitlement), `organization=None` resolves through the
     # route's reserved "default" sentinel slug to our bundled default logo -- the
     # same miss-path an unbranded organization's own logo request would take.
+    support_email = branding_row.support_email if branding_row else VINTA_DEFAULT_SUPPORT_EMAIL
+
     branding_context = {
         "app_name": (branding_row.app_name if branding_row else VINTA_DEFAULT_APP_NAME),
         "logo_url": build_logo_delivery_url(branding_row.organization if branding_row else None),
@@ -72,9 +74,7 @@ def organization_invitation_context(
         "secondary_color": (
             branding_row.secondary_color if branding_row else VINTA_DEFAULT_SECONDARY_COLOR
         ),
-        "support_email": (
-            branding_row.support_email if branding_row else VINTA_DEFAULT_SUPPORT_EMAIL
-        ),
+        "support_email": support_email,
     }
 
     return {
@@ -89,4 +89,11 @@ def organization_invitation_context(
         },
         "organization_join_url": invitation_url,
         "branding": branding_context,
+        # Read by ReplyToDjangoEmailNotificationAdapter (notifications/notification_adapters/
+        # django_email.py) to set the outbound message's reply-to. Empty string when there is
+        # no branding row or no entitlement -- the adapter treats a falsy reply_to as "no
+        # override" and falls back to our own From address, matching today's behavior exactly.
+        # The From address itself is never touched here: no custom sender, no
+        # sending-domain verification (Organization Auth-Area Branding plan, Non-goals).
+        "reply_to": support_email,
     }

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -403,12 +403,11 @@ class OrganizationService:
         invitation._raw_token = token  # type: ignore[attr-defined]
 
         if send_email:
-            # TODO: set From=support_email when branded.
-            # resolve_branding(invitation.organization) gives the reseller's support_email,
-            # but DjangoEmailNotificationAdapter.send() always uses
-            # NOTIFICATION_DEFAULT_FROM_EMAIL and does not accept a per-notification
-            # from_email override. Connecting this requires extending the vintasend
-            # adapter API.
+            # Reply-to (not From -- the From address is intentionally left untouched,
+            # see the Organization Auth-Area Branding plan's Non-goals) is resolved from
+            # the organization's branding by organization_invitation_context() at send
+            # time and applied by ReplyToDjangoEmailNotificationAdapter
+            # (notifications/notification_adapters/django_email.py).
             transaction.on_commit(
                 lambda: self.notification_service.create_one_off_notification(
                     email_or_phone=email,

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -5,12 +5,26 @@ import datetime
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.core import mail
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
 
 import pytest
 from model_bakery import baker
+from vintasend.app_settings import NotificationSettings
+from vintasend.constants import NotificationTypes
+from vintasend.services.dataclasses import NotificationContextDict
+from vintasend.services.notification_service import NotificationService
+from vintasend_django.services.notification_backends.django_db_notification_backend import (
+    DjangoDbNotificationBackend,
+)
+from vintasend_django.services.notification_template_renderers.django_templated_email_renderer import (
+    DjangoTemplatedEmailRenderer,
+)
 
+from notifications.notification_adapters.django_email import (
+    ReplyToDjangoEmailNotificationAdapter,
+)
 from organizations.branding_logo import sign_branding_logo_upload
 from organizations.exceptions import BrandingLogoUploadRejectedError
 from organizations.models import (
@@ -876,3 +890,152 @@ class TestInvitationContextLogoUrl:
         assert OrganizationBranding.objects.filter(
             organization=org, app_name="ShouldNotAppear"
         ).exists()
+
+
+def _build_email_notification_service() -> NotificationService:
+    """A NotificationService wired with only the real email adapter (mirrors the
+    email channel of the DI wiring in di_core/containers.py), so
+    ``create_one_off_notification`` sends through the actual send path -- context
+    resolution, template rendering, and ``ReplyToDjangoEmailNotificationAdapter`` --
+    landing in ``django.core.mail.outbox`` under the test settings' locmem backend."""
+    return NotificationService(
+        notification_adapters=[
+            ReplyToDjangoEmailNotificationAdapter(
+                DjangoTemplatedEmailRenderer(),
+                DjangoDbNotificationBackend(),
+            ),
+        ],
+        notification_backend=DjangoDbNotificationBackend(),
+    )
+
+
+@pytest.mark.django_db
+class TestInvitationReplyToEmailSend:
+    """Organization Auth-Area Branding plan, Phase 6 -- Use-case 2's reply-to half.
+
+    Sends a real invitation email end-to-end (context resolution -> template
+    rendering -> ReplyToDjangoEmailNotificationAdapter) and inspects
+    ``django.core.mail.outbox``. The From address must be identical in every case
+    -- branded, unbranded, or downgraded -- because Non-goals forbid a custom
+    sender; only the reply-to may vary.
+    """
+
+    def _make_invitation(self, organization: Organization) -> OrganizationInvitation:
+        inviter = UserFactory().create_user(email="inviter@example.com")
+        return baker.make(
+            OrganizationInvitation,
+            email="invitee@example.com",
+            organization=organization,
+            invited_by=inviter,
+            expires_at=timezone.now() + datetime.timedelta(days=7),
+            accepted_at=None,
+            membership_user_id=None,
+        )
+
+    def _send_invitation_email(self, invitation: OrganizationInvitation) -> None:
+        service = _build_email_notification_service()
+        service.create_one_off_notification(
+            email_or_phone=invitation.email,
+            first_name=invitation.first_name,
+            last_name=invitation.last_name,
+            notification_type=NotificationTypes.EMAIL.value,
+            title="Invitation to join organization",
+            body_template="organizations/emails/organization_invitation.body.html",
+            context_name="organization_invitation_context",
+            context_kwargs=NotificationContextDict(
+                {
+                    "organization_invitation_id": invitation.id,
+                    "invitation_url": "https://example.com/accept?token=fake",
+                }
+            ),
+            subject_template="organizations/emails/organization_invitation.subject.txt",
+            preheader_template="organizations/emails/organization_invitation.pre_header.txt",
+        )
+
+    def test_branded_entitled_organization_reply_to_is_its_support_address(self):
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING,
+            is_enabled=True,
+            parent=None,
+        )
+        org.slug = "brandco-replyto"
+        org.save(update_fields=["slug"])
+        baker.make(
+            OrganizationBranding,
+            organization=org,
+            app_name="BrandCo",
+            support_email="support@brandco.example",
+        )
+        invitation = self._make_invitation(org)
+
+        self._send_invitation_email(invitation)
+
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
+        assert sent.reply_to == ["support@brandco.example"]
+        # The From address is the one accepted exception (spec Objective 1) -- it
+        # must NOT be the organization's support address.
+        assert sent.from_email != "support@brandco.example"
+
+    def test_unbranded_organization_reply_to_is_our_address_same_as_from(self):
+        """No branding row at all -- today's behavior, unchanged."""
+        org = baker.make(Organization, parent=None)
+        invitation = self._make_invitation(org)
+
+        self._send_invitation_email(invitation)
+
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
+        assert sent.reply_to == [sent.from_email]
+
+    def test_unentitled_organization_with_a_branding_row_reply_to_is_our_address(self):
+        """A downgraded organization keeps its saved branding row (support_email
+        included), but the invitation must fully revert to vinta defaults -- reply-to
+        included, not just app_name/logo/colors."""
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING,
+            is_enabled=False,
+            parent=None,
+        )
+        org.slug = "downgraded-replyto"
+        org.save(update_fields=["slug"])
+        baker.make(
+            OrganizationBranding,
+            organization=org,
+            app_name="ShouldNotAppear",
+            support_email="support@shouldnotappear.example",
+        )
+        invitation = self._make_invitation(org)
+
+        self._send_invitation_email(invitation)
+
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
+        assert sent.reply_to == [sent.from_email]
+
+    def test_branded_entitled_organization_with_no_support_email_falls_back(self):
+        """An entitled, branded organization that never set a support email gets
+        our address as reply-to too -- a blank support_email is falsy, not a
+        distinct "empty reply-to" state."""
+        org = _org_with_entitlement(
+            Entitlement.WHITE_LABEL_BRANDING,
+            is_enabled=True,
+            parent=None,
+        )
+        org.slug = "brandco-no-support-email"
+        org.save(update_fields=["slug"])
+        baker.make(
+            OrganizationBranding,
+            organization=org,
+            app_name="BrandCo",
+            support_email="",
+        )
+        invitation = self._make_invitation(org)
+
+        self._send_invitation_email(invitation)
+
+        sent = mail.outbox[0]
+        assert sent.reply_to == [sent.from_email]

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -978,8 +978,9 @@ class TestInvitationReplyToEmailSend:
         # must NOT be the organization's support address.
         assert sent.from_email != "support@brandco.example"
 
-    def test_unbranded_organization_reply_to_is_our_address_same_as_from(self):
-        """No branding row at all -- today's behavior, unchanged."""
+    def test_unbranded_organization_has_no_reply_to_header(self):
+        """No branding row at all -- today's behavior, unchanged: no Reply-To
+        header at all."""
         org = baker.make(Organization, parent=None)
         invitation = self._make_invitation(org)
 
@@ -988,9 +989,9 @@ class TestInvitationReplyToEmailSend:
         assert len(mail.outbox) == 1
         sent = mail.outbox[0]
         assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
-        assert sent.reply_to == [sent.from_email]
+        assert sent.reply_to == []
 
-    def test_unentitled_organization_with_a_branding_row_reply_to_is_our_address(self):
+    def test_unentitled_organization_with_a_branding_row_has_no_reply_to_header(self):
         """A downgraded organization keeps its saved branding row (support_email
         included), but the invitation must fully revert to vinta defaults -- reply-to
         included, not just app_name/logo/colors."""
@@ -1014,11 +1015,11 @@ class TestInvitationReplyToEmailSend:
         assert len(mail.outbox) == 1
         sent = mail.outbox[0]
         assert sent.from_email == NotificationSettings().NOTIFICATION_DEFAULT_FROM_EMAIL
-        assert sent.reply_to == [sent.from_email]
+        assert sent.reply_to == []
 
-    def test_branded_entitled_organization_with_no_support_email_falls_back(self):
+    def test_branded_entitled_organization_with_no_support_email_has_no_reply_to_header(self):
         """An entitled, branded organization that never set a support email gets
-        our address as reply-to too -- a blank support_email is falsy, not a
+        no Reply-To header at all -- a blank support_email is falsy, not a
         distinct "empty reply-to" state."""
         org = _org_with_entitlement(
             Entitlement.WHITE_LABEL_BRANDING,
@@ -1038,4 +1039,4 @@ class TestInvitationReplyToEmailSend:
         self._send_invitation_email(invitation)
 
         sent = mail.outbox[0]
-        assert sent.reply_to == [sent.from_email]
+        assert sent.reply_to == []


### PR DESCRIPTION
## Phase 6 — Route invitation replies to the organization

Seventh phase of the [Organization Auth-Area Branding plan](../blob/main/ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md). Replies to a branded organization's invitation email now reach that organization's support address, while the From address stays on our sending domain.

> **Stacked on [#211](https://github.com/vintasoftware/vinta-schedule-api/pull/211) (Phase 5).** Review this diff against that branch.

### What's in it
- **`ReplyToDjangoEmailNotificationAdapter`** (new, subclasses vintasend's stock Django email adapter, wired via DI) — reads a new `reply_to` context key and sets `Reply-To` **only when it's present**; otherwise passes no reply-to, byte-identical to the base adapter. The reply-to concept did not exist in the send path before; this is the plumbing the phase called for.
- **`organization_invitation_context`** — the resolved branding `support_email` (via the Phase 5 widened root, entitlement-gated) is exposed as `reply_to`. A branded entitled org contributes its support address; an unbranded/unentitled/downgraded/blank org contributes nothing → no Reply-To header.
- **From address untouched** — `from_email` is computed exactly as the base adapter (`NOTIFICATION_DEFAULT_FROM_EMAIL`); `support_email` never reaches From. No custom sender, no domain verification, no reply-to address verification (Open Question 1 stays out of scope).
- No migration.

### Tests
Invitation email: branded+entitled → `Reply-To: support@org`, From = our address; unbranded / downgraded-unentitled / blank-support-email → no Reply-To header, From = our address (byte-identical to today). Adapter unit tests: no `reply_to` context / blank → no header; present → header. Full suite: **4826 passed**.

### Review notes (Tier 3 / sonnet) — no BLOCKER
Verified: From provably unchanged across branded/unbranded/downgraded; `support_email` resolves through the widened entitlement-gated root; no reply-to verification added; DI wiring has no bypass path. **Fixed a SHOULD-FIX**: the first pass always stamped a `Reply-To: <from>` header on *every* email through the shared adapter (dunning, usage-warning, password reset, calendar notifications) — scope creep. Narrowed so only branded invitations get a Reply-To; every other email is byte-identical to today (`reply_to == []`).

### Note for reviewers
The adapter re-implements the base package's `send()` (the base has no extension seam) plus one reply-to line — a drift-guard comment names the reviewed base version (`vintasend-django==1.2.1`) so a maintainer re-diffs on a version-pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2)_