### PR TITLE
feat(calendar): add group-slot scoping foundation to availability tables

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -1,0 +1,46 @@
+# Tracking — Calendar Group-Scoped Availability
+
+- **Plan**: `ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md`
+- **Started**: 2026-08-05
+- **Last updated**: 2026-08-05
+- **Feature flag**: none (self-gating via fall-through default; metering change in Phase 2c is not self-gating)
+
+## Run options
+
+- `pause_between_phases`: false
+- `generate_inline_comments`: false
+- `full_test_suite`: false (scoped)
+- `use_worktree`: true
+- `commit_strategy_resolved`: stacked-branches
+- `worktree_path`: `.claude/worktrees/plan-calendar-group-scoped-availability`
+- `worktree_branch`: `plan-calendar-group-scoped-availability`
+- `worktree_summary`: `.vinta-ai-workflows/worktrees/plan-calendar-group-scoped-availability.yaml`
+- `sandbox_tier`: enforced
+
+## Agent models
+
+- implementer: per-phase (plan-owned)
+- reviewer: T3→sonnet default; T4→opus on Phases 0, 1b, 3b
+- fixer: T2→haiku
+- worktree_prep: T1→haiku (done)
+- integrate: T1→haiku
+
+## Branch topology (stacked)
+
+Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase stacks on the previous.
+
+## Completed phases
+
+_(none yet)_
+
+## Current phase
+
+Phase 0 — Group-slot scoping on the availability tables
+
+## Remaining phases
+
+0b, 1a, 1b, 1c, 1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
+
+## Deferred phases
+
+_(none — no cross-repo phases, no flag-removal phase)_

--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -31,11 +31,18 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 
 ## Completed phases
 
-_(none yet)_
+### Phase 0 — Group-slot scoping on the availability tables ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-0` (base: `plan-calendar-group-scoped-availability`)
+- **Implementer model**: sonnet (plan Tier 3) — agent type `migration-author`
+- **Reviewer model**: opus (plan Tier-4 override) — no BLOCKERs; 1 doc SHOULD-FIX (recorded here), 2 NITs left as intended behavior
+- **Summary**: Added nullable `group_slot` `OrganizationForeignKey` (composite `group_slot`/`group_slot_fk`) on `AvailableTime` and `BlockedTime`, `on_delete=CASCADE`, with partial composite indexes on non-null rows. Default managers (`objects`) now exclude group-scoped rows via `base_rows_only()`; explicit `for_group_slot(id)` / `unscoped()` accessors expose the rest. `only_user_authored` stays scope-agnostic at the queryset level. Admin uses `unscoped()`. Lock-aware migration `0042`: metadata-only `ADD COLUMN`, FK `NOT VALID` + separate `VALIDATE`, `AddIndexConcurrently`, `DEFERRABLE INITIALLY DEFERRED` constraints (load-bearing for cascade correctness on nullable-CASCADE relations). Zero edits to existing call sites; full repo suite (4631) passed.
+- **SQL-function verification (Open Question 1 — RESOLVED)**: The occurrence functions (`calculate_recurring_available_times`, `calculate_recurring_blocked_times`, their `_with_bulk_modifications` and `get_*_occurrences_json` variants) all take a row id as input and select no rows themselves (e.g. `WHERE id = p_available_time_id`). Scoping is applied caller-side. **No SQL function version bumps were needed** — the phase did not grow.
+- **Carry-forward note for Phases 1b / 2a / 3b**: `RecurringMixin._get_occurrences_in_range` re-fetches `self` via the *default* (base-rows-only) manager, so calling `get_occurrences_in_range()` on a group-scoped instance would silently return nothing once such rows exist. Unreachable today (nothing writes `group_slot` yet). Group-scoped occurrence expansion must route through `for_group_slot`/`unscoped`, not that instance method as written.
 
 ## Current phase
 
-Phase 0 — Group-slot scoping on the availability tables
+Phase 0b — Organization week-start setting
 
 ## Remaining phases
 

--- a/calendar_integration/admin.py
+++ b/calendar_integration/admin.py
@@ -10,6 +10,8 @@ from django.utils.html import format_html
 
 from calendar_integration.constants import IncomingWebhookProcessingStatus
 from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
     BookingPolicy,
     CalendarEventGroupSelection,
     CalendarGroup,
@@ -397,6 +399,71 @@ class CalendarEventGroupSelectionAdmin(admin.ModelAdmin):
             super()
             .get_queryset(request)
             .select_related("organization", "event_fk", "slot_fk", "calendar_fk")
+        )
+
+
+@admin.register(BlockedTime)
+class BlockedTimeAdmin(admin.ModelAdmin):
+    """Admin interface for BlockedTime.
+
+    Uses the manager's ``unscoped()`` accessor rather than the default
+    ``get_queryset(request)`` chain: ``BlockedTimeManager.get_queryset`` (the
+    default manager, ``objects``) excludes group-scoped rows by design (see
+    ``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 0), and ``ModelAdmin`` builds
+    its own queryset from the model's default manager. Without this override,
+    admin would silently stop showing group-scoped blocks the moment any exist.
+    """
+
+    list_display = ("id", "calendar", "group_slot", "start_time", "end_time", "reason")
+    list_filter = ("organization", "group_slot_fk")
+    search_fields = ("reason", "external_id", "calendar_fk__name")
+    readonly_fields = ("created", "modified")
+    fields = (
+        "organization",
+        "calendar_fk",
+        "group_slot_fk",
+        "reason",
+        "external_id",
+        "start_time_tz_unaware",
+        "end_time_tz_unaware",
+        "timezone",
+        "created",
+        "modified",
+    )
+
+    def get_queryset(self, request: HttpRequest):
+        return self.model.objects.unscoped().select_related(
+            "organization", "calendar_fk", "group_slot_fk"
+        )
+
+
+@admin.register(AvailableTime)
+class AvailableTimeAdmin(admin.ModelAdmin):
+    """Admin interface for AvailableTime.
+
+    Uses the manager's ``unscoped()`` accessor for the same reason documented
+    on :class:`BlockedTimeAdmin` — the default manager excludes group-scoped
+    rows, and admin must keep showing every row.
+    """
+
+    list_display = ("id", "calendar", "group_slot", "start_time", "end_time")
+    list_filter = ("organization", "group_slot_fk")
+    search_fields = ("calendar_fk__name",)
+    readonly_fields = ("created", "modified")
+    fields = (
+        "organization",
+        "calendar_fk",
+        "group_slot_fk",
+        "start_time_tz_unaware",
+        "end_time_tz_unaware",
+        "timezone",
+        "created",
+        "modified",
+    )
+
+    def get_queryset(self, request: HttpRequest):
+        return self.model.objects.unscoped().select_related(
+            "organization", "calendar_fk", "group_slot_fk"
         )
 
 

--- a/calendar_integration/managers.py
+++ b/calendar_integration/managers.py
@@ -29,6 +29,7 @@ from organizations.managers import BaseOrganizationModelManager
 
 if TYPE_CHECKING:
     from calendar_integration.models import BookingPolicy, CalendarManagementToken
+    from calendar_integration.querysets import AvailableTimeQuerySet, BlockedTimeQuerySet
     from organizations.models import OrganizationMembership as OrganizationMembershipType
 
 
@@ -196,21 +197,57 @@ class CalendarSyncManager(BaseOrganizationModelManager):
 
 
 class BlockedTimeManager(BaseOrganizationModelManager, RecurringManagerMixin):
-    """Custom manager for BlockedTime model to handle specific queries."""
+    """Custom manager for BlockedTime model to handle specific queries.
 
-    def get_queryset(self):
+    ``group_slot`` scoping (``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 0):
+    :meth:`get_queryset` — and therefore every plain ``.objects`` call — returns
+    only base rows (``group_slot IS NULL``), which is today's behavior and every
+    existing call site's implicit expectation. Group-scoped rows are reachable
+    only through :meth:`for_group_slot` or :meth:`unscoped`, both explicit
+    opt-in accessors.
+    """
+
+    def get_queryset(self) -> "BlockedTimeQuerySet":
+        from calendar_integration.querysets import BlockedTimeQuerySet
+
+        return BlockedTimeQuerySet(self.model, using=self._db).base_rows_only()
+
+    def unscoped(self) -> "BlockedTimeQuerySet":
+        """Escape hatch: every row regardless of ``group_slot`` — admin and migrations only."""
         from calendar_integration.querysets import BlockedTimeQuerySet
 
         return BlockedTimeQuerySet(self.model, using=self._db)
 
+    def for_group_slot(self, group_slot_id: int) -> "BlockedTimeQuerySet":
+        """Explicit opt-in: only the blocked-time rows scoped to one ``CalendarGroupSlot``."""
+        return self.unscoped().for_group_slot(group_slot_id)
+
 
 class AvailableTimeManager(BaseOrganizationModelManager, RecurringManagerMixin):
-    """Custom manager for AvailableTime model to handle specific queries."""
+    """Custom manager for AvailableTime model to handle specific queries.
 
-    def get_queryset(self):
+    ``group_slot`` scoping (``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 0):
+    :meth:`get_queryset` — and therefore every plain ``.objects`` call — returns
+    only base rows (``group_slot IS NULL``), which is today's behavior and every
+    existing call site's implicit expectation. Group-scoped rows are reachable
+    only through :meth:`for_group_slot` or :meth:`unscoped`, both explicit
+    opt-in accessors.
+    """
+
+    def get_queryset(self) -> "AvailableTimeQuerySet":
+        from calendar_integration.querysets import AvailableTimeQuerySet
+
+        return AvailableTimeQuerySet(self.model, using=self._db).base_rows_only()
+
+    def unscoped(self) -> "AvailableTimeQuerySet":
+        """Escape hatch: every row regardless of ``group_slot`` — admin and migrations only."""
         from calendar_integration.querysets import AvailableTimeQuerySet
 
         return AvailableTimeQuerySet(self.model, using=self._db)
+
+    def for_group_slot(self, group_slot_id: int) -> "AvailableTimeQuerySet":
+        """Explicit opt-in: only the availability rows scoped to one ``CalendarGroupSlot``."""
+        return self.unscoped().for_group_slot(group_slot_id)
 
     def only_user_authored(self):
         """Wraps :meth:`AvailableTimeQuerySet.only_user_authored`."""

--- a/calendar_integration/migrations/0042_availabletime_blockedtime_group_slot.py
+++ b/calendar_integration/migrations/0042_availabletime_blockedtime_group_slot.py
@@ -1,0 +1,238 @@
+"""Add group-slot scoping to AvailableTime and BlockedTime (Phase 0 of
+CALENDAR_GROUP_SCOPED_AVAILABILITY).
+
+Both ``AvailableTime`` and ``BlockedTime`` are hot tables (recurring-event
+expansion runs against them on every availability read), so this migration
+follows the lock-aware column-addition pattern end to end:
+
+1. **Add the column, no default, no inline FK.** Plain ``ADD COLUMN ... NULL``
+   is metadata-only in Postgres — no table rewrite, brief ``ACCESS EXCLUSIVE``
+   lock. Deliberately issued as raw SQL rather than a plain Django ``AddField``
+   on a ``ForeignKey``: Django's own ``AddField`` for a FK field defers the
+   constraint SQL to a *separate* statement already, but that deferred
+   statement omits ``NOT VALID`` — it would still force an immediate,
+   lock-holding validation scan of the whole table (see step 2's comment).
+2. **Add the FK constraint ``NOT VALID``.** ``ADD CONSTRAINT ... NOT VALID``
+   takes a brief ``SHARE ROW EXCLUSIVE`` lock and — critically — skips
+   scanning existing rows, so it returns immediately regardless of table size.
+3. **``VALIDATE CONSTRAINT`` separately.** Scans the table to confirm existing
+   rows satisfy the constraint, but takes only ``SHARE UPDATE EXCLUSIVE``,
+   which does not block reads or concurrent writes. Every existing row's new
+   column is NULL (this migration writes nothing), and a NULL FK column is
+   exempt from FK checking (Postgres ``MATCH SIMPLE``), so the scan has
+   nothing to reject — it exists only to flip the constraint from
+   "not validated" to "validated" without ever holding a strong lock for the
+   scan's duration.
+4. **Partial indexes ``CONCURRENTLY``.** ``CREATE INDEX CONCURRENTLY`` avoids
+   the ``SHARE`` lock a plain ``CREATE INDEX`` would hold for the build's
+   duration, which would block writes on a hot table. The index is a partial
+   index (``WHERE group_slot_fk_id IS NOT NULL``) because the column is a base
+   row (NULL) for the overwhelming majority of existing and future rows — see
+   ``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Guiding Decisions, "Row scoping".
+
+No FK cascade is configured at the database level (``ON DELETE`` is omitted,
+matching every other ``OrganizationForeignKey`` in this codebase — see
+``common/fields.py``: ``TenantSafeForeignKey`` never passes a DB-level
+``on_delete`` clause). Cascade-on-slot-deletion is enforced by Django's
+Python-side deletion collector instead, via the model field's
+``on_delete=models.CASCADE``. The collector walks relations through
+``Model._base_manager`` (see ``django/db/models/deletion.py``), which for both
+models — since neither ``AvailableTime``/``BlockedTime`` nor any ancestor sets
+``Meta.base_manager_name`` — is Django's own auto-created, always-unfiltered
+``Manager()``, never the ``group_slot``-filtered ``objects`` manager added in
+this same phase. So deleting a ``CalendarGroupSlot`` still finds and cascades
+to every referencing row, scoped or not.
+
+**The FK constraints are ``DEFERRABLE INITIALLY DEFERRED`` — load-bearing, not
+cosmetic.** Every FK constraint Django creates natively on Postgres carries
+this clause (``django/db/backends/postgresql/operations.py::deferrable_sql``
+always returns it), and Django's deletion collector relies on it: for a
+*nullable* CASCADE relation, ``Collector.add()`` deliberately skips recording
+a delete-order dependency ("nullable relationships ... do not affect the
+order in which objects have to be deleted" — ``django/db/models/deletion.py``),
+on the assumption that the FK check itself is deferred to ``COMMIT`` and will
+therefore still pass even if the referenced row's ``DELETE`` executes before
+the referencing rows' ``DELETE`` within the same transaction. Both
+``group_slot_fk`` fields are nullable CASCADE relations, so this migration
+must reproduce that same deferrable constraint by hand — a plain (non
+-deferrable) ``NOT VALID`` constraint here would make ``CalendarGroupSlot``
+deletion intermittently raise a foreign-key violation instead of cascading,
+because Postgres would enforce the check immediately, before the collector's
+(unsequenced, in this case) ``DELETE`` of the referencing rows runs.
+
+``atomic = False`` is required for ``AddIndexConcurrently`` and also gives
+each ``RunSQL`` statement here its own transaction, so the NOT VALID / VALIDATE
+split actually avoids holding one lock across both steps.
+
+Reverse
+-------
+Rolling back runs, in order: drop the concurrent indexes, drop the two FK
+constraints (dropping a constraint is always instant — no scan), drop the two
+columns. No orphaned objects remain — this restores the exact pre-migration
+schema.
+"""
+
+import django.db.models.deletion
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+AVAILABLETIME_TABLE = "calendar_integration_availabletime"
+BLOCKEDTIME_TABLE = "calendar_integration_blockedtime"
+GROUPSLOT_TABLE = "calendar_integration_calendargroupslot"
+
+AVAILABLETIME_FK_CONSTRAINT = "availabletime_group_slot_fk"
+BLOCKEDTIME_FK_CONSTRAINT = "blockedtime_group_slot_fk"
+
+
+class Migration(migrations.Migration):
+    """Lock-aware: nullable column, NOT VALID FK + separate VALIDATE, concurrent indexes."""
+
+    atomic = False
+
+    dependencies = [
+        ("calendar_integration", "0041_alter_calendarorganizationresourcesimport_status"),
+        ("organizations", "0017_alter_organizationmembership_is_billing_owner"),
+    ]
+
+    operations = [
+        # --- Step 1: add the raw columns (metadata-only, no inline FK) -----
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="availabletime",
+                    name="group_slot_fk",
+                    field=models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "If set, this available time applies only when the calendar is "
+                            "evaluated inside this group slot, narrowing (never widening) base "
+                            "availability there. Null (the default) means a base row that "
+                            "applies everywhere the calendar is evaluated."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="group_scoped_available_times_fk_rel",
+                        to="calendar_integration.calendargroupslot",
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="availabletime",
+                    name="group_slot",
+                    field=models.ForeignObject(
+                        editable=False,
+                        from_fields=["group_slot_fk", "organization_id"],
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="group_scoped_available_times",
+                        to="calendar_integration.calendargroupslot",
+                        to_fields=["id", "organization_id"],
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="blockedtime",
+                    name="group_slot_fk",
+                    field=models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "If set, this blocked time applies only when the calendar is "
+                            "evaluated inside this group slot, and nowhere else. Null (the "
+                            "default) means a base row that blocks time everywhere the "
+                            "calendar is evaluated."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="group_scoped_blocked_times_fk_rel",
+                        to="calendar_integration.calendargroupslot",
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="blockedtime",
+                    name="group_slot",
+                    field=models.ForeignObject(
+                        editable=False,
+                        from_fields=["group_slot_fk", "organization_id"],
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="group_scoped_blocked_times",
+                        to="calendar_integration.calendargroupslot",
+                        to_fields=["id", "organization_id"],
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql=f"ALTER TABLE {AVAILABLETIME_TABLE} ADD COLUMN group_slot_fk_id bigint NULL;",
+                    reverse_sql=f"ALTER TABLE {AVAILABLETIME_TABLE} DROP COLUMN group_slot_fk_id;",
+                ),
+                migrations.RunSQL(
+                    sql=f"ALTER TABLE {BLOCKEDTIME_TABLE} ADD COLUMN group_slot_fk_id bigint NULL;",
+                    reverse_sql=f"ALTER TABLE {BLOCKEDTIME_TABLE} DROP COLUMN group_slot_fk_id;",
+                ),
+            ],
+        ),
+        # --- Step 2: add the FK constraints as NOT VALID --------------------
+        # DEFERRABLE INITIALLY DEFERRED matches every FK constraint Django
+        # creates natively on Postgres (see the module docstring) and is
+        # required for the ORM's deletion collector to cascade correctly.
+        migrations.RunSQL(
+            sql=(
+                f"ALTER TABLE {AVAILABLETIME_TABLE} "
+                f"ADD CONSTRAINT {AVAILABLETIME_FK_CONSTRAINT} "
+                f"FOREIGN KEY (group_slot_fk_id) REFERENCES {GROUPSLOT_TABLE} (id) "
+                f"DEFERRABLE INITIALLY DEFERRED "
+                f"NOT VALID;"
+            ),
+            reverse_sql=(
+                f"ALTER TABLE {AVAILABLETIME_TABLE} "
+                f"DROP CONSTRAINT IF EXISTS {AVAILABLETIME_FK_CONSTRAINT};"
+            ),
+        ),
+        migrations.RunSQL(
+            sql=(
+                f"ALTER TABLE {BLOCKEDTIME_TABLE} "
+                f"ADD CONSTRAINT {BLOCKEDTIME_FK_CONSTRAINT} "
+                f"FOREIGN KEY (group_slot_fk_id) REFERENCES {GROUPSLOT_TABLE} (id) "
+                f"DEFERRABLE INITIALLY DEFERRED "
+                f"NOT VALID;"
+            ),
+            reverse_sql=(
+                f"ALTER TABLE {BLOCKEDTIME_TABLE} "
+                f"DROP CONSTRAINT IF EXISTS {BLOCKEDTIME_FK_CONSTRAINT};"
+            ),
+        ),
+        # --- Step 3: validate the constraints in a separate, weak-lock step -
+        migrations.RunSQL(
+            sql=(
+                f"ALTER TABLE {AVAILABLETIME_TABLE} "
+                f"VALIDATE CONSTRAINT {AVAILABLETIME_FK_CONSTRAINT};"
+            ),
+            # The constraint is dropped wholesale by the ADD CONSTRAINT step's
+            # reverse; there is nothing to "un-validate" here.
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql=(
+                f"ALTER TABLE {BLOCKEDTIME_TABLE} "
+                f"VALIDATE CONSTRAINT {BLOCKEDTIME_FK_CONSTRAINT};"
+            ),
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        # --- Step 4: partial indexes, built concurrently ---------------------
+        AddIndexConcurrently(
+            model_name="availabletime",
+            index=models.Index(
+                fields=["organization", "group_slot_fk"],
+                condition=models.Q(("group_slot_fk__isnull", False)),
+                name="availabletime_group_slot_idx",
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="blockedtime",
+            index=models.Index(
+                fields=["organization", "group_slot_fk"],
+                condition=models.Q(("group_slot_fk__isnull", False)),
+                name="blockedtime_group_slot_idx",
+            ),
+        ),
+    ]

--- a/calendar_integration/models.py
+++ b/calendar_integration/models.py
@@ -1348,8 +1348,36 @@ class BlockedTime(RecurringMixin):
         help_text="If this is a continuation of a split series",
     )
 
+    # Group-scoped availability (Phase 0 of CALENDAR_GROUP_SCOPED_AVAILABILITY):
+    # NULL means a base row — today's behavior, visible on every read path. A
+    # non-null value scopes the row to that one CalendarGroupSlot; it is invisible
+    # to the default manager (`objects`) and only reachable through the explicit
+    # `for_group_slot` / `unscoped` accessors. `on_delete=CASCADE` so removing a
+    # calendar from a slot (or deleting the slot/group) deletes its group-scoped
+    # blocked time with it, matching the spec's cascade rule.
+    group_slot = OrganizationForeignKey(
+        CalendarGroupSlot,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="group_scoped_blocked_times",
+        help_text=(
+            "If set, this blocked time applies only when the calendar is "
+            "evaluated inside this group slot, and nowhere else. Null (the "
+            "default) means a base row that blocks time everywhere the "
+            "calendar is evaluated."
+        ),
+    )
+
     class Meta:
         unique_together = (("calendar_fk_id", "external_id"),)
+        indexes = (
+            models.Index(
+                fields=["organization", "group_slot_fk"],
+                condition=models.Q(group_slot_fk__isnull=False),
+                name="blockedtime_group_slot_idx",
+            ),
+        )
 
     def __str__(self):
         return f"Blocked from {self.start_time} to {self.end_time} ({self.reason})"
@@ -1421,6 +1449,36 @@ class AvailableTime(RecurringMixin):
         related_name="bulk_modifications",
         help_text="If this is a continuation of a split series",
     )
+
+    # Group-scoped availability (Phase 0 of CALENDAR_GROUP_SCOPED_AVAILABILITY):
+    # NULL means a base row — today's behavior, visible on every read path. A
+    # non-null value scopes the row to that one CalendarGroupSlot; it is invisible
+    # to the default manager (`objects`) and only reachable through the explicit
+    # `for_group_slot` / `unscoped` accessors. `on_delete=CASCADE` so removing a
+    # calendar from a slot (or deleting the slot/group) deletes its group-scoped
+    # availability windows with it, matching the spec's cascade rule.
+    group_slot = OrganizationForeignKey(
+        CalendarGroupSlot,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="group_scoped_available_times",
+        help_text=(
+            "If set, this available time applies only when the calendar is "
+            "evaluated inside this group slot, narrowing (never widening) base "
+            "availability there. Null (the default) means a base row that "
+            "applies everywhere the calendar is evaluated."
+        ),
+    )
+
+    class Meta:
+        indexes = (
+            models.Index(
+                fields=["organization", "group_slot_fk"],
+                condition=models.Q(group_slot_fk__isnull=False),
+                name="availabletime_group_slot_idx",
+            ),
+        )
 
     def __str__(self):
         return f"Available from {self.start_time} to {self.end_time}"

--- a/calendar_integration/querysets.py
+++ b/calendar_integration/querysets.py
@@ -2,6 +2,7 @@ import datetime
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
+from django.db import models
 from django.db.models import (
     Case,
     Count,
@@ -59,6 +60,47 @@ class CalendarManagementTokenQuerySet(BaseOrganizationModelQuerySet):
             used_at__isnull=True,
             revoked_at__isnull=True,
         ).filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
+
+
+if TYPE_CHECKING:
+    # Type-checking-only base so mypy resolves `self.filter(...)` below — at
+    # runtime this mixin is only ever combined with `BaseOrganizationModelQuerySet`
+    # subclasses (which already provide `filter`), never instantiated alone.
+    _GroupSlotScopedQuerySetBase = models.QuerySet
+else:
+    _GroupSlotScopedQuerySetBase = object
+
+
+class GroupSlotScopedQuerySetMixin(_GroupSlotScopedQuerySetBase):
+    """Chainable group-slot scoping shared by ``AvailableTimeQuerySet`` and ``BlockedTimeQuerySet``.
+
+    Both models carry a nullable ``group_slot`` reference (see
+    ``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 0): null means a base row —
+    today's behavior, visible on every existing read path. A non-null value
+    scopes the row to exactly one ``CalendarGroupSlot`` and must stay invisible
+    unless a caller explicitly opts in.
+
+    These methods are the composable building blocks; the corresponding
+    managers (``AvailableTimeManager`` / ``BlockedTimeManager``) wire
+    :meth:`base_rows_only` into ``get_queryset`` so it is the *default* — every
+    existing call site that goes through ``.objects`` keeps seeing only base
+    rows with zero edits. ``for_group_slot`` and an unfiltered queryset (the
+    "unscoped" view) are reached through the manager's explicit accessors,
+    never through ``get_queryset``.
+    """
+
+    def base_rows_only(self):
+        """Exclude group-scoped rows — the default, tenant-unaware-of-groups view."""
+        return self.filter(group_slot_fk__isnull=True)
+
+    def for_group_slot(self, group_slot_id: int):
+        """Return only the rows scoped to exactly one ``CalendarGroupSlot``.
+
+        Explicit opt-in accessor. Never chain this onto a queryset that has
+        already had :meth:`base_rows_only` applied — the two filters are
+        mutually exclusive and would always return nothing.
+        """
+        return self.filter(group_slot_fk_id=group_slot_id)
 
 
 class RecurringQuerySetMixin:
@@ -729,7 +771,9 @@ class CalendarSyncQuerySet(BaseOrganizationModelQuerySet):
         return self.filter(id=calendar_sync_id, status=CalendarSyncStatus.NOT_STARTED).first()
 
 
-class BlockedTimeQuerySet(BaseOrganizationModelQuerySet, RecurringQuerySetMixin):
+class BlockedTimeQuerySet(
+    BaseOrganizationModelQuerySet, RecurringQuerySetMixin, GroupSlotScopedQuerySetMixin
+):
     """
     Custom QuerySet for BlockedTime model to handle specific queries.
     """
@@ -975,7 +1019,9 @@ class CalendarEventGroupSelectionQuerySet(BaseOrganizationModelQuerySet):
     """
 
 
-class AvailableTimeQuerySet(BaseOrganizationModelQuerySet, RecurringQuerySetMixin):
+class AvailableTimeQuerySet(
+    BaseOrganizationModelQuerySet, RecurringQuerySetMixin, GroupSlotScopedQuerySetMixin
+):
     """
     Custom QuerySet for AvailableTime model to handle specific queries.
     """

--- a/calendar_integration/tests/services/test_group_slot_scoping_phase0.py
+++ b/calendar_integration/tests/services/test_group_slot_scoping_phase0.py
@@ -1,0 +1,226 @@
+"""Integration tests for group-slot scoping on AvailableTime/BlockedTime (Phase 0 of
+CALENDAR_GROUP_SCOPED_AVAILABILITY).
+
+Phase 0 adds a nullable ``group_slot`` reference to both models and makes the
+default manager exclude scoped rows. Nothing yet *writes* the column and no
+service consumes it as a scoping signal — Phase 0's job is only to prove that a
+group-scoped row, inserted directly (as a stand-in for what a later phase's
+write path will do), is invisible on every existing read path with zero call
+site edits: the availability service (single-calendar), the calendar-group
+service (group discovery / availability), and the REST/public-API queryset
+pattern (``.objects.filter_by_organization(...)``).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+import pytest
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+)
+from calendar_integration.services.availability_service import AvailabilityService
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.calendar_service_context import CalendarServiceContext
+from calendar_integration.services.recurrence_manager import RecurrenceManager
+from organizations.models import Organization
+
+
+class _FakeAvailabilityHost:
+    """Minimal AvailabilityServiceHost — no events, no side-effect writes needed here."""
+
+    def get_calendar_events_expanded(self, calendar, start_date, end_date):
+        return []
+
+    def bulk_create_manual_blocked_times(self, calendar, blocked_times):
+        return []
+
+    def _create_recurrence_rule_if_needed(self, rrule_string):
+        return None
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Phase0 Scoping Org", should_sync_rooms=False)
+
+
+@pytest.fixture
+def managed_calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="phase0-cal",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def group_slot(organization: Organization, managed_calendar: Calendar) -> CalendarGroupSlot:
+    group = CalendarGroup.objects.create(organization=organization, name="Surgery")
+    slot = CalendarGroupSlot.objects.create(organization=organization, group=group, name="Lead")
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=managed_calendar
+    )
+    return slot
+
+
+def _search_window() -> tuple[datetime.datetime, datetime.datetime]:
+    start = datetime.datetime(2025, 9, 2, 9, 0, tzinfo=datetime.UTC)
+    end = datetime.datetime(2025, 9, 2, 17, 0, tzinfo=datetime.UTC)
+    return start, end
+
+
+@pytest.mark.django_db
+def test_group_scoped_available_time_invisible_to_single_calendar_availability_service(
+    organization: Organization,
+    managed_calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """A group-scoped-only window must not make a managed calendar available on the
+    single-calendar read path — that path has no group context and must not gain one
+    (spec non-goal: "no changes to single-calendar booking").
+    """
+    start, end = _search_window()
+
+    # Directly insert a group-scoped row covering the whole search window. No base
+    # (group_slot IS NULL) row exists for this calendar.
+    AvailableTime.objects.unscoped().create(
+        organization=organization,
+        calendar=managed_calendar,
+        group_slot=group_slot,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+    context = CalendarServiceContext(
+        organization=organization,
+        user_or_token=None,
+        account=None,
+        calendar_adapter=None,
+        calendar_permission_service=None,
+        calendar_side_effects_service=None,
+    )
+    service = AvailabilityService(
+        context=context,
+        recurrence_manager=RecurrenceManager(),
+        host=_FakeAvailabilityHost(),
+    )
+
+    windows = list(service.get_availability_windows_in_range(managed_calendar, start, end))
+
+    assert windows == []
+
+
+@pytest.mark.django_db
+def test_group_scoped_available_time_invisible_to_group_availability_check(
+    organization: Organization,
+    managed_calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """A group-scoped-only window must not make the calendar count toward its own
+    slot's availability in group discovery — Phase 0 does not wire group-scoped
+    configuration into group reads yet, so this must behave exactly as "nothing
+    configured" (the calendar has no *base* availability).
+    """
+    start, end = _search_window()
+
+    AvailableTime.objects.unscoped().create(
+        organization=organization,
+        calendar=managed_calendar,
+        group_slot=group_slot,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+    group_service = CalendarGroupService()
+    group_service.initialize(organization=organization)
+
+    [availability] = group_service.check_group_availability(group_slot.group_fk_id, [(start, end)])
+    [slot_availability] = availability.slots
+    assert slot_availability.available_calendar_ids == []
+    assert not slot_availability.is_satisfied_for_required_count
+
+    proposals = group_service.find_bookable_slots(
+        group_id=group_slot.group_fk_id,
+        search_window_start=start,
+        search_window_end=end,
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(minutes=30),
+    )
+    assert proposals == []
+
+
+@pytest.mark.django_db
+def test_group_scoped_available_time_invisible_to_group_availability_check_even_with_base_row(
+    organization: Organization,
+    managed_calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """Sanity check that the *base* row is what group discovery actually reads —
+    proves the previous test's empty result comes from scoping, not from some
+    unrelated reason the calendar never appears (e.g. a broken fixture).
+    """
+    start, end = _search_window()
+
+    AvailableTime.objects.create(
+        organization=organization,
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+    group_service = CalendarGroupService()
+    group_service.initialize(organization=organization)
+
+    [availability] = group_service.check_group_availability(group_slot.group_fk_id, [(start, end)])
+    [slot_availability] = availability.slots
+    assert slot_availability.available_calendar_ids == [managed_calendar.id]
+
+
+@pytest.mark.django_db
+def test_group_scoped_available_time_invisible_to_rest_and_public_api_queryset_pattern(
+    organization: Organization,
+    managed_calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """Mirrors the exact queryset construction used by the REST viewset
+    (``AvailableTimeViewSet.get_queryset``) and the public GraphQL API
+    (``public_api/queries.py``): ``AvailableTime.objects.filter_by_organization(...)``.
+    Both call sites go through the default manager with zero changes required
+    for this phase, so a group-scoped row must not appear in either.
+    """
+    start, end = _search_window()
+
+    base_row = AvailableTime.objects.create(
+        organization=organization,
+        calendar=managed_calendar,
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+    group_scoped_row = AvailableTime.objects.unscoped().create(
+        organization=organization,
+        calendar=managed_calendar,
+        group_slot=group_slot,
+        start_time_tz_unaware=start + datetime.timedelta(hours=1),
+        end_time_tz_unaware=end,
+        timezone="UTC",
+    )
+
+    visible_ids = set(
+        AvailableTime.objects.filter_by_organization(organization.id).values_list("id", flat=True)
+    )
+    assert base_row.id in visible_ids
+    assert group_scoped_row.id not in visible_ids

--- a/calendar_integration/tests/test_models.py
+++ b/calendar_integration/tests/test_models.py
@@ -12,6 +12,8 @@ from calendar_integration.models import (
     BlockedTime,
     BlockedTimeBulkModification,
     CalendarEvent,
+    CalendarGroup,
+    CalendarGroupSlot,
     EventBulkModification,
     EventRecurrenceException,
     RecurrenceRule,
@@ -1347,3 +1349,237 @@ def test_blockedtime_and_availabletime_bulk_modification_records():
     )
 
     assert bulk_av.parent_available_time_fk_id == parent_av.id
+
+
+# --- Group-slot scoping (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 0) --------
+#
+# `AvailableTime` and `BlockedTime` gained a nullable `group_slot` reference.
+# The default manager (`objects`) must exclude group-scoped rows (group_slot
+# IS NOT NULL) so every existing call site keeps its current behavior with no
+# edits; `for_group_slot` and `unscoped` are the explicit opt-in accessors.
+
+
+def _make_group_slot(org) -> CalendarGroupSlot:
+    group = baker.make(CalendarGroup, organization=org, name=baker.seq("Group"))
+    return CalendarGroupSlot.objects.create(organization=org, group=group, name="Slot")
+
+
+@pytest.mark.django_db
+def test_available_time_default_manager_excludes_group_scoped_rows():
+    org = baker.make("organizations.Organization")
+    cal = baker.make(
+        "calendar_integration.Calendar", organization=org, external_id=baker.seq("cal")
+    )
+    slot = _make_group_slot(org)
+
+    base_row = baker.make(
+        AvailableTime,
+        calendar_fk=cal,
+        organization=org,
+        start_time_tz_unaware=_dt(2025, 1, 1),
+        end_time_tz_unaware=_dt(2025, 1, 1, 1),
+        timezone="UTC",
+    )
+    group_scoped_row = baker.make(
+        AvailableTime,
+        calendar_fk=cal,
+        organization=org,
+        group_slot=slot,
+        start_time_tz_unaware=_dt(2025, 1, 2),
+        end_time_tz_unaware=_dt(2025, 1, 2, 1),
+        timezone="UTC",
+    )
+
+    default_scope_ids = set(
+        AvailableTime.objects.filter(organization_id=org.id).values_list("id", flat=True)
+    )
+    assert base_row.id in default_scope_ids
+    assert group_scoped_row.id not in default_scope_ids
+
+    # Explicit opt-in: for_group_slot returns only that slot's rows.
+    group_scope_ids = set(
+        AvailableTime.objects.for_group_slot(slot.id)
+        .filter(organization_id=org.id)
+        .values_list("id", flat=True)
+    )
+    assert group_scope_ids == {group_scoped_row.id}
+
+    # Explicit opt-in: unscoped returns every row regardless of group_slot.
+    unscoped_ids = set(
+        AvailableTime.objects.unscoped().filter(organization_id=org.id).values_list("id", flat=True)
+    )
+    assert unscoped_ids == {base_row.id, group_scoped_row.id}
+
+
+@pytest.mark.django_db
+def test_blocked_time_default_manager_excludes_group_scoped_rows():
+    org = baker.make("organizations.Organization")
+    cal = baker.make(
+        "calendar_integration.Calendar", organization=org, external_id=baker.seq("cal")
+    )
+    slot = _make_group_slot(org)
+
+    base_row = baker.make(
+        BlockedTime,
+        calendar_fk=cal,
+        organization=org,
+        external_id="bt-base-1",
+        start_time_tz_unaware=_dt(2025, 1, 1),
+        end_time_tz_unaware=_dt(2025, 1, 1, 1),
+        timezone="UTC",
+    )
+    group_scoped_row = baker.make(
+        BlockedTime,
+        calendar_fk=cal,
+        organization=org,
+        group_slot=slot,
+        external_id="bt-group-1",
+        start_time_tz_unaware=_dt(2025, 1, 2),
+        end_time_tz_unaware=_dt(2025, 1, 2, 1),
+        timezone="UTC",
+    )
+
+    default_scope_ids = set(
+        BlockedTime.objects.filter(organization_id=org.id).values_list("id", flat=True)
+    )
+    assert base_row.id in default_scope_ids
+    assert group_scoped_row.id not in default_scope_ids
+
+    group_scope_ids = set(
+        BlockedTime.objects.for_group_slot(slot.id)
+        .filter(organization_id=org.id)
+        .values_list("id", flat=True)
+    )
+    assert group_scope_ids == {group_scoped_row.id}
+
+    unscoped_ids = set(
+        BlockedTime.objects.unscoped().filter(organization_id=org.id).values_list("id", flat=True)
+    )
+    assert unscoped_ids == {base_row.id, group_scoped_row.id}
+
+
+@pytest.mark.django_db
+def test_available_time_cascade_deletes_on_group_slot_deletion():
+    org = baker.make("organizations.Organization")
+    cal = baker.make(
+        "calendar_integration.Calendar", organization=org, external_id=baker.seq("cal")
+    )
+    slot = _make_group_slot(org)
+
+    base_row = baker.make(
+        AvailableTime,
+        calendar_fk=cal,
+        organization=org,
+        start_time_tz_unaware=_dt(2025, 1, 1),
+        end_time_tz_unaware=_dt(2025, 1, 1, 1),
+        timezone="UTC",
+    )
+    group_scoped_row = baker.make(
+        AvailableTime,
+        calendar_fk=cal,
+        organization=org,
+        group_slot=slot,
+        start_time_tz_unaware=_dt(2025, 1, 2),
+        end_time_tz_unaware=_dt(2025, 1, 2, 1),
+        timezone="UTC",
+    )
+
+    slot.delete()
+
+    remaining_ids = set(
+        AvailableTime.objects.unscoped().filter(organization_id=org.id).values_list("id", flat=True)
+    )
+    assert remaining_ids == {base_row.id}
+    assert group_scoped_row.id not in remaining_ids
+
+
+@pytest.mark.django_db
+def test_blocked_time_cascade_deletes_on_group_slot_deletion():
+    org = baker.make("organizations.Organization")
+    cal = baker.make(
+        "calendar_integration.Calendar", organization=org, external_id=baker.seq("cal")
+    )
+    slot = _make_group_slot(org)
+
+    base_row = baker.make(
+        BlockedTime,
+        calendar_fk=cal,
+        organization=org,
+        external_id="bt-base-2",
+        start_time_tz_unaware=_dt(2025, 1, 1),
+        end_time_tz_unaware=_dt(2025, 1, 1, 1),
+        timezone="UTC",
+    )
+    group_scoped_row = baker.make(
+        BlockedTime,
+        calendar_fk=cal,
+        organization=org,
+        group_slot=slot,
+        external_id="bt-group-2",
+        start_time_tz_unaware=_dt(2025, 1, 2),
+        end_time_tz_unaware=_dt(2025, 1, 2, 1),
+        timezone="UTC",
+    )
+
+    slot.delete()
+
+    remaining_ids = set(
+        BlockedTime.objects.unscoped().filter(organization_id=org.id).values_list("id", flat=True)
+    )
+    assert remaining_ids == {base_row.id}
+    assert group_scoped_row.id not in remaining_ids
+
+
+@pytest.mark.django_db
+def test_available_time_only_user_authored_composes_with_group_scoping():
+    """`only_user_authored` (the billing counter's filter) must keep working
+    whether it runs against the default (base-rows-only) manager or the
+    unscoped/for_group_slot accessors, since group-scoped windows are metered
+    too (see AvailableTimeQuerySet.only_user_authored and Guiding Decisions).
+    """
+    org = baker.make("organizations.Organization")
+    cal = baker.make(
+        "calendar_integration.Calendar", organization=org, external_id=baker.seq("cal")
+    )
+    slot = _make_group_slot(org)
+
+    base_row = baker.make(
+        AvailableTime,
+        calendar_fk=cal,
+        organization=org,
+        start_time_tz_unaware=_dt(2025, 1, 1),
+        end_time_tz_unaware=_dt(2025, 1, 1, 1),
+        timezone="UTC",
+    )
+    group_scoped_row = baker.make(
+        AvailableTime,
+        calendar_fk=cal,
+        organization=org,
+        group_slot=slot,
+        start_time_tz_unaware=_dt(2025, 1, 2),
+        end_time_tz_unaware=_dt(2025, 1, 2, 1),
+        timezone="UTC",
+    )
+
+    # Default manager: only the base row.
+    assert set(
+        AvailableTime.objects.only_user_authored()
+        .filter(organization_id=org.id)
+        .values_list("id", flat=True)
+    ) == {base_row.id}
+
+    # Unscoped: both rows, since group-scoped windows are metered too.
+    assert set(
+        AvailableTime.objects.unscoped()
+        .only_user_authored()
+        .filter(organization_id=org.id)
+        .values_list("id", flat=True)
+    ) == {base_row.id, group_scoped_row.id}
+
+    # for_group_slot: only that slot's row.
+    assert set(
+        AvailableTime.objects.for_group_slot(slot.id)
+        .filter(organization_id=org.id)
+        .only_user_authored()
+        .values_list("id", flat=True)
+    ) == {group_scoped_row.id}


### PR DESCRIPTION

## Summary

Phase 0 of the Calendar Group-Scoped Availability plan. It lays the schema and default-exclude scoping foundation that every later phase consumes, with **zero behavior change anywhere** — no code writes the new column yet.

Adds a nullable `group_slot` reference (`OrganizationForeignKey`, `on_delete=CASCADE`) to the existing `AvailableTime` and `BlockedTime` tables. `NULL` means a base row (today's behavior, visible on every read path); a non-null value scopes the row to exactly one `CalendarGroupSlot`. The default managers (`objects`) now exclude group-scoped rows; the rows are reachable only through the explicit `for_group_slot(id)` / `unscoped()` accessors.

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 0.

## Key decisions (not obvious from the diff)

- **Storage shape** (Guiding Decisions → "Storage shape"): reuse the existing recurring `AvailableTime`/`BlockedTime` models rather than new models, so the four versioned occurrence SQL functions, exception model, bulk-modification model, and queryset are reused unchanged.
- **Row scoping** (Guiding Decisions → "Row scoping"): the *default* manager excludes group-scoped rows. Chosen over per-call-site filtering because a missed call site is a silent correctness failure. Default-exclude means every existing call site is correct with zero edits — confirmed by the full existing suite passing untouched.
- **Cascade correctness**: the FK constraints are created `DEFERRABLE INITIALLY DEFERRED` (matching Django's native Postgres FK behavior). Django's deletion collector skips ordering deletes for nullable CASCADE relations, assuming the FK check is deferred to COMMIT; a non-deferrable constraint would make `CalendarGroupSlot` deletion intermittently raise a foreign-key violation instead of cascading. Cascade runs through `Model._base_manager` (unfiltered), so it reaches group-scoped rows even though `objects` hides them.
- **`only_user_authored` stays scope-agnostic** at the queryset level, so the billing counter can count group-scoped windows (metered too) via `unscoped()` in later phases.
- **SQL-function assumption verified** (Open Question 1): the occurrence functions take a row id as input and select no rows themselves, so scoping is caller-side and **no function version bumps were needed**.

## Migration safety

`0042` is lock-aware on these hot tables: metadata-only `ADD COLUMN ... NULL` (no rewrite), FK added `NOT VALID` then `VALIDATE` in a separate weak-lock step, partial indexes built `CONCURRENTLY` (`atomic = False`). Reverse path drops indexes → constraints → columns cleanly. No backfill.

## Feature flag

None — the feature is self-gating. An unconfigured calendar takes the fall-through path and behaves byte-for-byte as today. This phase is unreachable from any existing flow because no code writes the new column yet.

## Test plan

```bash
docker compose run --rm api uv run python manage.py makemigrations --check
docker compose run --rm api uv run pytest calendar_integration/tests/test_models.py calendar_integration/tests/services/test_group_slot_scoping_phase0.py -q
docker compose run --rm api uv run pytest calendar_integration/tests/ -n auto
```