### PR TITLE
feat(calendar): introduce group-scoped availability for calendars

### DIFF
--- a/ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md
+++ b/ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,485 @@
+# Calendar Group-Scoped Availability — Implementation Plan
+
+Spec: [2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_SPEC.md](2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_SPEC.md). This plan translates that spec into phases; it does not re-derive requirements. Where a phase implements a spec use-case, the use-case is named under the phase's **Spec use-case** line, referring to entries under the spec's **Decisions → Use-cases**.
+
+## 1. Goals
+
+1. A calendar in a group slot can be narrowed by **group-scoped availability windows** (intersect-only), removed from time by **group-scoped blocked time**, and capped by **quota rules**, without any of it affecting the calendar's behavior in other groups or in single-calendar booking.
+2. All three concepts are honored identically on four surfaces: group slot discovery, booking and rescheduling validation, the public API, and the internal REST management surface.
+3. Groups with no group-scoped configuration produce output identical to today, with no additional queries on that path.
+4. All writes are audited with before/after values, and permission-gated to the calendar's owner within groups they can see, with admin override.
+
+**Non-goals:**
+
+- Availability narrowed by event type or service rather than by group.
+- Bulk copy of configuration across groups or calendars.
+- Group throughput caps ("the group does at most 10 a week") — quota is per calendar only.
+- Rolling quota windows — fixed calendar periods only.
+- Admin override to book past a consumed quota.
+- Automatic cancellation, rescheduling, or attendee notification for bookings orphaned by a narrowing.
+- Any mechanism that makes a calendar bookable at a time its base availability excludes.
+- Optimistic locking or conflict surfacing on concurrent edits — last-write-wins is accepted.
+- Changes to single-calendar booking, to the existing availability read/write contract, or to booking-policy resolution.
+- New metrics or dashboards — the audit trail is the only observability added.
+
+## 2. Guiding Decisions
+
+| Decision | Resolution |
+|---|---|
+| **Storage shape** | A nullable group-slot reference on the existing `AvailableTime` and `BlockedTime` tables, rather than new models. Each recurring model in this codebase carries four versioned raw-SQL functions (`calculate_recurring_*`, `get_*_occurrences_json`, and `_with_bulk_modifications` variants of each), an exception model, a bulk-modification model, and a queryset. New models would duplicate eight SQL artifacts to obtain behavior that already exists and is already tested. |
+| **Row scoping** | The default manager on both models **excludes** group-scoped rows; group-scoped access is explicit opt-in. Chosen over per-call-site filtering because a missed call site is a silent correctness failure — a group-scoped window leaking into base availability makes someone bookable when they should not be. Default-exclude means every existing call site is correct with zero edits. |
+| **Intersect, never widen** | Group-scoped windows narrow the calendar's base availability and can never extend it. Base availability stays the single source of truth for when a person works at all, which is what makes the fall-through default safe. |
+| **Fall-through default** | No group-scoped configuration means base availability applies unchanged. This is what delivers goal 3 and is also the rollout gate (see below). |
+| **Quota storage** | A small non-recurring model. Multiple rules per (calendar, slot), **all** of which must pass, so "at most 1 a day and 3 a week" is expressible. |
+| **Quota counting** | Only bookings made **through that group** count. Events created directly on the calendar do not consume group quota — precise and cheap to compute, at the cost of a quota that reality can exceed. |
+| **Quota evaluation** | A new versioned Postgres function returning per-calendar per-period booking counts, matching how occurrence expansion is already done in this codebase. Counts are derived on read, never stored, so cancellation frees quota immediately and a reschedule across a period boundary moves the count automatically. |
+| **Week start** | A choice field on the organization model with a database default of Monday, matching the precedent of the other org policy fields. Used for quota period boundaries and nothing else. |
+| **No feature flag — waiver** | This project has no feature-flag library; the billing rollout stated so explicitly and used its `unlimited` plan as the switch. Introducing one is out of scope. The waiver is sound here because the feature is **self-gating**: an unconfigured calendar takes the fall-through path and behaves byte-for-byte as today, so nothing changes for anyone until an admin deliberately creates a window. Every phase that touches an existing read path carries a test asserting the unconfigured path is unchanged, which is the same guarantee a flag-off test would give. The one phase that is **not** self-gating is the blocked-time metering change, which is called out separately below. |
+| **Metering** | All blocked time becomes metered, base rows included — not only group-scoped blocks — so one rule holds: every time window an organization authors is metered, positive or negative. |
+| **Metering rollout** | Switched on immediately. The product is **pre-customer**, so there is no installed base whose usage jumps and no organization that lands over its limit — the change that would be breaking later is free now. Measuring first and raising limits was considered and declined because there is nothing to measure. It still gets its own phase, for reviewability and independent revert, not because it is dangerous. |
+| **Public API shape** | New dedicated operations for all three concepts. The existing availability query and batch mutation keep their exact current shape — the spec's negative scope freezes that contract, and partners depend on it. |
+| **Internal REST shape** | Nested under the group slot, so listing a slot's roster is one call and group-visibility permissions apply at the route rather than per object. |
+| **Write semantics** | Bulk upsert, replay is a no-op, last-write-wins on concurrent edits — identical to the existing availability batch write so integrations need not learn a second contract. |
+| **Error detail** | Booking rejections name the calendar and the rule type violated, not the configured values. Enough for an admin to act; does not leak roster detail to external bookers on public links. |
+| **Phase granularity** | Bundled by concept — foundation, then windows, then blocks, then quota — with sub-phases per surface where a concept exceeds MR size. Chosen over one-phase-per-use-case in Step 0. |
+| **Assumption to verify in Phase 0** | The occurrence SQL functions take row ids as input, so scoping is applied by the caller before the function runs and the functions themselves need no change. Phase 0 verifies this rather than assuming it; if any function selects rows itself, it needs a version bump and Phase 0 grows accordingly. |
+
+## 3. Data Model Changes
+
+### 3.1 `AvailableTime.group_slot` and `BlockedTime.group_slot`
+
+Nullable organization-scoped foreign key to `CalendarGroupSlot` on both models in [calendar_integration/models.py](calendar_integration/models.py), `on_delete=CASCADE` so the spec's "deleted with the membership" rule falls out of the schema rather than application code.
+
+Null means a base row (today's behavior). Non-null means the row applies only when the calendar is evaluated inside that slot.
+
+An index on the group-slot column supports the group-scoped read path. A partial index restricted to non-null rows keeps it small, since the overwhelming majority of rows are and will remain base rows.
+
+### 3.2 Manager and queryset scoping
+
+`AvailableTimeManager` and `BlockedTimeManager` in [calendar_integration/managers.py](calendar_integration/managers.py) filter to `group_slot IS NULL` by default. Explicit accessors expose the other views — group-scoped rows for one slot, and an unscoped escape hatch for admin and migrations.
+
+The corresponding querysets in [calendar_integration/querysets.py](calendar_integration/querysets.py) gain the matching methods. `AvailableTimeQuerySet.only_user_authored` — which the billing counter relies on — must keep working across both scopes, since group-scoped windows are metered too.
+
+### 3.3 New `CalendarGroupSlotQuotaRule`
+
+A non-recurring organization-scoped model: the group slot, the calendar, the period (day / week / month), and the cap. Unique per (calendar, slot, period) so at most one rule per period per pair, while allowing the daily-plus-weekly combination.
+
+Deleted with the slot membership, matching the windows.
+
+### 3.4 `Organization.week_start`
+
+A choice field on the organization model in [organizations/models.py](organizations/models.py), database default Monday, mirroring how `external_event_update_policy` is declared. Read only by quota period math.
+
+### 3.5 New Postgres function — per-period booking counts
+
+A versioned raw-SQL function under [calendar_integration/migrations/sql/functions/](calendar_integration/migrations/sql/functions/), authored through the framework at [common/raw_sql_migration_managers.py](common/raw_sql_migration_managers.py). Given a set of calendar ids, a group, a period type, a week start, and a search window, it returns per-calendar per-period counts of live bookings made through that group.
+
+### 3.6 Type plumbing
+
+The dataclasses in [calendar_integration/services/dataclasses.py](calendar_integration/services/dataclasses.py) that carry slot availability and bookable-slot proposals gain the fields needed to express a rejection reason (calendar plus rule type), and the write paths gain a result type carrying the orphaned-booking warning.
+
+## 4. API Design
+
+### 4.1 Internal REST — nested under the group slot
+
+Collections for windows, blocks, and quota rules hang off a group's slot. Standard list / create / update / delete, organization-scoped, gated so a calendar owner may act on their own calendar within groups they can see, and an org admin on anyone's.
+
+The narrowing write returns, alongside the saved object, the list of confirmed future bookings in that group that now fall outside the configuration. Nothing is cancelled.
+
+### 4.2 Public API — new dedicated operations
+
+New queries and batch-upsert mutations for the three concepts, using the same auth, organization scoping, and resource-mapping conventions as the existing availability operations, registered in [public_api/queries.py](public_api/queries.py) and [public_api/mutations.py](public_api/mutations.py).
+
+Batch semantics match the existing availability batch write exactly: all-or-nothing, replay is a no-op, and a batch that would exceed the plan limit is rejected whole with the existing over-limit response body.
+
+The existing availability query and batch mutation are **not** modified.
+
+### 4.3 Errors
+
+A booking or reschedule that names a calendar violating any of the three rules is rejected with the calendar identifier and the rule type — outside window, inside block, or quota consumed. Configured values are not included.
+
+## 5. Phased Rollout
+
+No feature flag; see the waiver in **Guiding Decisions**. Consequently there is no flag-removal phase. Every phase that touches an existing read path carries a test asserting the unconfigured path is byte-for-byte unchanged, which is this plan's substitute for a flag-off test.
+
+---
+
+### Phase 0 — Group-slot scoping on the availability tables
+
+**Goal**: the schema and the default-exclude scoping exist, with zero behavior change anywhere. Ship value: none on its own — this is the foundation every later phase consumes, and it is separated because getting default-exclude wrong is the plan's highest-blast-radius failure.
+
+**Feature flag**: none — see the waiver in **Guiding Decisions**. This phase is unreachable from any existing flow: no code writes the new column yet.
+
+Changes:
+1. [calendar_integration/models.py](calendar_integration/models.py): nullable group-slot foreign key on `AvailableTime` and `BlockedTime`, cascading on slot deletion.
+2. Migration: add both columns nullable with no default so the change is metadata-only, add the foreign key constraints as not-valid and validate separately, and create the partial indexes concurrently. Hot tables — the lock-aware path is mandatory, not optional.
+3. [calendar_integration/managers.py](calendar_integration/managers.py) and [calendar_integration/querysets.py](calendar_integration/querysets.py): default manager filters to base rows; explicit accessors for group-scoped and unscoped views.
+4. [calendar_integration/admin.py](calendar_integration/admin.py): use the unscoped accessor so admin keeps showing every row.
+5. Verify the assumption recorded in **Guiding Decisions**: confirm the occurrence SQL functions under [calendar_integration/migrations/sql/functions/](calendar_integration/migrations/sql/functions/) take row ids as input and select no rows themselves. If any does, bump its version to respect the scope column and note the added surface.
+
+**Spec use-case**: shared scaffolding — no use-case yet.
+
+Tests:
+- **Unit**: [calendar_integration/tests/test_models.py](calendar_integration/tests/test_models.py) — default manager excludes group-scoped rows; explicit accessors return them; cascade on slot deletion removes them.
+- **Integration**: [calendar_integration/tests/services/](calendar_integration/tests/services/) — the full existing availability and group test suites pass unchanged, and a group-scoped row inserted directly is invisible to every base read path (services, serializers, public API).
+
+**Suggested AI model**: Tier 3 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Not the migration itself, which is routine, but the default-manager change reaches every consumer of two hot models and the blast radius of getting it wrong is silent incorrect availability.
+
+**Review models**: reviewer Tier 4 — a leak here makes calendars bookable when they should not be, and the failure is silent rather than loud. The independent review runs on the most capable model. Fixer left on the project default.
+
+**Reusable skills**: `add-migration` (lock-aware column addition on hot tables; couple with the `migration-author` agent).
+
+**Acceptance**: both columns exist and are indexed, the full existing test suite passes with no edits to existing call sites, and a directly-inserted group-scoped row is returned by no base read path.
+
+---
+
+### Phase 0b — Organization week-start setting
+
+**Goal**: organizations can declare whether their week starts Monday or Sunday. Ship value: none until quota lands; separated because it is a different app and can be reviewed and merged independently.
+
+**Feature flag**: none — purely additive field with a database default; nothing reads it yet.
+
+Changes:
+1. [organizations/models.py](organizations/models.py): week-start choice field, database default Monday, following the `external_event_update_policy` precedent.
+2. Migration adding the column with a database default.
+3. Admin and the organization serializer: expose the field, admin-editable only.
+
+**Spec use-case**: shared scaffolding — supports UC-2.
+
+Tests:
+- **Unit**: [organizations/tests/](organizations/tests/) — default is Monday for new and existing organizations; non-admins cannot change it.
+
+**Suggested AI model**: Tier 1 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Single field, migration, admin registration, exact precedent in the same file.
+
+**Reusable skills**: `add-migration`.
+
+**Acceptance**: every existing organization reads Monday, admins can change it, and nothing else in the system consults it yet.
+
+---
+
+### Phase 1a — Group-scoped availability windows: writes
+
+**Goal**: an admin or calendar owner can create, edit, and delete group-scoped availability windows through the service layer, audited and permission-gated, and a narrowing reports the bookings it orphans.
+
+**Feature flag**: none. Reachable only through new service methods; no existing caller enters this code.
+
+Changes:
+1. [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py): write methods for group-scoped windows — create, update, delete — writing through the explicit group-scoped accessor.
+2. Permission checks in [calendar_integration/services/calendar_permission_service.py](calendar_integration/services/calendar_permission_service.py): calendar owner within a group they can see, or org admin. A member must not learn a group exists from an error message.
+3. Audit wiring following the pattern already established in [calendar_integration/services/booking_policy_service.py](calendar_integration/services/booking_policy_service.py) — all three operations, before/after values on update.
+4. Orphaned-booking detection: on a narrowing, collect confirmed future bookings in that group for that calendar now outside the configuration and return them. Cancel nothing.
+5. [calendar_integration/services/dataclasses.py](calendar_integration/services/dataclasses.py): the write result type carrying the warning.
+
+**Spec use-case**: UC-1 (admin narrows a surgeon to operating days), UC-6 (admin tightens a window that orphans bookings).
+
+Tests:
+- **Unit**: [calendar_integration/tests/services/](calendar_integration/tests/services/) — create/update/delete; recurrence and per-window timezone round-trip; audit records emitted with diffs; owner-outside-group and non-owner both denied without disclosing the group.
+- **Integration**: narrowing a window with confirmed future bookings returns them and modifies none of them; deleting the slot membership removes the windows.
+
+**Suggested AI model**: Tier 3 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Multi-file orchestration across service, permission, and audit layers with non-trivial permission branching.
+
+**Reusable skills**: none — no clean match; the audit and permission patterns are followed from the existing booking-policy service.
+
+**Acceptance**: windows can be written and read back through the service layer with full recurrence, every write produces an audit record, permission rules hold, and a narrowing returns its orphaned bookings without touching them.
+
+---
+
+### Phase 1b — Windows in discovery and booking validation
+
+**Goal**: a calendar with group-scoped windows is offered only inside them, in that group only, and a booking that names it outside them is rejected.
+
+**Feature flag**: none. **Self-gating**: a calendar with no group-scoped windows takes an early-out before any new work runs, so the unconfigured path is unchanged and issues no extra queries. This is the phase where goal 3 is proven.
+
+Changes:
+1. [calendar_integration/services/slot_engine.py](calendar_integration/services/slot_engine.py): fetch group-scoped windows for the search range and intersect them into the free-check, after base availability and before anything else.
+2. [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py): `find_bookable_slots` and `check_group_availability` consume the intersected result. The early-out when no calendar in the group has group-scoped windows must skip the fetch entirely.
+3. Booking and rescheduling validation: reject a selected calendar that is outside its window for the requested time, with the calendar identifier and rule type.
+4. [calendar_integration/services/bookable_slots_service.py](calendar_integration/services/bookable_slots_service.py): confirm the single-calendar path is untouched — it has no group context and must not gain one.
+
+**Spec use-case**: UC-1, UC-4 (patient books through the group), and the discovery half of UC-6.
+
+Tests:
+- **Integration**: [calendar_integration/tests/services/](calendar_integration/tests/services/) — the surgeon scenario end to end, including that the same calendar is unaffected in a second group; a window outside base availability yields no offered time; explicit booking outside the window is rejected with the right shape.
+- **Integration — unchanged path**: for a group with no group-scoped configuration, discovery output is identical to the pre-change result **and** the query count is unchanged. This is the substitute for a flag-off test and is required.
+
+**Suggested AI model**: Tier 3 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Hot read path, an early-out that must be exactly right, and integration tests spanning discovery through booking.
+
+**Review models**: reviewer Tier 4 — this phase modifies the main booking read path, and the zero-change guarantee is easy to assert and hard to actually hold. Fixer left on the project default.
+
+**Reusable skills**: none.
+
+**Acceptance**: a calendar with a Tuesday/Thursday window in one group is offered only Tuesdays and Thursdays there and on its full base availability elsewhere; a group with nothing configured produces byte-for-byte identical discovery output with no extra queries.
+
+---
+
+### Phase 1c — Windows on the internal REST surface
+
+**Goal**: the first-party web app can manage group-scoped windows for a calendar within a slot.
+
+**Feature flag**: none — new routes nested under the group slot; no existing route changes shape.
+
+Changes:
+1. [calendar_integration/serializers.py](calendar_integration/serializers.py), [calendar_integration/views.py](calendar_integration/views.py), [calendar_integration/routes.py](calendar_integration/routes.py): a viewset nested under the group slot, delegating to the Phase 1a service methods.
+2. [calendar_integration/permissions.py](calendar_integration/permissions.py): route-level group-visibility gating.
+3. The narrowing response carries the orphaned-booking warning.
+4. Regenerate the OpenAPI schema.
+
+**Spec use-case**: UC-1, UC-6 (their user-facing entry point).
+
+Tests:
+- **Integration**: [calendar_integration/tests/](calendar_integration/tests/) — full lifecycle through the endpoints; cross-organization and cross-group access denied; the warning appears in the narrowing response.
+
+**Suggested AI model**: Tier 2 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Serializer plus viewset plus route registration against an established pattern, delegating logic already built.
+
+**Reusable skills**: `create-rest-endpoint`.
+
+**Acceptance**: windows are manageable through the nested routes, the schema regenerates cleanly, and no existing route's shape changed.
+
+---
+
+### Phase 1d — Windows on the public API
+
+**Goal**: partner integrations can read and batch-write group-scoped windows, idempotently and under the plan limit.
+
+**Feature flag**: none — new operations; existing availability operations untouched.
+
+Changes:
+1. [calendar_integration/graphql.py](calendar_integration/graphql.py): a type for group-scoped windows.
+2. [public_api/queries.py](public_api/queries.py) and [public_api/mutations.py](public_api/mutations.py): a query and a batch-upsert mutation, following the existing availability batch write's all-or-nothing and over-limit behavior exactly.
+3. [public_api/permissions.py](public_api/permissions.py) and [public_api/constants.py](public_api/constants.py): resource mapping and scoping for the new operations.
+4. Confirm group-scoped windows count toward the availability window limit through `only_user_authored`.
+
+**Spec use-case**: UC-5 (upstream rostering system pushes windows).
+
+Tests:
+- **Integration**: [public_api/tests/](public_api/tests/) — batch upsert applies; identical replay is a no-op; a batch exceeding the plan limit is rejected whole with the existing over-limit body and creates nothing; cross-organization scoping holds; the existing availability operations' responses are unchanged.
+
+**Suggested AI model**: Tier 3 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Batch-upsert semantics interacting with entitlement enforcement, where partial application would be a data-integrity bug.
+
+**Reusable skills**: `create-graphql-public-query`.
+
+**Acceptance**: an integration can push a roster batch, replay it safely, and is blocked at the plan limit with nothing partially created; existing availability operations are byte-for-byte unchanged.
+
+---
+
+### Phase 2a — Group-scoped blocked time: writes and enforcement
+
+**Goal**: a member can block time within one group without affecting any other group, and the block wins over any window.
+
+**Feature flag**: none. Self-gating — no group-scoped blocks means the fetch is skipped.
+
+Changes:
+1. [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py): write methods for group-scoped blocks, mirroring Phase 1a including audit and permissions.
+2. [calendar_integration/services/slot_engine.py](calendar_integration/services/slot_engine.py): blocks applied after base availability and before windows, per the spec's resolution order — a block removes time regardless of what a window says.
+3. Booking and rescheduling validation rejects a calendar inside a block, with the rule type.
+
+**Spec use-case**: UC-3 (member blocks one week for one activity).
+
+Tests:
+- **Unit**: write lifecycle, audit, permissions.
+- **Integration**: a group-scoped block hides the calendar in that group and nowhere else; a block overlapping a group-scoped window wins; the unconfigured path is unchanged with no extra queries.
+
+**Suggested AI model**: Tier 2 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Close mirror of Phase 1a and 1b with the precedent freshly established in the same files; step up to Tier 3 if the resolution-order change in the slot engine proves more invasive than a filter insertion.
+
+**Reusable skills**: none.
+
+**Acceptance**: a block created in one group removes time there only, beats an overlapping window, and leaves unconfigured groups unchanged.
+
+---
+
+### Phase 2b — Blocks on the REST and public surfaces
+
+**Goal**: blocks are manageable and readable everywhere windows are.
+
+**Feature flag**: none — new routes and operations.
+
+Changes:
+1. REST viewset, serializer, and nested route mirroring Phase 1c; regenerate the schema.
+2. Public API query and batch-upsert mutation mirroring Phase 1d, with resource mapping and scoping.
+
+**Spec use-case**: UC-3 (its entry points).
+
+Tests:
+- **Integration**: lifecycle through both surfaces; scoping and permission denials; batch idempotency and over-limit rejection.
+
+**Suggested AI model**: Tier 2 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Direct application of the pattern established in Phases 1c and 1d.
+
+**Reusable skills**: `create-rest-endpoint`, `create-graphql-public-query`.
+
+**Acceptance**: blocks have full parity with windows on both surfaces.
+
+---
+
+### Phase 2c — Meter all blocked time
+
+**Goal**: blocked time counts toward the availability window plan limit, base rows included, so one rule covers every authored time window.
+
+**Feature flag**: none, and this phase is **not self-gating** — it changes the meaning of the counter for every organization rather than only for configured ones. With the product pre-customer there is no installed base to affect, so this is a rule change made at its cheapest moment rather than a breaking one. It stays in its own phase for reviewability and independent revert.
+
+Changes:
+1. [payments/services/entitlement_service.py](payments/services/entitlement_service.py): the availability window counter includes blocked time — base and group-scoped — alongside availability. Apply the same user-authored filtering the availability counter already uses, so recurrence exceptions and series splits do not inflate the count; if `BlockedTimeQuerySet` lacks that filter, add its equivalent.
+2. Confirm the existing limit-warning notification path fires for organizations pushed near or over their limit by the change.
+
+**Spec use-case**: none — billing rule change required by the spec's metering decision.
+
+Tests:
+- **Unit**: [payments/tests/services/](payments/tests/services/) — the counter includes base and group-scoped blocked time; recurrence exceptions and split series do not inflate it.
+- **Integration**: an organization over the new limit is blocked from creating further windows and receives the existing over-limit response; the limit-warning notification fires.
+
+**Suggested AI model**: Tier 2 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). A counter change against an established pattern, with the subtlety concentrated in the user-authored filtering.
+
+**Reusable skills**: none.
+
+**Acceptance**: the counter reports base plus group-scoped blocked time plus availability, without inflation from recurrence exceptions, and an organization over its limit hits the existing over-limit path rather than any new error.
+
+---
+
+### Phase 3a — Quota model and period-counting function
+
+**Goal**: quota rules can be stored and per-period booking counts can be computed. Ship value: none on its own — the model and the counting primitive that Phase 3b consumes.
+
+**Feature flag**: none — new model, new SQL function, nothing reads them yet.
+
+Changes:
+1. [calendar_integration/models.py](calendar_integration/models.py): the quota rule model with its manager and queryset; unique per (calendar, slot, period); cascade with the slot membership.
+2. Migration for the model.
+3. A versioned raw-SQL function under [calendar_integration/migrations/sql/functions/](calendar_integration/migrations/sql/functions/) returning per-calendar per-period counts of live bookings made through a given group, honoring the organization's week start, plus its migration and the Django function wrapper in [calendar_integration/database_functions.py](calendar_integration/database_functions.py).
+4. [calendar_integration/factories.py](calendar_integration/factories.py): a factory for the new model.
+
+**Spec use-case**: shared scaffolding — supports UC-2.
+
+Tests:
+- **Unit**: model constraints; cascade behavior.
+- **Integration**: the counting function against day, week, and month periods; Monday and Sunday week starts; cancelled bookings excluded; a booking rescheduled across a period boundary counted in the new period only; bookings made outside the group excluded.
+
+**Suggested AI model**: Tier 3 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). New versioned SQL function plus model plus migration, with period-boundary and timezone edges that are easy to get subtly wrong.
+
+**Reusable skills**: `add-model`, `create-postgres-function`, `add-migration`.
+
+**Acceptance**: quota rules persist with their constraints, and the counting function returns correct counts across all three periods, both week starts, and the cancellation and reschedule edges.
+
+---
+
+### Phase 3b — Quota in discovery and booking validation
+
+**Goal**: a calendar that has consumed its quota for a period stops being offered for that period and is rejected if named directly.
+
+**Feature flag**: none. Self-gating — no quota rules in the group means the counting query is never issued.
+
+Changes:
+1. [calendar_integration/services/slot_engine.py](calendar_integration/services/slot_engine.py) and [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py): one counting call per discovery covering the whole search window, bucketed by period, consulted per candidate as a lookup. All rules for a calendar must pass.
+2. Booking and rescheduling validation rejects a calendar with no headroom, naming the quota as the rule type.
+
+**Spec use-case**: UC-2 (member caps their own weekly load), and the quota half of UC-4.
+
+Tests:
+- **Integration**: a calendar at its cap is not offered for that period and is offered again the following period; cancelling a booking makes it available again with no further action; two rules (daily and weekly) both enforced; explicit booking past the cap rejected with the right shape; the unconfigured path unchanged with no extra queries.
+
+**Suggested AI model**: Tier 3 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Hot read path plus multi-rule evaluation plus period bucketing, with the performance risk the spec flagged concentrated here.
+
+**Review models**: reviewer Tier 4 — quota evaluation lands on the main discovery loop, and the phase must add at most one query per discovery regardless of candidate count. A per-candidate query here is a production performance regression that tests will not catch. Fixer left on the project default.
+
+**Reusable skills**: none.
+
+**Acceptance**: a calendar capped at three a week disappears from that week once three are booked and returns when one is cancelled; discovery issues one counting query per call, not one per candidate; unconfigured groups are unchanged.
+
+---
+
+### Phase 3c — Quota rules on the REST and public surfaces
+
+**Goal**: quota rules are manageable and readable everywhere windows and blocks are.
+
+**Feature flag**: none — new routes and operations.
+
+Changes:
+1. REST viewset, serializer, and nested route; regenerate the schema.
+2. Public API query and mutation with resource mapping and scoping. Quota rules are not metered, so no entitlement check applies to their creation.
+
+**Spec use-case**: UC-2 (its entry points).
+
+Tests:
+- **Integration**: lifecycle through both surfaces; multiple rules per calendar and slot; the uniqueness constraint surfaced as a validation error, not a server error; permission and scoping denials.
+
+**Suggested AI model**: Tier 2 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Established pattern from the four preceding surface phases.
+
+**Reusable skills**: `create-rest-endpoint`, `create-graphql-public-query`.
+
+**Acceptance**: quota rules have full parity with windows and blocks on both surfaces, and no entitlement check gates their creation.
+
+---
+
+### Phase 4 — Client handoff document
+
+**Goal**: the web SPA and partner integration teams have a written contract for everything added, without reading this repository.
+
+**Feature flag**: none — documentation only.
+
+Changes:
+1. Generate the handoff covering every new REST route and public API operation across Phases 1c, 1d, 2b, and 3c: request and response shapes, auth, errors including the rejection reason shape, and the orphaned-booking warning field.
+2. Record explicitly that the existing availability operations are unchanged, and that the blocked-time metering change from Phase 2c alters plan-limit consumption for existing integrations.
+
+**Spec use-case**: none — delivery artifact.
+
+Tests: none — documentation.
+
+**Suggested AI model**: Tier 2 (IDs in [.claude/skills/plan-feature/resources/ai-models.yaml](../.claude/skills/plan-feature/resources/ai-models.yaml)). Reading a branch diff and writing accurate contract documentation.
+
+**Reusable skills**: `handoff-to-client`.
+
+**Acceptance**: the handoff document covers every added operation and both breaking-change notes, and a client implementer can build against it without opening this repository.
+
+## 6. Risk & Rollout Notes
+
+**No feature flag.** Justified in **Guiding Decisions**. The protection is structural: every phase touching an existing read path early-outs when no group-scoped configuration exists, and carries a test asserting identical output and unchanged query count on that path. If any phase cannot hold that assertion, stop and reconsider rather than weakening the test.
+
+**Migration safety.** Phase 0 adds columns to two hot tables. Add them nullable with no default so the change is metadata-only; add the foreign keys as not-valid and validate in a separate step; create the partial indexes concurrently. Phase 0b and Phase 3a are ordinary migrations on cold paths. Couple Phase 0 with the `migration-author` agent.
+
+**The default-manager change is the highest-blast-radius edit in the plan.** It silently alters what every existing consumer of two hot models sees. A mistake does not raise — it just returns the wrong availability. Phase 0's acceptance requires the existing suite to pass with no edits to existing call sites; treat any needed edit as a signal the scoping is wrong, not as a task.
+
+**Phase 2c changes a billing rule, and is cheap only because the product is pre-customer.** Metering all blocked time would raise reported usage for any organization that has authored some — with none on the product, it affects nobody. This is the reason to do it now rather than later: the same change costs a measurement pass, a limit-raising exercise, and customer communication once there is an installed base. **If customers onboard before this phase merges, revisit it** — the declined measure-first path becomes the right one at that point.
+
+**Query-plan risk on discovery.** Phases 1b, 2a, and 3b all add fetches to the main booking read path. Each must issue a fixed number of queries per discovery call, independent of candidate count — the existing engine already batches this way and the pattern must be preserved. Phase 3b is the one most likely to regress, since a naive implementation counts per candidate.
+
+**No backfill.** Nothing needs backfilling: the new columns default to null, which is exactly today's behavior, and quota is derived on read rather than stored.
+
+**Rollback.** Every phase is independently reversible. Phases 1a through 3c revert as ordinary code reverts, since no existing behavior depends on them. Phase 2c reverts by restoring the counter. Phase 0's columns can be left in place on a revert — they are nullable and unread — so the migration does not need to be reversed under pressure.
+
+**Deploy ordering.** No cross-repo producer, so no ordering constraint outside this repository. Client teams consume Phase 4's handoff after the API phases have merged; nothing in this plan blocks on them.
+
+## 7. Open Questions
+
+The spec resolved every question raised during its own drafting, and Step 0 of this plan resolved the implementation decisions. Two items are carried deliberately rather than unresolved:
+
+1. **Does the occurrence SQL machinery need version bumps?** Recorded in **Guiding Decisions** as an assumption with a verification step in Phase 0 rather than a decision. Recommended default: assume no change is needed, since the functions take row ids and scoping happens in the caller. If Phase 0 finds otherwise, the phase grows by however many function versions are affected, and that should be reported before continuing rather than absorbed silently. Answerable in Phase 0 itself.
+
+2. **Does `BlockedTimeQuerySet` need a user-authored filter?** The availability counter avoids over-reporting by excluding rows that recurrence editing inserts. Blocked time has no such filter today because it was never metered. Recommended default: add the equivalent in Phase 2c. If the recurrence models differ enough that the filter is not a direct translation, that phase grows. Answerable by whoever implements Phase 2c.
+
+## 8. Touch List
+
+**Phase 0** — edited: [calendar_integration/models.py](calendar_integration/models.py), [calendar_integration/managers.py](calendar_integration/managers.py), [calendar_integration/querysets.py](calendar_integration/querysets.py), [calendar_integration/admin.py](calendar_integration/admin.py). New: migration under @calendar_integration/migrations/.
+
+**Phase 0b** — edited: [organizations/models.py](organizations/models.py), [organizations/admin.py](organizations/admin.py), [organizations/serializers.py](organizations/serializers.py). New: migration under @organizations/migrations/.
+
+**Phase 1a** — edited: [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py), [calendar_integration/services/calendar_permission_service.py](calendar_integration/services/calendar_permission_service.py), [calendar_integration/services/dataclasses.py](calendar_integration/services/dataclasses.py), [calendar_integration/exceptions.py](calendar_integration/exceptions.py).
+
+**Phase 1b** — edited: [calendar_integration/services/slot_engine.py](calendar_integration/services/slot_engine.py), [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py).
+
+**Phase 1c** — edited: [calendar_integration/serializers.py](calendar_integration/serializers.py), [calendar_integration/views.py](calendar_integration/views.py), [calendar_integration/routes.py](calendar_integration/routes.py), [calendar_integration/permissions.py](calendar_integration/permissions.py), @schema.yml.
+
+**Phase 1d** — edited: [calendar_integration/graphql.py](calendar_integration/graphql.py), [public_api/queries.py](public_api/queries.py), [public_api/mutations.py](public_api/mutations.py), [public_api/permissions.py](public_api/permissions.py), [public_api/constants.py](public_api/constants.py).
+
+**Phase 2a** — edited: [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py), [calendar_integration/services/slot_engine.py](calendar_integration/services/slot_engine.py).
+
+**Phase 2b** — edited: the same REST and public API files as Phases 1c and 1d, plus @schema.yml.
+
+**Phase 2c** — edited: [payments/services/entitlement_service.py](payments/services/entitlement_service.py), [calendar_integration/querysets.py](calendar_integration/querysets.py).
+
+**Phase 3a** — edited: [calendar_integration/models.py](calendar_integration/models.py), [calendar_integration/managers.py](calendar_integration/managers.py), [calendar_integration/querysets.py](calendar_integration/querysets.py), [calendar_integration/database_functions.py](calendar_integration/database_functions.py), [calendar_integration/factories.py](calendar_integration/factories.py), [calendar_integration/admin.py](calendar_integration/admin.py). New: model migration and SQL function migration under @calendar_integration/migrations/, function source under @calendar_integration/migrations/sql/functions/.
+
+**Phase 3b** — edited: [calendar_integration/services/slot_engine.py](calendar_integration/services/slot_engine.py), [calendar_integration/services/calendar_group_service.py](calendar_integration/services/calendar_group_service.py).
+
+**Phase 3c** — edited: the same REST and public API files as the earlier surface phases, plus @schema.yml.
+
+**Phase 4** — new: handoff document under @.vinta-ai-workflows/client-handoffs/.
+
+Test files accompany every phase under @calendar_integration/tests/, @organizations/tests/, @payments/tests/, and @public_api/tests/, as named in each phase's Tests section.

--- a/ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_SPEC.md
+++ b/ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_SPEC.md
@@ -1,0 +1,260 @@
+# Calendar Group-Scoped Availability — Spec
+
+## 1. Business Context
+
+A calendar group aggregates calendars into named slots so one booking can pick a calendar from each slot and guarantee everyone picked is free at the same time. Availability today lives in exactly one place: on the calendar itself. A calendar is either available at a time or it is not, and every group that calendar belongs to sees the same answer.
+
+Real rosters do not work that way. A surgeon is on shift Monday to Friday, 9am to 5pm — that is their calendar availability, and it is correct for consults, rounds, and admin. But they only operate on Tuesdays and Thursdays, they take at most three operations a week, and next week they are at a conference and will take no operations at all while still seeing patients. None of that can be expressed today.
+
+What organizations do instead is split one person into several resource calendars — a "Dr. X surgery" calendar and a "Dr. X consults" calendar — each with its own availability, each placed in a different group. This has three costs:
+
+- **It double-books the human.** The two calendars do not know about each other, so the surgery group can book Dr. X at 10am on a Tuesday while the consult group books the same person at the same time. The system's core promise — that everyone selected is simultaneously free — is silently false for anyone who has been split.
+- **It inflates the resource calendar plan limit.** An organization pays for calendars proportional to the number of activities per person, not the number of people.
+- **It multiplies configuration.** Every schedule change has to be replicated across each of a person's calendars, by hand, correctly.
+
+The alternative workaround — blocking out the unwanted days — is worse: a block on Monday hides the surgeon from every group, including the consult group where they genuinely are available.
+
+Stakeholders: organization admins and schedulers who will configure rosters, the org members whose time is being scheduled, and the integration partners who will push roster data in from upstream systems.
+
+**There are no customers on the product yet.** That shapes this spec in two ways. The cost of doing nothing is entirely prospective, not incurred: no support tickets, no double-booking incidents, no churn — the cost is that organizations with role-specific staff cannot model their roster, which makes calendar groups unusable for a large share of the intended market. And because there is no installed base, decisions that would ordinarily be breaking changes are free right now. Where this spec makes a rule consistent at the cost of changing existing behavior, it does so deliberately, on the reasoning that the change gets more expensive with every customer added.
+
+## 2. Hypothesis (to be validated)
+
+Not a hypothesis — **known requirement**. The driver is that calendar groups cannot model role-specific staff, which is the majority of the clinical, legal, and professional-services scheduling this product targets. There is no validation gate and no kill criterion; correctness and scope discipline are what matter. There is no hard deadline.
+
+## 3. Objectives (and definition of done)
+
+1. **A calendar can be narrowed inside one group without affecting any other group.**
+   - Signal: a calendar configured with group-scoped availability in one group is offered only in the narrowed windows there, and remains offered on its full base availability in every other group and in single-calendar booking.
+   - Source: acceptance scenarios, exercised end to end.
+   - Threshold: binary — it holds or it does not.
+
+2. **Existing groups behave exactly as they do today.**
+   - Signal: for any group where no group-scoped availability, blocked time, or quota rule is configured, slot discovery and group availability checks return output identical to the current behavior, with no additional queries issued.
+   - Source: comparison against pre-change behavior across the existing group test suite.
+   - Threshold: byte-for-byte identical output; zero extra queries on the unconfigured path.
+   - This mirrors the identical-output guarantee the booking-policy work already holds itself to.
+
+3. **Every enforcement surface agrees.**
+   - Signal: a calendar that is outside its group-scoped window, inside a group-scoped block, or over its quota is simultaneously (a) absent from slot discovery, (b) rejected when named explicitly at booking time, and (c) reported consistently by the public and internal read surfaces.
+   - Source: acceptance scenarios covering each surface for the same configuration.
+   - Threshold: no surface disagrees with any other.
+
+4. **Configuration changes are attributable.**
+   - Signal: creating, editing, or deleting a window, block, or quota rule produces an audit record naming the actor, with before/after values on updates.
+   - Source: audit trail.
+   - Threshold: all three concepts, all three operations.
+
+Definition of done: objectives 1 through 4 all hold, verified by the acceptance scenarios below.
+
+## 4. Decisions
+
+Three group-scoped concepts are introduced. All three attach to a **(calendar, group slot)** pair — the calendar as it participates in one specific role of one specific group. A calendar may belong to at most one slot per group, so this is equivalent to per-(calendar, group) granularity today, while leaving room for a calendar to sit in differently-configured slots later.
+
+| Concept | What it does | Interaction with base availability | Counts against the availability window plan limit |
+| --- | --- | --- | --- |
+| Group-scoped availability window | Positive time windows, full recurrence | **Intersects** — narrows only, never widens | Yes |
+| Group-scoped blocked time | Removes time within that group only | Always wins over windows and base availability | Yes — a block is a window in every practical sense |
+| Group-scoped quota rule | Caps booked events per fixed period | Independent of time; caps volume | No — not a time window, and few per organization |
+
+Metering blocked time only when it is group-scoped would leave two identical-looking rows metered differently. To keep one rule — *every time window an organization authors is metered, positive or negative* — **all blocked time becomes metered, base rows included**.
+
+This is a change to existing billing behavior rather than an additive one, and it is made now precisely because there are no customers. With an installed base it would mean usage jumping on deploy and organizations landing over their limit without having done anything; with none, it costs nothing and the rule is consistent from the first customer onward. Deferring it would mean either living with the asymmetry permanently or paying for the migration later.
+
+Availability windows and blocked time use the same recurrence expressiveness as existing availability: recurrence rules, per-occurrence exceptions, bulk modifications, and a per-window timezone chosen by the author.
+
+**Fall-through is the default.** A calendar in a group slot with none of the three configured behaves exactly as it does today: its base availability applies unchanged. Configuring group-scoped behavior is opt-in, per calendar, per slot.
+
+### 4.1 Use-cases
+
+**UC-1 — Admin narrows a surgeon to operating days**
+- Actor: organization admin.
+- Trigger: setting up the Surgery group's roster.
+- Flow:
+  1. Admin opens Dr. Reyes' entry in the Surgery group's "Lead Surgeon" slot.
+  2. Admin adds a weekly recurring availability window: Tuesdays and Thursdays, 9am to 5pm, in the clinic's timezone.
+  3. Admin saves.
+- Outcome: the Surgery group offers Dr. Reyes only on Tuesdays and Thursdays. The Consults group, where Dr. Reyes also sits, still offers them Monday to Friday. Dr. Reyes' base availability is untouched.
+
+**UC-2 — Member caps their own weekly load**
+- Actor: Dr. Reyes, who owns their calendar.
+- Trigger: they are being over-booked for operations.
+- Flow:
+  1. Dr. Reyes opens their own entry in the Surgery group.
+  2. They add a quota rule: at most 3 bookings per week.
+  3. They save.
+- Outcome: once three operations are booked in a given week, Dr. Reyes stops being offered for that week in the Surgery group and any direct booking attempt naming them for that week is rejected. The following week resets. They remain fully offered in the Consults group.
+
+**UC-3 — Member blocks one week for one activity**
+- Actor: Dr. Reyes.
+- Trigger: a conference next Tuesday and Thursday, during which they will still take remote consults.
+- Flow:
+  1. Dr. Reyes adds a group-scoped block covering next Tuesday and Thursday in the Surgery group.
+  2. They save.
+- Outcome: the Surgery group offers nothing for Dr. Reyes on those two days. The Consults group is unaffected — no base availability was changed and no global block was created.
+
+**UC-4 — Patient books through the group**
+- Actor: an external person booking through a public scheduling link.
+- Trigger: they request a surgery appointment.
+- Flow:
+  1. They ask for available slots in the Surgery group over the next month.
+  2. The group returns only windows where every slot has enough calendars satisfying all of: base availability, group-scoped windows, no group-scoped block, and quota not yet consumed for that period.
+  3. They pick a slot and confirm.
+- Outcome: the booking succeeds and no one is offered a time they would have declined.
+
+**UC-5 — Upstream rostering system pushes windows**
+- Actor: an integration partner's rostering system, with no human present.
+- Trigger: the monthly roster is published upstream.
+- Flow:
+  1. The system authenticates against the public API and submits a batch of group-scoped windows for many calendars across several groups.
+  2. The batch is applied as a bulk upsert.
+  3. The system replays the same batch after a network timeout.
+- Outcome: the first call applies the roster; the replay is a no-op. If the batch would push the organization past its availability window plan limit, the whole batch is rejected with the same over-limit response shape the existing availability batch write already returns.
+
+**UC-6 — Admin tightens a window that orphans bookings**
+- Actor: organization admin.
+- Trigger: Dr. Reyes drops Tuesdays.
+- Flow:
+  1. Admin edits the window from Tuesdays and Thursdays down to Thursdays only.
+  2. Admin saves.
+- Outcome: the change is applied, and the response lists every confirmed future booking for Dr. Reyes in the Surgery group that now falls outside the window. The admin decides individually whether to cancel or reschedule each one. Nothing is cancelled automatically.
+
+### 4.2 State transitions & edge cases
+
+There is no lifecycle state machine — windows, blocks, and quota rules exist or they do not. What matters is the **resolution order** that decides whether a calendar is bookable in a slot at a given time.
+
+```mermaid
+flowchart TD
+    A["Candidate: calendar C, slot S, window T"] --> B{"C free per base availability at T?"}
+    B -- No --> X["Not bookable"]
+    B -- Yes --> C{"Any group-scoped block for C in S covering T?"}
+    C -- Yes --> X
+    C -- No --> D{"Any group-scoped availability window for C in S?"}
+    D -- "None configured" --> F
+    D -- "Configured" --> E{"T fully inside one of them?"}
+    E -- No --> X
+    E -- Yes --> F{"Any quota rule for C in S?"}
+    F -- "None configured" --> G["Bookable"]
+    F -- "Configured" --> H{"Live bookings in T's period < cap?"}
+    H -- No --> X
+    H -- Yes --> G
+```
+
+Two properties follow from this order and are load-bearing:
+
+- **Narrowing only.** A group-scoped window can never make a calendar bookable at a time its base availability excludes. Base availability stays the single source of truth for when a person or resource works at all.
+- **Blocks beat everything.** A group-scoped block removes time regardless of what any window says, and only within its own group.
+
+**Edge cases and their decided handling:**
+
+| Edge case | Handling |
+| --- | --- |
+| Nothing configured for a calendar in a slot | Base availability applies unchanged. No extra work is done on this path. |
+| Group-scoped window extends beyond base availability | The excess is ignored. If a window falls entirely outside base availability, the calendar is simply never offered — the save is accepted, not rejected. |
+| Narrowing orphans confirmed future bookings | Save succeeds. The response lists the affected future bookings. No automatic cancellation, no notification to attendees. |
+| Calendar removed from a slot, or the slot or group is deleted | Its group-scoped windows, blocks, and quota rules are deleted with it. Re-adding the calendar starts from an empty configuration. |
+| Quota consumed for the period | The calendar is both hidden from discovery for that period and rejected if named explicitly at booking time. No admin escape hatch in v1. |
+| Booking cancelled | Quota is counted from live bookings and recomputed on read, so the freed capacity is immediately available again. |
+| Booking rescheduled across a period boundary | The count moves with it — it leaves the old period and joins the new one. Recomputation makes this automatic. |
+| Slot requires more than one calendar | Each candidate calendar is evaluated independently; the slot is satisfied when enough candidates pass the full chain. |
+| Calendar in several groups | Each group's configuration is independent. A block in one group has no effect in any other. |
+| Daylight saving transitions | Windows carry their own timezone, as existing availability does, so a "9am to 5pm Tuesday" window stays 9am to 5pm local across a DST shift. |
+| Bundle calendar sits in a group slot | A group-scoped window, block, or quota rule attaches to the bundle calendar itself. Its children are evaluated on base availability alone and carry no group-scoped configuration of their own. |
+| Batch write exceeds the availability window plan limit | The whole batch is rejected, matching how the existing availability batch write behaves — no partial application. Windows and blocks both consume the limit; quota rules do not. |
+
+**Idempotency.** Writes are bulk upserts. Replaying an identical batch is a no-op and leaves the same final state. This is deliberately identical to the existing availability batch write so integrations do not need to learn a second contract.
+
+**Concurrency.** Last-write-wins. Two admins editing the same window concurrently means the later save stands; no conflict is surfaced. This matches existing availability writes.
+
+**Time-bounded rules.** Quota periods are fixed calendar periods — day, week, or month — chosen per rule and aligned to calendar boundaries in the relevant timezone. No rolling windows, no TTLs, no scheduled re-evaluation: quota is derived on read, never stored.
+
+Week boundaries need an organization week-start setting, and none exists today — the only week start in the system is per recurrence rule, defaulting to Monday. A new organization-level setting is introduced: editable by admins, defaulting to Monday, and used for nothing except quota period boundaries. It does not affect recurrence rules, existing week handling, or any display.
+
+**Permissions.** A calendar's owner may edit that calendar's group-scoped configuration, and only within groups they can see — so a member cannot learn about groups they are not part of through error messages or listings. Organization admins may edit anyone's. Resource calendars with no owner are admin-only by construction.
+
+**Audit.** Creating, editing, and deleting windows, blocks, and quota rules is written to the audit trail, with before/after values on updates. "Who made the surgeon unbookable on Tuesdays" is precisely the question this exists to answer.
+
+**Surfaces.** All three concepts — windows, blocks, and quota rules — are honored on all four surfaces, with no concept exposed on fewer than another:
+
+1. Group slot discovery and group availability checks filter on all three.
+2. Booking and rescheduling reject a calendar that violates any of the three, including when the caller names the calendar explicitly rather than picking a discovered slot.
+3. The public API can read and batch-write all three, under the same permission and organization-scoping rules the existing availability surface uses.
+4. The internal management surface can list, create, edit, and delete all three.
+
+### 4.3 Acceptance scenarios
+
+1. **Happy path — narrowing works, and is scoped.**
+   Given Dr. Reyes is available Monday to Friday 9am–5pm and belongs to both the Surgery group and the Consults group, when an admin adds a Tuesday-and-Thursday 9am–5pm window for Dr. Reyes in the Surgery group, then Surgery slot discovery offers Dr. Reyes only on Tuesdays and Thursdays, and Consults slot discovery still offers them Monday to Friday.
+
+2. **Zero change for unconfigured groups.**
+   Given a group where no calendar has any group-scoped window, block, or quota rule, when slot discovery runs over any search window, then the result is identical to the pre-change result and no additional queries are issued.
+
+3. **Narrowing cannot widen.**
+   Given Dr. Reyes' base availability is Monday to Friday, when an admin adds a Saturday 9am–1pm group-scoped window in the Surgery group, then the window is saved but Saturday is never offered, because base availability excludes it.
+
+4. **Error path — explicit booking outside the window is rejected.**
+   Given Dr. Reyes has a Tuesday-and-Thursday window in the Surgery group, when a caller attempts to book Dr. Reyes into that group for a Wednesday at 10am by naming the calendar directly rather than picking a discovered slot, then the booking is rejected with an error identifying the calendar and the reason.
+
+5. **Edge case — quota consumed and then released.**
+   Given Dr. Reyes has a quota of 3 bookings per week in the Surgery group and 3 are booked for the week of the 10th, when slot discovery runs for that week, then Dr. Reyes is not offered; and when one of the three bookings is cancelled, then Dr. Reyes is offered again for that week without any further action.
+
+6. **Edge case — narrowing orphans a booking.**
+   Given Dr. Reyes has confirmed Surgery bookings on upcoming Tuesdays, when an admin narrows the window to Thursdays only, then the save succeeds, the response lists those Tuesday bookings, and none of them is cancelled or modified.
+
+7. **Integration-driven — idempotent batch write under the plan limit.**
+   Given an integration submits a batch of group-scoped windows through the public API, when the identical batch is submitted a second time after a timeout, then the final state matches the single-submission state; and given a batch that would push the organization past its availability window plan limit, when it is submitted, then the entire batch is rejected with the existing over-limit response and nothing is created.
+
+### 4.4 Negative scope
+
+- **Availability per event type or service.** Narrowing by what is being booked — a 30-minute consult versus a 3-hour operation — is a different axis from which group. Deferred; no v2 commitment.
+- **Bulk copy across groups or calendars.** "Apply this Tuesday/Thursday pattern to all six surgeons" and "copy the Surgery group's config to the Endoscopy group" are convenience tooling on top of the core model. Deferred until the core model is proven in use.
+- **Group throughput caps.** Quota in v1 is per calendar. "The Surgery group does at most 10 operations a week" across everyone is a different rule with different resolution and is not included.
+- **Rolling quota windows.** "At most 3 in any rolling 7 days" is excluded — fixed calendar periods only.
+- **Admin override of quota at booking time.** No escape hatch for urgent cases in v1; over quota means rejected, for everyone.
+- **Automatic handling of orphaned bookings.** No auto-cancel, no auto-reschedule, no notification to affected attendees. The warning is returned to the caller and the decision is theirs.
+- **Widening.** No mechanism, flag, or admin power makes a calendar bookable in a group at a time its base availability excludes.
+- **Conflict detection on concurrent edits.** Last-write-wins is accepted; no optimistic locking is added here.
+- **Changes to single-calendar booking.** Booking a calendar directly, outside any group, is untouched. Its availability, its policy resolution, and its outputs must not shift.
+- **Changes to the existing availability contract.** The existing calendar availability read and batch-write surfaces keep their current shapes and semantics byte-for-byte; group-scoped configuration is additive.
+- **Changes to booking policy resolution.** Lead time, max horizon, and buffers resolve exactly as they do today. Group-scoped availability is a separate filter, not a new level in that chain.
+
+## 5. Alternatives considered
+
+**Keep splitting people into multiple resource calendars.** This is the status quo. Rejected because it defeats the product's core guarantee — two calendars representing the same human do not know about each other, so the system will confidently double-book a person it has promised is free. It also charges organizations per activity rather than per person.
+
+**Express the restriction as blocked time on the calendar.** Rejected because blocks are global. Blocking Monday to hide a surgeon from the Surgery group also hides them from the Consults group where they genuinely are available, which is the exact problem being solved.
+
+**Attach the window to the group as a whole rather than per calendar.** A group-level operating window ("Surgery runs Tuesdays and Thursdays") is simpler, but cannot express two surgeons with different operating days in the same group — which is the normal case, not the exception.
+
+**Let the group-scoped window override base availability instead of intersecting it.** Rejected because it lets a group make someone bookable at a time their own calendar says they are not working, and it removes any single answer to "when does this person work". Intersection keeps base availability authoritative and makes the group configuration purely subtractive, which is also what makes the fall-through default safe.
+
+**Attach at (calendar, group) instead of (calendar, group slot).** Equivalent today, since a calendar belongs to at most one slot per group. Slot granularity was chosen because it costs nothing now and leaves room for a calendar to occupy differently-configured roles later without a migration.
+
+## 6. Open questions
+
+All questions raised while drafting were resolved on 2026-08-05 and now live in **Decisions**: plan-limit treatment of each concept, the organization week-start setting, bundle calendar behavior, and public API exposure of all three concepts. A follow-up question about whether plan limits need raising, given blocked time now consumes the counter, was also resolved: limits stay as they are and metering switches on immediately, which costs nothing while the product is pre-customer.
+
+Nothing is outstanding. Two things are deliberately deferred rather than unknown, and are recorded where they belong:
+
+- Whether slot discovery should explain *why* a calendar is absent, rather than silently omitting it. Accepted as-is for v1; see **Risks assumed**.
+- Retuning plan limits once real usage exists. Nothing to measure while pre-customer; see **Risks assumed**.
+
+## 7. Risks assumed
+
+- **Quota recomputation degrades discovery performance.** Quota is derived on read, so a search window with many candidate times against many calendars means repeated counting. *Assumption:* participant counts per group and booking volumes per period are small enough that counting stays cheap. *Mitigation:* count only for slots that actually have a quota rule, and skip the path entirely when none is configured — which also protects the zero-change guarantee. *Likelihood medium, severity medium.*
+
+- **~~Reusing the recurrence machinery inherits its known defect.~~** *Resolved 2026-08-05.* The bulk-modification defect that duplicated open-ended recurring series has been fixed, so group-scoped windows and blocks reuse the recurrence machinery without inheriting it. No longer a prerequisite.
+
+- **Metering all blocked time would be a breaking change with an installed base.** Blocked time is not metered today, so counting it raises reported usage for anyone who has authored any. *Assumption:* there are no live customer organizations at the time this ships. *Mitigation:* ship it before there are — the change is free now and expensive later. If the customer situation changes before this lands, revisit: the measure-first-then-raise-limits path was considered and declined only because there is nothing to measure. *Likelihood low while pre-customer, severity low — but severity rises to medium the moment the first organization onboards.*
+
+- **Quota silently removing someone reads as a bug.** A scheduler who does not know a quota rule exists sees a surgeon vanish from next week's availability with no explanation. *Assumption:* the reason is surfaced somewhere the scheduler will look. *Mitigation:* the booking-time rejection names the quota as the reason; whether discovery also explains absences is undecided — accepted for v1. *Likelihood high, severity low.*
+
+- **Intersect-only confuses admins.** Someone configures a Saturday surgery window, saves successfully, and Saturday never appears — because base availability excludes it. The save gave no hint. *Assumption:* admins will connect the two. *Mitigation:* none in v1 beyond documentation; a validation warning at save time is a candidate improvement. *Likelihood medium, severity low.*
+
+- **Plan limits may be set at the wrong level for real usage.** Group-scoped windows *and* blocks share the existing counter, and an ad-hoc "no surgery next week" block is a routine, repeated member action rather than one-time setup. Plan values were chosen before any of this existed. *Assumption:* current limits are roughly right. *Mitigation:* none needed yet — with no customers, limits can be retuned freely once real usage appears. The existing limit-warning notification path gives the signal to retune. *Likelihood medium that limits need adjusting, severity low while pre-customer.*
+
+- **The zero-change guarantee is hard to prove rather than assert.** Adding filters to a hot read path risks subtly altering results for groups that configured nothing. *Assumption:* the unconfigured path can be short-circuited before any new work is done. *Mitigation:* make it an explicit acceptance scenario asserting both identical output and no extra queries, as the booking-policy work did. *Likelihood low, severity high.*
+
+- **Cascade deletion loses configuration silently.** Removing a calendar from a slot — a routine roster edit — destroys a carefully-built recurring schedule with no recovery path. *Assumption:* roster membership is stable enough that this is rare. *Mitigation:* accepted, no mitigation; the audit trail records what was deleted, which allows manual reconstruction. *Likelihood low, severity medium.*
+
+- **Three concepts is a large v1.** Windows alone solve the stated surgeon example; blocks and quota expand the surface considerably, and quota in particular is a counting mechanism unrelated to time windows. *Assumption:* all three are genuinely required together. *Mitigation:* accepted after explicit confirmation; the phased plan should sequence windows first so partial delivery is still useful. *Likelihood medium, severity medium.*


### PR DESCRIPTION
- Added specifications for group-scoped availability windows, blocked time, and quota rules.
- Defined business context highlighting the need for role-specific scheduling.
- Established objectives to ensure existing group behavior remains unchanged while introducing new features.
- Included use cases demonstrating how admins and members can manage availability effectively.
- Documented state transitions, edge cases, and acceptance scenarios to guide implementation.
- Addressed potential risks and assumptions related to the new features.