### PR TITLE
feat: resolve post-authentication destination server-side (Phase 7 — auth branding)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -4,6 +4,10 @@
 DJANGO_SETTINGS_MODULE=vinta_schedule_api.settings.local
 CELERY_BROKER_URL=amqp://broker:5672//
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
+# SPA/dashboard base URL. Used as the post-authentication fallback destination
+# (accounts/views.py) when the acting organization has no configured branding
+# redirect_url. Reached from the host, like CORS_ALLOWED_ORIGINS above.
+FRONTEND_BASE_URL=http://localhost:3000
 REDIS_URL=redis://result:6379
 DATABASE_URL=postgres://vinta_schedule_api:password@db:5432/vinta_schedule_api
 FLOCI_ENDPOINT=http://floci:4566

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ CELERY_BROKER_URL=amqp://localhost:5672//
 # Local dev CORS origins. Production deploys add: https://schedule.vintasoftware.com (prod)
 # and https://schedule-staging.vintasoftware.com (staging) via Render environment config.
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
+# SPA/dashboard base URL. Used as the post-authentication fallback destination
+# (accounts/views.py) when the acting organization has no configured branding
+# redirect_url.
+FRONTEND_BASE_URL=http://localhost:3000
 REDIS_URL=redis://localhost:6379
 DATABASE_URL=postgres://vinta_schedule_api:password@localhost:5432/vinta_schedule_api
 FLOCI_ENDPOINT=http://localhost:4566

--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -1,11 +1,20 @@
+import datetime
 import json
 from unittest.mock import MagicMock, patch
 
-from django.http import JsonResponse
+from django.conf import settings
+from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
+from django.utils import timezone
 
 import pytest
 from allauth.socialaccount.providers.base import ProviderException
+from model_bakery import baker
+
+from organizations.models import Organization, OrganizationBranding, OrganizationMembership
+from payments.billing_constants import BillingState, Entitlement
+from payments.models import BillingPlan, Subscription, SubscriptionEntitlement
+from users.factories import UserFactory
 
 
 class TestProviderCallbackAPIView:
@@ -94,6 +103,179 @@ class TestProviderCallbackAPIView:
         assert response.status_code == 400
         assert "error" in response.json()
         assert "message" in response.json()
+
+
+@pytest.mark.django_db
+class TestProviderCallbackDestinationResolution:
+    """Phase 7 -- the callback's response carries the resolved post-authentication
+    destination, and no client-supplied value (``state["next"]``, which doubles as the
+    OAuth ``callback_url``) can influence it.
+
+    ``_complete_login`` mocks the whole social-login/token-exchange pipeline exactly
+    like ``TestProviderCallbackAPIView`` above -- that machinery is allauth-headless
+    internals and is not what this class is about. What makes ``request.user``
+    authenticated here is ``client.force_login(user)``, called *before* the POST, so
+    the view's own post-login destination resolution runs against a real,
+    authenticated ``request.user`` while the surrounding OAuth exchange stays a stub.
+    """
+
+    @staticmethod
+    def get_url():
+        return reverse("provider_callback_json")
+
+    def _complete_login(self, client, user, *, next_url="https://client.example/callback"):
+        client.force_login(user)
+        data = {"provider_id": "test", "code": "dummy_code", "state": "dummy_state"}
+        with (
+            patch("accounts.views.get_socialaccount_adapter") as mock_adapter,
+            patch(
+                "accounts.views.statekit.unstash_state",
+                return_value={"next": next_url, "process": "login"},
+            ),
+            patch(
+                "accounts.views.complete_social_login",
+                return_value=HttpResponseRedirect(next_url),
+            ),
+        ):
+            mock_app = MagicMock()
+            mock_provider = MagicMock()
+            mock_oauth2_adapter = MagicMock()
+            mock_client = MagicMock()
+            mock_oauth2_adapter.get_client.return_value = mock_client
+            mock_provider.get_oauth2_adapter.return_value = mock_oauth2_adapter
+            mock_app.get_provider.return_value = mock_provider
+            mock_adapter.return_value.get_app.return_value = mock_app
+            mock_oauth2_adapter.supports_state = True
+            mock_oauth2_adapter.parse_token.return_value = MagicMock()
+            mock_oauth2_adapter.complete_login.return_value = MagicMock()
+            mock_client.get_access_token.return_value = {"access_token": "token"}
+            mock_client.callback_url = next_url
+            mock_provider.app = mock_app
+            # The headless "app" client authenticates off an explicit
+            # ``X-Session-Token`` header, not the session cookie -- see
+            # ``allauth.headless.internal.authkit.authentication_context``, which
+            # swaps ``request.session`` for a fresh, empty one and only restores the
+            # cookie-backed session if this header resolves to it. ``force_login``
+            # above still does the real work of building a legitimate,
+            # database-backed session (with ``_auth_user_id`` etc. set); this just
+            # forwards its key the way a real headless "app" client would.
+            return client.post(
+                self.get_url(),
+                data=json.dumps(data),
+                content_type="application/json",
+                HTTP_X_SESSION_TOKEN=client.session.session_key,
+            )
+
+    def test_branded_entitled_organization_returns_configured_destination(self, client):
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+        baker.make(
+            OrganizationBranding, organization=org, redirect_url="https://org.example.com/app"
+        )
+
+        response = self._complete_login(client, user)
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == "https://org.example.com/app"
+
+    def test_unbranded_organization_returns_dashboard(self, client):
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+
+        response = self._complete_login(client, user)
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == settings.FRONTEND_BASE_URL
+
+    @pytest.mark.no_auto_subscription
+    def test_unentitled_organization_with_branding_row_returns_dashboard(self, client):
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        now = timezone.now()
+        subscription = baker.make(
+            Subscription,
+            organization=org,
+            plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+            billing_state=BillingState.FREE,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+        )
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=Entitlement.WHITE_LABEL_BRANDING,
+            is_enabled=False,
+        )
+        baker.make(OrganizationMembership, user=user, organization=org)
+        baker.make(
+            OrganizationBranding, organization=org, redirect_url="https://org.example.com/app"
+        )
+
+        response = self._complete_login(client, user)
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == settings.FRONTEND_BASE_URL
+
+    def test_entitled_organization_with_no_redirect_url_returns_dashboard(self, client):
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+        baker.make(OrganizationBranding, organization=org, redirect_url="")
+
+        response = self._complete_login(client, user)
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == settings.FRONTEND_BASE_URL
+
+    def test_reseller_child_membership_returns_reseller_destination(self, client):
+        """Acceptance scenario 8 -- the redirect resolution applies to reseller
+        subtrees under the unified route just like a standalone organization."""
+        reseller = baker.make(Organization, can_invite_organizations=True)
+        baker.make(
+            OrganizationBranding,
+            organization=reseller,
+            redirect_url="https://reseller.example.com/app",
+        )
+        child = baker.make(Organization, parent=reseller, can_invite_organizations=False)
+        user = UserFactory().create_user()
+        baker.make(OrganizationMembership, user=user, organization=child)
+
+        response = self._complete_login(client, user)
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == "https://reseller.example.com/app"
+
+    def test_client_supplied_next_cannot_override_the_resolved_destination(self, client):
+        """The open-redirect regression guard: a client-supplied ``state["next"]``
+        (which doubles as the OAuth ``callback_url``) pointing somewhere else must
+        never change the returned destination."""
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+        baker.make(
+            OrganizationBranding, organization=org, redirect_url="https://org.example.com/app"
+        )
+
+        response = self._complete_login(client, user, next_url="https://evil.example/steal")
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == "https://org.example.com/app"
+        assert response.json()["destination"] != "https://evil.example/steal"
+
+    def test_client_supplied_next_cannot_override_the_dashboard_fallback(self, client):
+        """Same guard, unbranded-organization side: an evil ``next`` must not leak
+        through as the dashboard fallback either."""
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+
+        response = self._complete_login(client, user, next_url="https://evil.example/steal")
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == settings.FRONTEND_BASE_URL
+        assert response.json()["destination"] != "https://evil.example/steal"
 
 
 class TestProviderRedirectAPIView:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,5 +1,7 @@
 import json
+import logging
 
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -23,6 +25,11 @@ from allauth.socialaccount.providers.oauth2.client import (
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from requests.exceptions import RequestException
 from rest_framework import status
+
+from organizations.models import get_active_organization_membership, resolve_branding_for_display
+
+
+logger = logging.getLogger(__name__)
 
 
 class ProviderRedirectAPIView(AllauthAPIView):
@@ -151,8 +158,10 @@ class ProviderCallbackAPIView(AllauthAPIView):
             login.state = state
             response = complete_social_login(request, login)
             if isinstance(response, JsonResponse):
-                return response
-            return AuthenticationResponse.from_response(request, response)
+                return self._with_post_auth_destination(request, response)
+            return self._with_post_auth_destination(
+                request, AuthenticationResponse.from_response(request, response)
+            )
         except (
             PermissionDenied,
             OAuth2Error,
@@ -166,6 +175,51 @@ class ProviderCallbackAPIView(AllauthAPIView):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+    def _with_post_auth_destination(self, request, response: JsonResponse) -> JsonResponse:
+        """Merge the resolved post-authentication destination into a completed-login response.
+
+        No-ops (returns ``response`` unchanged) unless ``request.user`` is authenticated:
+        a completed login is the only case with an acting organization to resolve
+        branding for. An interim response (a pending stage, a cancelled/failed
+        attempt) leaves the request unauthenticated, so it passes through untouched.
+
+        The destination is resolved *only* from the acting organization's stored
+        branding (``organizations.models.resolve_branding_for_display``) -- never
+        from ``state["next"]``, a query parameter, or a header. ``state["next"]``
+        keeps serving as the OAuth ``callback_url`` for the token exchange above
+        (a protocol requirement); it plays no part in this method. That separation
+        is what removes the open-redirect surface the old caller-supplied-allowlist
+        design carried.
+        """
+        if not request.user.is_authenticated:
+            return response
+
+        membership = get_active_organization_membership(request.user)
+        organization = membership.organization if membership else None
+        branding = resolve_branding_for_display(organization)
+
+        if branding is not None and branding.redirect_url:
+            destination = branding.redirect_url
+            destination_source = "configured"
+        else:
+            destination = settings.FRONTEND_BASE_URL
+            destination_source = "dashboard_fallback"
+
+        logger.info(
+            "Post-authentication destination resolved",
+            extra={
+                "organization_id": organization.pk if organization else None,
+                "destination_source": destination_source,
+            },
+        )
+
+        payload = json.loads(response.content)
+        payload["destination"] = destination
+        augmented_response = JsonResponse(payload, status=response.status_code)
+        for header, value in response.items():
+            augmented_response[header] = value
+        return augmented_response
 
     def _get_state(self, request, state_id):
         if self.adapter.supports_state and state_id:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -3,7 +3,7 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.http import JsonResponse
+from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from allauth.headless.base.response import (
@@ -176,7 +176,9 @@ class ProviderCallbackAPIView(AllauthAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-    def _with_post_auth_destination(self, request, response: JsonResponse) -> JsonResponse:
+    def _with_post_auth_destination(
+        self, request: HttpRequest, response: JsonResponse
+    ) -> JsonResponse:
         """Merge the resolved post-authentication destination into a completed-login response.
 
         No-ops (returns ``response`` unchanged) unless ``request.user`` is authenticated:
@@ -195,6 +197,10 @@ class ProviderCallbackAPIView(AllauthAPIView):
         if not request.user.is_authenticated:
             return response
 
+        # The OAuth callback has no selected-org concept: a user with multiple
+        # active memberships deterministically resolves to their oldest active
+        # membership's org via get_active_organization_membership. Intentional
+        # and safe -- all candidate orgs are the user's own.
         membership = get_active_organization_membership(request.user)
         organization = membership.organization if membership else None
         branding = resolve_branding_for_display(organization)
@@ -214,12 +220,13 @@ class ProviderCallbackAPIView(AllauthAPIView):
             },
         )
 
+        # Mutate the response body in place rather than building a fresh
+        # JsonResponse: this preserves cookies and any other header not covered
+        # by the header-copy loop it would otherwise take to replicate them.
         payload = json.loads(response.content)
         payload["destination"] = destination
-        augmented_response = JsonResponse(payload, status=response.status_code)
-        for header, value in response.items():
-            augmented_response[header] = value
-        return augmented_response
+        response.content = json.dumps(payload).encode("utf-8")
+        return response
 
     def _get_state(self, request, state_id):
         if self.adapter.supports_state and state_id:

--- a/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
+++ b/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
@@ -60,7 +60,7 @@ Command translation (container → host):
 | 4 | Audit + capability field | 2 | ✅ done — [PR #210](https://github.com/vintasoftware/vinta-schedule-api/pull/210) | plan/organization-auth-branding/phase-4 |
 | 5 | Resolve branding (parentless) | 3 | ✅ done — [PR #211](https://github.com/vintasoftware/vinta-schedule-api/pull/211) | plan/organization-auth-branding/phase-5 |
 | 6 | Invitation reply-to | 2 | ✅ done — [PR #212](https://github.com/vintasoftware/vinta-schedule-api/pull/212) | plan/organization-auth-branding/phase-6 |
-| 7 | Post-auth destination server-side | 3 | ⏳ pending | plan/organization-auth-branding/phase-7 |
+| 7 | Post-auth destination server-side | 3 | ✅ done — [PR #213](https://github.com/vintasoftware/vinta-schedule-api/pull/213) | plan/organization-auth-branding/phase-7 |
 | 8 | Branded login by slug | 2 | ⏳ pending | plan/organization-auth-branding/phase-8 |
 | 9 | Client handoff (SPA) | 1 | ⏳ pending | plan/organization-auth-branding/phase-9 |
 
@@ -131,9 +131,17 @@ Command translation (container → host):
 - **Review (no BLOCKER)**: fixed scope creep — first pass stamped `Reply-To: <from>` on EVERY email through the shared adapter (dunning/usage-warning/password-reset/calendar); narrowed to only-branded-invitations (`reply_to` set only when context supplies it; else `[]`, byte-identical to today). Drift-guard comment names reviewed base version `vintasend-django==1.2.1`.
 - Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, **full suite 4826 passed**. No schema change.
 
+### Phase 7 — Post-auth destination server-side ✅
+- **Branch**: `plan/organization-auth-branding/phase-7` (base: phase-6) · **PR**: [#213](https://github.com/vintasoftware/vinta-schedule-api/pull/213)
+- **Implementer**: sonnet (T3) · **Reviewer**: opus (T4) · **Fixer**: sonnet (T2)
+- `ProviderCallbackAPIView` (allauth headless) merges a `destination` into the JSON response: configured `redirect_url` when entitled+set, else dashboard (`FRONTEND_BASE_URL`). Resolved ONLY from `request.user` + DB branding (`resolve_branding_for_display`), never `state`/query/header. `state["next"]` still = OAuth `client.callback_url` (token exchange) but no longer decides landing. Structured log (`organization_id` + `destination_source`, URL not logged). In-place response body rewrite (preserves cookies/headers). No migration; no 302 route.
+- New setting `FRONTEND_BASE_URL` in `base.py` + `.env.example` + `.env.docker.example` (was staging/production only).
+- **Review (no BLOCKER)**: open-redirect verdict CLEAN by full trace (custom dispatch skips tenant-scoping so even `X-Organization-Id` can't steer org). Fixed: type hint, env-example docs, in-place response rewrite. Open-redirect guards (`state["next"]=https://evil.example` → destination unaffected on branded + fallback paths) pass.
+- Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, **full suite 4833 passed**.
+
 ## Current phase
 
-Phase 7 — Resolve the post-authentication destination server-side.
+Phase 8 — Branded login by organization slug.
 
 ## Deferred phases
 

--- a/vinta_schedule_api/settings/base.py
+++ b/vinta_schedule_api/settings/base.py
@@ -353,6 +353,13 @@ HEADLESS_FRONTEND_URLS = {
     "account_signup": "http://localhost:3000/account/signup",
     "socialaccount_login_error": "http://localhost:3000/account/provider/callback",
 }
+# The SPA's own base URL -- "our dashboard" for callers that need a stable, non
+# organization-specific fallback destination (e.g. accounts.views.ProviderCallbackAPIView,
+# which lands a just-authenticated user here when their organization has no configured
+# post-authentication redirect). staging.py/production.py override this with their real
+# frontend origin; this default matches the local dev frontend port used throughout
+# HEADLESS_FRONTEND_URLS above.
+FRONTEND_BASE_URL = config("FRONTEND_BASE_URL", default="http://localhost:3000").rstrip("/")
 MFA_SUPPORTED_TYPES = ["totp", "recovery_codes"]
 MFA_PASSKEY_LOGIN_ENABLED = False
 HEADLESS_SERVE_SPECIFICATION = True


### PR DESCRIPTION
## Phase 7 — Resolve the post-authentication destination server-side

Eighth phase of the [Organization Auth-Area Branding plan](../blob/main/ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md). Authentication now returns the destination the organization configured, resolved by us, never taken from the client — closing the open-redirect surface the allowlist removal (Phase 2a) was meant to eliminate.

> **Stacked on [#212](https://github.com/vintasoftware/vinta-schedule-api/pull/212) (Phase 6).** Review this diff against that branch.

### What's in it
- **`ProviderCallbackAPIView`** (`accounts/views.py`, allauth headless) — after login completes and tokens are issued, resolves the acting org's branding via `resolve_branding_for_display` and merges a `destination` into the JSON response body: the org's configured `redirect_url` when entitled and set, our dashboard (`FRONTEND_BASE_URL`) otherwise. Applies to every org, resellers included.
- **`state["next"]` still serves the OAuth token exchange** (`client.callback_url`, protocol requirement) but **no longer decides where the user lands**. The returned `destination` is derived ONLY from `request.user` (established by the completed login) and the DB-resolved, HTTPS-validated `redirect_url` — never from `state`, a query param, or a header.
- **Structured log** per completion (`organization_id` + `destination_source: configured|dashboard_fallback`); the URL itself is not logged. No 302 route added — the SPA navigates to the returned value.
- `FRONTEND_BASE_URL` added to `base.py` + both env example files (previously only staging/production). No migration.

### Tests
Destination matrix: branded+entitled → configured `redirect_url`; unbranded / unentitled-with-row / empty-`redirect_url` → dashboard; reseller → reseller's destination (Acceptance scenario 8). **Open-redirect regression guards**: a client-supplied `state["next"]` = `https://evil.example/steal` does NOT change the returned destination on either the branded or the dashboard-fallback path. Full suite: **4833 passed**.

### Review notes (Tier 4 / opus) — no BLOCKER
**Open-redirect verdict: no client-supplied value can reach the destination**, confirmed by full trace — and notably the custom `dispatch` skips tenant-scoping, so even the `X-Organization-Id` header can't steer org resolution. All success branches route through the resolver; error branches leak no destination; the log doesn't leak the URL. Fixed minor findings: added the missing `HttpRequest` type hint; documented `FRONTEND_BASE_URL` in both env example files; and rewrote the callback response **in place** (instead of reconstructing a fresh `JsonResponse`) so cookies/headers on this auth response are never silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2)_