### PR TITLE
feat(calendar): add nested REST endpoints for group-scoped availability windows

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -56,16 +56,23 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 - **Summary**: Service-layer create/update/delete for group-scoped availability windows on `CalendarGroupService`. Writes/reads via `AvailableTime.objects.for_group_slot(...)`/`.unscoped()`. New `_group_scoped_available_times_expanded` (annotates occurrences before `get_occurrences_in_range` to dodge the Phase-0 base-manager re-fetch). Non-disclosure permissions via identical `CalendarGroupSlotConfigNotFoundError` (stranger / other-calendar-owner / missing-membership all indistinguishable). Audit on all ops with before/after diff. Orphaned-booking detection on narrowing update AND first-window create (returns them in `GroupScopedAvailabilityWriteResult`, mutates nothing). New `CalendarPermissionService.can_manage_group_scoped_calendar_config`. No migration.
 - **BLOCKER fixed**: `_reconcile_slot` now deletes (and audits) group-scoped windows when a calendar is removed from a slot — the slot-FK cascade fires only on slot deletion, not membership removal (spec edge case + plan's required test).
 
-**CARRY-FORWARD for Phases 1b / 2a / 3b (occurrence-expansion trap, still open):**
-`RecurringMixin._get_occurrences_in_range` (calendar_integration/models.py ~L823-845) has TWO default-manager re-fetches. Phase 1a neutralized the OUTER one (via annotation). The INNER exception-instance lookup (`self.__class__.objects.filter(id__in=[...])` ~L837) STILL uses the DEFAULT (base-rows-only) manager, so a recurrence EXCEPTION on a group-scoped master is silently missed (falls through to an un-excepted occurrence). Not triggered in 1a (no group-scoped exception-write path). Any phase that expands group-scoped occurrences where exceptions may exist (1b enforcement, 2a blocks, 3b quota) MUST either route this lookup through a group-aware accessor, or expand exclusively via `_group_scoped_available_times_expanded` and never call `get_occurrences_in_range()` directly on a group-scoped instance. Fix it (scope the inner lookup) in the phase that first makes group-scoped exceptions reachable.
+**CARRY-FORWARD (occurrence-expansion trap) — RESOLVED in Phase 1b:**
+`RecurringMixin._get_occurrences_in_range` (calendar_integration/models.py ~L835-854) now guards the inner exception-instance lookup: when `getattr(self, "group_slot_fk_id", None) is not None` it uses `self.__class__._base_manager` (unfiltered), else the default manager. So a recurrence exception on a group-scoped master is found, not silently missed. All other recurring models are unchanged (guarded on the group-scoped case only). Covered by `test_group_scoped_recurring_exception_is_honored_when_master_is_group_scoped`. No longer an open risk for Phases 2a/3b.
+
+### Phase 1b — Windows in discovery and booking validation ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-1b` (base: phase-1a) — **PR [#221](https://github.com/vintasoftware/vinta-schedule-api/pull/221)**
+- **Implementer model**: sonnet (plan Tier 3) — agent type `implementer`
+- **Reviewer model**: opus (plan Tier-4 override) — no BLOCKERs; 2 SHOULD-FIX + 2 NIT fixed (haiku fixer)
+- **Summary**: Group-scoped windows intersected into slot-engine discovery + booking/reschedule validation. **Zero-change early-out** via an `Exists()` annotation folded into the existing membership query (no new round trip; `find_bookable_slots` 6→6, `check_group_availability` 5→5 queries; byte-identical output — asserted). Intersect-only via `base_free` short-circuit. New `slot_engine` batched span fetch (`fetch_group_scoped_available_spans`, recurrence-aware), consumed by discovery and by `_assert_calendars_within_group_scoped_windows` (wired into create + reschedule; reschedule extended to all selected calendars). New `GroupScopedRuleType` + `CalendarGroupScopedRuleViolationError` (names calendar + rule type, no configured-value leak). `bookable_slots_service.py` untouched. Resolved the recurrence-exception trap (see above). No migration.
 
 ## Current phase
 
-Phase 1b — Windows in discovery and booking validation
+Phase 1c — Windows on the internal REST surface (haiku attempt discarded — escalated to sonnet)
 
 ## Remaining phases
 
-1b, 1c, 1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
+1c, 1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -1,7 +1,9 @@
+from django.http import Http404
+
 from dependency_injector.wiring import Provide, inject
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
-from calendar_integration.models import CalendarOwnership
+from calendar_integration.models import CalendarGroupSlot, CalendarOwnership
 from calendar_integration.services.booking_policy_permission_service import (
     BookingPolicyPermissionService,
 )
@@ -175,3 +177,80 @@ class CalendarGroupPermission(BasePermission):
         return self.calendar_permission_service.can_manage_calendar_group(
             user=request.user, group=obj
         )
+
+
+class GroupScopedAvailabilityWindowPermission(BasePermission):
+    """Route-level group-visibility gate for the group-scoped availability
+    window routes nested under a group's slot
+    (``calendar-groups/<group_id>/slots/<slot_id>/availability-windows/...``,
+    CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1c).
+
+    ``has_permission`` resolves the ``(group_id, slot_id)`` pair from the URL
+    once, org-scoped, and stashes it on the view as ``view.group_slot`` so the
+    viewset doesn't repeat the query. Visibility uses the same "can this user
+    see the group at all" rule as ``CalendarGroupPermission``
+    (``CalendarPermissionService.can_manage_calendar_group`` — admin, or owns
+    ANY calendar in ANY slot of the group; matches the Phase 1a service tests,
+    where owning a calendar in a *different* slot of the same group is enough
+    to see the group but not enough to manage a calendar the caller doesn't
+    own). A caller who cannot see the ``(group, slot)`` — because it genuinely
+    doesn't exist, belongs to another organization, or they own no calendar
+    anywhere in the group and are not an org admin — gets the exact same
+    ``Http404`` as a caller hitting a URL for a slot that never existed; there
+    is no separate 403 branch to compare it against (spec: "a member cannot
+    learn about groups they are not part of through error messages or
+    listings").
+
+    This is a coarse, route-level gate only. The fine-grained decision — may
+    *this* user write *this specific* calendar's config within the slot —
+    stays where Phase 1a put it: ``CalendarGroupService`` re-checks
+    ``can_manage_group_scoped_calendar_config`` on every write and raises the
+    identically-shaped ``CalendarGroupSlotConfigNotFoundError`` (mapped to the
+    same 404 by the view) when a visible member targets a calendar they don't
+    own. Both gates matter: this one stops a stranger from even proving the
+    slot exists; the service one stops a legitimate group member from writing
+    a calendar that isn't theirs.
+    """
+
+    @inject
+    def __init__(
+        self,
+        calendar_permission_service: "CalendarPermissionService | None" = Provide[
+            "calendar_permission_service"
+        ],
+    ):
+        self.calendar_permission_service = calendar_permission_service
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+        if not user.is_authenticated:
+            return False
+        membership = get_active_organization_membership(user)
+        if membership is None:
+            return False
+
+        group_id = view.kwargs.get("group_id")
+        slot_id = view.kwargs.get("slot_id")
+        if group_id is None or slot_id is None:
+            return False
+
+        try:
+            group_slot = (
+                CalendarGroupSlot.objects.filter_by_organization(membership.organization_id)
+                .select_related("group")
+                .get(id=slot_id, group_fk_id=group_id)
+            )
+        except CalendarGroupSlot.DoesNotExist:
+            raise Http404() from None
+
+        if self.calendar_permission_service is None or not (
+            self.calendar_permission_service.can_manage_calendar_group(
+                user=user, group=group_slot.group
+            )
+        ):
+            # Same not-found shape as a genuinely missing slot -- a member must
+            # not learn this group/slot exists through a distinguishable 403.
+            raise Http404()
+
+        view.group_slot = group_slot
+        return True

--- a/calendar_integration/routes.py
+++ b/calendar_integration/routes.py
@@ -8,6 +8,7 @@ from .views import (
     CalendarGroupViewSet,
     CalendarViewSet,
     ExternalEventChangeRequestViewSet,
+    GroupScopedAvailabilityWindowViewSet,
 )
 
 
@@ -21,6 +22,11 @@ routes: list[RouteDict] = [
         "regex": r"calendar-groups",
         "viewset": CalendarGroupViewSet,
         "basename": "CalendarGroups",
+    },
+    {
+        "regex": r"calendar-groups/<int:group_id>/slots/<int:slot_id>/availability-windows",
+        "viewset": GroupScopedAvailabilityWindowViewSet,
+        "basename": "GroupScopedAvailabilityWindows",
     },
     {
         "regex": r"calendar",

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -68,6 +68,7 @@ from calendar_integration.virtual_models import (
     EventRecurrenceExceptionVirtualModel,
     ExternalAttendeeVirtualModel,
     ExternalEventChangeRequestVirtualModel,
+    GroupScopedAvailabilityWindowVirtualModel,
     RecurrenceRuleVirtualModel,
     ResourceAllocationVirtualModel,
 )
@@ -2531,7 +2532,7 @@ class GroupScopedAvailabilityWindowSerializer(VirtualModelSerializer):
 
     class Meta:
         model = AvailableTime
-        virtual_model = AvailableTimeVirtualModel
+        virtual_model = GroupScopedAvailabilityWindowVirtualModel
         fields = (
             "id",
             "calendar_id",

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -2512,6 +2512,156 @@ class CalendarGroupSlotMembershipSerializer(VirtualModelSerializer):
         fields = ("id", "calendar")
 
 
+class GroupScopedAvailabilityWindowSerializer(VirtualModelSerializer):
+    """Read representation of a group-scoped availability window
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1c).
+
+    Deliberately narrower than ``AvailableTimeSerializer``: there is no nested
+    ``recurrence_rule`` write path here, only ``rrule_string`` -- matching
+    exactly what ``CalendarGroupService``'s window-write methods accept, so the
+    REST shape and the service signature cannot drift apart.
+    """
+
+    calendar_id = serializers.IntegerField(source="calendar_fk_id", read_only=True)
+    group_slot_id = serializers.IntegerField(source="group_slot_fk_id", read_only=True)
+    rrule_string = serializers.SerializerMethodField(read_only=True)
+    is_recurring = serializers.SerializerMethodField(read_only=True)
+    start_time = serializers.DateTimeField(read_only=True)
+    end_time = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = AvailableTime
+        virtual_model = AvailableTimeVirtualModel
+        fields = (
+            "id",
+            "calendar_id",
+            "group_slot_id",
+            "start_time",
+            "end_time",
+            "timezone",
+            "rrule_string",
+            "is_recurring",
+            "created",
+            "modified",
+        )
+        read_only_fields = fields
+
+    @v.hints.no_deferred_fields()
+    def get_rrule_string(self, obj: AvailableTime) -> str | None:
+        """RRULE string for the window's recurrence, or ``None`` when it doesn't recur."""
+        return obj.recurrence_rule.to_rrule_string() if obj.recurrence_rule else None
+
+    @v.hints.no_deferred_fields()
+    def get_is_recurring(self, obj: AvailableTime) -> bool:
+        return obj.is_recurring
+
+    def to_representation(self, instance):
+        """Render start_time/end_time in the window's own IANA timezone, not UTC."""
+        data = super().to_representation(instance)
+        return _localize_times_in_representation(
+            data, instance, getattr(instance, "timezone", None)
+        )
+
+
+class GroupScopedAvailabilityWindowCreateSerializer(serializers.Serializer):
+    """Input for creating a group-scoped availability window.
+
+    Field names map 1:1 onto
+    ``CalendarGroupService.create_group_scoped_availability_window``'s keyword
+    arguments (``calendar_id``, ``start_time``, ``end_time``, ``tz``,
+    ``rrule_string``) so the REST shape can never silently drift from the
+    service signature it delegates to.
+    """
+
+    calendar = serializers.PrimaryKeyRelatedField(
+        queryset=Calendar.original_manager.none(),
+        help_text="Calendar this window applies to. Must be a member of the target slot.",
+    )
+    start_time = serializers.DateTimeField(required=True)
+    end_time = serializers.DateTimeField(required=True)
+    timezone = serializers.CharField(required=True)
+    rrule_string = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="RRULE string for a recurring window. Omit for a one-off window.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = (
+            self.context["request"].user if self.context and self.context.get("request") else None
+        )
+        membership = (
+            get_active_organization_membership(user) if user and user.is_authenticated else None
+        )
+        self.fields["calendar"].queryset = (
+            Calendar.objects.filter_by_organization(membership.organization_id)
+            if membership
+            else Calendar.original_manager.none()
+        )
+
+    def validate(self, attrs):
+        if attrs["start_time"] >= attrs["end_time"]:
+            raise serializers.ValidationError("start_time must be before end_time.")
+        return attrs
+
+
+class GroupScopedAvailabilityWindowUpdateSerializer(serializers.Serializer):
+    """Input for partially updating a group-scoped availability window.
+
+    Every field is optional -- only provided fields change, mirroring
+    ``CalendarGroupService.update_group_scoped_availability_window``.
+    """
+
+    start_time = serializers.DateTimeField(required=False)
+    end_time = serializers.DateTimeField(required=False)
+    timezone = serializers.CharField(required=False)
+    rrule_string = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="RRULE string for a recurring window. Set to null to make it non-recurring.",
+    )
+
+    def validate(self, attrs):
+        start_time = attrs.get("start_time")
+        end_time = attrs.get("end_time")
+        if start_time is not None and end_time is not None and start_time >= end_time:
+            raise serializers.ValidationError("start_time must be before end_time.")
+        return attrs
+
+
+class GroupScopedAvailabilityOrphanedBookingSerializer(serializers.Serializer):
+    """Minimal identification of a booking a narrowing write orphaned (spec UC-6)
+    -- enough for an admin to act on. Nothing about the booking itself is
+    modified by the write that produced this entry.
+    """
+
+    id = serializers.IntegerField(read_only=True)
+    calendar_id = serializers.IntegerField(source="calendar_fk_id", read_only=True)
+    title = serializers.CharField(read_only=True)
+    start_time = serializers.DateTimeField(read_only=True)
+    end_time = serializers.DateTimeField(read_only=True)
+
+
+class GroupScopedAvailabilityWriteResultSerializer(serializers.Serializer):
+    """Wraps a ``GroupScopedAvailabilityWriteResult``: the saved window plus any
+    confirmed future bookings the write orphaned. Returned by the create and
+    update actions of ``GroupScopedAvailabilityWindowViewSet``.
+    """
+
+    window = GroupScopedAvailabilityWindowSerializer(read_only=True)
+    orphaned_bookings = GroupScopedAvailabilityOrphanedBookingSerializer(
+        many=True,
+        read_only=True,
+        help_text=(
+            "Confirmed future bookings in this slot for this window's calendar that no "
+            "longer fall inside the calendar's group-scoped availability after this "
+            "write. Nothing about them is modified or cancelled -- act on them manually "
+            "if needed."
+        ),
+    )
+
+
 class CalendarGroupSlotSerializer(VirtualModelSerializer):
     """Nested slot representation used inside CalendarGroupSerializer.
 

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -70,6 +70,12 @@ if TYPE_CHECKING:
     from payments.services.entitlement_service import EntitlementService
 
 
+# Sentinel for partial updates: distinguishes "omit rrule_string" (leave the
+# recurrence alone) from an explicit ``None`` (clear it, making the window
+# non-recurring). Mirrors ``calendar_service._UNCHANGED``.
+_UNCHANGED = object()
+
+
 def _time_range_fully_covered(
     windows: Iterable[tuple[datetime.datetime, datetime.datetime]],
     start: datetime.datetime,
@@ -762,11 +768,15 @@ class CalendarGroupService:
         start_time: datetime.datetime | None = None,
         end_time: datetime.datetime | None = None,
         tz: str | None = None,
-        rrule_string: str | None = None,
+        rrule_string: str | None = _UNCHANGED,  # type: ignore[assignment]
         now: datetime.datetime | None = None,
     ) -> GroupScopedAvailabilityWriteResult:
         """Partially update a group-scoped availability window (only provided
         fields change -- mirrors ``AvailabilityService.update_blocked_time``).
+
+        ``rrule_string`` is tri-state: the sentinel ``_UNCHANGED`` (the default)
+        leaves the recurrence untouched, explicit ``None`` clears it (the window
+        becomes non-recurring), and a string sets/replaces it.
 
         After the update is applied, every confirmed future booking in the
         window's group slot for its calendar that no longer falls inside the
@@ -798,7 +808,8 @@ class CalendarGroupService:
         if tz is not None:
             window.timezone = tz
             update_fields.append("timezone")
-        if rrule_string is not None:
+        if rrule_string is not _UNCHANGED:
+            # ``None`` clears the recurrence (non-recurring); a string sets/replaces it.
             window.recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
             # Assigning through the ForeignObject property name ("recurrence_rule")
             # sets the underlying concrete column ("recurrence_rule_fk"); `save`'s

--- a/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
+++ b/calendar_integration/tests/services/test_calendar_group_service_availability_windows.py
@@ -455,6 +455,74 @@ def test_update_group_scoped_availability_window_timezone_round_trip(
 
 
 @pytest.mark.django_db
+def test_update_group_scoped_availability_window_explicit_none_clears_recurrence(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """Explicit ``rrule_string=None`` is the tri-state "clear" case -- distinct
+    from the default sentinel (omitted), which leaves recurrence untouched."""
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    result = service.update_group_scoped_availability_window(
+        acting_user=admin_user,
+        window_id=window_id,
+        rrule_string=None,
+    )
+    assert result.window is not None
+    assert result.window.recurrence_rule is None
+    assert result.window.is_recurring is False
+
+    reloaded = (
+        AvailableTime.objects.unscoped()
+        .filter_by_organization(service.organization.id)
+        .get(id=window_id)
+    )
+    assert reloaded.recurrence_rule is None
+    assert reloaded.is_recurring is False
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_availability_window_omitted_rrule_string_leaves_it_unchanged(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """Omitting ``rrule_string`` (the ``_UNCHANGED`` sentinel default) must
+    leave an existing recurrence untouched."""
+    created = service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    window_id = created.window.id  # type: ignore[union-attr]
+
+    result = service.update_group_scoped_availability_window(
+        acting_user=admin_user,
+        window_id=window_id,
+        tz="America/Sao_Paulo",
+    )
+    assert result.window is not None
+    assert result.window.recurrence_rule is not None
+    assert result.window.recurrence_rule.to_rrule_string() == "FREQ=WEEKLY;BYDAY=TU,TH"
+
+
+@pytest.mark.django_db
 def test_update_group_scoped_availability_window_denies_non_owner(
     service: CalendarGroupService,
     admin_user: User,

--- a/calendar_integration/tests/test_views_group_scoped_availability_windows.py
+++ b/calendar_integration/tests/test_views_group_scoped_availability_windows.py
@@ -337,6 +337,78 @@ class TestGroupScopedAvailabilityWindowLifecycle:
         )
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
+    def test_patch_null_rrule_string_clears_recurrence(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        """PATCH `{"rrule_string": null}` is the tri-state "clear" case -- it
+        must actually detach the recurrence rule, not be a silent no-op."""
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH"),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        window_id = create_response.data["window"]["id"]
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, window_id),
+            {"rrule_string": None},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        window_data = update_response.data["window"]
+        assert window_data["rrule_string"] is None
+        assert window_data["is_recurring"] is False
+
+        reloaded = (
+            AvailableTime.objects.unscoped()
+            .filter_by_organization(calendar.organization_id)
+            .get(id=window_id)
+        )
+        assert reloaded.recurrence_rule is None
+        assert reloaded.is_recurring is False
+
+    def test_patch_omitting_rrule_string_leaves_recurrence_unchanged(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        """PATCH that never mentions `rrule_string` must leave the existing
+        recurrence untouched -- the "absent" tri-state case."""
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH"),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        window_id = create_response.data["window"]["id"]
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, window_id),
+            {"timezone": "America/Sao_Paulo"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        window_data = update_response.data["window"]
+        assert window_data["is_recurring"] is True
+        assert window_data["rrule_string"] == "FREQ=WEEKLY;BYDAY=TU,TH"
+
+        reloaded = (
+            AvailableTime.objects.unscoped()
+            .filter_by_organization(calendar.organization_id)
+            .get(id=window_id)
+        )
+        assert reloaded.recurrence_rule is not None
+        assert reloaded.is_recurring is True
+
 
 # ---------------------------------------------------------------------------
 # Non-disclosure / visibility
@@ -435,12 +507,16 @@ class TestGroupScopedAvailabilityWindowNonDisclosure:
     def test_slot_not_belonging_to_group_in_url_is_not_found(
         self,
         owner_membership: OrganizationMembership,
-        other_owner_membership: OrganizationMembership,
         organization: Organization,
+        calendar: Calendar,
         other_calendar: Calendar,
     ) -> None:
         """A slot that exists, but under a DIFFERENT group than the one named in
-        the URL, must not resolve -- same not-found shape."""
+        the URL, must not resolve -- same not-found shape. The caller here
+        genuinely has visibility into `group_b` (owns a calendar in ANOTHER of
+        its slots), so the 404 must come from the group/slot mismatch branch
+        in `GroupScopedAvailabilityWindowPermission.has_permission` -- not
+        merely from the caller having no relationship to `group_b` at all."""
         group_a = CalendarGroup.objects.create(organization=organization, name="A")
         group_b = CalendarGroup.objects.create(organization=organization, name="B")
         slot_on_b = CalendarGroupSlot.objects.create(
@@ -449,7 +525,22 @@ class TestGroupScopedAvailabilityWindowNonDisclosure:
         CalendarGroupSlotMembership.objects.create(
             organization=organization, slot=slot_on_b, calendar=other_calendar
         )
+        # A second slot in `group_b`, owned by the caller -- gives them genuine
+        # visibility into `group_b` without owning `slot_on_b`'s calendar.
+        callers_slot_on_b = CalendarGroupSlot.objects.create(
+            organization=organization, group=group_b, name="Caller's Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=callers_slot_on_b, calendar=calendar
+        )
+
         client = _auth_client(owner_membership)
+        # Sanity check: the caller genuinely sees `group_b` through their own slot.
+        sanity_response = client.get(_list_url(group_b.id, callers_slot_on_b.id))
+        assert sanity_response.status_code == status.HTTP_200_OK, sanity_response.data
+
+        # `slot_on_b` belongs to `group_b`, not `group_a` -- naming `group_a` in
+        # the URL must 404 even though the caller can see `group_b`.
         response = client.get(_list_url(group_a.id, slot_on_b.id))
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -614,3 +705,57 @@ class TestGroupScopedAvailabilityWindowOrphanedBookings:
             ).count()
             == 2
         )
+
+
+# ---------------------------------------------------------------------------
+# Query budget (bounded, must not scale with row count)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedAvailabilityWindowQueryBudget:
+    def test_list_query_count_is_bounded_and_does_not_scale_with_window_count(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+        django_assert_max_num_queries,
+    ) -> None:
+        """`GroupScopedAvailabilityWindowSerializer` never nests `calendar` (it
+        sources `calendar_id` straight from `calendar_fk_id`), so listing
+        several windows must not eagerly pull in the general-purpose
+        `CalendarVirtualModel` sub-graph (memberships/calendar_ownerships) --
+        the query count must stay flat as the number of windows grows."""
+        for i in range(4):
+            AvailableTime.objects.unscoped().create(
+                organization=calendar.organization,
+                calendar=calendar,
+                group_slot=group_slot,
+                start_time_tz_unaware=_utc(2025, 9, 2 + i, 9),
+                end_time_tz_unaware=_utc(2025, 9, 2 + i, 17),
+                timezone="UTC",
+            )
+
+        client = _auth_client(owner_membership)
+        # Generous margin over the observed ~6-7 queries -- what matters is
+        # that this bound does NOT scale with the number of windows below.
+        with django_assert_max_num_queries(12):
+            response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 4
+
+        for i in range(4, 8):
+            AvailableTime.objects.unscoped().create(
+                organization=calendar.organization,
+                calendar=calendar,
+                group_slot=group_slot,
+                start_time_tz_unaware=_utc(2025, 9, 2 + i, 9),
+                end_time_tz_unaware=_utc(2025, 9, 2 + i, 17),
+                timezone="UTC",
+            )
+
+        with django_assert_max_num_queries(12):
+            response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 8

--- a/calendar_integration/tests/test_views_group_scoped_availability_windows.py
+++ b/calendar_integration/tests/test_views_group_scoped_availability_windows.py
@@ -1,0 +1,616 @@
+"""Integration tests for the internal REST surface exposing group-scoped
+availability windows (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1c).
+
+Covers:
+- Full lifecycle through the nested routes (create -> list -> retrieve ->
+  update -> delete), for both the calendar's owner and an org admin.
+- Route-level group-visibility gating: a stranger and the owner of a
+  *different* calendar in the same group (different slot) are both denied
+  with the exact same not-found shape -- neither can distinguish "forbidden"
+  from "does not exist".
+- Cross-organization access denied with the same not-found shape.
+- The orphaned-booking warning surfaces in the narrowing response, both on
+  the first-window create and on a narrowing update.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from django.urls import reverse
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.factories import create_calendar_ownership
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.factories import UserFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_client(membership: OrganizationMembership) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=membership.user)
+    return client
+
+
+def _next_weekday(after: datetime.datetime, weekday: int) -> datetime.date:
+    """Next date (strictly after `after`'s date) landing on ISO `weekday`
+    (Monday=0 ... Sunday=6)."""
+    days_ahead = (weekday - after.weekday()) % 7
+    days_ahead = days_ahead or 7
+    return (after + datetime.timedelta(days=days_ahead)).date()
+
+
+def _list_url(group_id: int, slot_id: int) -> str:
+    return reverse(
+        "api:GroupScopedAvailabilityWindows-list",
+        kwargs={"group_id": group_id, "slot_id": slot_id},
+    )
+
+
+def _detail_url(group_id: int, slot_id: int, pk: int) -> str:
+    return reverse(
+        "api:GroupScopedAvailabilityWindows-detail",
+        kwargs={"group_id": group_id, "slot_id": slot_id, "pk": pk},
+    )
+
+
+def _utc(year: int, month: int, day: int, hour: int) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization() -> Organization:
+    return baker.make(Organization, name="Windows REST Test Org")
+
+
+@pytest.fixture
+def admin_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.ADMIN, is_active=True
+    )
+
+
+@pytest.fixture
+def owner_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def other_owner_membership(organization: Organization) -> OrganizationMembership:
+    """Owns a DIFFERENT calendar (in a different slot of the SAME group) --
+    used to prove that seeing the group is not enough to manage a calendar
+    the caller does not own."""
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def stranger_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="dr_reyes",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def other_calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Costa",
+        external_id="dr_costa",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ownerships(
+    owner_membership: OrganizationMembership,
+    other_owner_membership: OrganizationMembership,
+    calendar: Calendar,
+    other_calendar: Calendar,
+) -> None:
+    create_calendar_ownership(calendar=calendar, user=owner_membership.user)
+    create_calendar_ownership(calendar=other_calendar, user=other_owner_membership.user)
+
+
+@pytest.fixture
+def group(organization: Organization) -> CalendarGroup:
+    return CalendarGroup.objects.create(organization=organization, name="Surgery")
+
+
+@pytest.fixture
+def group_slot(
+    organization: Organization, group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Lead Surgeon"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def other_slot(
+    organization: Organization, group: CalendarGroup, other_calendar: Calendar
+) -> CalendarGroupSlot:
+    """A second slot in the same group, populated with `other_calendar` -- makes
+    `other_owner_membership`'s user a genuine member of the group without
+    owning `calendar`."""
+    slot = CalendarGroupSlot.objects.create(organization=organization, group=group, name="Assist")
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=other_calendar
+    )
+    return slot
+
+
+def _create_payload(calendar_id: int, **overrides) -> dict:
+    payload = {
+        "calendar": calendar_id,
+        "start_time": _utc(2025, 9, 2, 9).isoformat(),  # 2025-09-02 is a Tuesday
+        "end_time": _utc(2025, 9, 2, 17).isoformat(),
+        "timezone": "UTC",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedAvailabilityWindowLifecycle:
+    def test_full_lifecycle_as_owner(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+
+        # Create.
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH"),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        window_data = create_response.data["window"]
+        assert window_data["calendar_id"] == calendar.id
+        assert window_data["group_slot_id"] == group_slot.id
+        assert window_data["timezone"] == "UTC"
+        assert window_data["is_recurring"] is True
+        assert window_data["rrule_string"] == "FREQ=WEEKLY;BYDAY=TU,TH"
+        assert create_response.data["orphaned_bookings"] == []
+        window_id = window_data["id"]
+
+        # Invisible on the base (unscoped-from-group) manager.
+        assert (
+            not AvailableTime.objects.filter_by_organization(calendar.organization_id)
+            .filter(id=window_id)
+            .exists()
+        )
+        assert (
+            AvailableTime.objects.for_group_slot(group_slot.id)
+            .filter_by_organization(calendar.organization_id)
+            .filter(id=window_id)
+            .exists()
+        )
+
+        # List.
+        list_response = client.get(_list_url(group.id, group_slot.id))
+        assert list_response.status_code == status.HTTP_200_OK
+        ids = [w["id"] for w in list_response.data["results"]]
+        assert ids == [window_id]
+
+        # Retrieve.
+        retrieve_response = client.get(_detail_url(group.id, group_slot.id, window_id))
+        assert retrieve_response.status_code == status.HTTP_200_OK
+        assert retrieve_response.data["id"] == window_id
+
+        # Update (narrow the recurrence to Thursdays only).
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, window_id),
+            {"rrule_string": "RRULE:FREQ=WEEKLY;BYDAY=TH"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        assert update_response.data["window"]["rrule_string"] == "FREQ=WEEKLY;BYDAY=TH"
+        assert update_response.data["orphaned_bookings"] == []
+
+        # Delete.
+        delete_response = client.delete(_detail_url(group.id, group_slot.id, window_id))
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        assert not AvailableTime.objects.unscoped().filter(id=window_id).exists()
+
+        # Now invisible everywhere, including the group-scoped read path.
+        retrieve_after_delete = client.get(_detail_url(group.id, group_slot.id, window_id))
+        assert retrieve_after_delete.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_admin_can_manage_any_calendars_window(
+        self,
+        admin_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(admin_membership)
+
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        window_id = create_response.data["window"]["id"]
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, window_id), {"timezone": "America/Sao_Paulo"}
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+        assert update_response.data["window"]["timezone"] == "America/Sao_Paulo"
+
+        delete_response = client.delete(_detail_url(group.id, group_slot.id, window_id))
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_create_requires_start_before_end(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+        response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(
+                calendar.id,
+                start_time=_utc(2025, 9, 2, 17).isoformat(),
+                end_time=_utc(2025, 9, 2, 9).isoformat(),
+            ),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_put_not_allowed(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        window_id = create_response.data["window"]["id"]
+
+        response = client.put(
+            _detail_url(group.id, group_slot.id, window_id),
+            {"timezone": "America/Sao_Paulo"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+# ---------------------------------------------------------------------------
+# Non-disclosure / visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedAvailabilityWindowNonDisclosure:
+    def test_stranger_cannot_list_or_create(
+        self,
+        stranger_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(stranger_membership)
+
+        list_response = client.get(_list_url(group.id, group_slot.id))
+        assert list_response.status_code == status.HTTP_404_NOT_FOUND
+
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        assert create_response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_owner_of_other_calendar_in_same_group_denied_same_shape_as_stranger(
+        self,
+        other_owner_membership: OrganizationMembership,
+        stranger_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+        other_slot: CalendarGroupSlot,
+    ) -> None:
+        """`other_owner_membership`'s user owns a calendar in the SAME group (a
+        different slot), so they can see the group -- but they do not own
+        `calendar`, so writing its window must still be denied, with the exact
+        same not-found shape a genuine stranger gets."""
+        other_owner_client = _auth_client(other_owner_membership)
+        stranger_client = _auth_client(stranger_membership)
+
+        other_owner_response = other_owner_client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        stranger_response = stranger_client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+
+        assert other_owner_response.status_code == status.HTTP_404_NOT_FOUND
+        assert stranger_response.status_code == status.HTTP_404_NOT_FOUND
+        assert other_owner_response.data == stranger_response.data
+        assert not AvailableTime.objects.unscoped().filter(group_slot_fk=group_slot).exists()
+
+    def test_other_owner_can_see_and_manage_their_own_slot_in_the_group(
+        self,
+        other_owner_membership: OrganizationMembership,
+        other_calendar: Calendar,
+        group: CalendarGroup,
+        other_slot: CalendarGroupSlot,
+    ) -> None:
+        """Sanity check for the fixture setup above: `other_owner_membership`'s
+        user genuinely can manage `other_calendar`'s window in `other_slot` --
+        the denial in the sibling test is calendar-specific, not group-wide."""
+        client = _auth_client(other_owner_membership)
+        response = client.post(
+            _list_url(group.id, other_slot.id), _create_payload(other_calendar.id), format="json"
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+
+    def test_cross_organization_access_denied(
+        self,
+        owner_membership: OrganizationMembership,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        other_org = baker.make(Organization)
+        other_cal = Calendar.objects.create(
+            organization=other_org,
+            name="Other",
+            external_id="other",
+            provider=CalendarProvider.GOOGLE,
+        )
+        other_group = CalendarGroup.objects.create(organization=other_org, name="Other Group")
+        other_org_slot = CalendarGroupSlot.objects.create(
+            organization=other_org, group=other_group, name="Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=other_org, slot=other_org_slot, calendar=other_cal
+        )
+
+        # `owner_membership`'s user has no membership in `other_org` at all.
+        client = _auth_client(owner_membership)
+        response = client.get(_list_url(other_group.id, other_org_slot.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_slot_not_belonging_to_group_in_url_is_not_found(
+        self,
+        owner_membership: OrganizationMembership,
+        other_owner_membership: OrganizationMembership,
+        organization: Organization,
+        other_calendar: Calendar,
+    ) -> None:
+        """A slot that exists, but under a DIFFERENT group than the one named in
+        the URL, must not resolve -- same not-found shape."""
+        group_a = CalendarGroup.objects.create(organization=organization, name="A")
+        group_b = CalendarGroup.objects.create(organization=organization, name="B")
+        slot_on_b = CalendarGroupSlot.objects.create(
+            organization=organization, group=group_b, name="Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=slot_on_b, calendar=other_calendar
+        )
+        client = _auth_client(owner_membership)
+        response = client.get(_list_url(group_a.id, slot_on_b.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unauthenticated_returns_401(
+        self, group: CalendarGroup, group_slot: CalendarGroupSlot
+    ) -> None:
+        client = APIClient()
+        response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Orphaned-booking warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedAvailabilityWindowOrphanedBookings:
+    def test_create_first_window_reports_orphaned_booking(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        now = datetime.datetime.now(datetime.UTC)
+        thursday = _next_weekday(now, weekday=3)
+
+        booking = CalendarEvent.objects.create(
+            organization=calendar.organization,
+            calendar=calendar,
+            title="Operation",
+            description="",
+            external_id="ev_thursday_rest",
+            start_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(18), tzinfo=datetime.UTC
+            ),
+            end_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(19), tzinfo=datetime.UTC
+            ),
+            timezone="UTC",
+            calendar_group=group,
+        )
+        CalendarEventGroupSelection.objects.create(
+            organization=calendar.organization,
+            event=booking,
+            slot=group_slot,
+            calendar=calendar,
+        )
+
+        client = _auth_client(owner_membership)
+        response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(
+                calendar.id,
+                start_time=datetime.datetime.combine(
+                    thursday, datetime.time(9), tzinfo=datetime.UTC
+                ).isoformat(),
+                end_time=datetime.datetime.combine(
+                    thursday, datetime.time(17), tzinfo=datetime.UTC
+                ).isoformat(),
+            ),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        orphaned = response.data["orphaned_bookings"]
+        assert len(orphaned) == 1
+        assert orphaned[0]["id"] == booking.id
+        assert orphaned[0]["calendar_id"] == calendar.id
+        assert orphaned[0]["title"] == "Operation"
+
+        # Nothing about the booking was touched.
+        booking.refresh_from_db()
+        assert booking.title == "Operation"
+
+    def test_update_narrowing_reports_orphaned_booking(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        now = datetime.datetime.now(datetime.UTC)
+        tuesday = _next_weekday(now, weekday=1)
+        thursday = tuesday + datetime.timedelta(days=2)
+
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(
+                calendar.id,
+                start_time=datetime.datetime.combine(
+                    tuesday, datetime.time(9), tzinfo=datetime.UTC
+                ).isoformat(),
+                end_time=datetime.datetime.combine(
+                    tuesday, datetime.time(17), tzinfo=datetime.UTC
+                ).isoformat(),
+                rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+            ),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        window_id = create_response.data["window"]["id"]
+
+        tuesday_event = CalendarEvent.objects.create(
+            organization=calendar.organization,
+            calendar=calendar,
+            title="Tuesday Op",
+            description="",
+            external_id="ev_tuesday_rest",
+            start_time_tz_unaware=datetime.datetime.combine(
+                tuesday, datetime.time(10), tzinfo=datetime.UTC
+            ),
+            end_time_tz_unaware=datetime.datetime.combine(
+                tuesday, datetime.time(11), tzinfo=datetime.UTC
+            ),
+            timezone="UTC",
+            calendar_group=group,
+        )
+        CalendarEventGroupSelection.objects.create(
+            organization=calendar.organization,
+            event=tuesday_event,
+            slot=group_slot,
+            calendar=calendar,
+        )
+        thursday_event = CalendarEvent.objects.create(
+            organization=calendar.organization,
+            calendar=calendar,
+            title="Thursday Op",
+            description="",
+            external_id="ev_thursday_rest2",
+            start_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(10), tzinfo=datetime.UTC
+            ),
+            end_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(11), tzinfo=datetime.UTC
+            ),
+            timezone="UTC",
+            calendar_group=group,
+        )
+        CalendarEventGroupSelection.objects.create(
+            organization=calendar.organization,
+            event=thursday_event,
+            slot=group_slot,
+            calendar=calendar,
+        )
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, window_id),
+            {"rrule_string": "RRULE:FREQ=WEEKLY;BYDAY=TH"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        orphaned_ids = {b["id"] for b in update_response.data["orphaned_bookings"]}
+        assert orphaned_ids == {tuesday_event.id}
+
+        # Neither booking nor its group selection was touched.
+        assert CalendarEvent.objects.filter_by_organization(calendar.organization_id).count() == 2
+        assert (
+            CalendarEventGroupSelection.objects.filter_by_organization(
+                calendar.organization_id
+            ).count()
+            == 2
+        )

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -29,6 +29,7 @@ from calendar_integration.constants import (
 )
 from calendar_integration.exceptions import (
     CalendarGroupError,
+    CalendarGroupSlotConfigNotFoundError,
     CalendarIntegrationError,
     ChangeRequestIneligibleError,
     ChangeRequestNotPendingError,
@@ -57,6 +58,7 @@ from calendar_integration.permissions import (
     CalendarEventPermission,
     CalendarGroupPermission,
     ExternalEventChangeRequestPermission,
+    GroupScopedAvailabilityWindowPermission,
 )
 from calendar_integration.serializers import (
     AvailableTimeBatchSerializer,
@@ -84,6 +86,10 @@ from calendar_integration.serializers import (
     EventBulkModificationSerializer,
     EventRecurringExceptionSerializer,
     ExternalEventChangeRequestSerializer,
+    GroupScopedAvailabilityWindowCreateSerializer,
+    GroupScopedAvailabilityWindowSerializer,
+    GroupScopedAvailabilityWindowUpdateSerializer,
+    GroupScopedAvailabilityWriteResultSerializer,
     ResourceCalendarCreateSerializer,
     UnavailableTimeWindowSerializer,
 )
@@ -1739,6 +1745,178 @@ class AvailableTimeViewSet(VintaScheduleModelViewSet):
             )
         except ValueError as e:
             raise ValidationError({"non_field_errors": [str(e)]}) from e
+
+
+@extend_schema(tags=["Calendar Group Scoped Availability Windows"])
+class GroupScopedAvailabilityWindowViewSet(VintaScheduleModelViewSet):
+    """Nested under a group's slot: manage group-scoped availability windows
+    for calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+    Phase 1c).
+
+    Reads go through ``AvailableTime.objects.for_group_slot(...)``. Every
+    write delegates to ``CalendarGroupService`` (Phase 1a) -- this view holds
+    no business logic of its own, only request/response translation. Route
+    visibility is gated by ``GroupScopedAvailabilityWindowPermission``; the
+    per-calendar write authorization is re-checked by the service and its
+    ``CalendarGroupSlotConfigNotFoundError`` is translated to a 404 here so a
+    denied write and a genuinely missing window are indistinguishable.
+    """
+
+    permission_classes = (GroupScopedAvailabilityWindowPermission,)
+    queryset = AvailableTime.objects.unscoped()
+    serializer_class = GroupScopedAvailabilityWindowSerializer
+    # PUT is intentionally unsupported: the underlying service is a partial
+    # update by design (only provided fields change), so only PATCH applies.
+    http_method_names = ("get", "post", "patch", "delete", "head", "options")
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return AvailableTime.original_manager.none()
+        membership = get_active_organization_membership(user)
+        if not membership:
+            return AvailableTime.original_manager.none()
+        slot_id = self.kwargs.get("slot_id")
+        return (
+            super()
+            .get_queryset()
+            .filter_by_organization(membership.organization_id)
+            .for_group_slot(slot_id)
+            # `AvailableTimeVirtualModel` doesn't know about `recurrence_rule` under
+            # the "rrule_string" name our serializer exposes it as -- select it
+            # explicitly so `GroupScopedAvailabilityWindowSerializer.get_rrule_string`
+            # doesn't N+1 on the way to `recurrence_rule.to_rrule_string()`.
+            .select_related("recurrence_rule")
+        )
+
+    @extend_schema(
+        summary="Create a group-scoped availability window",
+        description=(
+            "Creates a group-scoped availability window for a calendar within a group "
+            "slot's roster. If this is the calendar's FIRST group-scoped window (i.e. "
+            "the write narrows it from base availability), confirmed future bookings "
+            "that now fall outside it are returned in `orphaned_bookings`; nothing "
+            "about them is modified."
+        ),
+        request=GroupScopedAvailabilityWindowCreateSerializer,
+        responses={201: GroupScopedAvailabilityWriteResultSerializer},
+    )
+    @inject
+    def create(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        serializer = GroupScopedAvailabilityWindowCreateSerializer(
+            data=request.data, context=self.get_serializer_context()
+        )
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            # Unreachable in practice -- `GroupScopedAvailabilityWindowPermission`
+            # already requires an active membership -- but narrows the type for
+            # mypy and fails closed rather than crashing on `None.organization`.
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            result = calendar_group_service.create_group_scoped_availability_window(
+                acting_user=request.user,
+                group_slot_id=self.kwargs["slot_id"],
+                calendar_id=data["calendar"].id,
+                start_time=data["start_time"],
+                end_time=data["end_time"],
+                tz=data["timezone"],
+                rrule_string=data.get("rrule_string"),
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing window -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+
+        response_serializer = GroupScopedAvailabilityWriteResultSerializer(
+            result, context=self.get_serializer_context()
+        )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        summary="Update a group-scoped availability window",
+        description=(
+            "Partial update -- only provided fields change. If the change narrows the "
+            "window, confirmed future bookings that now fall outside it are returned "
+            "in `orphaned_bookings`; nothing about them is modified."
+        ),
+        request=GroupScopedAvailabilityWindowUpdateSerializer,
+        responses={200: GroupScopedAvailabilityWriteResultSerializer},
+    )
+    @inject
+    def partial_update(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        instance = self.get_object()
+        serializer = GroupScopedAvailabilityWindowUpdateSerializer(
+            data=request.data, partial=True, context=self.get_serializer_context()
+        )
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            result = calendar_group_service.update_group_scoped_availability_window(
+                acting_user=request.user,
+                window_id=instance.id,
+                start_time=data.get("start_time"),
+                end_time=data.get("end_time"),
+                tz=data.get("timezone"),
+                rrule_string=data.get("rrule_string"),
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing window -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+
+        response_serializer = GroupScopedAvailabilityWriteResultSerializer(
+            result, context=self.get_serializer_context()
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Delete a group-scoped availability window",
+        description="Deletes the window (a recurring window is one row -- deletes the whole series).",
+        responses={204: None},
+    )
+    @inject
+    def destroy(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        instance = self.get_object()
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            calendar_group_service.delete_group_scoped_availability_window(
+                acting_user=request.user, window_id=instance.id
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing window -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class CalendarGroupViewSet(VintaScheduleModelViewSet):

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -94,7 +94,7 @@ from calendar_integration.serializers import (
     UnavailableTimeWindowSerializer,
 )
 from calendar_integration.services.booking_policy_service import BookingPolicyService
-from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.calendar_group_service import _UNCHANGED, CalendarGroupService
 from calendar_integration.services.calendar_service import CalendarService
 from calendar_integration.services.external_event_change_request_service import (
     ExternalEventChangeRequestService,
@@ -1871,6 +1871,17 @@ class GroupScopedAvailabilityWindowViewSet(VintaScheduleModelViewSet):
         if membership is None:
             raise Http404
         calendar_group_service.initialize(organization=membership.organization)
+        # `rrule_string` is tri-state: absent from `validated_data` (DRF drops
+        # optional fields not present in the request via SkipField) means
+        # "leave the recurrence alone"; present and `None` means "clear it";
+        # present and a string means "set/replace it". `.get()` would collapse
+        # the first two cases -- checking membership is required to tell them
+        # apart.
+        # mypy: _UNCHANGED is object() but the service accepts it as the sentinel
+        # for "str | None"; suppress the mismatch, matching the service's own annotation.
+        rrule_string: str | None = (  # type: ignore[assignment]
+            data["rrule_string"] if "rrule_string" in data else _UNCHANGED  # type: ignore[assignment]
+        )
         try:
             result = calendar_group_service.update_group_scoped_availability_window(
                 acting_user=request.user,
@@ -1878,7 +1889,7 @@ class GroupScopedAvailabilityWindowViewSet(VintaScheduleModelViewSet):
                 start_time=data.get("start_time"),
                 end_time=data.get("end_time"),
                 tz=data.get("timezone"),
-                rrule_string=data.get("rrule_string"),
+                rrule_string=rrule_string,
             )
         except CalendarGroupSlotConfigNotFoundError as e:
             # Same not-found shape as a genuinely missing window -- no message

--- a/calendar_integration/virtual_models.py
+++ b/calendar_integration/virtual_models.py
@@ -152,6 +152,26 @@ class AvailableTimeVirtualModel(v.VirtualModel):
         model = AvailableTime
 
 
+class GroupScopedAvailabilityWindowVirtualModel(v.VirtualModel):
+    """Virtual model for ``GroupScopedAvailabilityWindowSerializer``
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1c).
+
+    Deliberately narrower than ``AvailableTimeVirtualModel``: that serializer
+    sources ``calendar_id``/``group_slot_id`` from the raw FK columns and
+    never nests a ``calendar`` field, so no sub-field is declared here for it
+    -- avoids pulling in ``CalendarVirtualModel``'s eager
+    memberships/calendar_ownerships graph, which this serializer never reads.
+    ``rrule_string``/``is_recurring`` are ``no_deferred_fields()``-hinted
+    ``SerializerMethodField``s that read ``recurrence_rule`` directly; the
+    view selects that relation explicitly (``.select_related("recurrence_rule")``
+    in ``GroupScopedAvailabilityWindowViewSet.get_queryset``) since it isn't
+    exposed under a matching field name here for the optimizer to infer.
+    """
+
+    class Meta:
+        model = AvailableTime
+
+
 class ExternalEventChangeRequestVirtualModel(v.VirtualModel):
     """Virtual model for ``ExternalEventChangeRequest`` serialization.
 

--- a/schema.yml
+++ b/schema.yml
@@ -5297,6 +5297,561 @@ paths:
               schema:
                 $ref: '#/components/schemas/CalendarGroup'
           description: ''
+  /calendar-groups/{group_id}/slots/{slot_id}/availability-windows/:
+    get:
+      operationId: calendar_groups_slots_availability_windows_list
+      description: |-
+        Nested under a group's slot: manage group-scoped availability windows
+        for calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 1c).
+
+        Reads go through ``AvailableTime.objects.for_group_slot(...)``. Every
+        write delegates to ``CalendarGroupService`` (Phase 1a) -- this view holds
+        no business logic of its own, only request/response translation. Route
+        visibility is gated by ``GroupScopedAvailabilityWindowPermission``; the
+        per-calendar write authorization is re-checked by the service and its
+        ``CalendarGroupSlotConfigNotFoundError`` is translated to a 404 here so a
+        denied write and a genuinely missing window are indistinguishable.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGroupScopedAvailabilityWindowList'
+          description: ''
+    post:
+      operationId: calendar_groups_slots_availability_windows_create
+      description: Creates a group-scoped availability window for a calendar within
+        a group slot's roster. If this is the calendar's FIRST group-scoped window
+        (i.e. the write narrows it from base availability), confirmed future bookings
+        that now fall outside it are returned in `orphaned_bookings`; nothing about
+        them is modified.
+      summary: Create a group-scoped availability window
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupScopedAvailabilityWindowCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GroupScopedAvailabilityWindowCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GroupScopedAvailabilityWindowCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedAvailabilityWriteResult'
+          description: ''
+  /calendar-groups/{group_id}/slots/{slot_id}/availability-windows{format}:
+    get:
+      operationId: calendar_groups_slots_availability_windows_formatted_list
+      description: |-
+        Nested under a group's slot: manage group-scoped availability windows
+        for calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 1c).
+
+        Reads go through ``AvailableTime.objects.for_group_slot(...)``. Every
+        write delegates to ``CalendarGroupService`` (Phase 1a) -- this view holds
+        no business logic of its own, only request/response translation. Route
+        visibility is gated by ``GroupScopedAvailabilityWindowPermission``; the
+        per-calendar write authorization is re-checked by the service and its
+        ``CalendarGroupSlotConfigNotFoundError`` is translated to a 404 here so a
+        denied write and a genuinely missing window are indistinguishable.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGroupScopedAvailabilityWindowList'
+          description: ''
+    post:
+      operationId: calendar_groups_slots_availability_windows_formatted_create
+      description: Creates a group-scoped availability window for a calendar within
+        a group slot's roster. If this is the calendar's FIRST group-scoped window
+        (i.e. the write narrows it from base availability), confirmed future bookings
+        that now fall outside it are returned in `orphaned_bookings`; nothing about
+        them is modified.
+      summary: Create a group-scoped availability window
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupScopedAvailabilityWindowCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GroupScopedAvailabilityWindowCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GroupScopedAvailabilityWindowCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedAvailabilityWriteResult'
+          description: ''
+  /calendar-groups/{group_id}/slots/{slot_id}/availability-windows/{id}/:
+    get:
+      operationId: calendar_groups_slots_availability_windows_retrieve
+      description: |-
+        Nested under a group's slot: manage group-scoped availability windows
+        for calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 1c).
+
+        Reads go through ``AvailableTime.objects.for_group_slot(...)``. Every
+        write delegates to ``CalendarGroupService`` (Phase 1a) -- this view holds
+        no business logic of its own, only request/response translation. Route
+        visibility is gated by ``GroupScopedAvailabilityWindowPermission``; the
+        per-calendar write authorization is re-checked by the service and its
+        ``CalendarGroupSlotConfigNotFoundError`` is translated to a 404 here so a
+        denied write and a genuinely missing window are indistinguishable.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedAvailabilityWindow'
+          description: ''
+    patch:
+      operationId: calendar_groups_slots_availability_windows_partial_update
+      description: Partial update -- only provided fields change. If the change narrows
+        the window, confirmed future bookings that now fall outside it are returned
+        in `orphaned_bookings`; nothing about them is modified.
+      summary: Update a group-scoped availability window
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedAvailabilityWindowUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedAvailabilityWindowUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedAvailabilityWindowUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedAvailabilityWriteResult'
+          description: ''
+    delete:
+      operationId: calendar_groups_slots_availability_windows_destroy
+      description: Deletes the window (a recurring window is one row -- deletes the
+        whole series).
+      summary: Delete a group-scoped availability window
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /calendar-groups/{group_id}/slots/{slot_id}/availability-windows/{id}{format}:
+    get:
+      operationId: calendar_groups_slots_availability_windows_formatted_retrieve
+      description: |-
+        Nested under a group's slot: manage group-scoped availability windows
+        for calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 1c).
+
+        Reads go through ``AvailableTime.objects.for_group_slot(...)``. Every
+        write delegates to ``CalendarGroupService`` (Phase 1a) -- this view holds
+        no business logic of its own, only request/response translation. Route
+        visibility is gated by ``GroupScopedAvailabilityWindowPermission``; the
+        per-calendar write authorization is re-checked by the service and its
+        ``CalendarGroupSlotConfigNotFoundError`` is translated to a 404 here so a
+        denied write and a genuinely missing window are indistinguishable.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedAvailabilityWindow'
+          description: ''
+    patch:
+      operationId: calendar_groups_slots_availability_windows_formatted_partial_update
+      description: Partial update -- only provided fields change. If the change narrows
+        the window, confirmed future bookings that now fall outside it are returned
+        in `orphaned_bookings`; nothing about them is modified.
+      summary: Update a group-scoped availability window
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedAvailabilityWindowUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedAvailabilityWindowUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedAvailabilityWindowUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedAvailabilityWriteResult'
+          description: ''
+    delete:
+      operationId: calendar_groups_slots_availability_windows_formatted_destroy
+      description: Deletes the window (a recurring window is one row -- deletes the
+        whole series).
+      summary: Delete a group-scoped availability window
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Availability Windows
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /calendar-groups/{id}/:
     get:
       operationId: calendar_groups_retrieve
@@ -14858,6 +15413,150 @@ components:
         * `WEEKLY` - Weekly
         * `MONTHLY` - Monthly
         * `YEARLY` - Yearly
+    GroupScopedAvailabilityOrphanedBooking:
+      type: object
+      description: |-
+        Minimal identification of a booking a narrowing write orphaned (spec UC-6)
+        -- enough for an admin to act on. Nothing about the booking itself is
+        modified by the write that produced this entry.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        calendar_id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+        start_time:
+          type: string
+          format: date-time
+          readOnly: true
+        end_time:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - calendar_id
+      - end_time
+      - id
+      - start_time
+      - title
+    GroupScopedAvailabilityWindow:
+      type: object
+      description: |-
+        Read representation of a group-scoped availability window
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1c).
+
+        Deliberately narrower than ``AvailableTimeSerializer``: there is no nested
+        ``recurrence_rule`` write path here, only ``rrule_string`` -- matching
+        exactly what ``CalendarGroupService``'s window-write methods accept, so the
+        REST shape and the service signature cannot drift apart.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        calendar_id:
+          type: integer
+          readOnly: true
+        group_slot_id:
+          type: integer
+          readOnly: true
+        start_time:
+          type: string
+          format: date-time
+          readOnly: true
+        end_time:
+          type: string
+          format: date-time
+          readOnly: true
+        timezone:
+          type: string
+          readOnly: true
+        rrule_string:
+          type: string
+          nullable: true
+          description: RRULE string for the window's recurrence, or ``None`` when
+            it doesn't recur.
+          readOnly: true
+        is_recurring:
+          type: boolean
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - calendar_id
+      - created
+      - end_time
+      - group_slot_id
+      - id
+      - is_recurring
+      - modified
+      - rrule_string
+      - start_time
+      - timezone
+    GroupScopedAvailabilityWindowCreate:
+      type: object
+      description: |-
+        Input for creating a group-scoped availability window.
+
+        Field names map 1:1 onto
+        ``CalendarGroupService.create_group_scoped_availability_window``'s keyword
+        arguments (``calendar_id``, ``start_time``, ``end_time``, ``tz``,
+        ``rrule_string``) so the REST shape can never silently drift from the
+        service signature it delegates to.
+      properties:
+        calendar:
+          type: integer
+          description: Calendar this window applies to. Must be a member of the target
+            slot.
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        timezone:
+          type: string
+        rrule_string:
+          type: string
+          nullable: true
+          description: RRULE string for a recurring window. Omit for a one-off window.
+      required:
+      - calendar
+      - end_time
+      - start_time
+      - timezone
+    GroupScopedAvailabilityWriteResult:
+      type: object
+      description: |-
+        Wraps a ``GroupScopedAvailabilityWriteResult``: the saved window plus any
+        confirmed future bookings the write orphaned. Returned by the create and
+        update actions of ``GroupScopedAvailabilityWindowViewSet``.
+      properties:
+        window:
+          allOf:
+          - $ref: '#/components/schemas/GroupScopedAvailabilityWindow'
+          readOnly: true
+        orphaned_bookings:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupScopedAvailabilityOrphanedBooking'
+          readOnly: true
+          description: Confirmed future bookings in this slot for this window's calendar
+            that no longer fall inside the calendar's group-scoped availability after
+            this write. Nothing about them is modified or cancelled -- act on them
+            manually if needed.
+      required:
+      - orphaned_bookings
+      - window
     MyMembership:
       type: object
       description: |-
@@ -15436,6 +16135,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExternalEventChangeRequest'
+    PaginatedGroupScopedAvailabilityWindowList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupScopedAvailabilityWindow'
     PaginatedOrganizationInvitationList:
       type: object
       required:
@@ -16036,6 +16758,27 @@ components:
           type: string
           format: date-time
           readOnly: true
+    PatchedGroupScopedAvailabilityWindowUpdate:
+      type: object
+      description: |-
+        Input for partially updating a group-scoped availability window.
+
+        Every field is optional -- only provided fields change, mirroring
+        ``CalendarGroupService.update_group_scoped_availability_window``.
+      properties:
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        timezone:
+          type: string
+        rrule_string:
+          type: string
+          nullable: true
+          description: RRULE string for a recurring window. Set to null to make it
+            non-recurring.
     PatchedOrganization:
       type: object
       description: |-


### PR DESCRIPTION

## Summary

Phase 1c of the Calendar Group-Scoped Availability plan. Adds the internal REST surface for managing group-scoped availability windows, nested under a group's slot, so the first-party web app can create/list/update/delete them. Thin viewset — all business logic delegates to the Phase 1a `CalendarGroupService`.

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 1c. Spec use-cases UC-1, UC-6.

## Key decisions

- **Nested under the group slot** (Guiding Decisions → "Internal REST shape"): `/calendar-groups/{group_id}/slots/{slot_id}/availability-windows/`, so listing a slot's roster is one call and group-visibility permissions apply at the route.
- **Route-level group-visibility gating** (`GroupScopedAvailabilityWindowPermission`): resolves `(group_id, slot_id)` org-scoped and checks `can_manage_calendar_group` before any service call. **Non-disclosure is byte-identical**: a stranger, a cross-org caller, an owner of a *different* calendar in the same group, and a missing/mismatched slot ALL get the same `Http404` `{"detail": "Not found."}` — verified by an equality assertion (`data ==`) across the stranger and other-owner responses. The service's `CalendarGroupSlotConfigNotFoundError` is caught in the view and re-raised as a bare `Http404`, so the fine-grained per-calendar denial is indistinguishable from the coarse route denial.
- **Orphaned-booking warning**: create (first window) and update responses use a `{window, orphaned_bookings}` wrapper populated from `GroupScopedAvailabilityWriteResult`; list/retrieve return the plain window object. Each orphaned booking carries id/calendar/title/times — enough for an admin to act.
- **Tri-state recurrence editing**: `PATCH {"rrule_string": null}` clears recurrence (window becomes non-recurring); omitting the field leaves it unchanged; a string sets/replaces it. Implemented with an `_UNCHANGED` sentinel so "absent" and "explicit null" are never conflated.
- **Bounded list queries**: a dedicated narrow virtual model avoids eager-loading the calendar sub-graph the serializer never reads; a `django_assert_max_num_queries` test asserts list query count does not scale with window count.
- The existing availability REST contract is unchanged — the schema diff is purely additive (new nested paths + new schemas only).

## Feature flag

None — new nested routes; no existing route changes shape; no migration.

## Test plan

```bash
docker compose run --rm api uv run pytest calendar_integration/tests/test_views_group_scoped_availability_windows.py -vs
docker compose run --rm api uv run pytest calendar_integration/tests/ -n auto
```

Covers: full CRUD lifecycle; cross-org / cross-group / non-owner denial with identical not-found shape; org admin manages anyone's; orphaned-booking warning on narrowing create + update; clear-recurrence via PATCH null; bounded list query count.