### PR TITLE
test: branded login by organization slug + generic-login guarantees (Phase 8 — auth branding)

### DIFF
--- a/accounts/tests/test_views.py
+++ b/accounts/tests/test_views.py
@@ -278,6 +278,155 @@ class TestProviderCallbackDestinationResolution:
         assert response.json()["destination"] != "https://evil.example/steal"
 
 
+@pytest.mark.django_db
+class TestGenericLoginPathUnaffectedByBrowserContext:
+    """Phase 8 -- Branded login by organization slug.
+
+    The organization-scoped login URL is resolved entirely on the SPA side through
+    ``brandingForTenant(slug=...)`` (Phase 5): there is no backend routing to add for
+    it, because the OAuth redirect/callback endpoints below take no
+    organization/slug/tenant input and never acquire one from the request. This class
+    pins that guarantee so it survives future refactors:
+
+    - The generic login path (no organization in the URL) is unchanged: a cold visit
+      still goes through ``ProviderRedirectAPIView`` with no organization concept at
+      all, and ``ProviderCallbackAPIView`` still resolves the post-authentication
+      destination purely from the authenticated user's own active membership
+      (``get_active_organization_membership`` / Phase 7) -- never from the request.
+    - Nothing about the destination changes when the request carries an
+      ``X-Organization-Id`` header (the header ordinary tenant-scoped REST endpoints
+      honor via ``TenantScopedViewMixin``), a ``Referer`` header naming a different
+      organization's branded login URL, or an organization-flavored cookie. This view
+      never mixes in that tenant-scoping machinery, so none of these are read.
+    """
+
+    @staticmethod
+    def get_redirect_url():
+        return reverse("provider_redirect_json")
+
+    @staticmethod
+    def get_callback_url():
+        return reverse("provider_callback_json")
+
+    def test_redirect_form_has_no_organization_or_slug_field(self):
+        """The redirect-initiation form accepts only ``provider``, ``callback_url``,
+        and ``process`` -- there is no organization/tenant/slug field for a client to
+        supply in the first place, so there is nothing for the view to read even if a
+        caller tried to smuggle one in."""
+        from allauth.headless.socialaccount.forms import RedirectToProviderForm
+
+        assert set(RedirectToProviderForm.base_fields) == {"provider", "callback_url", "process"}
+
+    def _complete_login(
+        self, client, user, *, next_url="https://client.example/callback", **extra_headers
+    ):
+        """Mirrors ``TestProviderCallbackDestinationResolution._complete_login``, with
+        the addition of forwarding arbitrary extra request headers (``HTTP_*`` /
+        ``HTTP_X_ORGANIZATION_ID`` / ``HTTP_REFERER``) so each test below can assert
+        those headers have zero effect on the resolved destination.
+        """
+        client.force_login(user)
+        data = {"provider_id": "test", "code": "dummy_code", "state": "dummy_state"}
+        with (
+            patch("accounts.views.get_socialaccount_adapter") as mock_adapter,
+            patch(
+                "accounts.views.statekit.unstash_state",
+                return_value={"next": next_url, "process": "login"},
+            ),
+            patch(
+                "accounts.views.complete_social_login",
+                return_value=HttpResponseRedirect(next_url),
+            ),
+        ):
+            mock_app = MagicMock()
+            mock_provider = MagicMock()
+            mock_oauth2_adapter = MagicMock()
+            mock_client = MagicMock()
+            mock_oauth2_adapter.get_client.return_value = mock_client
+            mock_provider.get_oauth2_adapter.return_value = mock_oauth2_adapter
+            mock_app.get_provider.return_value = mock_provider
+            mock_adapter.return_value.get_app.return_value = mock_app
+            mock_oauth2_adapter.supports_state = True
+            mock_oauth2_adapter.parse_token.return_value = MagicMock()
+            mock_oauth2_adapter.complete_login.return_value = MagicMock()
+            mock_client.get_access_token.return_value = {"access_token": "token"}
+            mock_client.callback_url = next_url
+            mock_provider.app = mock_app
+            return client.post(
+                self.get_callback_url(),
+                data=json.dumps(data),
+                content_type="application/json",
+                HTTP_X_SESSION_TOKEN=client.session.session_key,
+                **extra_headers,
+            )
+
+    def test_callback_destination_ignores_x_organization_id_header(self, client):
+        """A client-supplied ``X-Organization-Id`` naming a DIFFERENT organization
+        than the user's real membership must not steer the resolved destination --
+        this view never mixes in ``TenantScopedViewMixin``, so the header is never
+        read on this path."""
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        other_org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+        baker.make(
+            OrganizationBranding, organization=org, redirect_url="https://org.example.com/app"
+        )
+        baker.make(
+            OrganizationBranding,
+            organization=other_org,
+            redirect_url="https://other-org.example.com/app",
+        )
+
+        response = self._complete_login(client, user, HTTP_X_ORGANIZATION_ID=str(other_org.id))
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == "https://org.example.com/app"
+
+    def test_callback_destination_ignores_referer_header(self, client):
+        """A ``Referer`` pointing at a different organization's branded login URL
+        must not steer the resolved destination -- the destination is resolved only
+        from the authenticated user's own membership, never from where the browser
+        says it came from."""
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+        baker.make(
+            OrganizationBranding, organization=org, redirect_url="https://org.example.com/app"
+        )
+
+        response = self._complete_login(
+            client,
+            user,
+            HTTP_REFERER="https://app.example.com/login/some-other-org-slug/",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == "https://org.example.com/app"
+
+    def test_callback_destination_ignores_organization_cookie(self, client):
+        """An organization-flavored cookie must not steer the resolved destination --
+        there is no cookie-based organization inference on this path at all."""
+        user = UserFactory().create_user()
+        org = baker.make(Organization)
+        other_org = baker.make(Organization)
+        baker.make(OrganizationMembership, user=user, organization=org)
+        baker.make(
+            OrganizationBranding, organization=org, redirect_url="https://org.example.com/app"
+        )
+        baker.make(
+            OrganizationBranding,
+            organization=other_org,
+            redirect_url="https://other-org.example.com/app",
+        )
+        client.cookies["organization_slug"] = "whatever-the-other-org-slug-is"
+
+        response = self._complete_login(client, user)
+
+        assert response.status_code == 200
+        assert response.json()["destination"] == "https://org.example.com/app"
+
+
 class TestProviderRedirectAPIView:
     @staticmethod
     def get_url():

--- a/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
+++ b/ai-plans/TRACKING_ORGANIZATION_AUTH_BRANDING.md
@@ -61,7 +61,7 @@ Command translation (container → host):
 | 5 | Resolve branding (parentless) | 3 | ✅ done — [PR #211](https://github.com/vintasoftware/vinta-schedule-api/pull/211) | plan/organization-auth-branding/phase-5 |
 | 6 | Invitation reply-to | 2 | ✅ done — [PR #212](https://github.com/vintasoftware/vinta-schedule-api/pull/212) | plan/organization-auth-branding/phase-6 |
 | 7 | Post-auth destination server-side | 3 | ✅ done — [PR #213](https://github.com/vintasoftware/vinta-schedule-api/pull/213) | plan/organization-auth-branding/phase-7 |
-| 8 | Branded login by slug | 2 | ⏳ pending | plan/organization-auth-branding/phase-8 |
+| 8 | Branded login by slug | 2 | ✅ done — [PR #214](https://github.com/vintasoftware/vinta-schedule-api/pull/214) | plan/organization-auth-branding/phase-8 |
 | 9 | Client handoff (SPA) | 1 | ⏳ pending | plan/organization-auth-branding/phase-9 |
 
 ## Completed phases
@@ -139,9 +139,16 @@ Command translation (container → host):
 - **Review (no BLOCKER)**: open-redirect verdict CLEAN by full trace (custom dispatch skips tenant-scoping so even `X-Organization-Id` can't steer org). Fixed: type hint, env-example docs, in-place response rewrite. Open-redirect guards (`state["next"]=https://evil.example` → destination unaffected on branded + fallback paths) pass.
 - Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, **full suite 4833 passed**.
 
+### Phase 8 — Branded login by slug ✅
+- **Branch**: `plan/organization-auth-branding/phase-8` (base: phase-7) · **PR**: [#214](https://github.com/vintasoftware/vinta-schedule-api/pull/214)
+- **Implementer**: sonnet (T2) · **Reviewer**: sonnet (T3)
+- **Tests-only, no production change** — no backend gap (confirmed by reviewer): `brandingForTenant(slug=...)` already delivered in Phase 5; login is SPA-driven headless (no server-rendered login page); Phase 7 destination resolves only from `request.user`'s membership. Touch List's `accounts/urls.py`/`queries.py` entries were aspirational/superseded.
+- Added: standalone (parentless non-reseller entitled) org resolves own branding by own slug (prior slug tests all used resellers); generic-login-unchanged guards (callback ignores `X-Organization-Id` header, `Referer`, org cookie; redirect form has no org/slug field). No-oracle relies on existing Phase 5 tests.
+- Gates: ruff/format clean, `makemigrations --check` no changes, `manage.py check` clean, mypy no new errors, schema.yml byte-identical, **full suite 4838 passed**. NIT (docstring Phase 4→5) corrected.
+
 ## Current phase
 
-Phase 8 — Branded login by organization slug.
+Phase 9 — Client handoff for the SPA.
 
 ## Deferred phases
 

--- a/public_api/tests/test_queries.py
+++ b/public_api/tests/test_queries.py
@@ -2517,6 +2517,61 @@ class TestBrandingForTenantQuery:
         assert branding["primaryColor"] == ""
         assert branding["secondaryColor"] == ""
 
+    def test_branding_for_tenant_by_slug_resolves_a_standalone_entitled_organizations_own_branding(
+        self, mock_rate_limiter, anonymous_client
+    ):
+        """Phase 8 -- Use-case 3 (a returning user opens the organization-scoped
+        login URL and it resolves that organization's own branding). Every slug
+        test above uses a reseller; this pins the shape that Phase 5 widened
+        ``get_branding_root`` to cover and that most branded organizations will
+        actually have going forward: a parentless, non-reseller, entitled
+        organization resolving to ITS OWN branding row via its own slug, not a
+        reseller ancestor's."""
+        mock_rate_limiter.return_value = iter([None])
+
+        org = baker.make(
+            Organization,
+            name="Standalone Co",
+            slug="standalone-brand",
+        )
+        assert org.parent_id is None
+        assert org.can_invite_organizations is False
+
+        baker.make(
+            "organizations.OrganizationBranding",
+            organization=org,
+            app_name="StandaloneBrand",
+            logo="uploads/branding_logos/logo.png",
+            primary_color="#123123",
+            secondary_color="#321321",
+        )
+
+        query = """
+            query GetBrandingForTenant($slug: String!) {
+                brandingForTenant(slug: $slug) {
+                    appName
+                    logoUrl
+                    primaryColor
+                    secondaryColor
+                }
+            }
+        """
+        variables = {"slug": "standalone-brand"}
+
+        response = anonymous_client.post(
+            "/graphql/",
+            data=json.dumps({"query": query, "variables": variables}),
+            content_type="application/json",
+        )
+
+        data = assert_graphql_success(response)
+        branding = data["brandingForTenant"]
+
+        assert branding["appName"] == "StandaloneBrand"
+        assert branding["logoUrl"].endswith("/branding/logo/standalone-brand/")
+        assert branding["primaryColor"] == "#123123"
+        assert branding["secondaryColor"] == "#321321"
+
 
 @pytest.mark.django_db
 class TestValidateReturnUrlRemoved:


### PR DESCRIPTION
## Phase 8 — Branded login by organization slug

Ninth phase of the [Organization Auth-Area Branding plan](../blob/main/ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md). A returning user opening an organization-scoped login URL sees that organization's branding before signing in.

> **Stacked on [#213](https://github.com/vintasoftware/vinta-schedule-api/pull/213) (Phase 7).** Review this diff against that branch.

### Why this is tests-only (no production code change)
Tracing the actual call paths shows the backend already delivers everything the branded-login use case needs, so the honest deliverable is coverage, not new code:
- **Slug→branding resolution already exists**: `brandingForTenant(slug=...)` was delivered in **Phase 5** (the plan's Phase 5 change list, not a new Phase 8 endpoint). The SPA reads branding by slug through it.
- **Login is SPA-driven headless** (`allauth.headless` JSON + two custom OAuth redirect/callback views) — there is no server-rendered login page in this repo, and the branded login *route* is an SPA concern (Non-goal: no client-side work here). Login initiation resolves a single global `SocialApp` per provider; there is no per-org OAuth client for a slug to route to.
- **Post-auth destination** (Phase 7) already resolves the org solely from `request.user`'s real membership, never from the URL/headers/browser.

The plan's Phase 8 Touch List named `accounts/urls.py` + `public_api/queries.py`, but the plan's own Phase 8 body scopes this to "whatever routing or context the login path needs **on top of** [Phase 5's query]" — which, once traced, is nothing. Adding an endpoint would have duplicated Phase 5's resolver. (Reviewer independently confirmed this read.)

### Tests added
- **Slug resolution for the common branded-org shape**: a standalone (parentless, non-reseller, entitled) org resolves to its **own** branding via its own slug — every prior slug test used a reseller fixture, so this closes a real coverage gap post-Phase-4/5.
- **Generic login unchanged / no browser inference** (the "Login with no organization context" edge case): the callback destination ignores an `X-Organization-Id` header (user's real membership differs from the header's target → destination follows the membership), a `Referer`, and an org cookie; and the redirect form has no org/slug field. Combined with Phase 7's `state["next"]` guard, the destination path is now pinned against every browser-inference vector.
- No-oracle on unknown slug relies on Phase 5's existing byte-for-byte indistinguishability tests (still passing).

No migration, no schema change (`schema.yml` byte-identical). Full suite: **4838 passed**.

### Review notes (Tier 3 / sonnet) — no BLOCKER, no SHOULD-FIX
Independently verified there is no backend gap (the tests-only scope is correct, not under-delivery) and that the generic-login guards are non-vacuous. One NIT (a docstring citing "Phase 4" instead of "Phase 5") corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhB71XXpM9repoyHaWMxe2)_