### PR TITLE
feat(public_api): add group-scoped availability window query and batch-upsert mutation

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -66,13 +66,21 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 - **Reviewer model**: opus (plan Tier-4 override) — no BLOCKERs; 2 SHOULD-FIX + 2 NIT fixed (haiku fixer)
 - **Summary**: Group-scoped windows intersected into slot-engine discovery + booking/reschedule validation. **Zero-change early-out** via an `Exists()` annotation folded into the existing membership query (no new round trip; `find_bookable_slots` 6→6, `check_group_availability` 5→5 queries; byte-identical output — asserted). Intersect-only via `base_free` short-circuit. New `slot_engine` batched span fetch (`fetch_group_scoped_available_spans`, recurrence-aware), consumed by discovery and by `_assert_calendars_within_group_scoped_windows` (wired into create + reschedule; reschedule extended to all selected calendars). New `GroupScopedRuleType` + `CalendarGroupScopedRuleViolationError` (names calendar + rule type, no configured-value leak). `bookable_slots_service.py` untouched. Resolved the recurrence-exception trap (see above). No migration.
 
+### Phase 1c — Windows on the internal REST surface ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-1c` (base: phase-1b) — **PR [#222](https://github.com/vintasoftware/vinta-schedule-api/pull/222)**
+- **Implementer model**: sonnet (escalated — initial haiku attempt DISCARDED for committing failing tests, skipping required tests, and removing the required route-level gating; it also wrongly amended the tracking commit) — agent type `implementer`
+- **Reviewer model**: sonnet — no BLOCKERs; 2 SHOULD-FIX + 1 NIT fixed (sonnet fixer)
+- **Summary**: Nested REST viewset `.../calendar-groups/{group_id}/slots/{slot_id}/availability-windows/`, thin, delegating to Phase 1a `CalendarGroupService`. `GroupScopedAvailabilityWindowPermission` for route-level group-visibility gating; **non-disclosure byte-identical** across stranger / cross-org / other-calendar-owner / missing-or-mismatched slot (all `Http404 {"detail":"Not found."}`, asserted via `data ==`). Create/update responses wrap `{window, orphaned_bookings}`; list/retrieve return the window. Tri-state recurrence editing (`PATCH null` clears, omit leaves, string sets) via `_UNCHANGED` sentinel. Narrow virtual model + bounded-query test. Schema purely additive. No migration.
+- **Process note**: reinforced hard rules on the retry (no amend, no commit with red tests, gating is required not optional).
+
 ## Current phase
 
-Phase 1c — Windows on the internal REST surface (haiku attempt discarded — escalated to sonnet)
+Phase 1d — Windows on the public API
 
 ## Remaining phases
 
-1c, 1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
+1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/graphql.py
+++ b/calendar_integration/graphql.py
@@ -590,6 +590,51 @@ class UnavailableTimeWindowGraphQLType:
     reason: str
 
 
+@strawberry.type
+class GroupScopedAvailabilityWindowGraphQLType:
+    """Public API representation of one group-scoped availability window
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1d).
+
+    A raw window row -- one entry per recurring master or one-off window, not
+    an expanded occurrence -- mirroring the internal REST surface's
+    ``GroupScopedAvailabilityWindowSerializer`` (Phase 1c) field shape.
+    """
+
+    id: int  # noqa: A003
+    calendar_id: int
+    group_slot_id: int
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+    rrule_string: str | None
+    is_recurring: bool
+    created: datetime.datetime
+    modified: datetime.datetime
+
+
+def group_scoped_availability_window_from_model(
+    window: AvailableTime,
+) -> GroupScopedAvailabilityWindowGraphQLType:
+    """Build a :class:`GroupScopedAvailabilityWindowGraphQLType` from an
+    ``AvailableTime`` row.
+
+    Callers should ``select_related("recurrence_rule")`` on the source
+    queryset to avoid N+1 when building a list.
+    """
+    return GroupScopedAvailabilityWindowGraphQLType(
+        id=window.id,  # type: ignore[arg-type]
+        calendar_id=window.calendar_fk_id,  # type: ignore[arg-type]
+        group_slot_id=window.group_slot_fk_id,  # type: ignore[arg-type]
+        start_time=window.start_time,
+        end_time=window.end_time,
+        timezone=window.timezone,
+        rrule_string=(window.recurrence_rule.to_rrule_string() if window.recurrence_rule else None),
+        is_recurring=window.is_recurring,
+        created=window.created,
+        modified=window.modified,
+    )
+
+
 @strawberry_django.type(CalendarWebhookSubscription)
 class CalendarWebhookSubscriptionGraphQLType:
     """GraphQL type for calendar webhook subscriptions."""

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -935,15 +935,24 @@ class CalendarGroupService:
           row it names, like the base availability batch write's ``id``-keyed
           operations.
 
-        Authorization is the CALLER's responsibility. Unlike the single-window
-        Phase 1a writes above, this method does not call
+        Authorization is split between the CALLER and this method. Unlike the
+        single-window Phase 1a writes above, this method does not call
         ``CalendarPermissionService`` -- every public-API availability write
         authorizes via ``OrganizationResourceAccess`` (token resource grant)
         plus owner-scope (``public_api.scoping.assert_calendar_in_owner_scope``),
         never the human-facing per-membership permission check, because a
         public-API ``SystemUser`` token has no ``CalendarOwnership``-linked
-        ``User`` to check it against for an org-wide token. ``acting_principal``
-        is used for audit attribution only.
+        ``User`` to check it against for an org-wide token. The caller's
+        owner-scope guard only proves the token owns each op's
+        ``calendar_id`` -- it says nothing about which calendar an
+        update/delete op's ``window_id`` actually belongs to. This method
+        closes that gap itself: for every update/delete op it cross-checks
+        the resolved window's ``calendar_fk_id`` against that op's own
+        ``calendar_id`` and rejects the whole batch (not-found-shaped, see
+        ``:raises CalendarGroupSlotConfigNotFoundError:`` below) if they
+        don't match, so a token cannot use a calendar it owns to reach a
+        window that belongs to a different calendar. ``acting_principal`` is
+        used for audit attribution only.
 
         :param operations: dicts with ``action`` (create/update/delete) and
             ``calendar_id``; create/update also take ``start_time``,
@@ -957,7 +966,8 @@ class CalendarGroupService:
         :raises CalendarGroupSlotConfigNotFoundError: a create op's
             ``calendar_id`` is not a member of ``group_slot_id``'s roster, or
             an update/delete op's ``window_id`` does not resolve to a
-            group-scoped window in this slot.
+            group-scoped window in this slot, or that window does not belong
+            to the op's own ``calendar_id``.
         :raises ValueError: an operation's shape is invalid (unknown action,
             missing required field).
         :return: every group-scoped window in ``group_slot_id``'s roster
@@ -989,6 +999,19 @@ class CalendarGroupService:
         if self.entitlement_service is not None and operations:
             self.entitlement_service.check_not_restricted(organization)
 
+        # Lock the billing root BEFORE _find_matching_group_scoped_window's
+        # idempotent-create content-match reads (and before the delete-credit
+        # read further below) -- not just before check_limit, like
+        # batch_modify_available_times's later lock does. The content-match is
+        # itself a read whose "no identical window exists yet" answer a
+        # concurrent replay of the same batch (spec UC-5) can invalidate: two
+        # genuinely concurrent identical batches would otherwise both see no
+        # match, both create, and double-charge the entitlement. Taking the
+        # lock this early serializes them so the second sees the first's
+        # committed windows and correctly no-ops.
+        if self.entitlement_service is not None and operations:
+            self.entitlement_service.lock_billing_root(organization)
+
         # Resolve every touched row up front (read-only): a missing/foreign
         # window_id or a calendar not on this slot's roster fails the whole
         # batch before anything is written.
@@ -997,6 +1020,15 @@ class CalendarGroupService:
             if op["action"] in ("update", "delete"):
                 window = self._get_group_scoped_window(op["window_id"])
                 if window.group_slot_fk_id != group_slot_id:
+                    raise CalendarGroupSlotConfigNotFoundError()
+                # Cross-check the resolved window against the op's OWN calendar_id --
+                # public_api's assert_calendar_in_owner_scope only proves the token owns
+                # op["calendar_id"], not that window_id actually belongs to it. Without
+                # this, a calendar-owner-scoped token could target another calendar's
+                # window in the same slot by pairing a calendar_id it owns with a
+                # window_id it doesn't. Raises the same non-disclosure exception as an
+                # unresolvable window_id so the two cases are indistinguishable.
+                if window.calendar_fk_id != op["calendar_id"]:
                     raise CalendarGroupSlotConfigNotFoundError()
                 windows_by_op_id[op["window_id"]] = window
 
@@ -1031,10 +1063,9 @@ class CalendarGroupService:
         )
         delete_ids = [op["window_id"] for op in operations if op["action"] == "delete"]
 
-        # Lock *before* the delete-credit read for the same reason
-        # batch_modify_available_times does -- see its docstring.
-        if genuine_create_count and delete_ids and self.entitlement_service is not None:
-            self.entitlement_service.lock_billing_root(organization)
+        # The billing root is already locked above (before the idempotent-create
+        # content-match), so the delete-credit read below is already covered --
+        # no separate lock call needed here, unlike batch_modify_available_times.
 
         # Only deletions of rows the usage counter counts offset the creates.
         # Reads through ``unscoped()`` because group-scoped rows are invisible

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     from calendar_integration.services.booking_policy_service import BookingPolicyService
     from calendar_integration.services.calendar_service import CalendarService
     from payments.services.entitlement_service import EntitlementService
+    from public_api.models import SystemUser
 
 
 # Sentinel for partial updates: distinguishes "omit rrule_string" (leave the
@@ -584,7 +585,7 @@ class CalendarGroupService:
     def _audit_group_scoped_availability_write(
         self,
         action: str,
-        acting_user: User,
+        acting_user: "User | SystemUser",
         subject_instance: AvailableTime,
         diff: dict | None = None,
     ) -> None:
@@ -595,6 +596,10 @@ class CalendarGroupService:
         acting principal explicitly -- they are reachable without a bound
         ``calendar_service``. No-op when no ``audit_service`` / ``organization``
         is bound, so instrumentation never breaks a write path.
+
+        ``acting_user`` accepts a ``SystemUser`` too (public-API batch write,
+        CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1d) --
+        ``AuditService.actor_from_user_or_token`` already resolves either.
         """
         if self.audit_service is None or self.organization is None:
             return
@@ -855,6 +860,273 @@ class CalendarGroupService:
 
         self._audit_group_scoped_availability_write(AuditAction.DELETE, acting_user, window)
         window.delete()
+
+    def _find_matching_group_scoped_window(
+        self,
+        group_slot_id: int,
+        calendar_id: int,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        tz: str,
+        rrule_string: str | None,
+    ) -> AvailableTime | None:
+        """Find an existing group-scoped window with identical content, if any.
+
+        Backs the batch-upsert write path's idempotent ``create``
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1d): an upstream system
+        that resends the same batch after a network timeout (spec UC-5) must
+        land on the identical final state, not accumulate duplicate rows.
+        Matched on (calendar, group slot, start_time, end_time, timezone,
+        rrule). ``start_time``/``end_time`` are compared as the aware
+        instants they are -- paired with an exact ``timezone`` match this is
+        a safe point lookup, not the cross-timezone comparison
+        ``start_time_tz_unaware`` is unsafe for (see AGENTS.md).
+        """
+        organization = cast(Organization, self.organization)
+        candidates = (
+            AvailableTime.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(organization.id)
+            .filter(
+                calendar_fk_id=calendar_id,
+                start_time_tz_unaware=start_time,
+                end_time_tz_unaware=end_time,
+                timezone=tz,
+            )
+            .select_related("recurrence_rule")
+        )
+        for candidate in candidates:
+            candidate_rrule = (
+                candidate.recurrence_rule.to_rrule_string() if candidate.recurrence_rule else None
+            )
+            if candidate_rrule == rrule_string:
+                return candidate
+        return None
+
+    @transaction.atomic()
+    def batch_upsert_group_scoped_availability_windows(
+        self,
+        group_slot_id: int,
+        operations: Iterable[dict],
+        acting_principal: "User | SystemUser",
+    ) -> list[AvailableTime]:
+        """Apply an atomic bulk-upsert batch of group-scoped availability
+        window create/update/delete operations within one group slot's
+        roster (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1d -- public API).
+
+        Mirrors ``AvailabilityService.batch_modify_available_times``'s
+        transaction / entitlement / net-growth structure so the two batch
+        contracts read the same way to an integration:
+
+        * **All-or-nothing.** The whole batch runs inside one transaction
+          (this method's own ``@transaction.atomic()``, nested inside the
+          request's ``ATOMIC_REQUESTS`` transaction); every operation is
+          validated and every touched row is resolved *before* any write, so
+          a bad ``window_id`` or a batch that would exceed the plan's
+          ``availability_windows`` ceiling rolls back cleanly with nothing
+          partially applied.
+        * **Idempotent create.** A ``create`` operation is an upsert, not a
+          blind insert: :meth:`_find_matching_group_scoped_window` looks for
+          an existing group-scoped window with identical content first. A
+          match is returned unchanged (no write, no entitlement charge, no
+          audit record) rather than duplicated, so replaying an identical
+          batch (spec UC-5: "the system replays the same batch after a
+          network timeout") lands on the exact same final state.
+        * **update / delete** require ``window_id`` and act on exactly the
+          row it names, like the base availability batch write's ``id``-keyed
+          operations.
+
+        Authorization is the CALLER's responsibility. Unlike the single-window
+        Phase 1a writes above, this method does not call
+        ``CalendarPermissionService`` -- every public-API availability write
+        authorizes via ``OrganizationResourceAccess`` (token resource grant)
+        plus owner-scope (``public_api.scoping.assert_calendar_in_owner_scope``),
+        never the human-facing per-membership permission check, because a
+        public-API ``SystemUser`` token has no ``CalendarOwnership``-linked
+        ``User`` to check it against for an org-wide token. ``acting_principal``
+        is used for audit attribution only.
+
+        :param operations: dicts with ``action`` (create/update/delete) and
+            ``calendar_id``; create/update also take ``start_time``,
+            ``end_time``, ``timezone``, ``rrule_string`` (optional); update/
+            delete also take ``window_id``.
+        :param acting_principal: the ``User`` or public-API ``SystemUser``
+            this write is attributed to in the audit trail.
+        :raises OverLimitError: when the batch's net growth (genuine creates
+            minus credited deletes) would take the organization past its
+            effective ``availability_windows`` ceiling. Nothing is applied.
+        :raises CalendarGroupSlotConfigNotFoundError: a create op's
+            ``calendar_id`` is not a member of ``group_slot_id``'s roster, or
+            an update/delete op's ``window_id`` does not resolve to a
+            group-scoped window in this slot.
+        :raises ValueError: an operation's shape is invalid (unknown action,
+            missing required field).
+        :return: every group-scoped window in ``group_slot_id``'s roster
+            (all calendars) after the batch is applied.
+        """
+        self._assert_initialized()
+        organization = cast(Organization, self.organization)
+        operations = list(operations)
+
+        valid_actions = {"create", "update", "delete"}
+        for op in operations:
+            action = op.get("action")
+            if action not in valid_actions:
+                raise ValueError(f"Invalid operation action: {action}")
+            if action == "create" and (
+                "calendar_id" not in op
+                or "start_time" not in op
+                or "end_time" not in op
+                or "timezone" not in op
+            ):
+                raise ValueError(
+                    "create operation requires calendar_id, start_time, end_time, timezone"
+                )
+            if action in ("update", "delete") and "window_id" not in op:
+                raise ValueError(f"{action} operation requires window_id")
+
+        # RESTRICTED must block the batch outright, including an update-only
+        # or delete-only batch -- mirrors batch_modify_available_times.
+        if self.entitlement_service is not None and operations:
+            self.entitlement_service.check_not_restricted(organization)
+
+        # Resolve every touched row up front (read-only): a missing/foreign
+        # window_id or a calendar not on this slot's roster fails the whole
+        # batch before anything is written.
+        windows_by_op_id: dict[int, AvailableTime] = {}
+        for op in operations:
+            if op["action"] in ("update", "delete"):
+                window = self._get_group_scoped_window(op["window_id"])
+                if window.group_slot_fk_id != group_slot_id:
+                    raise CalendarGroupSlotConfigNotFoundError()
+                windows_by_op_id[op["window_id"]] = window
+
+        memberships_by_calendar: dict[int, CalendarGroupSlotMembership] = {}
+        for op in operations:
+            if op["action"] == "create" and op["calendar_id"] not in memberships_by_calendar:
+                memberships_by_calendar[op["calendar_id"]] = self._resolve_group_scoped_membership(
+                    group_slot_id, op["calendar_id"]
+                )
+
+        # Idempotent-create resolution: match each create op against an
+        # existing group-scoped window before it counts toward net growth.
+        matched_existing: dict[int, AvailableTime] = {}
+        for i, op in enumerate(operations):
+            if op["action"] != "create":
+                continue
+            existing = self._find_matching_group_scoped_window(
+                group_slot_id=group_slot_id,
+                calendar_id=op["calendar_id"],
+                start_time=op["start_time"],
+                end_time=op["end_time"],
+                tz=op["timezone"],
+                rrule_string=op.get("rrule_string"),
+            )
+            if existing is not None:
+                matched_existing[i] = existing
+
+        genuine_create_count = sum(
+            1
+            for i, op in enumerate(operations)
+            if op["action"] == "create" and i not in matched_existing
+        )
+        delete_ids = [op["window_id"] for op in operations if op["action"] == "delete"]
+
+        # Lock *before* the delete-credit read for the same reason
+        # batch_modify_available_times does -- see its docstring.
+        if genuine_create_count and delete_ids and self.entitlement_service is not None:
+            self.entitlement_service.lock_billing_root(organization)
+
+        # Only deletions of rows the usage counter counts offset the creates.
+        # Reads through ``unscoped()`` because group-scoped rows are invisible
+        # to the default manager ``only_user_authored`` wraps.
+        credited_delete_count = (
+            AvailableTime.objects.unscoped()
+            .filter_by_organization(organization.id)
+            .only_user_authored()
+            .filter(id__in=delete_ids)
+            .count()
+            if genuine_create_count and delete_ids
+            else 0
+        )
+        delta = max(genuine_create_count - credited_delete_count, 0)
+
+        if delta and self.entitlement_service is not None:
+            result = self.entitlement_service.check_limit(
+                organization, LimitedResource.AVAILABILITY_WINDOWS, delta=delta, lock=True
+            )
+            if not result.allowed:
+                raise OverLimitError.from_check_result(result)
+
+        for i, op in enumerate(operations):
+            action = op["action"]
+            if action == "create":
+                if i in matched_existing:
+                    continue
+                membership = memberships_by_calendar[op["calendar_id"]]
+                recurrence_rule = self._create_recurrence_rule_if_needed(op.get("rrule_string"))
+                window = AvailableTime.objects.unscoped().create(
+                    organization=organization,
+                    calendar=membership.calendar,
+                    group_slot=membership.slot,
+                    start_time_tz_unaware=op["start_time"],
+                    end_time_tz_unaware=op["end_time"],
+                    timezone=op["timezone"],
+                    recurrence_rule=recurrence_rule,
+                )
+                self._audit_group_scoped_availability_write(
+                    AuditAction.CREATE, acting_principal, window
+                )
+            elif action == "update":
+                window = windows_by_op_id[op["window_id"]]
+                before = {
+                    "start_time_tz_unaware": window.start_time_tz_unaware.isoformat(),
+                    "end_time_tz_unaware": window.end_time_tz_unaware.isoformat(),
+                    "timezone": window.timezone,
+                    "rrule": (
+                        window.recurrence_rule.to_rrule_string() if window.recurrence_rule else None
+                    ),
+                }
+                update_fields: list[str] = []
+                if "start_time" in op:
+                    window.start_time_tz_unaware = op["start_time"]
+                    update_fields.append("start_time_tz_unaware")
+                if "end_time" in op:
+                    window.end_time_tz_unaware = op["end_time"]
+                    update_fields.append("end_time_tz_unaware")
+                if "timezone" in op:
+                    window.timezone = op["timezone"]
+                    update_fields.append("timezone")
+                if "rrule_string" in op:
+                    window.recurrence_rule = self._create_recurrence_rule_if_needed(
+                        op["rrule_string"]
+                    )
+                    update_fields.append("recurrence_rule_fk")
+                if update_fields:
+                    window.save(update_fields=[*update_fields, "modified"])
+                after = {
+                    "start_time_tz_unaware": window.start_time_tz_unaware.isoformat(),
+                    "end_time_tz_unaware": window.end_time_tz_unaware.isoformat(),
+                    "timezone": window.timezone,
+                    "rrule": (
+                        window.recurrence_rule.to_rrule_string() if window.recurrence_rule else None
+                    ),
+                }
+                self._audit_group_scoped_availability_write(
+                    AuditAction.UPDATE, acting_principal, window, diff=compute_diff(before, after)
+                )
+            elif action == "delete":
+                window = windows_by_op_id[op["window_id"]]
+                self._audit_group_scoped_availability_write(
+                    AuditAction.DELETE, acting_principal, window
+                )
+                window.delete()
+
+        return list(
+            AvailableTime.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(organization.id)
+            .select_related("recurrence_rule")
+            .order_by("pk")
+        )
 
     # ------------------------------------------------------------------
     # Queries

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -127,9 +127,17 @@ def _count_availability_windows(context: UsageContext) -> int:
     of 5 that created 3 recurring windows and edited 3 occurrences would read as 6
     and be blocked below its real usage, which the rollout's "nobody is blocked as
     a consequence of the rollout itself" rule forbids.
+
+    Reads through ``unscoped()`` (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 0/1d):
+    ``AvailableTime.objects`` — the default manager — excludes group-scoped rows
+    (``group_slot`` set) by design, so counting through it would under-report and
+    let group-scoped windows bypass the plan limit entirely. The spec's metering
+    rule is "every time window an organization authors is metered" regardless of
+    scope, so base and group-scoped rows are counted together here.
     """
     return (
-        AvailableTime.objects.only_user_authored()
+        AvailableTime.objects.unscoped()
+        .only_user_authored()
         .filter(organization_id__in=context.organization_ids)
         .count()
     )

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -62,6 +62,14 @@ class PublicAPIResources(TextChoices):
     )
     BOOKING_POLICY = "booking_policy", "Booking Policy"
     BOOKABLE_SLOTS = "bookable_slots", "Bookable Slots"
+    GROUP_SCOPED_AVAILABILITY_WINDOWS = (
+        "group_scoped_availability_windows",
+        "Group-Scoped Availability Windows",
+    )
+    BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS = (
+        "batch_upsert_group_scoped_availability_windows",
+        "Batch Upsert Group-Scoped Availability Windows",
+    )
 
 
 PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
@@ -79,5 +87,7 @@ PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
         PublicAPIResources.UPDATE_AVAILABILITY_WINDOW,
         PublicAPIResources.DELETE_AVAILABILITY_WINDOW,
         PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS,
+        PublicAPIResources.GROUP_SCOPED_AVAILABILITY_WINDOWS,
+        PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS,
     ]
 )

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -2039,11 +2039,16 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         2. Asserts every operation's ``calendarId`` is within the token
            owner's scope (no-op for org-wide tokens) — one guard per
            operation, since (unlike the base availability batch) this batch
-           may span several calendars in the slot's roster.
+           may span several calendars in the slot's roster. This only proves
+           the token owns each op's ``calendarId``; it does not prove that an
+           update/delete op's ``windowId`` belongs to that calendar.
         3. Delegates to ``CalendarGroupService.batch_upsert_group_scoped_availability_windows``,
-           which resolves every touched row, checks the ``availability_windows``
-           plan limit against the batch's net genuine-create growth, and applies
-           the whole batch inside its own transaction.
+           which resolves every touched row, cross-checks that an
+           update/delete op's resolved window actually belongs to that op's
+           own ``calendarId`` (closing the gap step 2 leaves open), checks the
+           ``availability_windows`` plan limit against the batch's net
+           genuine-create growth, and applies the whole batch inside its own
+           transaction.
         4. Returns every group-scoped window in the slot's roster after the
            batch is applied.
 
@@ -2094,7 +2099,13 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         # Owner-scope guard per operation's calendarId -- reveals nothing about
         # existence for a calendar outside a scoped token's owner set. Checked
         # for EVERY operation up front, so a cross-owner op anywhere in the
-        # batch rejects the whole thing before any service call.
+        # batch rejects the whole thing before any service call. This only
+        # proves the token owns op.calendarId; it does NOT prove that an
+        # update/delete op's windowId actually resolves to that calendar --
+        # CalendarGroupService.batch_upsert_group_scoped_availability_windows
+        # cross-checks that itself (window.calendar_fk_id == op.calendar_id)
+        # before applying anything, so a token can't pair a calendarId it owns
+        # with a windowId belonging to a different calendar.
         request: PublicApiHttpRequest = info.context.request
         system_user = request.public_api_system_user
         try:

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -18,6 +18,7 @@ from graphql import GraphQLError
 from calendar_integration.constants import CalendarType
 from calendar_integration.exceptions import (
     BookingPolicyViolationError,
+    CalendarGroupSlotConfigNotFoundError,
     CalendarIntegrationError,
     DuplicateBookingPolicyError,
     NoAvailableTimeWindowsError,
@@ -32,7 +33,9 @@ from calendar_integration.graphql import (
     CreateBookingPolicyInput,
     DeleteBookingPolicyInput,
     DeleteBookingPolicyResult,
+    GroupScopedAvailabilityWindowGraphQLType,
     UpdateBookingPolicyInput,
+    group_scoped_availability_window_from_model,
 )
 from calendar_integration.models import BookingPolicy, Calendar, CalendarEvent, CalendarGroup
 from calendar_integration.mutations import (
@@ -481,6 +484,60 @@ class BatchUpdateAvailabilityWindowsResult:
     success: bool
     error_message: str | None = None
     available_times: list[AvailableTimeGraphQLType]
+
+
+@strawberry.input
+class GroupScopedAvailabilityWindowOperationInput:
+    """A single create/update/delete operation in a batch group-scoped
+    availability window upsert (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1d).
+
+    ``calendarId`` is required on every operation (not only ``create``) so
+    the owner-scope guard can be applied per-operation before any service
+    call, mirroring how ``updateAvailabilityWindow`` / ``deleteAvailabilityWindow``
+    carry ``calendarId`` alongside their id even though the id alone would
+    resolve it.
+
+    For action='create': calendarId, startTime, endTime, and timezone are
+    required; rruleString is optional. An identical create (same calendar,
+    group slot, start/end time, timezone, and rrule as an existing window)
+    is a no-op — replaying the same batch never duplicates a window (spec
+    UC-5).
+    For action='update': windowId is required; other fields are optional
+    (only provided fields change).
+    For action='delete': windowId is required; no other fields are needed.
+    """
+
+    action: str
+    calendar_id: int
+    window_id: int | None = None
+    start_time: datetime.datetime | None = None
+    end_time: datetime.datetime | None = None
+    timezone: str | None = None
+    rrule_string: str | None = None
+
+
+@strawberry.input
+class BatchGroupScopedAvailabilityWindowsInput:
+    """Input for applying an atomic batch of group-scoped availability window
+    operations within one group slot's roster."""
+
+    organization_id: int
+    group_slot_id: int
+    operations: list[GroupScopedAvailabilityWindowOperationInput]
+
+
+@strawberry.type
+class BatchUpsertGroupScopedAvailabilityWindowsResult:
+    """Result of the batchUpsertGroupScopedAvailabilityWindows mutation.
+
+    On success, ``windows`` contains every group-scoped window in the group
+    slot's roster (all calendars) after the batch is applied. On failure,
+    ``windows`` is an empty list and nothing was written.
+    """
+
+    success: bool
+    error_message: str | None = None
+    windows: list[GroupScopedAvailabilityWindowGraphQLType]
 
 
 @strawberry.input
@@ -1956,6 +2013,143 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         return BatchUpdateAvailabilityWindowsResult(
             success=True,
             available_times=available_times,  # type: ignore[arg-type]
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def batch_upsert_group_scoped_availability_windows(
+        self,
+        info: strawberry.Info,
+        input: BatchGroupScopedAvailabilityWindowsInput,  # noqa: A002
+    ) -> BatchUpsertGroupScopedAvailabilityWindowsResult:
+        """Apply an atomic create/update/delete batch of group-scoped
+        availability windows within one group slot's roster
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1d).
+
+        Mirrors ``batchUpdateAvailabilityWindows``'s all-or-nothing and
+        over-limit behavior exactly (same transaction/entitlement structure,
+        same ``OverLimitError`` -> ``raise_over_limit_graphql_error`` render),
+        with one addition: a ``create`` operation is an upsert — an identical
+        replay of the same batch (spec UC-5: "the system replays the same
+        batch after a network timeout") is a no-op, landing on the same final
+        state rather than duplicating windows.
+
+        The mutation:
+        1. Resolves the organization and validates every operation's shape
+           up front (no partial write on a malformed batch).
+        2. Asserts every operation's ``calendarId`` is within the token
+           owner's scope (no-op for org-wide tokens) — one guard per
+           operation, since (unlike the base availability batch) this batch
+           may span several calendars in the slot's roster.
+        3. Delegates to ``CalendarGroupService.batch_upsert_group_scoped_availability_windows``,
+           which resolves every touched row, checks the ``availability_windows``
+           plan limit against the batch's net genuine-create growth, and applies
+           the whole batch inside its own transaction.
+        4. Returns every group-scoped window in the slot's roster after the
+           batch is applied.
+
+        The token's OrganizationResourceAccess must include the
+        BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS resource.
+        """
+        _valid_actions = {"create", "update", "delete"}
+
+        org = info.context.request.public_api_organization
+        if not org:
+            return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                windows=[],
+            )
+        if input.organization_id != org.id:
+            return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                windows=[],
+            )
+
+        # Validate all operations before touching anything -- fail fast, no writes.
+        for op_input in input.operations:
+            if op_input.action not in _valid_actions:
+                return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                    success=False,
+                    error_message=f"Invalid operation action: {op_input.action}",
+                    windows=[],
+                )
+            if op_input.action == "create" and (
+                op_input.start_time is None
+                or op_input.end_time is None
+                or op_input.timezone is None
+            ):
+                return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                    success=False,
+                    error_message="create operation requires startTime, endTime, and timezone",
+                    windows=[],
+                )
+            if op_input.action in ("update", "delete") and op_input.window_id is None:
+                return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                    success=False,
+                    error_message=f"{op_input.action} operation requires windowId",
+                    windows=[],
+                )
+
+        # Owner-scope guard per operation's calendarId -- reveals nothing about
+        # existence for a calendar outside a scoped token's owner set. Checked
+        # for EVERY operation up front, so a cross-owner op anywhere in the
+        # batch rejects the whole thing before any service call.
+        request: PublicApiHttpRequest = info.context.request
+        system_user = request.public_api_system_user
+        try:
+            for op_input in input.operations:
+                assert_calendar_in_owner_scope(system_user, org, op_input.calendar_id)
+        except Calendar.DoesNotExist:
+            return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                success=False, error_message="Calendar not found.", windows=[]
+            )
+
+        ops: list[dict[str, object]] = []
+        for op_input in input.operations:
+            op: dict[str, object] = {"action": op_input.action, "calendar_id": op_input.calendar_id}
+            if op_input.window_id is not None:
+                op["window_id"] = op_input.window_id
+            if op_input.start_time is not None:
+                op["start_time"] = op_input.start_time
+            if op_input.end_time is not None:
+                op["end_time"] = op_input.end_time
+            if op_input.timezone is not None:
+                op["timezone"] = op_input.timezone
+            if op_input.rrule_string is not None:
+                op["rrule_string"] = op_input.rrule_string
+            ops.append(op)
+
+        deps = get_calendar_mutation_dependencies()
+        deps.calendar_group_service.initialize(organization=org)
+
+        if system_user is None:
+            return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                windows=[],
+            )
+
+        try:
+            windows = deps.calendar_group_service.batch_upsert_group_scoped_availability_windows(
+                group_slot_id=input.group_slot_id,
+                operations=ops,
+                acting_principal=system_user,
+            )
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
+        except CalendarGroupSlotConfigNotFoundError:
+            return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                success=False, error_message="Group slot not found.", windows=[]
+            )
+        except (CalendarIntegrationError, ValueError, DjangoValidationError) as e:
+            return BatchUpsertGroupScopedAvailabilityWindowsResult(
+                success=False, error_message=str(e), windows=[]
+            )
+
+        return BatchUpsertGroupScopedAvailabilityWindowsResult(
+            success=True,
+            windows=[group_scoped_availability_window_from_model(w) for w in windows],
         )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -68,6 +68,10 @@ class OrganizationResourceAccess(BasePermission):
         "updateAvailabilityWindow": PublicAPIResources.UPDATE_AVAILABILITY_WINDOW,
         "deleteAvailabilityWindow": PublicAPIResources.DELETE_AVAILABILITY_WINDOW,
         "batchUpdateAvailabilityWindows": PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS,
+        "groupScopedAvailabilityWindows": PublicAPIResources.GROUP_SCOPED_AVAILABILITY_WINDOWS,
+        "batchUpsertGroupScopedAvailabilityWindows": (
+            PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS
+        ),
         "createBlockedTime": PublicAPIResources.CREATE_BLOCKED_TIME,
         "updateBlockedTime": PublicAPIResources.UPDATE_BLOCKED_TIME,
         "deleteBlockedTime": PublicAPIResources.DELETE_BLOCKED_TIME,

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -35,8 +35,10 @@ from calendar_integration.graphql import (
     CalendarWebhookEventGraphQLType,
     CalendarWebhookSubscriptionGraphQLType,
     ExternalEventChangeRequestGraphQLType,
+    GroupScopedAvailabilityWindowGraphQLType,
     UnavailableTimeWindowGraphQLType,
     WebhookSubscriptionStatusGraphQLType,
+    group_scoped_availability_window_from_model,
 )
 from calendar_integration.models import (
     AvailableTime,
@@ -965,6 +967,45 @@ class Query:
             group_id=group_id, start=start_datetime, end=end_datetime
         )
         return cast(list[CalendarEventGraphQLType], list(events))
+
+    @strawberry.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def group_scoped_availability_windows(
+        self,
+        info: strawberry.Info,
+        group_slot_id: int,
+        calendar_id: int | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[GroupScopedAvailabilityWindowGraphQLType]:
+        """List group-scoped availability windows for a group slot's roster.
+
+        Returns raw window rows (one per recurring master or one-off window,
+        not expanded occurrences) -- mirrors the internal REST surface's list
+        shape (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1c). Optionally
+        filtered to a single calendar in the slot's roster.
+        """
+        org = _get_org(info)
+
+        qs = (
+            AvailableTime.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(org.id)
+            .select_related("recurrence_rule")
+        )
+
+        # Owner-scope: for scoped tokens, only return windows on calendars in
+        # the token owner's set.
+        request: PublicApiHttpRequest = info.context.request
+        system_user = request.public_api_system_user
+        if system_user is not None:
+            allowed_ids = scoped_calendar_ids(system_user, org)
+            if allowed_ids is not None:
+                qs = qs.filter(calendar_fk__in=allowed_ids)
+
+        if calendar_id is not None:
+            qs = qs.filter(calendar_fk_id=calendar_id)
+
+        windows = _slice_qs(qs.order_by("pk"), offset, limit)
+        return [group_scoped_availability_window_from_model(w) for w in windows]
 
     @strawberry_django.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
     def child_organizations(

--- a/public_api/tests/test_group_scoped_availability_windows.py
+++ b/public_api/tests/test_group_scoped_availability_windows.py
@@ -1,0 +1,728 @@
+"""Integration tests for the public GraphQL surface of group-scoped
+availability windows (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1d).
+
+Covers ``groupScopedAvailabilityWindows`` (query) and
+``batchUpsertGroupScopedAvailabilityWindows`` (batch-upsert mutation):
+batch apply, idempotent replay (identical final state, no duplicates),
+whole-batch rejection at the plan limit with the SAME over-limit response
+body the existing ``batchUpdateAvailabilityWindows`` mutation already
+returns, cross-organization scoping, and a no-regression check that the
+existing (frozen) availability query/mutation are byte-for-byte unchanged.
+"""
+
+import datetime
+import uuid
+
+from django.utils import timezone as django_timezone
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarOwnership,
+)
+from organizations.models import Organization, OrganizationMembership
+from payments.billing_constants import BillingState, Entitlement, LimitedResource, LimitKind
+from payments.models import (
+    BillingPlan,
+    Subscription,
+    SubscriptionEntitlement,
+    SubscriptionPlanLimit,
+)
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+GROUP_SCOPED_AVAILABILITY_WINDOWS_QUERY = """
+query GroupScopedAvailabilityWindows($groupSlotId: Int!, $calendarId: Int) {
+    groupScopedAvailabilityWindows(groupSlotId: $groupSlotId, calendarId: $calendarId) {
+        id
+        calendarId
+        groupSlotId
+        startTime
+        endTime
+        timezone
+        rruleString
+        isRecurring
+    }
+}
+"""
+
+BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION = """
+mutation BatchUpsertGroupScopedAvailabilityWindows($input: BatchGroupScopedAvailabilityWindowsInput!) {
+    batchUpsertGroupScopedAvailabilityWindows(input: $input) {
+        success
+        errorMessage
+        windows {
+            id
+            calendarId
+            groupSlotId
+            startTime
+            endTime
+            timezone
+            rruleString
+        }
+    }
+}
+"""
+
+BATCH_UPDATE_AVAILABILITY_WINDOWS_MUTATION = """
+mutation BatchUpdateAvailabilityWindows($input: BatchAvailabilityInput!) {
+    batchUpdateAvailabilityWindows(input: $input) {
+        success
+        errorMessage
+        availableTimes {
+            id
+            startTime
+            endTime
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestGroupScopedAvailabilityWindowsPublicAPI:
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _setup_org(self) -> Organization:
+        return baker.make(Organization, name="Test Org")
+
+    def _make_org_wide_system_user(self, org, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_owner_with_calendar(self, org: Organization):
+        """Create a user, their active membership, and a calendar they own.
+
+        Returns (user, membership, calendar).
+        """
+        from django.contrib.auth import get_user_model
+
+        user_model = get_user_model()
+        unique = uuid.uuid4().hex[:8]
+        owner = baker.make(user_model, email=f"owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = Calendar.objects.create(
+            organization=org,
+            name=f"Calendar {unique}",
+            external_id=f"cal-{unique}",
+            provider=CalendarProvider.GOOGLE,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+        )
+        CalendarOwnership.objects.create(
+            organization=org, calendar=calendar, membership_user_id=owner.id
+        )
+        return owner, membership, calendar
+
+    def _make_calendar(self, org: Organization) -> Calendar:
+        unique = uuid.uuid4().hex[:8]
+        return Calendar.objects.create(
+            organization=org,
+            name=f"Calendar {unique}",
+            external_id=f"cal-{unique}",
+            provider=CalendarProvider.GOOGLE,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+        )
+
+    def _make_group_slot(self, org: Organization, *calendars: Calendar) -> CalendarGroupSlot:
+        group = CalendarGroup.objects.create(organization=org, name="Surgery")
+        slot = CalendarGroupSlot.objects.create(organization=org, group=group, name="Lead")
+        for calendar in calendars:
+            CalendarGroupSlotMembership.objects.create(
+                organization=org, slot=slot, calendar=calendar
+            )
+        return slot
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def _organization_with_availability_windows_limit(self, limit_value: int) -> Organization:
+        """A standalone organization with a finite ceiling on availability_windows.
+
+        Mirrors calendar_integration/tests/services/test_calendar_limits.py's
+        ``_organization_with_limit`` helper, plus an explicit ``partner_api``
+        entitlement -- unlike that helper's service-layer callers, these tests
+        go through the real GraphQL endpoint, which
+        ``PublicApiSystemUserMiddleware`` gates on ``partner_api`` before any
+        resolver runs (``EntitlementService.has_entitlement`` fails closed on a
+        bespoke plan with no entitlement rows).
+        """
+        organization = baker.make(Organization, parent=None, can_invite_organizations=False)
+        now = django_timezone.now()
+        subscription = baker.make(
+            Subscription,
+            organization=organization,
+            plan=baker.make(BillingPlan, is_default_for_new_organizations=False),
+            billing_state=BillingState.FREE,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+        )
+        baker.make(
+            SubscriptionPlanLimit,
+            subscription=subscription,
+            resource_key=LimitedResource.AVAILABILITY_WINDOWS,
+            limit_value=limit_value,
+            kind=LimitKind.PREPAID,
+        )
+        baker.make(
+            SubscriptionEntitlement,
+            subscription=subscription,
+            entitlement_key=Entitlement.PARTNER_API,
+            is_enabled=True,
+        )
+        return organization
+
+    # ------------------------------------------------------------------
+    # groupScopedAvailabilityWindows -- query
+    # ------------------------------------------------------------------
+
+    def test_query_returns_group_scoped_windows_for_the_slot(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org,
+            [
+                PublicAPIResources.GROUP_SCOPED_AVAILABILITY_WINDOWS,
+                PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS,
+            ],
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        window = AvailableTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=end,
+            timezone="UTC",
+        )
+
+        response = self._post(
+            GROUP_SCOPED_AVAILABILITY_WINDOWS_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        windows = data["data"]["groupScopedAvailabilityWindows"]
+        assert len(windows) == 1
+        assert windows[0]["id"] == window.id
+        assert windows[0]["calendarId"] == calendar.id
+        assert windows[0]["groupSlotId"] == slot.id
+        assert windows[0]["timezone"] == "UTC"
+
+    def test_query_cross_organization_scoping_returns_empty(self):
+        """A group slot belonging to another organization is invisible."""
+        org_a = self._setup_org()
+        org_b = self._setup_org()
+        calendar_b = self._make_calendar(org_b)
+        slot_b = self._make_group_slot(org_b, calendar_b)
+
+        AvailableTime.objects.unscoped().create(
+            organization=org_b,
+            calendar=calendar_b,
+            group_slot=slot_b,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org_a, [PublicAPIResources.GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        response = self._post(
+            GROUP_SCOPED_AVAILABILITY_WINDOWS_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot_b.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        assert data["data"]["groupScopedAvailabilityWindows"] == []
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedAvailabilityWindows -- apply
+    # ------------------------------------------------------------------
+
+    def test_batch_upsert_applies_mixed_operations(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        existing = AvailableTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+        to_delete = AvailableTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 2, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 2, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+
+        create_start = datetime.datetime(2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        create_end = datetime.datetime(2026, 10, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        new_start = datetime.datetime(2026, 11, 1, 8, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 1, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "startTime": create_start.isoformat(),
+                            "endTime": create_end.isoformat(),
+                            "timezone": "UTC",
+                        },
+                        {
+                            "action": "update",
+                            "calendarId": calendar.id,
+                            "windowId": existing.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                        },
+                        {
+                            "action": "delete",
+                            "calendarId": calendar.id,
+                            "windowId": to_delete.id,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert result["success"] is True
+        assert result["errorMessage"] is None
+        # Final roster state: the updated row + the newly created row (deleted row gone).
+        assert len(result["windows"]) == 2
+
+        existing.refresh_from_db()
+        assert existing.start_time_tz_unaware == new_start
+        assert existing.end_time_tz_unaware == new_end
+        assert not (
+            AvailableTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(id=to_delete.id)
+            .exists()
+        )
+
+        remaining = AvailableTime.objects.for_group_slot(slot.id).filter_by_organization(org.id)
+        assert remaining.count() == 2
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedAvailabilityWindows -- idempotent replay
+    # ------------------------------------------------------------------
+
+    def test_identical_replay_is_a_no_op(self):
+        """Replaying an identical create-only batch (spec UC-5) lands on the
+        same final state instead of duplicating rows."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        variables = {
+            "input": {
+                "organizationId": org.id,
+                "groupSlotId": slot.id,
+                "operations": [
+                    {
+                        "action": "create",
+                        "calendarId": calendar.id,
+                        "startTime": start.isoformat(),
+                        "endTime": end.isoformat(),
+                        "timezone": "UTC",
+                    },
+                ],
+            }
+        }
+
+        first = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            variables,
+        )
+        assert first.status_code == 200
+        first_result = first.json()["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert first_result["success"] is True
+        assert len(first_result["windows"]) == 1
+        first_window_id = first_result["windows"][0]["id"]
+
+        rows_after_first = (
+            AvailableTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+        )
+        assert rows_after_first == 1
+
+        second = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            variables,
+        )
+        assert second.status_code == 200
+        second_result = second.json()["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert second_result["success"] is True
+
+        # Same final state: one row, same id, no duplicate created.
+        assert len(second_result["windows"]) == 1
+        assert second_result["windows"][0]["id"] == first_window_id
+        rows_after_replay = (
+            AvailableTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+        )
+        assert rows_after_replay == 1, (
+            "Replaying an identical batch must not create a duplicate window."
+        )
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedAvailabilityWindows -- over-limit rejects whole batch
+    # ------------------------------------------------------------------
+
+    @pytest.mark.no_auto_subscription
+    def test_over_limit_batch_rejected_whole_with_same_body_as_base_batch_write(self):
+        """A batch that would exceed the plan's availability_windows ceiling is
+        rejected wholesale (nothing created), with the SAME over-limit response
+        body the existing batchUpdateAvailabilityWindows mutation returns for the
+        identical resource ceiling.
+        """
+        org = self._organization_with_availability_windows_limit(2)
+        base_calendar = self._make_calendar(org)
+        group_calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, group_calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org,
+            [
+                PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS,
+                PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS,
+            ],
+        )
+
+        def _create_op(day: int) -> dict:
+            return {
+                "action": "create",
+                "startTime": datetime.datetime(
+                    2026, 9, day, 9, 0, 0, tzinfo=datetime.UTC
+                ).isoformat(),
+                "endTime": datetime.datetime(
+                    2026, 9, day, 17, 0, 0, tzinfo=datetime.UTC
+                ).isoformat(),
+                "timezone": "UTC",
+            }
+
+        # --- Existing (frozen) base batch write, over the limit (3 creates, ceiling 2). ---
+        base_response = self._post(
+            BATCH_UPDATE_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": base_calendar.id,
+                    "operations": [_create_op(1), _create_op(2), _create_op(3)],
+                }
+            },
+        )
+        assert base_response.status_code == 200
+        base_data = base_response.json()
+        assert len(base_data["errors"]) == 1
+        base_extensions = base_data["errors"][0]["extensions"]
+        assert base_extensions["code"] == "limit_exceeded"
+        assert base_extensions["resource"] == LimitedResource.AVAILABILITY_WINDOWS
+        assert (
+            AvailableTime.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=base_calendar.id)
+            .count()
+            == 0
+        ), "The over-limit base batch must create nothing."
+
+        # --- New group-scoped batch write, same ceiling, same net growth. ---
+        group_create_ops = [
+            {
+                "action": "create",
+                "calendarId": group_calendar.id,
+                "startTime": datetime.datetime(
+                    2026, 10, day, 9, 0, 0, tzinfo=datetime.UTC
+                ).isoformat(),
+                "endTime": datetime.datetime(
+                    2026, 10, day, 17, 0, 0, tzinfo=datetime.UTC
+                ).isoformat(),
+                "timezone": "UTC",
+            }
+            for day in (1, 2, 3)
+        ]
+        group_response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": group_create_ops,
+                }
+            },
+        )
+        assert group_response.status_code == 200
+        group_data = group_response.json()
+        assert len(group_data["errors"]) == 1
+        group_extensions = group_data["errors"][0]["extensions"]
+
+        # Byte-identical over-limit body: nothing about usage changed between the
+        # two attempts (both rolled back, creating nothing), so the shared
+        # OverLimitError contract renders identically for either write path.
+        assert group_extensions == base_extensions
+        assert group_extensions["code"] == "limit_exceeded"
+        assert group_extensions["resource"] == LimitedResource.AVAILABILITY_WINDOWS
+
+        assert (
+            AvailableTime.objects.for_group_slot(slot.id).filter_by_organization(org.id).count()
+            == 0
+        ), "The over-limit group-scoped batch must create nothing."
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedAvailabilityWindows -- cross-organization scoping
+    # ------------------------------------------------------------------
+
+    def test_cross_organization_group_slot_is_rejected(self):
+        org_a = self._setup_org()
+        org_b = self._setup_org()
+        calendar_b = self._make_calendar(org_b)
+        slot_b = self._make_group_slot(org_b, calendar_b)
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org_a.id,
+                    "groupSlotId": slot_b.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar_b.id,
+                            "startTime": datetime.datetime(
+                                2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "endTime": datetime.datetime(
+                                2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert result["success"] is False
+        assert result["windows"] == []
+        assert (
+            not AvailableTime.objects.for_group_slot(slot_b.id)
+            .filter_by_organization(org_b.id)
+            .filter(calendar_fk_id=calendar_b.id, timezone="UTC")
+            .exists()
+        )
+
+    def test_cross_owner_scoped_token_rejected_wholesale(self):
+        """A scoped token may not write group-scoped windows on a calendar it
+        does not own -- same not-found shape as a genuinely missing calendar,
+        and nothing is written."""
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_b)
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar_b.id,
+                            "startTime": datetime.datetime(
+                                2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "endTime": datetime.datetime(
+                                2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Calendar not found."
+        assert (
+            AvailableTime.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
+    # Existing availability operations are unchanged (no-regression)
+    # ------------------------------------------------------------------
+
+    def test_existing_batch_update_availability_windows_response_shape_unchanged(self):
+        """Byte-for-byte shape check: the frozen batchUpdateAvailabilityWindows
+        mutation's response is unaffected by this phase's additions."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS]
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            BATCH_UPDATE_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "calendarId": calendar.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "startTime": start.isoformat(),
+                            "endTime": end.isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpdateAvailabilityWindows"]
+
+        # Exact shape: only these three top-level keys, and availableTimes
+        # entries carry only id/startTime/endTime (as queried) -- unchanged
+        # from before this phase's additions.
+        assert set(result.keys()) == {"success", "errorMessage", "availableTimes"}
+        assert result["success"] is True
+        assert result["errorMessage"] is None
+        assert len(result["availableTimes"]) == 1
+        window = result["availableTimes"][0]
+        assert set(window.keys()) == {"id", "startTime", "endTime"}
+        assert datetime.datetime.fromisoformat(window["startTime"]) == start
+        assert datetime.datetime.fromisoformat(window["endTime"]) == end

--- a/public_api/tests/test_group_scoped_availability_windows.py
+++ b/public_api/tests/test_group_scoped_availability_windows.py
@@ -674,6 +674,322 @@ class TestGroupScopedAvailabilityWindowsPublicAPI:
         )
 
     # ------------------------------------------------------------------
+    # batchUpsertGroupScopedAvailabilityWindows -- IDOR (window/calendar
+    # cross-check on update/delete)
+    # ------------------------------------------------------------------
+
+    def test_update_with_window_from_another_calendar_rejected_wholesale(self):
+        """A calendar-owner-scoped token pairs a calendarId it owns with a
+        windowId belonging to a DIFFERENT calendar in the same slot's roster.
+        assert_calendar_in_owner_scope alone would let this through (it only
+        checks ownership of calendarId) -- the service must ALSO reject
+        because the resolved window does not belong to that calendar. Whole
+        batch fails, not-found shape, nothing changes."""
+        org = self._setup_org()
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_a, calendar_b)
+
+        foreign_window = AvailableTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar_b,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        new_start = datetime.datetime(2026, 11, 1, 8, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 1, 16, 0, 0, tzinfo=datetime.UTC)
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            # calendarId the token owns...
+                            "calendarId": calendar_a.id,
+                            # ...but windowId belongs to calendar_b.
+                            "windowId": foreign_window.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["windows"] == []
+
+        foreign_window.refresh_from_db()
+        assert foreign_window.start_time_tz_unaware != new_start
+        assert foreign_window.end_time_tz_unaware != new_end
+        assert foreign_window.calendar_fk_id == calendar_b.id
+
+    def test_delete_with_window_from_another_calendar_rejected_wholesale(self):
+        """Same IDOR as the update case above, but for a delete op: the
+        foreign window must still exist, unmodified, afterward."""
+        org = self._setup_org()
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_a, calendar_b)
+
+        foreign_window = AvailableTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar_b,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+        )
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "delete",
+                            # calendarId the token owns, windowId belongs to calendar_b.
+                            "calendarId": calendar_a.id,
+                            "windowId": foreign_window.id,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["windows"] == []
+
+        assert (
+            AvailableTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(id=foreign_window.id)
+            .exists()
+        ), "The foreign window must NOT be deleted by a batch it was never authorized for."
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedAvailabilityWindows -- create outside the slot's roster
+    # ------------------------------------------------------------------
+
+    def test_create_with_calendar_outside_slot_roster_rejected_wholesale(self):
+        """A create op's calendarId is a calendar the token owns/can access, but
+        it is not a member of the target groupSlotId's roster -- rejected with
+        the not-found shape, nothing created."""
+        org = self._setup_org()
+        roster_calendar = self._make_calendar(org)
+        outside_calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, roster_calendar)
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": outside_calendar.id,
+                            "startTime": datetime.datetime(
+                                2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "endTime": datetime.datetime(
+                                2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedAvailabilityWindows"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["windows"] == []
+        assert (
+            AvailableTime.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=outside_calendar.id)
+            .count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
+    # Anonymous / unauthorized access -- query and mutation
+    # ------------------------------------------------------------------
+
+    def test_query_anonymous_request_denied(self):
+        """No Authorization header -- the standard auth error, no data leaked."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+
+        response = self.client.post(
+            "/graphql/",
+            data={
+                "query": GROUP_SCOPED_AVAILABILITY_WINDOWS_QUERY,
+                "variables": {"groupSlotId": slot.id, "calendarId": None},
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+
+    def test_mutation_anonymous_request_denied(self):
+        """No Authorization header on the mutation -- the standard auth error,
+        no write applied."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+
+        response = self.client.post(
+            "/graphql/",
+            data={
+                "query": BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+                "variables": {
+                    "input": {
+                        "organizationId": org.id,
+                        "groupSlotId": slot.id,
+                        "operations": [
+                            {
+                                "action": "create",
+                                "calendarId": calendar.id,
+                                "startTime": "2026-09-01T09:00:00Z",
+                                "endTime": "2026-09-01T17:00:00Z",
+                                "timezone": "UTC",
+                            }
+                        ],
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert (
+            AvailableTime.objects.for_group_slot(slot.id).filter_by_organization(org.id).count()
+            == 0
+        )
+
+    def test_query_token_without_resource_grant_denied(self):
+        """An authenticated token that lacks the GROUP_SCOPED_AVAILABILITY_WINDOWS
+        resource grant is denied."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        # Grant an unrelated resource only.
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        response = self._post(
+            GROUP_SCOPED_AVAILABILITY_WINDOWS_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_mutation_token_without_resource_grant_denied(self):
+        """An authenticated token that lacks the
+        BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS resource grant is denied,
+        and nothing is written."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        # Grant an unrelated resource only.
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "startTime": "2026-09-01T09:00:00Z",
+                            "endTime": "2026-09-01T17:00:00Z",
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+        assert (
+            AvailableTime.objects.for_group_slot(slot.id).filter_by_organization(org.id).count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
     # Existing availability operations are unchanged (no-regression)
     # ------------------------------------------------------------------
 

--- a/schema.yml
+++ b/schema.yml
@@ -13918,6 +13918,8 @@ components:
       - external_event_change_request
       - booking_policy
       - bookable_slots
+      - group_scoped_availability_windows
+      - batch_upsert_group_scoped_availability_windows
       type: string
       description: |-
         * `calendar_event` - Calendar Event
@@ -13964,6 +13966,8 @@ components:
         * `external_event_change_request` - External Event Change Request
         * `booking_policy` - Booking Policy
         * `bookable_slots` - Bookable Slots
+        * `group_scoped_availability_windows` - Group-Scoped Availability Windows
+        * `batch_upsert_group_scoped_availability_windows` - Batch Upsert Group-Scoped Availability Windows
     AvailableTime:
       type: object
       description: Serializer for AvailableTime model with recurring support.


### PR DESCRIPTION

## Summary

Phase 1d of the Calendar Group-Scoped Availability plan — completes the windows concept. Partner integrations can now read group-scoped windows and push them in bulk, idempotently and under the plan limit (UC-5, upstream rostering). The existing availability query and batch mutation are untouched (frozen contract).

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 1d. Spec use-case UC-5.

## Key decisions

- **New dedicated operations** (Guiding Decisions → "Public API shape"): a `group_scoped_availability_windows` query and a `batch_upsert_group_scoped_availability_windows` mutation. The existing availability operations keep their exact shape — asserted unchanged by a response-shape test.
- **Batch semantics identical to the existing availability batch write** (Guiding Decisions → "Write semantics"): all-or-nothing via `@transaction.atomic()` with `SELECT FOR UPDATE` (does NOT rely on the prod-only `ATOMIC_REQUESTS`); over-limit rejects the whole batch, reusing `raise_over_limit_graphql_error` — the over-limit `extensions` body is byte-identical to the base batch write's (asserted). Idempotent replay: `create` ops content-match on `(calendar, group_slot, start, end, timezone, rrule)`; `update`/`delete` carry an explicit `windowId`.
- **Metering** (Guiding Decisions → "Metering"): fixed the entitlement counter — `_count_availability_windows` now reads `AvailableTime.objects.unscoped().only_user_authored()`, so group-scoped windows count toward the availability-window plan limit (the default manager excluded them). Composes correctly: `unscoped()` only lifts the `group_slot IS NULL` filter; `only_user_authored()`'s exclusion of recurrence-exception / split rows is independent of scope. No change for orgs without group-scoped windows.
- **Authorization** uses the public-API model (`OrganizationResourceAccess` token grant + `assert_calendar_in_owner_scope` per op), consistent with other public-API availability writes, rather than the user-based Phase 1a permission service (a `SystemUser` token has no membership user). The service additionally cross-checks that an update/delete's resolved window belongs to the op's calendar (closes an IDOR where an owner-scoped token could otherwise modify another calendar's window in the same slot by pairing its own `calendarId` with a foreign `windowId`) — failures use the non-disclosure not-found shape.

## Feature flag

None — new operations; existing availability operations untouched; no migration.

## Test plan

```bash
docker compose run --rm api uv run pytest public_api/tests/test_group_scoped_availability_windows.py -vs
docker compose run --rm api uv run pytest public_api/tests/ calendar_integration/tests/ payments/tests/ -n auto
```

Covers: batch applies; identical replay is a no-op; over-limit rejects the whole batch with the identical body and creates nothing; cross-org scoping; existing availability op response shape unchanged; IDOR (owned calendarId + foreign windowId) rejected wholesale; out-of-slot-roster calendar rejected; anonymous + unauthorized-token denial on query and mutation.