### PR TITLE
feat(calendar): add group-scoped availability window write service

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -40,13 +40,21 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 - **SQL-function verification (Open Question 1 — RESOLVED)**: The occurrence functions (`calculate_recurring_available_times`, `calculate_recurring_blocked_times`, their `_with_bulk_modifications` and `get_*_occurrences_json` variants) all take a row id as input and select no rows themselves (e.g. `WHERE id = p_available_time_id`). Scoping is applied caller-side. **No SQL function version bumps were needed** — the phase did not grow.
 - **Carry-forward note for Phases 1b / 2a / 3b**: `RecurringMixin._get_occurrences_in_range` re-fetches `self` via the *default* (base-rows-only) manager, so calling `get_occurrences_in_range()` on a group-scoped instance would silently return nothing once such rows exist. Unreachable today (nothing writes `group_slot` yet). Group-scoped occurrence expansion must route through `for_group_slot`/`unscoped`, not that instance method as written.
 
+### Phase 0b — Organization week-start setting ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-0b` (base: phase-0) — **PR [#219](https://github.com/vintasoftware/vinta-schedule-api/pull/219)**
+- **Implementer model**: haiku (plan Tier 1) — agent type `migration-author`
+- **Reviewer model**: sonnet — no BLOCKERs; 3 SHOULD-FIX + 1 NIT, all fixed by a haiku fixer
+- **Summary**: Added `Organization.week_start` (`TextChoices` Monday/Sunday, `default` + `db_default` Monday) mirroring `external_event_update_policy`. Migration `0018` adds the column with a `db_default` (existing rows backfill to Monday, no data migration). Exposed in Django admin (editable via `OrganizationAdminForm`, in `list_filter`), and on the organization serializer; gated admin-only via `IsOrganizationAdmin` on update/partial_update. Wired `week_start` through `create_organization` service so it's settable at creation, matching the sibling policy field. Nothing reads the field yet.
+- **Fixes applied**: made `week_start` admin-editable (was erroneously read-only); wired it through the create path (was silently dropped at create); added a raw-SQL `db_default` test proving pre-migration rows read Monday.
+
 ## Current phase
 
-Phase 0b — Organization week-start setting
+Phase 1a — Group-scoped availability windows: writes
 
 ## Remaining phases
 
-0b, 1a, 1b, 1c, 1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
+1a, 1b, 1c, 1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/exceptions.py
+++ b/calendar_integration/exceptions.py
@@ -335,6 +335,21 @@ class CalendarGroupHasFutureEventsError(CalendarGroupError):
     default_message = "Cannot delete CalendarGroup because it has future bookings."
 
 
+class CalendarGroupSlotConfigNotFoundError(CalendarGroupError):
+    """Raised when a (calendar, group slot) target for group-scoped availability
+    configuration cannot be resolved.
+
+    Deliberately the SAME exception -- same type, same message -- whether the
+    membership genuinely does not exist or the acting user is simply not
+    authorized to manage it. A member must not be able to learn that a group
+    or roster entry exists by comparing error shapes (see the spec's
+    permission decision under CALENDAR_GROUP_SCOPED_AVAILABILITY): a plain
+    404-shaped error here is indistinguishable from a 403 in disguise.
+    """
+
+    default_message = "No group-scoped availability configuration found for this calendar and slot."
+
+
 # Bookable Slots errors
 class BookableSlotsValidationError(CalendarIntegrationError):
     """Raised when single-calendar / bundle bookable-slot input data is invalid."""

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -436,6 +436,21 @@ class CalendarGroupService:
 
         if to_remove:
             self._ensure_no_future_selections(slot=slot, calendar_ids=to_remove)
+
+            # Delete group-scoped windows for the removed calendars.
+            # The FK on AvailableTime.group_slot → CalendarGroupSlot cascades on
+            # SLOT deletion only, not on membership removal, so we must explicitly
+            # clean up the orphaned rows here. These deletions are cascading from
+            # membership removal (already audited as part of the group update), so
+            # we do not audit them individually.
+            # TODO(Phase 2a, 3a): BlockedTime.for_group_slot() and quota rules
+            # must extend this cleanup when those phases add their group-scoped rows,
+            # using the same pattern: delete rows for removed calendars in to_remove.
+            org_id = cast(Organization, self.organization).id
+            AvailableTime.objects.unscoped().filter_by_organization(org_id).filter(
+                group_slot_fk=slot, calendar_fk_id__in=to_remove
+            ).delete()
+
             CalendarGroupSlotMembership.objects.filter_by_organization(self.organization.id).filter(
                 slot_fk=slot, calendar_fk_id__in=to_remove
             ).delete()
@@ -624,6 +639,11 @@ class CalendarGroupService:
         calendar's configured availability, as it stands after the write, no
         longer covers it. Nothing here is cancelled or modified; this is
         purely a read (spec UC-6).
+
+        Performance: expands all group-scoped windows ONCE over the union range
+        covering all candidate bookings (min start → max end), then checks each
+        booking against that single cached expansion, rather than expanding
+        once per booking (O(N) → O(1) expansions).
         """
         org_id = cast(Organization, self.organization).id
         selections = (
@@ -636,14 +656,27 @@ class CalendarGroupService:
             .select_related("event")
         )
 
+        selections_list = list(selections)
+        if not selections_list:
+            return []
+
+        # Find the union range covering all candidate bookings: min start → max end.
+        min_start = min(sel.event.start_time for sel in selections_list)
+        max_end = max(sel.event.end_time for sel in selections_list)
+
+        # Expand ALL group-scoped windows once over the union range.
+        all_windows = self._group_scoped_available_times_expanded(
+            calendar_id, group_slot.id, min_start, max_end
+        )
+
+        # Check each booking against the single cached expansion.
         orphaned: list[CalendarEvent] = []
-        for selection in selections:
+        for selection in selections_list:
             event = selection.event
-            windows = self._group_scoped_available_times_expanded(
-                calendar_id, group_slot.id, event.start_time, event.end_time
-            )
             covered = _time_range_fully_covered(
-                ((w.start_time, w.end_time) for w in windows), event.start_time, event.end_time
+                ((w.start_time, w.end_time) for w in all_windows),
+                event.start_time,
+                event.end_time,
             )
             if not covered:
                 orphaned.append(event)
@@ -659,6 +692,7 @@ class CalendarGroupService:
         end_time: datetime.datetime,
         tz: str,
         rrule_string: str | None = None,
+        now: datetime.datetime | None = None,
     ) -> GroupScopedAvailabilityWriteResult:
         """Create a group-scoped availability window for ``(calendar, group_slot)``.
 
@@ -669,11 +703,30 @@ class CalendarGroupService:
         window. Permission-gated: ``acting_user`` must own the calendar or be
         an org admin (see
         ``CalendarPermissionService.can_manage_group_scoped_calendar_config``).
+
+        On creating the FIRST group-scoped window for a (calendar, group_slot),
+        collects confirmed future bookings that fall outside the new window and
+        returns them as orphaned_bookings (spec UC-6). Creating subsequent
+        windows only widens the union (can never orphan), so orphaned-booking
+        detection runs only on the first create. Nothing is cancelled.
         """
         self._assert_initialized()
+        if now is None:
+            now = timezone.now()
+
         organization = cast(Organization, self.organization)
         membership = self._resolve_group_scoped_membership(group_slot_id, calendar_id)
         self._authorize_group_scoped_write(acting_user, membership.calendar, membership.slot)
+
+        # Check if this will be the calendar's FIRST window in this slot.
+        # If so, narrowing is happening and we must detect orphaned bookings.
+        existing_window_count = (
+            AvailableTime.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(organization.id)
+            .filter(calendar_fk_id=calendar_id)
+            .count()
+        )
+        is_first_window = existing_window_count == 0
 
         recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
         window = AvailableTime.objects.unscoped().create(
@@ -686,7 +739,19 @@ class CalendarGroupService:
             recurrence_rule=recurrence_rule,
         )
         self._audit_group_scoped_availability_write(AuditAction.CREATE, acting_user, window)
-        return GroupScopedAvailabilityWriteResult(window=window, orphaned_bookings=[])
+
+        # Detect orphaned bookings only on the first window create.
+        orphaned_bookings: list[CalendarEvent] = []
+        if is_first_window:
+            orphaned_bookings = self._find_orphaned_bookings(
+                calendar_id=calendar_id,
+                group_slot=membership.slot,
+                now=now,
+            )
+
+        return GroupScopedAvailabilityWriteResult(
+            window=window, orphaned_bookings=orphaned_bookings
+        )
 
     @transaction.atomic()
     def update_group_scoped_availability_window(

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Annotated, cast
 
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from dependency_injector.wiring import Provide, inject
@@ -14,11 +15,13 @@ from calendar_integration.constants import CalendarProvider, CalendarType
 from calendar_integration.exceptions import (
     BookingPolicyViolationError,
     CalendarGroupHasFutureEventsError,
+    CalendarGroupSlotConfigNotFoundError,
     CalendarGroupSlotInUseError,
     CalendarGroupValidationError,
     CalendarServiceOrganizationNotSetError,
 )
 from calendar_integration.models import (
+    AvailableTime,
     BlockedTime,
     Calendar,
     CalendarEvent,
@@ -27,6 +30,7 @@ from calendar_integration.models import (
     CalendarGroupSlot,
     CalendarGroupSlotMembership,
     CalendarOwnership,
+    RecurrenceRule,
 )
 from calendar_integration.querysets import CalendarEventQuerySet
 from calendar_integration.services import slot_engine
@@ -49,6 +53,7 @@ from calendar_integration.services.dataclasses import (
     EventAttendanceInputData,
     EventExternalAttendanceInputData,
     ExternalAttendeeInputData,
+    GroupScopedAvailabilityWriteResult,
     ResourceAllocationInputData,
 )
 from organizations.models import Organization
@@ -62,6 +67,36 @@ if TYPE_CHECKING:
     from calendar_integration.services.booking_policy_service import BookingPolicyService
     from calendar_integration.services.calendar_service import CalendarService
     from payments.services.entitlement_service import EntitlementService
+
+
+def _time_range_fully_covered(
+    windows: Iterable[tuple[datetime.datetime, datetime.datetime]],
+    start: datetime.datetime,
+    end: datetime.datetime,
+) -> bool:
+    """Whether ``[start, end)`` is fully covered by the union of ``windows``.
+
+    Used to decide whether a confirmed future booking still falls inside a
+    calendar's group-scoped availability configuration after a write.
+    ``windows`` may be unsorted or overlapping; each is clipped against the
+    shrinking set of remaining uncovered gaps.
+    """
+    remaining = [(start, end)]
+    for window_start, window_end in windows:
+        next_remaining: list[tuple[datetime.datetime, datetime.datetime]] = []
+        for gap_start, gap_end in remaining:
+            if window_end <= gap_start or window_start >= gap_end:
+                # No overlap with this gap -- carry it forward untouched.
+                next_remaining.append((gap_start, gap_end))
+                continue
+            if window_start > gap_start:
+                next_remaining.append((gap_start, window_start))
+            if window_end < gap_end:
+                next_remaining.append((window_end, gap_end))
+        remaining = next_remaining
+        if not remaining:
+            break
+    return not remaining
 
 
 class CalendarGroupService:
@@ -416,6 +451,333 @@ class CalendarGroupService:
                     for cid in to_add
                 ]
             )
+
+    # ------------------------------------------------------------------
+    # Group-scoped availability windows (Phase 1a of
+    # CALENDAR_GROUP_SCOPED_AVAILABILITY -- writes)
+    # ------------------------------------------------------------------
+
+    def _resolve_group_scoped_membership(
+        self, group_slot_id: int, calendar_id: int
+    ) -> CalendarGroupSlotMembership:
+        """Resolve the roster entry (calendar, group slot) a group-scoped
+        availability write targets.
+
+        Raises the same not-found-shaped ``CalendarGroupSlotConfigNotFoundError``
+        whether the slot doesn't exist, the calendar doesn't exist, or the
+        calendar simply isn't a member of that slot -- callers must not be able
+        to tell which case applies from the error alone.
+        """
+        org_id = cast(Organization, self.organization).id
+        try:
+            return (
+                CalendarGroupSlotMembership.objects.filter_by_organization(org_id)
+                .select_related("slot", "calendar")
+                .get(slot_fk_id=group_slot_id, calendar_fk_id=calendar_id)
+            )
+        except CalendarGroupSlotMembership.DoesNotExist:
+            raise CalendarGroupSlotConfigNotFoundError() from None
+
+    def _get_group_scoped_window(self, window_id: int) -> AvailableTime:
+        """Fetch a group-scoped ``AvailableTime`` row by id, scoped to this org.
+
+        Reads through the ``unscoped`` accessor (never the default manager,
+        which excludes group-scoped rows) and requires ``group_slot`` to be
+        set, so an id belonging to a base row raises the same not-found error
+        as a genuinely missing id.
+        """
+        org_id = cast(Organization, self.organization).id
+        try:
+            return (
+                AvailableTime.objects.unscoped()
+                .filter_by_organization(org_id)
+                .select_related("group_slot", "calendar", "recurrence_rule")
+                .get(id=window_id, group_slot_fk__isnull=False)
+            )
+        except AvailableTime.DoesNotExist:
+            raise CalendarGroupSlotConfigNotFoundError() from None
+
+    def _authorize_group_scoped_write(
+        self, acting_user: User, calendar: Calendar, group_slot: CalendarGroupSlot
+    ) -> None:
+        """Gate a group-scoped availability write to the calendar's owner (within
+        a group they can see) or an org admin.
+
+        Fails closed -- raises when no ``calendar_permission_service`` is bound,
+        rather than silently allowing the write, since this path exists
+        specifically to be permission-gated (spec goal 4). Denial and
+        "the roster entry doesn't exist" share the exact same exception, so a
+        member cannot learn a group exists through the error shape.
+        """
+        if self.calendar_permission_service is None or not (
+            self.calendar_permission_service.can_manage_group_scoped_calendar_config(
+                user=acting_user, calendar=calendar, group_slot=group_slot
+            )
+        ):
+            raise CalendarGroupSlotConfigNotFoundError()
+
+    def _create_recurrence_rule_if_needed(self, rrule_string: str | None) -> RecurrenceRule | None:
+        """Create (and persist) a ``RecurrenceRule`` from an RRULE string, or None.
+
+        Self-contained variant of the identically-named helper
+        ``CalendarService``/``AvailabilityService`` expose through their host
+        protocol -- this write path does not require a bound
+        ``calendar_service``, so it builds the ``RecurrenceRule`` directly.
+        """
+        if not rrule_string:
+            return None
+        organization = cast(Organization, self.organization)
+        recurrence_rule = RecurrenceRule.from_rrule_string(rrule_string, organization)
+        recurrence_rule.save()
+        return recurrence_rule
+
+    def _audit_group_scoped_availability_write(
+        self,
+        action: str,
+        acting_user: User,
+        subject_instance: AvailableTime,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a group-scoped availability window write.
+
+        Unlike ``_audit_group_write`` (which resolves the actor from a bound
+        ``calendar_service``'s auth context), these write methods take the
+        acting principal explicitly -- they are reachable without a bound
+        ``calendar_service``. No-op when no ``audit_service`` / ``organization``
+        is bound, so instrumentation never breaks a write path.
+        """
+        if self.audit_service is None or self.organization is None:
+            return
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=action,
+            actor=self.audit_service.actor_from_user_or_token(acting_user, self.organization.id),
+            subject=self.audit_service.subject_from_instance(subject_instance),
+            diff=diff,
+        )
+
+    def _group_scoped_available_times_expanded(
+        self,
+        calendar_id: int,
+        group_slot_id: int,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[AvailableTime]:
+        """Expand every group-scoped ``AvailableTime`` for ``(calendar, group_slot)``
+        that overlaps ``[start_date, end_date)``, recurrence included.
+
+        Mirrors ``AvailabilityService.get_available_times_expanded``, but reads
+        through ``AvailableTime.objects.for_group_slot(...)`` instead of the
+        default (base-rows-only) manager. Masters are fetched WITH the
+        ``annotate_recurring_occurrences_on_date_range`` annotation attached, so
+        ``get_occurrences_in_range()`` below finds ``recurring_occurrences``
+        already cached on the instance and skips its own internal re-fetch
+        through ``self.__class__.objects`` -- the *default*, base-rows-only
+        manager, which would otherwise silently return nothing for a
+        group-scoped master (see the Phase 0 carry-forward note about that
+        re-fetch being unsafe for group-scoped rows).
+        """
+        org_id = cast(Organization, self.organization).id
+        base_qs = (
+            AvailableTime.objects.for_group_slot(group_slot_id)
+            .annotate_recurring_occurrences_on_date_range(start_date, end_date, overlap=True)
+            .select_related("recurrence_rule")
+            .filter(
+                organization_id=org_id,
+                calendar_fk_id=calendar_id,
+                parent_recurring_object__isnull=True,
+            )
+        )
+
+        non_recurring_times = base_qs.filter(
+            start_time__lt=end_date,
+            end_time__gt=start_date,
+            recurrence_rule__isnull=True,
+            is_recurring_exception=False,
+        )
+
+        recurring_times = base_qs.filter(recurrence_rule__isnull=False).filter(
+            Q(recurrence_rule__until__isnull=True) | Q(recurrence_rule__until__gte=start_date),
+            start_time__lte=end_date,
+        )
+
+        times: list[AvailableTime] = list(non_recurring_times)
+        for master_time in recurring_times:
+            instances = master_time.get_occurrences_in_range(
+                start_date, end_date, include_self=False, include_exceptions=True, overlap=True
+            )
+            times.extend(instances)
+
+        times.sort(key=lambda t: t.start_time)
+        return times
+
+    def _find_orphaned_bookings(
+        self, calendar_id: int, group_slot: CalendarGroupSlot, now: datetime.datetime
+    ) -> list[CalendarEvent]:
+        """Confirmed future bookings in ``group_slot`` for ``calendar_id`` that
+        fall outside the calendar's current group-scoped availability
+        configuration.
+
+        Runs against every group-scoped window that currently exists for this
+        ``(calendar, slot)`` pair -- the whole union, not just the one row a
+        caller just wrote -- so a booking is reported exactly when the
+        calendar's configured availability, as it stands after the write, no
+        longer covers it. Nothing here is cancelled or modified; this is
+        purely a read (spec UC-6).
+        """
+        org_id = cast(Organization, self.organization).id
+        selections = (
+            CalendarEventGroupSelection.objects.filter_by_organization(org_id)
+            .filter(
+                slot_fk=group_slot,
+                calendar_fk_id=calendar_id,
+                event_fk__start_time__gt=now,
+            )
+            .select_related("event")
+        )
+
+        orphaned: list[CalendarEvent] = []
+        for selection in selections:
+            event = selection.event
+            windows = self._group_scoped_available_times_expanded(
+                calendar_id, group_slot.id, event.start_time, event.end_time
+            )
+            covered = _time_range_fully_covered(
+                ((w.start_time, w.end_time) for w in windows), event.start_time, event.end_time
+            )
+            if not covered:
+                orphaned.append(event)
+        return orphaned
+
+    @transaction.atomic()
+    def create_group_scoped_availability_window(
+        self,
+        acting_user: User,
+        group_slot_id: int,
+        calendar_id: int,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        tz: str,
+        rrule_string: str | None = None,
+    ) -> GroupScopedAvailabilityWriteResult:
+        """Create a group-scoped availability window for ``(calendar, group_slot)``.
+
+        Writes through the explicit group-scoped accessor
+        (``AvailableTime.objects.unscoped().create(..., group_slot=...)``),
+        never the default manager. Carries the same recurrence expressiveness
+        as a base ``AvailableTime`` -- pass ``rrule_string`` for a recurring
+        window. Permission-gated: ``acting_user`` must own the calendar or be
+        an org admin (see
+        ``CalendarPermissionService.can_manage_group_scoped_calendar_config``).
+        """
+        self._assert_initialized()
+        organization = cast(Organization, self.organization)
+        membership = self._resolve_group_scoped_membership(group_slot_id, calendar_id)
+        self._authorize_group_scoped_write(acting_user, membership.calendar, membership.slot)
+
+        recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
+        window = AvailableTime.objects.unscoped().create(
+            organization=organization,
+            calendar=membership.calendar,
+            group_slot=membership.slot,
+            start_time_tz_unaware=start_time,
+            end_time_tz_unaware=end_time,
+            timezone=tz,
+            recurrence_rule=recurrence_rule,
+        )
+        self._audit_group_scoped_availability_write(AuditAction.CREATE, acting_user, window)
+        return GroupScopedAvailabilityWriteResult(window=window, orphaned_bookings=[])
+
+    @transaction.atomic()
+    def update_group_scoped_availability_window(
+        self,
+        acting_user: User,
+        window_id: int,
+        start_time: datetime.datetime | None = None,
+        end_time: datetime.datetime | None = None,
+        tz: str | None = None,
+        rrule_string: str | None = None,
+        now: datetime.datetime | None = None,
+    ) -> GroupScopedAvailabilityWriteResult:
+        """Partially update a group-scoped availability window (only provided
+        fields change -- mirrors ``AvailabilityService.update_blocked_time``).
+
+        After the update is applied, every confirmed future booking in the
+        window's group slot for its calendar that no longer falls inside the
+        calendar's group-scoped configuration is collected and returned.
+        Narrowing a window never cancels or edits a booking (spec UC-6) --
+        the caller decides what to do with each one.
+        """
+        self._assert_initialized()
+        if now is None:
+            now = timezone.now()
+
+        window = self._get_group_scoped_window(window_id)
+        self._authorize_group_scoped_write(acting_user, window.calendar, window.group_slot)
+
+        before = {
+            "start_time_tz_unaware": window.start_time_tz_unaware.isoformat(),
+            "end_time_tz_unaware": window.end_time_tz_unaware.isoformat(),
+            "timezone": window.timezone,
+            "rrule": window.recurrence_rule.to_rrule_string() if window.recurrence_rule else None,
+        }
+
+        update_fields: list[str] = []
+        if start_time is not None:
+            window.start_time_tz_unaware = start_time
+            update_fields.append("start_time_tz_unaware")
+        if end_time is not None:
+            window.end_time_tz_unaware = end_time
+            update_fields.append("end_time_tz_unaware")
+        if tz is not None:
+            window.timezone = tz
+            update_fields.append("timezone")
+        if rrule_string is not None:
+            window.recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
+            # Assigning through the ForeignObject property name ("recurrence_rule")
+            # sets the underlying concrete column ("recurrence_rule_fk"); `save`'s
+            # `update_fields` must name the concrete field.
+            update_fields.append("recurrence_rule_fk")
+
+        if update_fields:
+            window.save(update_fields=[*update_fields, "modified"])
+
+        after = {
+            "start_time_tz_unaware": window.start_time_tz_unaware.isoformat(),
+            "end_time_tz_unaware": window.end_time_tz_unaware.isoformat(),
+            "timezone": window.timezone,
+            "rrule": window.recurrence_rule.to_rrule_string() if window.recurrence_rule else None,
+        }
+        self._audit_group_scoped_availability_write(
+            AuditAction.UPDATE, acting_user, window, diff=compute_diff(before, after)
+        )
+
+        orphaned_bookings = self._find_orphaned_bookings(
+            calendar_id=window.calendar_fk_id,  # type: ignore[arg-type]
+            group_slot=window.group_slot,
+            now=now,
+        )
+        return GroupScopedAvailabilityWriteResult(
+            window=window, orphaned_bookings=orphaned_bookings
+        )
+
+    @transaction.atomic()
+    def delete_group_scoped_availability_window(self, acting_user: User, window_id: int) -> None:
+        """Delete a group-scoped availability window (a single ``AvailableTime`` row).
+
+        A recurring window is stored as one row; deleting it removes the whole
+        series (mirrors ``AvailabilityService.delete_blocked_time``). No
+        orphaned-booking report is computed here -- the spec scopes that to
+        narrowing UPDATEs (UC-6). Removing a calendar from a slot's roster
+        entirely (which cascades away its windows per the Phase 0 schema
+        constraint) is a distinct action, exercised through ``update_group``.
+        """
+        self._assert_initialized()
+        window = self._get_group_scoped_window(window_id)
+        self._authorize_group_scoped_write(acting_user, window.calendar, window.group_slot)
+
+        self._audit_group_scoped_availability_write(AuditAction.DELETE, acting_user, window)
+        window.delete()
 
     # ------------------------------------------------------------------
     # Queries

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -440,13 +440,41 @@ class CalendarGroupService:
             # Delete group-scoped windows for the removed calendars.
             # The FK on AvailableTime.group_slot → CalendarGroupSlot cascades on
             # SLOT deletion only, not on membership removal, so we must explicitly
-            # clean up the orphaned rows here. These deletions are cascading from
-            # membership removal (already audited as part of the group update), so
-            # we do not audit them individually.
+            # clean up the orphaned rows here. Each window deletion is audited
+            # individually because the group-update diff only captures name/description
+            # /accepts_public_scheduling, not membership or window changes.
             # TODO(Phase 2a, 3a): BlockedTime.for_group_slot() and quota rules
             # must extend this cleanup when those phases add their group-scoped rows,
             # using the same pattern: delete rows for removed calendars in to_remove.
             org_id = cast(Organization, self.organization).id
+            windows_to_delete = list(
+                AvailableTime.objects.unscoped()
+                .filter_by_organization(org_id)
+                .filter(group_slot_fk=slot, calendar_fk_id__in=to_remove)
+            )
+
+            # Audit each window deletion before removing it.
+            for window in windows_to_delete:
+                if self.audit_service is None or self.organization is None:
+                    break
+                user_or_token = getattr(self.calendar_service, "user_or_token", None)
+                permission_service = getattr(
+                    self.calendar_service, "calendar_permission_service", None
+                )
+                self.audit_service.record(
+                    organization_id=self.organization.id,
+                    action=AuditAction.DELETE,
+                    actor=self.audit_service.actor_from_user_or_token(
+                        user_or_token,
+                        self.organization.id,
+                        single_use_token=resolve_acting_single_use_token(
+                            user_or_token, permission_service
+                        ),
+                    ),
+                    subject=self.audit_service.subject_from_instance(window),
+                )
+
+            # Delete the windows after auditing them.
             AvailableTime.objects.unscoped().filter_by_organization(org_id).filter(
                 group_slot_fk=slot, calendar_fk_id__in=to_remove
             ).delete()

--- a/calendar_integration/services/calendar_permission_service.py
+++ b/calendar_integration/services/calendar_permission_service.py
@@ -19,7 +19,9 @@ from calendar_integration.exceptions import (
     TokenRevokedError,
 )
 from calendar_integration.models import (
+    Calendar,
     CalendarGroup,
+    CalendarGroupSlot,
     CalendarGroupSlotMembership,
     CalendarManagementToken,
     CalendarOwnership,
@@ -468,6 +470,36 @@ class CalendarPermissionService:
             return True
 
         return False
+
+    def can_manage_group_scoped_calendar_config(
+        self, user: User, calendar: Calendar, group_slot: CalendarGroupSlot
+    ) -> bool:
+        """Return True if `user` may create/update/delete group-scoped
+        availability configuration (windows -- and, in later phases, blocks
+        and quota rules) for `calendar` within `group_slot`.
+
+        Rules, in order:
+          1. Org admins in ``group_slot``'s organization may always manage it.
+          2. Otherwise, `user` must own `calendar` directly (a
+             ``CalendarOwnership`` row) -- owning some *other* calendar in the
+             same group is not enough. Resource calendars with no owner are
+             therefore admin-only by construction.
+
+        Callers are responsible for having already resolved `calendar` as an
+        actual member of `group_slot` (e.g. via ``CalendarGroupSlotMembership``)
+        -- this method only decides whether `user` may act on `calendar`'s
+        config, not whether the (calendar, group_slot) pairing is real. Doing
+        the membership resolution first and raising the same not-found-shaped
+        error for both "no such membership" and "not authorized" is what keeps
+        a member from learning a group exists through the error shape alone.
+        """
+        if user.is_organization_admin(group_slot.organization_id):
+            return True
+        return (
+            CalendarOwnership.objects.filter_by_organization(group_slot.organization_id)
+            .filter(membership_user_id=user.id, calendar_fk=calendar)
+            .exists()
+        )
 
     def can_manage_calendar_group(self, user: User, group: CalendarGroup) -> bool:
         """Return True if `user` may create/update/delete `group` and create

--- a/calendar_integration/services/dataclasses.py
+++ b/calendar_integration/services/dataclasses.py
@@ -8,6 +8,7 @@ from calendar_integration.constants import (
     CalendarProvider,
 )
 from calendar_integration.models import (
+    AvailableTime,
     BlockedTime,
     CalendarEvent,
     EventAttendance,
@@ -364,6 +365,23 @@ class BookableSlotProposal:
 
     start_time: datetime.datetime
     end_time: datetime.datetime
+
+
+@dataclass
+class GroupScopedAvailabilityWriteResult:
+    """Result of a group-scoped availability window write (create/update/delete).
+
+    ``window`` is the saved ``AvailableTime`` row, or ``None`` after a delete.
+    ``orphaned_bookings`` lists confirmed future ``CalendarEvent`` bookings in
+    the window's group slot, for the window's calendar, that fall outside the
+    calendar's group-scoped configuration *after* the write is applied --
+    populated only by the update path (spec UC-6: "admin tightens a window
+    that orphans bookings"). Nothing about the orphaned bookings is modified;
+    this is a read-only report for the caller to act on.
+    """
+
+    window: AvailableTime | None
+    orphaned_bookings: list[CalendarEvent] = dataclass_field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
+++ b/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
@@ -1,0 +1,680 @@
+"""Tests for group-scoped availability window writes on ``CalendarGroupService``
+(Phase 1a of ``CALENDAR_GROUP_SCOPED_AVAILABILITY``).
+
+Covers create/update/delete through the explicit group-scoped accessor,
+recurrence + per-window timezone round-trip, audit emission with before/after
+diffs on update, permission gating (owner-within-group or org admin, with a
+member unable to learn a group exists through the error shape), and
+orphaned-booking detection on a narrowing update.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import patch
+
+from django.utils import timezone as django_timezone
+
+import pytest
+
+from audit.constants import AuditAction
+from audit.services import AuditService
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.exceptions import CalendarGroupSlotConfigNotFoundError
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarOwnership,
+)
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.dataclasses import (
+    CalendarGroupInputData,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payloads(mock_task) -> list[dict]:
+    return [call.args[0] for call in mock_task.delay.call_args_list]
+
+
+def _next_weekday(after: datetime.datetime, weekday: int) -> datetime.date:
+    """Next date (strictly after `after`'s date) landing on ISO `weekday`
+    (Monday=0 ... Sunday=6)."""
+    days_ahead = (weekday - after.weekday()) % 7
+    days_ahead = days_ahead or 7
+    return (after + datetime.timedelta(days=days_ahead)).date()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Windows Test Org", should_sync_rooms=False)
+
+
+@pytest.fixture
+def audit_service() -> AuditService:
+    from di_core.containers import container
+
+    return container.audit_service()
+
+
+@pytest.fixture
+def admin_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="admin@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.ADMIN
+    )
+    return u
+
+
+@pytest.fixture
+def owner_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="owner@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.MEMBER
+    )
+    return u
+
+
+@pytest.fixture
+def other_owner_user(db: Any, organization: Organization) -> User:
+    """Owns a DIFFERENT calendar (not the one under test) -- used to prove that
+    being a member of the org (and even owning some calendar in the group) is
+    not enough; only the target calendar's own owner may edit it."""
+    u = User.objects.create_user(email="other_owner@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.MEMBER
+    )
+    return u
+
+
+@pytest.fixture
+def stranger_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="stranger@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.MEMBER
+    )
+    return u
+
+
+@pytest.fixture
+def calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="dr_reyes",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def other_calendar(organization: Organization) -> Calendar:
+    """A second calendar in the same group (different slot) -- owned by
+    `other_owner_user`, so that fixture can "see" the group without owning
+    `calendar`."""
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Costa",
+        external_id="dr_costa",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ownerships(
+    organization: Organization,
+    owner_user: User,
+    other_owner_user: User,
+    calendar: Calendar,
+    other_calendar: Calendar,
+) -> None:
+    CalendarOwnership.objects.create(
+        organization=organization, calendar=calendar, membership_user_id=owner_user.id
+    )
+    CalendarOwnership.objects.create(
+        organization=organization,
+        calendar=other_calendar,
+        membership_user_id=other_owner_user.id,
+    )
+
+
+@pytest.fixture
+def group(organization: Organization) -> CalendarGroup:
+    return CalendarGroup.objects.create(organization=organization, name="Surgery")
+
+
+@pytest.fixture
+def group_slot(
+    organization: Organization, group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Lead Surgeon"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def other_slot(
+    organization: Organization, group: CalendarGroup, other_calendar: Calendar
+) -> CalendarGroupSlot:
+    """A second slot in the same group, populated with `other_calendar` -- makes
+    `other_owner_user` a genuine member of the group without owning `calendar`."""
+    slot = CalendarGroupSlot.objects.create(organization=organization, group=group, name="Assist")
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=other_calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def service(organization: Organization, audit_service: AuditService) -> CalendarGroupService:
+    svc = CalendarGroupService(
+        calendar_permission_service=CalendarPermissionService(),
+        audit_service=audit_service,
+    )
+    svc.initialize(organization=organization)
+    return svc
+
+
+def _utc(year: int, month: int, day: int, hour: int) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# create_group_scoped_availability_window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_availability_window_admin_happy_path(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    django_capture_on_commit_callbacks,
+) -> None:
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            result = service.create_group_scoped_availability_window(
+                acting_user=admin_user,
+                group_slot_id=group_slot.id,
+                calendar_id=calendar.id,
+                start_time=_utc(2025, 9, 2, 9),
+                end_time=_utc(2025, 9, 2, 17),
+                tz="UTC",
+            )
+
+    window = result.window
+    assert window is not None
+    assert result.orphaned_bookings == []
+    assert window.group_slot_fk_id == group_slot.id
+    assert window.calendar_fk_id == calendar.id
+
+    # Invisible on the default (base-rows-only) manager...
+    assert (
+        not AvailableTime.objects.filter_by_organization(service.organization.id)
+        .filter(id=window.id)
+        .exists()
+    )
+    # ...and visible through the explicit group-scoped accessor.
+    assert (
+        AvailableTime.objects.for_group_slot(group_slot.id)
+        .filter_by_organization(service.organization.id)
+        .get(id=window.id)
+        == window
+    )
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    assert payloads[0]["action"] == AuditAction.CREATE
+    assert payloads[0]["subject"]["subject_type"] == "calendar_integration.AvailableTime"
+    assert payloads[0]["subject"]["subject_id"] == str(window.pk)
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_availability_window_owner_happy_path(
+    service: CalendarGroupService,
+    owner_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    result = service.create_group_scoped_availability_window(
+        acting_user=owner_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    assert result.window is not None
+    assert result.window.calendar_fk_id == calendar.id
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_availability_window_denies_non_owner_without_disclosing_group(
+    service: CalendarGroupService,
+    stranger_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError) as excinfo:
+        service.create_group_scoped_availability_window(
+            acting_user=stranger_user,
+            group_slot_id=group_slot.id,
+            calendar_id=calendar.id,
+            start_time=_utc(2025, 9, 2, 9),
+            end_time=_utc(2025, 9, 2, 17),
+            tz="UTC",
+        )
+    stranger_message = str(excinfo.value)
+
+    # A genuinely missing (group_slot_id, calendar_id) pairing must raise the
+    # exact same exception, message included -- a caller cannot distinguish
+    # "forbidden" from "does not exist" from the error alone.
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError) as excinfo_missing:
+        service.create_group_scoped_availability_window(
+            acting_user=stranger_user,
+            group_slot_id=group_slot.id,
+            calendar_id=calendar.id + 999_999,
+            start_time=_utc(2025, 9, 2, 9),
+            end_time=_utc(2025, 9, 2, 17),
+            tz="UTC",
+        )
+    assert str(excinfo_missing.value) == stranger_message
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_availability_window_denies_owner_outside_target_calendar(
+    service: CalendarGroupService,
+    other_owner_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    other_slot: CalendarGroupSlot,
+) -> None:
+    """`other_owner_user` owns a calendar in the SAME group (a different slot),
+    so they can see the group -- but they do not own `calendar`, so they must
+    still be denied, with the same not-found-shaped error."""
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError):
+        service.create_group_scoped_availability_window(
+            acting_user=other_owner_user,
+            group_slot_id=group_slot.id,
+            calendar_id=calendar.id,
+            start_time=_utc(2025, 9, 2, 9),
+            end_time=_utc(2025, 9, 2, 17),
+            tz="UTC",
+        )
+    assert not AvailableTime.objects.unscoped().filter(group_slot_fk=group_slot).exists()
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_availability_window_recurrence_and_timezone_round_trip(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    result = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),  # 2025-09-02 is a Tuesday
+        end_time=_utc(2025, 9, 2, 17),
+        tz="America/Sao_Paulo",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    window = result.window
+    assert window is not None
+    assert window.timezone == "America/Sao_Paulo"
+    assert window.recurrence_rule is not None
+    assert window.recurrence_rule.to_rrule_string() == "FREQ=WEEKLY;BYDAY=TU,TH"
+
+    # Read back through the group-scoped accessor and expand recurrence over two
+    # weeks -- must land on Tuesdays and Thursdays only. Annotating BEFORE calling
+    # get_occurrences_in_range caches `recurring_occurrences` on the instance, so
+    # the read never falls through RecurringMixin's internal re-fetch via the
+    # DEFAULT (base-rows-only) manager -- see the Phase 0 carry-forward note.
+    range_start = _utc(2025, 9, 1, 0)
+    range_end = _utc(2025, 9, 15, 0)
+    master = (
+        AvailableTime.objects.for_group_slot(group_slot.id)
+        .filter_by_organization(service.organization.id)
+        .annotate_recurring_occurrences_on_date_range(range_start, range_end)
+        .get(id=window.id)
+    )
+    occurrences = master.get_occurrences_in_range(range_start, range_end, include_self=True)
+    weekdays = sorted({o.start_time.weekday() for o in occurrences})
+    assert weekdays == [1, 3]  # Tuesday, Thursday
+    assert len(occurrences) == 4  # two Tuesdays + two Thursdays in the range
+
+
+# ---------------------------------------------------------------------------
+# update_group_scoped_availability_window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_availability_window_records_diff(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    django_capture_on_commit_callbacks,
+) -> None:
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            result = service.update_group_scoped_availability_window(
+                acting_user=admin_user,
+                window_id=window_id,
+                rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TH",
+            )
+
+    assert result.window is not None
+    assert result.window.recurrence_rule.to_rrule_string() == "FREQ=WEEKLY;BYDAY=TH"
+
+    payloads = _payloads(mock_task)
+    update_payloads = [p for p in payloads if p["action"] == AuditAction.UPDATE]
+    assert len(update_payloads) == 1
+    diff = update_payloads[0]["diff"]
+    assert diff is not None
+    assert "rrule" in diff
+    assert diff["rrule"]["old"] == "FREQ=WEEKLY;BYDAY=TU,TH"
+    assert diff["rrule"]["new"] == "FREQ=WEEKLY;BYDAY=TH"
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_availability_window_timezone_round_trip(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    result = service.update_group_scoped_availability_window(
+        acting_user=admin_user,
+        window_id=window_id,
+        tz="America/Sao_Paulo",
+    )
+    assert result.window is not None
+    assert result.window.timezone == "America/Sao_Paulo"
+
+    reloaded = (
+        AvailableTime.objects.unscoped()
+        .filter_by_organization(service.organization.id)
+        .get(id=window_id)
+    )
+    assert reloaded.timezone == "America/Sao_Paulo"
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_availability_window_denies_non_owner(
+    service: CalendarGroupService,
+    admin_user: User,
+    stranger_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError):
+        service.update_group_scoped_availability_window(
+            acting_user=stranger_user, window_id=window_id, tz="America/Sao_Paulo"
+        )
+
+    reloaded = (
+        AvailableTime.objects.unscoped()
+        .filter_by_organization(service.organization.id)
+        .get(id=window_id)
+    )
+    assert reloaded.timezone == "UTC"  # untouched
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_availability_window_narrowing_returns_orphaned_bookings_untouched(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """UC-6: narrowing Tuesday+Thursday down to Thursday-only returns the future
+    Tuesday booking as orphaned, and modifies neither the event nor the group
+    selection."""
+    now = django_timezone.now()
+    # The window's own recurrence anchor is `tuesday` -- recurrence only generates
+    # occurrences forward from its own start, so `thursday` must fall in the SAME
+    # week, strictly after `tuesday` (picking it independently via `_next_weekday`
+    # could land it chronologically BEFORE the window's anchor, e.g. if "today" is
+    # a Wednesday -- the nearest future Thursday would then precede the nearest
+    # future Tuesday, and no occurrence could ever generate for it).
+    tuesday = _next_weekday(now, weekday=1)
+    thursday = tuesday + datetime.timedelta(days=2)
+
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(tuesday, datetime.time(9), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(tuesday, datetime.time(17), tzinfo=datetime.UTC),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    tuesday_event = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Operation",
+        description="",
+        external_id="ev_tuesday",
+        start_time_tz_unaware=datetime.datetime.combine(
+            tuesday, datetime.time(10), tzinfo=datetime.UTC
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            tuesday, datetime.time(11), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=tuesday_event,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    thursday_event = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Operation",
+        description="",
+        external_id="ev_thursday",
+        start_time_tz_unaware=datetime.datetime.combine(
+            thursday, datetime.time(10), tzinfo=datetime.UTC
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            thursday, datetime.time(11), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=thursday_event,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    result = service.update_group_scoped_availability_window(
+        acting_user=admin_user,
+        window_id=window_id,
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TH",
+        now=now,
+    )
+
+    orphaned_ids = {e.id for e in result.orphaned_bookings}
+    assert orphaned_ids == {tuesday_event.id}
+
+    # Nothing about either booking was touched.
+    tuesday_event.refresh_from_db()
+    thursday_event.refresh_from_db()
+    assert tuesday_event.title == "Operation"
+    assert CalendarEvent.objects.filter_by_organization(service.organization.id).count() == 2
+    assert (
+        CalendarEventGroupSelection.objects.filter_by_organization(service.organization.id).count()
+        == 2
+    )
+
+
+# ---------------------------------------------------------------------------
+# delete_group_scoped_availability_window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_delete_group_scoped_availability_window_admin(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    django_capture_on_commit_callbacks,
+) -> None:
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.delete_group_scoped_availability_window(
+                acting_user=admin_user, window_id=window_id
+            )
+
+    assert not AvailableTime.objects.unscoped().filter(id=window_id).exists()
+    payloads = _payloads(mock_task)
+    delete_payloads = [p for p in payloads if p["action"] == AuditAction.DELETE]
+    assert len(delete_payloads) == 1
+    assert delete_payloads[0]["subject"]["subject_id"] == str(window_id)
+
+
+@pytest.mark.django_db
+def test_delete_group_scoped_availability_window_denies_non_owner(
+    service: CalendarGroupService,
+    admin_user: User,
+    stranger_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError):
+        service.delete_group_scoped_availability_window(
+            acting_user=stranger_user, window_id=window_id
+        )
+    assert AvailableTime.objects.unscoped().filter(id=window_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Cascade through this service path (schema-enforced by Phase 0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_deleting_slot_through_update_group_cascades_group_scoped_windows(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+    assert AvailableTime.objects.unscoped().filter(id=window_id).exists()
+
+    # Reconcile the group with no slots at all -- CalendarGroupService.update_group
+    # deletes the now-absent "Lead Surgeon" slot, which cascades (on_delete=CASCADE
+    # on AvailableTime.group_slot, established in Phase 0) to every group-scoped
+    # window that referenced it.
+    service.update_group(group.id, CalendarGroupInputData(name=group.name, slots=[]))
+
+    assert (
+        not CalendarGroupSlot.objects.filter_by_organization(service.organization.id)
+        .filter(id=group_slot.id)
+        .exists()
+    )
+    assert not AvailableTime.objects.unscoped().filter(id=window_id).exists()

--- a/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
+++ b/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
@@ -36,6 +36,7 @@ from calendar_integration.services.calendar_group_service import CalendarGroupSe
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
 from calendar_integration.services.dataclasses import (
     CalendarGroupInputData,
+    CalendarGroupSlotInputData,
 )
 from organizations.models import Organization, OrganizationMembership, OrganizationRole
 from users.models import Profile, User
@@ -678,3 +679,225 @@ def test_deleting_slot_through_update_group_cascades_group_scoped_windows(
         .exists()
     )
     assert not AvailableTime.objects.unscoped().filter(id=window_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# FIX 1: Removing a calendar from a slot removes its group-scoped windows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_removing_calendar_from_slot_removes_group_scoped_windows(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    other_calendar: Calendar,
+    group: CalendarGroup,
+    django_capture_on_commit_callbacks,
+) -> None:
+    """FIX 1 (BLOCKER): When removing a calendar from a slot's membership,
+    its group-scoped availability windows must be deleted (not orphaned).
+    A second calendar's windows in the same slot survive.
+    """
+    # Create a slot with TWO calendars.
+    slot = CalendarGroupSlot.objects.create(
+        organization=service.organization, group=group, name="Test Slot"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=service.organization, slot=slot, calendar=calendar
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=service.organization, slot=slot, calendar=other_calendar
+    )
+
+    # Create group-scoped windows for BOTH calendars.
+    window1_result = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    window1_id = window1_result.window.id  # type: ignore[union-attr]
+
+    window2_result = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=slot.id,
+        calendar_id=other_calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    window2_id = window2_result.window.id  # type: ignore[union-attr]
+
+    # Verify both windows exist.
+    assert AvailableTime.objects.unscoped().filter(id=window1_id).exists()
+    assert AvailableTime.objects.unscoped().filter(id=window2_id).exists()
+
+    # Remove ONLY the first calendar from the slot (via update_group → _reconcile_slot).
+    with django_capture_on_commit_callbacks(execute=True):
+        service.update_group(
+            group.id,
+            CalendarGroupInputData(
+                name=group.name,
+                slots=[
+                    CalendarGroupSlotInputData(
+                        name=slot.name,
+                        calendar_ids=[other_calendar.id],
+                        required_count=1,
+                    )
+                ],
+            ),
+        )
+
+    # The first calendar's window must be deleted.
+    assert not AvailableTime.objects.unscoped().filter(id=window1_id).exists()
+    # The second calendar's window must survive.
+    assert AvailableTime.objects.unscoped().filter(id=window2_id).exists()
+    # The first calendar's membership is gone.
+    assert (
+        not CalendarGroupSlotMembership.objects.filter_by_organization(service.organization.id)
+        .filter(slot_fk=slot, calendar_fk_id=calendar.id)
+        .exists()
+    )
+    # The second calendar's membership remains.
+    assert (
+        CalendarGroupSlotMembership.objects.filter_by_organization(service.organization.id)
+        .filter(slot_fk=slot, calendar_fk_id=other_calendar.id)
+        .exists()
+    )
+
+
+# ---------------------------------------------------------------------------
+# FIX 2: Creating first window detects orphaned bookings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_availability_window_first_detects_orphaned_bookings(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """FIX 2 (SHOULD-FIX): Creating the FIRST group-scoped window for a
+    (calendar, slot) flips from fall-through (base availability) to narrowed
+    evaluation, which can orphan pre-existing bookings. Return them in
+    orphaned_bookings; do NOT modify/cancel them.
+    """
+    now = django_timezone.now()
+    # Pick a date in the future that will be a Thursday.
+    thursday = _next_weekday(now, weekday=3)
+
+    # Create a booking for Thursday outside the window we'll create.
+    booking = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Operation",
+        description="",
+        external_id="ev_thursday",
+        start_time_tz_unaware=datetime.datetime.combine(
+            thursday,
+            datetime.time(18),
+            tzinfo=datetime.UTC,  # 6pm = outside window
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            thursday, datetime.time(19), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=booking,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    # Create the FIRST group-scoped window for this (calendar, slot):
+    # 9am-5pm on Thursdays. The 6pm booking is now orphaned.
+    result = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(thursday, datetime.time(9), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(thursday, datetime.time(17), tzinfo=datetime.UTC),
+        tz="UTC",
+        now=now,
+    )
+
+    # The booking must be returned as orphaned.
+    orphaned_ids = {e.id for e in result.orphaned_bookings}
+    assert orphaned_ids == {booking.id}
+
+    # The booking itself must be untouched (not cancelled).
+    booking.refresh_from_db()
+    assert booking.title == "Operation"
+    assert CalendarEvent.objects.filter_by_organization(service.organization.id).count() == 1
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_availability_window_second_plus_no_orphans(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """When creating a SECOND (or later) group-scoped window, it only widens
+    the union and cannot orphan bookings. Verify orphaned_bookings=[] even
+    if a booking sits outside this specific window (but within an existing one).
+    """
+    now = django_timezone.now()
+    thursday = _next_weekday(now, weekday=3)
+    tuesday = thursday - datetime.timedelta(days=2)
+
+    # Create the FIRST window: Tuesday 9am-5pm.
+    service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(tuesday, datetime.time(9), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(tuesday, datetime.time(17), tzinfo=datetime.UTC),
+        tz="UTC",
+        now=now,
+    )
+
+    # Create a booking on Thursday (outside the first window).
+    booking = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Operation",
+        description="",
+        external_id="ev_thursday",
+        start_time_tz_unaware=datetime.datetime.combine(
+            thursday, datetime.time(10), tzinfo=datetime.UTC
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            thursday, datetime.time(11), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=booking,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    # Create the SECOND window: Thursday 9am-5pm. Union now covers both days.
+    result = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(thursday, datetime.time(9), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(thursday, datetime.time(17), tzinfo=datetime.UTC),
+        tz="UTC",
+        now=now,
+    )
+
+    # No booking is orphaned (widening the union cannot orphan).
+    assert result.orphaned_bookings == []

--- a/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
+++ b/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
@@ -698,6 +698,7 @@ def test_removing_calendar_from_slot_removes_group_scoped_windows(
     """FIX 1 (BLOCKER): When removing a calendar from a slot's membership,
     its group-scoped availability windows must be deleted (not orphaned).
     A second calendar's windows in the same slot survive.
+    Each deleted window is audited with a DELETE action naming the actor.
     """
     # Create a slot with TWO calendars.
     slot = CalendarGroupSlot.objects.create(
@@ -736,20 +737,21 @@ def test_removing_calendar_from_slot_removes_group_scoped_windows(
     assert AvailableTime.objects.unscoped().filter(id=window2_id).exists()
 
     # Remove ONLY the first calendar from the slot (via update_group → _reconcile_slot).
-    with django_capture_on_commit_callbacks(execute=True):
-        service.update_group(
-            group.id,
-            CalendarGroupInputData(
-                name=group.name,
-                slots=[
-                    CalendarGroupSlotInputData(
-                        name=slot.name,
-                        calendar_ids=[other_calendar.id],
-                        required_count=1,
-                    )
-                ],
-            ),
-        )
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.update_group(
+                group.id,
+                CalendarGroupInputData(
+                    name=group.name,
+                    slots=[
+                        CalendarGroupSlotInputData(
+                            name=slot.name,
+                            calendar_ids=[other_calendar.id],
+                            required_count=1,
+                        )
+                    ],
+                ),
+            )
 
     # The first calendar's window must be deleted.
     assert not AvailableTime.objects.unscoped().filter(id=window1_id).exists()
@@ -767,6 +769,18 @@ def test_removing_calendar_from_slot_removes_group_scoped_windows(
         .filter(slot_fk=slot, calendar_fk_id=other_calendar.id)
         .exists()
     )
+
+    # Verify that a DELETE audit record was emitted for the deleted window.
+    payloads = _payloads(mock_task)
+    delete_payloads = [p for p in payloads if p["action"] == AuditAction.DELETE]
+    # Should have at least one DELETE for window1 (may also have UPDATE for group).
+    window_delete_payloads = [
+        p
+        for p in delete_payloads
+        if p["subject"]["subject_type"] == "calendar_integration.AvailableTime"
+    ]
+    assert len(window_delete_payloads) == 1
+    assert window_delete_payloads[0]["subject"]["subject_id"] == str(window1_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

Phase 1a of the Calendar Group-Scoped Availability plan. Adds the service-layer create/update/delete for group-scoped availability windows — audited, permission-gated, and reporting the bookings a narrowing orphans. Reachable only through new service methods; no existing caller enters this code.

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 1a. Spec use-cases UC-1 (admin narrows a surgeon to operating days) and UC-6 (admin tightens a window that orphans bookings).

## Key decisions

- **A group-scoped window is an `AvailableTime` row with `group_slot` set** (Guiding Decisions → "Storage shape"), reusing the existing recurrence machinery (recurrence rules, per-window timezone, occurrence expansion). All writes/reads go through the explicit `AvailableTime.objects.for_group_slot(...)` / `.unscoped()` accessors from Phase 0 — never the default `objects` manager, which excludes group-scoped rows.
- **Occurrence-expansion safety**: `_group_scoped_available_times_expanded` annotates occurrences (`annotate_recurring_occurrences_on_date_range`) BEFORE calling `get_occurrences_in_range()`, so the instance's cached `recurring_occurrences` short-circuits `RecurringMixin`'s internal re-fetch through the default (base-rows-only) manager — which would otherwise silently return nothing for a group-scoped master (the Phase 0 carry-forward note).
- **Non-disclosure permissions** (spec Permissions decision): a stranger, an owner of a *different* calendar in the same group, and a genuinely-missing membership all raise the identical `CalendarGroupSlotConfigNotFoundError` (same type + message), so no error shape reveals a group the caller cannot see. Org admins may manage anyone's; resource calendars with no owner are admin-only.
- **Audit** (Objective 4): create/update/delete each emit an audit record; update captures a before/after diff over times, timezone, and the rrule string.
- **Orphaned-booking detection** (UC-6): a narrowing update — and creating the *first* window for a (calendar, slot), which flips the slot from fall-through to narrowed evaluation — collects confirmed future bookings now outside the configuration and returns them in `GroupScopedAvailabilityWriteResult`. Nothing is cancelled or modified. Adding a later window only widens the union and cannot orphan.
- **Slot-membership removal cleanup**: removing a calendar from a slot while the slot survives deletes only the membership row; the `group_slot` FK cascades on *slot* deletion, not membership removal. So `_reconcile_slot` now explicitly deletes that calendar's group-scoped windows on membership removal — audited per window — satisfying the spec's "calendar removed from a slot → windows deleted" edge case. (Phases 2a/3a must extend the same cleanup for blocks and quota rules — noted in a code comment.)

## Feature flag

None — self-gating; reachable only through new service methods, no existing caller enters this code, no migration.

## Test plan

```bash
docker compose run --rm api uv run pytest calendar_integration/tests/services/test_calendar_group_service_availability_windows.py -vs
docker compose run --rm api uv run pytest calendar_integration/tests/ -n auto
```

Covers: CRUD; recurrence + per-window timezone round-trip; audit records with diffs; both permission-denial cases without disclosing the group; orphan detection on update and first-window create (returns them, mutates nothing); window deletion on both whole-slot deletion and calendar-removed-from-slot (with audit).