### PR TITLE
feat(calendar): add group-scoped blocked time writes and enforcement

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -74,13 +74,21 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 - **Summary**: Nested REST viewset `.../calendar-groups/{group_id}/slots/{slot_id}/availability-windows/`, thin, delegating to Phase 1a `CalendarGroupService`. `GroupScopedAvailabilityWindowPermission` for route-level group-visibility gating; **non-disclosure byte-identical** across stranger / cross-org / other-calendar-owner / missing-or-mismatched slot (all `Http404 {"detail":"Not found."}`, asserted via `data ==`). Create/update responses wrap `{window, orphaned_bookings}`; list/retrieve return the window. Tri-state recurrence editing (`PATCH null` clears, omit leaves, string sets) via `_UNCHANGED` sentinel. Narrow virtual model + bounded-query test. Schema purely additive. No migration.
 - **Process note**: reinforced hard rules on the retry (no amend, no commit with red tests, gating is required not optional).
 
+### Phase 1d — Windows on the public API ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-1d` (base: phase-1c) — **PR [#223](https://github.com/vintasoftware/vinta-schedule-api/pull/223)**
+- **Implementer model**: sonnet (plan Tier 3) — agent type `implementer`
+- **Reviewer model**: sonnet — 1 security BLOCKER (IDOR) + 2 SHOULD-FIX + NITs, all fixed (sonnet fixer)
+- **Summary**: Public GraphQL `group_scoped_availability_windows` query + `batch_upsert_group_scoped_availability_windows` mutation. Batch semantics mirror the existing availability batch write exactly (all-or-nothing via own `@transaction.atomic()` + `SELECT FOR UPDATE`, NOT relying on prod-only `ATOMIC_REQUESTS`; over-limit rejects whole with byte-identical body; content-match idempotent replay for create, explicit `windowId` for update/delete). Fixed the entitlement counter `_count_availability_windows` to `unscoped().only_user_authored()` so group-scoped windows meter (composes correctly — still excludes non-user-authored rows). Public-API token auth (`OrganizationResourceAccess` + `assert_calendar_in_owner_scope`). Existing availability ops frozen (asserted). No migration.
+- **Security BLOCKER fixed (IDOR)**: update/delete now cross-check the resolved window's `calendar_fk_id == op.calendar_id` (was authorizing only by the op's own calendar, letting an owner-scoped token modify another calendar's window in the same slot via a foreign `windowId`). **Concurrency fix**: billing-root lock now taken before the idempotency content-match (concurrent UC-5 retries no longer double-create).
+
 ## Current phase
 
-Phase 1d — Windows on the public API
+Phase 2a — Group-scoped blocked time: writes and enforcement
 
 ## Remaining phases
 
-1d, 2a, 2b, 2c, 3a, 3b, 3c, 4
+2a, 2b, 2c, 3a, 3b, 3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/constants.py
+++ b/calendar_integration/constants.py
@@ -111,8 +111,10 @@ class GroupScopedRuleType(TextChoices):
 
     Named exactly as the spec requires them surfaced to a caller: outside
     window, inside block, quota consumed -- never the configured values
-    themselves. Only ``OUTSIDE_WINDOW`` is enforced as of Phase 1b; the other
-    two are reserved for Phase 2a (blocks) and Phase 3b (quota).
+    themselves. ``OUTSIDE_WINDOW`` is enforced as of Phase 1b and
+    ``INSIDE_BLOCK`` as of Phase 2a; ``QUOTA_CONSUMED`` is reserved for
+    Phase 3b.
     """
 
     OUTSIDE_WINDOW = "outside_window", "Outside window"
+    INSIDE_BLOCK = "inside_block", "Inside block"

--- a/calendar_integration/exceptions.py
+++ b/calendar_integration/exceptions.py
@@ -360,8 +360,8 @@ class CalendarGroupScopedRuleViolationError(CalendarGroupError):
     callers can build a structured error response -- never the configured
     rule values themselves (spec Decisions -> Errors: enough for an admin to
     act on, without leaking roster detail to external bookers on public
-    links). As of Phase 1b only ``OUTSIDE_WINDOW`` is raised; ``INSIDE_BLOCK``
-    and ``QUOTA_CONSUMED`` are reserved for Phase 2a and Phase 3b.
+    links). ``OUTSIDE_WINDOW`` is raised as of Phase 1b and ``INSIDE_BLOCK``
+    as of Phase 2a; ``QUOTA_CONSUMED`` is reserved for Phase 3b.
     """
 
     def __init__(

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -1,17 +1,18 @@
 import datetime
+import uuid
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Annotated, cast
 
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, QuerySet
 from django.utils import timezone
 
 from dependency_injector.wiring import Provide, inject
 
 from audit.constants import AuditAction
 from audit.diff import compute_diff
-from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.constants import CalendarProvider, CalendarType, GroupScopedRuleType
 from calendar_integration.exceptions import (
     BookingPolicyViolationError,
     CalendarGroupHasFutureEventsError,
@@ -55,6 +56,7 @@ from calendar_integration.services.dataclasses import (
     EventExternalAttendanceInputData,
     ExternalAttendeeInputData,
     GroupScopedAvailabilityWriteResult,
+    GroupScopedBlockWriteResult,
     ResourceAllocationInputData,
 )
 from organizations.models import Organization
@@ -426,6 +428,38 @@ class CalendarGroupService:
                 ]
             )
 
+    def _delete_group_scoped_rows_for_removed_calendars(
+        self,
+        queryset: "QuerySet[AvailableTime] | QuerySet[BlockedTime]",
+    ) -> None:
+        """Audit-then-delete every row in ``queryset`` (already filtered to one
+        slot and a set of removed calendar ids).
+
+        Shared by ``_reconcile_slot`` for both group-scoped windows
+        (``AvailableTime``) and group-scoped blocked time (``BlockedTime``,
+        Phase 2a) -- same cleanup shape, different model. No-op (still issues
+        the delete) when no ``audit_service`` is bound.
+        """
+        rows = list(queryset)
+        for row in rows:
+            if self.audit_service is None or self.organization is None:
+                break
+            user_or_token = getattr(self.calendar_service, "user_or_token", None)
+            permission_service = getattr(self.calendar_service, "calendar_permission_service", None)
+            self.audit_service.record(
+                organization_id=self.organization.id,
+                action=AuditAction.DELETE,
+                actor=self.audit_service.actor_from_user_or_token(
+                    user_or_token,
+                    self.organization.id,
+                    single_use_token=resolve_acting_single_use_token(
+                        user_or_token, permission_service
+                    ),
+                ),
+                subject=self.audit_service.subject_from_instance(row),
+            )
+        queryset.delete()
+
     def _reconcile_slot(
         self,
         slot: CalendarGroupSlot,
@@ -445,47 +479,28 @@ class CalendarGroupService:
         if to_remove:
             self._ensure_no_future_selections(slot=slot, calendar_ids=to_remove)
 
-            # Delete group-scoped windows for the removed calendars.
-            # The FK on AvailableTime.group_slot → CalendarGroupSlot cascades on
-            # SLOT deletion only, not on membership removal, so we must explicitly
-            # clean up the orphaned rows here. Each window deletion is audited
-            # individually because the group-update diff only captures name/description
-            # /accepts_public_scheduling, not membership or window changes.
-            # TODO(Phase 2a, 3a): BlockedTime.for_group_slot() and quota rules
-            # must extend this cleanup when those phases add their group-scoped rows,
-            # using the same pattern: delete rows for removed calendars in to_remove.
+            # Delete group-scoped windows and blocked time for the removed
+            # calendars. The FK on AvailableTime.group_slot /
+            # BlockedTime.group_slot → CalendarGroupSlot cascades on SLOT
+            # deletion only, not on membership removal, so we must explicitly
+            # clean up the orphaned rows here. Each row deletion is audited
+            # individually because the group-update diff only captures
+            # name/description/accepts_public_scheduling, not membership or
+            # window/block changes.
+            # TODO(Phase 3a): quota rules must extend this cleanup when that
+            # phase adds its group-scoped rows, using the same pattern: delete
+            # rows for removed calendars in to_remove.
             org_id = cast(Organization, self.organization).id
-            windows_to_delete = list(
+            self._delete_group_scoped_rows_for_removed_calendars(
                 AvailableTime.objects.unscoped()
                 .filter_by_organization(org_id)
                 .filter(group_slot_fk=slot, calendar_fk_id__in=to_remove)
             )
-
-            # Audit each window deletion before removing it.
-            for window in windows_to_delete:
-                if self.audit_service is None or self.organization is None:
-                    break
-                user_or_token = getattr(self.calendar_service, "user_or_token", None)
-                permission_service = getattr(
-                    self.calendar_service, "calendar_permission_service", None
-                )
-                self.audit_service.record(
-                    organization_id=self.organization.id,
-                    action=AuditAction.DELETE,
-                    actor=self.audit_service.actor_from_user_or_token(
-                        user_or_token,
-                        self.organization.id,
-                        single_use_token=resolve_acting_single_use_token(
-                            user_or_token, permission_service
-                        ),
-                    ),
-                    subject=self.audit_service.subject_from_instance(window),
-                )
-
-            # Delete the windows after auditing them.
-            AvailableTime.objects.unscoped().filter_by_organization(org_id).filter(
-                group_slot_fk=slot, calendar_fk_id__in=to_remove
-            ).delete()
+            self._delete_group_scoped_rows_for_removed_calendars(
+                BlockedTime.objects.unscoped()
+                .filter_by_organization(org_id)
+                .filter(group_slot_fk=slot, calendar_fk_id__in=to_remove)
+            )
 
             CalendarGroupSlotMembership.objects.filter_by_organization(self.organization.id).filter(
                 slot_fk=slot, calendar_fk_id__in=to_remove
@@ -1160,6 +1175,295 @@ class CalendarGroupService:
         )
 
     # ------------------------------------------------------------------
+    # Group-scoped blocked time (Phase 2a of
+    # CALENDAR_GROUP_SCOPED_AVAILABILITY -- writes)
+    # ------------------------------------------------------------------
+
+    def _get_group_scoped_block(self, block_id: int) -> BlockedTime:
+        """Fetch a group-scoped ``BlockedTime`` row by id, scoped to this org.
+
+        Reads through the ``unscoped`` accessor (never the default manager,
+        which excludes group-scoped rows) and requires ``group_slot`` to be
+        set, so an id belonging to a base row raises the same not-found error
+        as a genuinely missing id. Mirrors ``_get_group_scoped_window``.
+        """
+        org_id = cast(Organization, self.organization).id
+        try:
+            return (
+                BlockedTime.objects.unscoped()
+                .filter_by_organization(org_id)
+                .select_related("group_slot", "calendar", "recurrence_rule")
+                .get(id=block_id, group_slot_fk__isnull=False)
+            )
+        except BlockedTime.DoesNotExist:
+            raise CalendarGroupSlotConfigNotFoundError() from None
+
+    def _audit_group_scoped_block_write(
+        self,
+        action: str,
+        acting_user: "User | SystemUser",
+        subject_instance: BlockedTime,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a group-scoped blocked-time write.
+
+        Mirrors ``_audit_group_scoped_availability_write``: the acting
+        principal is taken explicitly (this write path is reachable without a
+        bound ``calendar_service``), and this is a no-op when no
+        ``audit_service`` / ``organization`` is bound.
+        """
+        if self.audit_service is None or self.organization is None:
+            return
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=action,
+            actor=self.audit_service.actor_from_user_or_token(acting_user, self.organization.id),
+            subject=self.audit_service.subject_from_instance(subject_instance),
+            diff=diff,
+        )
+
+    def _group_scoped_blocked_times_expanded(
+        self,
+        calendar_id: int,
+        group_slot_id: int,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[BlockedTime]:
+        """Expand every group-scoped ``BlockedTime`` for ``(calendar, group_slot)``
+        that overlaps ``[start_date, end_date)``, recurrence included.
+
+        Mirrors ``_group_scoped_available_times_expanded``, delegating to
+        ``slot_engine.expand_group_scoped_blocked_times`` -- the single-pair
+        case of the same batched implementation the discovery-side fetch
+        uses.
+        """
+        org_id = cast(Organization, self.organization).id
+        return slot_engine.expand_group_scoped_blocked_times(
+            org_id, [group_slot_id], [calendar_id], start_date, end_date
+        )
+
+    def _find_bookings_orphaned_by_group_scoped_block(
+        self, calendar_id: int, group_slot: CalendarGroupSlot, now: datetime.datetime
+    ) -> list[CalendarEvent]:
+        """Confirmed future bookings in ``group_slot`` for ``calendar_id`` that
+        fall INSIDE the calendar's current group-scoped blocked time, after a
+        block write.
+
+        The block analog of ``_find_orphaned_bookings``, with the coverage
+        test inverted: a window write orphans a booking that falls OUTSIDE the
+        configured union of windows (the window no longer grants that time); a
+        block write orphans a booking that falls INSIDE any configured block
+        (the block now removes that time). Runs against every group-scoped
+        block currently configured for this ``(calendar, slot)`` pair, not
+        just the one a caller just wrote, for the same reason windows do.
+        Nothing here is cancelled or modified; this is purely a read (spec
+        UC-6's rule applied to blocks).
+        """
+        org_id = cast(Organization, self.organization).id
+        selections = (
+            CalendarEventGroupSelection.objects.filter_by_organization(org_id)
+            .filter(
+                slot_fk=group_slot,
+                calendar_fk_id=calendar_id,
+                event_fk__start_time__gt=now,
+            )
+            .select_related("event")
+        )
+
+        selections_list = list(selections)
+        if not selections_list:
+            return []
+
+        # Find the union range covering all candidate bookings: min start → max end.
+        min_start = min(sel.event.start_time for sel in selections_list)
+        max_end = max(sel.event.end_time for sel in selections_list)
+
+        # Expand ALL group-scoped blocks once over the union range.
+        all_blocks = self._group_scoped_blocked_times_expanded(
+            calendar_id, group_slot.id, min_start, max_end
+        )
+
+        # Check each booking against the single cached expansion.
+        orphaned: list[CalendarEvent] = []
+        for selection in selections_list:
+            event = selection.event
+            overlaps_block = any(
+                slot_engine.intervals_overlap(
+                    (block.start_time, block.end_time), (event.start_time, event.end_time)
+                )
+                for block in all_blocks
+            )
+            if overlaps_block:
+                orphaned.append(event)
+        return orphaned
+
+    @transaction.atomic()
+    def create_group_scoped_blocked_time(
+        self,
+        acting_user: User,
+        group_slot_id: int,
+        calendar_id: int,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        tz: str,
+        reason: str = "",
+        rrule_string: str | None = None,
+        now: datetime.datetime | None = None,
+    ) -> GroupScopedBlockWriteResult:
+        """Create a group-scoped blocked time for ``(calendar, group_slot)``.
+
+        Writes through the explicit group-scoped accessor
+        (``BlockedTime.objects.unscoped().create(..., group_slot=...)``),
+        never the default manager. Carries the same recurrence expressiveness
+        as a base ``BlockedTime`` -- pass ``rrule_string`` for a recurring
+        block. Permission-gated identically to windows: ``acting_user`` must
+        own the calendar or be an org admin (see
+        ``CalendarPermissionService.can_manage_group_scoped_calendar_config``).
+
+        Unlike a group-scoped WINDOW -- where windows OR together, so only the
+        FIRST one flips a calendar from fall-through to narrowed and can
+        orphan a booking -- every group-scoped BLOCK independently subtracts
+        time from whatever was previously offered. So orphaned-booking
+        detection runs on EVERY create, not just the first (spec UC-6's rule
+        applied to blocks). Nothing is cancelled.
+        """
+        self._assert_initialized()
+        if now is None:
+            now = timezone.now()
+
+        organization = cast(Organization, self.organization)
+        membership = self._resolve_group_scoped_membership(group_slot_id, calendar_id)
+        self._authorize_group_scoped_write(acting_user, membership.calendar, membership.slot)
+
+        recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
+        block = BlockedTime.objects.unscoped().create(
+            organization=organization,
+            calendar=membership.calendar,
+            group_slot=membership.slot,
+            start_time_tz_unaware=start_time,
+            end_time_tz_unaware=end_time,
+            timezone=tz,
+            reason=reason,
+            # BlockedTime enforces uniqueness on (calendar, external_id); this
+            # write path has no natural external id (unlike provider-synced
+            # blocks), so a uuid4 guarantees no collision with any other block
+            # -- base or group-scoped -- on the same calendar.
+            external_id=f"group-scoped-block-{uuid.uuid4()}",
+            recurrence_rule=recurrence_rule,
+        )
+        self._audit_group_scoped_block_write(AuditAction.CREATE, acting_user, block)
+
+        orphaned_bookings = self._find_bookings_orphaned_by_group_scoped_block(
+            calendar_id=calendar_id,
+            group_slot=membership.slot,
+            now=now,
+        )
+
+        return GroupScopedBlockWriteResult(block=block, orphaned_bookings=orphaned_bookings)
+
+    @transaction.atomic()
+    def update_group_scoped_blocked_time(
+        self,
+        acting_user: User,
+        block_id: int,
+        start_time: datetime.datetime | None = None,
+        end_time: datetime.datetime | None = None,
+        tz: str | None = None,
+        reason: str | None = None,
+        rrule_string: str | None = _UNCHANGED,  # type: ignore[assignment]
+        now: datetime.datetime | None = None,
+    ) -> GroupScopedBlockWriteResult:
+        """Partially update a group-scoped blocked time (only provided fields
+        change -- mirrors ``update_group_scoped_availability_window``).
+
+        ``rrule_string`` is tri-state: the sentinel ``_UNCHANGED`` (the
+        default) leaves the recurrence untouched, explicit ``None`` clears it
+        (the block becomes non-recurring), and a string sets/replaces it.
+
+        After the update is applied, every confirmed future booking in the
+        block's group slot for its calendar that now falls INSIDE the
+        calendar's group-scoped blocked time is collected and returned.
+        Changing a block never cancels or edits a booking (spec UC-6's rule
+        applied to blocks) -- the caller decides what to do with each one.
+        """
+        self._assert_initialized()
+        if now is None:
+            now = timezone.now()
+
+        block = self._get_group_scoped_block(block_id)
+        self._authorize_group_scoped_write(acting_user, block.calendar, block.group_slot)
+
+        before = {
+            "start_time_tz_unaware": block.start_time_tz_unaware.isoformat(),
+            "end_time_tz_unaware": block.end_time_tz_unaware.isoformat(),
+            "timezone": block.timezone,
+            "reason": block.reason,
+            "rrule": block.recurrence_rule.to_rrule_string() if block.recurrence_rule else None,
+        }
+
+        update_fields: list[str] = []
+        if start_time is not None:
+            block.start_time_tz_unaware = start_time
+            update_fields.append("start_time_tz_unaware")
+        if end_time is not None:
+            block.end_time_tz_unaware = end_time
+            update_fields.append("end_time_tz_unaware")
+        if tz is not None:
+            block.timezone = tz
+            update_fields.append("timezone")
+        if reason is not None:
+            block.reason = reason
+            update_fields.append("reason")
+        if rrule_string is not _UNCHANGED:
+            # ``None`` clears the recurrence (non-recurring); a string sets/replaces it.
+            block.recurrence_rule = self._create_recurrence_rule_if_needed(rrule_string)
+            # Assigning through the ForeignObject property name ("recurrence_rule")
+            # sets the underlying concrete column ("recurrence_rule_fk"); `save`'s
+            # `update_fields` must name the concrete field.
+            update_fields.append("recurrence_rule_fk")
+
+        if update_fields:
+            block.save(update_fields=[*update_fields, "modified"])
+
+        after = {
+            "start_time_tz_unaware": block.start_time_tz_unaware.isoformat(),
+            "end_time_tz_unaware": block.end_time_tz_unaware.isoformat(),
+            "timezone": block.timezone,
+            "reason": block.reason,
+            "rrule": block.recurrence_rule.to_rrule_string() if block.recurrence_rule else None,
+        }
+        self._audit_group_scoped_block_write(
+            AuditAction.UPDATE, acting_user, block, diff=compute_diff(before, after)
+        )
+
+        orphaned_bookings = self._find_bookings_orphaned_by_group_scoped_block(
+            calendar_id=block.calendar_fk_id,  # type: ignore[arg-type]
+            group_slot=block.group_slot,
+            now=now,
+        )
+        return GroupScopedBlockWriteResult(block=block, orphaned_bookings=orphaned_bookings)
+
+    @transaction.atomic()
+    def delete_group_scoped_blocked_time(self, acting_user: User, block_id: int) -> None:
+        """Delete a group-scoped blocked time (a single ``BlockedTime`` row).
+
+        A recurring block is stored as one row; deleting it removes the whole
+        series (mirrors ``delete_group_scoped_availability_window``). No
+        orphaned-booking report is computed here -- deleting a block only
+        WIDENS available time (the inverse of a window delete narrowing it),
+        so it can never orphan a booking. Removing a calendar from a slot's
+        roster entirely (which cascades away its blocks per the Phase 0
+        schema constraint) is a distinct action, exercised through
+        ``update_group``.
+        """
+        self._assert_initialized()
+        block = self._get_group_scoped_block(block_id)
+        self._authorize_group_scoped_write(acting_user, block.calendar, block.group_slot)
+
+        self._audit_group_scoped_block_write(AuditAction.DELETE, acting_user, block)
+        block.delete()
+
+    # ------------------------------------------------------------------
     # Queries
     # ------------------------------------------------------------------
     def get_group_events(
@@ -1189,30 +1493,35 @@ class CalendarGroupService:
 
     def _slot_pools_with_group_scoped_flags(
         self, slots: Iterable[CalendarGroupSlot]
-    ) -> tuple[dict[int, set[int]], dict[int, set[int]]]:
-        """Build the (slot_id -> calendar_id pool) map, folding in a per-row
-        ``EXISTS`` subquery flagging which pool calendars have ANY group-scoped
-        availability window configured for that slot (regardless of whether it
-        overlaps a caller's search window).
+    ) -> tuple[dict[int, set[int]], dict[int, set[int]], dict[int, set[int]]]:
+        """Build the (slot_id -> calendar_id pool) map, folding in two per-row
+        ``EXISTS`` subqueries flagging which pool calendars have ANY
+        group-scoped availability window, and ANY group-scoped blocked time,
+        configured for that slot (regardless of whether either overlaps a
+        caller's search window).
 
-        This is the Phase 1b self-gating early-out mechanism
-        (``CALENDAR_GROUP_SCOPED_AVAILABILITY``): the ``EXISTS`` clause is
-        folded into the SAME per-slot membership query every caller of this
-        method already issued before this phase, so an unconfigured group
-        costs exactly as many round trips as it did before -- zero added
-        queries. Only when the returned "configured" map is non-empty for a
-        slot does the caller go on to fetch the actual group-scoped spans (a
-        fixed, non-per-candidate number of additional queries -- see
-        ``slot_engine.fetch_group_scoped_available_spans``).
+        This is the Phase 1b (windows) / Phase 2a (blocks) self-gating
+        early-out mechanism (``CALENDAR_GROUP_SCOPED_AVAILABILITY``): both
+        ``EXISTS`` clauses are folded into the SAME per-slot membership query
+        every caller of this method already issued before Phase 1b, so an
+        unconfigured group costs exactly as many round trips as it did before
+        either phase -- zero added queries. Only when the returned "window
+        configured" or "block configured" map is non-empty for a slot does the
+        caller go on to fetch the actual group-scoped spans (a fixed,
+        non-per-candidate number of additional queries -- see
+        ``slot_engine.fetch_group_scoped_available_spans`` /
+        ``slot_engine.fetch_group_scoped_blocking_spans``).
 
-        Returns ``(slot_pool_by_id, group_scoped_calendar_ids_by_slot)``. The
-        second mapping omits a slot entirely when nothing in its pool is
-        configured, so ``bool(group_scoped_calendar_ids_by_slot)`` alone tells
-        a caller whether ANY group-scoped window exists anywhere in the group.
+        Returns ``(slot_pool_by_id, group_scoped_window_calendar_ids_by_slot,
+        group_scoped_block_calendar_ids_by_slot)``. The second and third
+        mappings each omit a slot entirely when nothing in its pool is
+        configured, so ``bool(...)`` on either alone tells a caller whether
+        ANY group-scoped window / block exists anywhere in the group.
         """
         org_id = cast(Organization, self.organization).id
         slot_pool_by_id: dict[int, set[int]] = {}
-        group_scoped_calendar_ids_by_slot: dict[int, set[int]] = {}
+        group_scoped_window_calendar_ids_by_slot: dict[int, set[int]] = {}
+        group_scoped_block_calendar_ids_by_slot: dict[int, set[int]] = {}
         for s in slots:
             rows = (
                 CalendarGroupSlotMembership.objects.filter_by_organization(org_id)
@@ -1222,20 +1531,34 @@ class CalendarGroupService:
                         AvailableTime.objects.unscoped()
                         .filter_by_organization(org_id)
                         .filter(calendar_fk_id=OuterRef("calendar_fk_id"), group_slot_fk_id=s.id)
-                    )
+                    ),
+                    has_group_scoped_block=Exists(
+                        BlockedTime.objects.unscoped()
+                        .filter_by_organization(org_id)
+                        .filter(calendar_fk_id=OuterRef("calendar_fk_id"), group_slot_fk_id=s.id)
+                    ),
                 )
-                .values_list("calendar_fk_id", "has_group_scoped_window")
+                .values_list("calendar_fk_id", "has_group_scoped_window", "has_group_scoped_block")
             )
             pool: set[int] = set()
-            configured: set[int] = set()
-            for cid, has_window in rows:
+            window_configured: set[int] = set()
+            block_configured: set[int] = set()
+            for cid, has_window, has_block in rows:
                 pool.add(cid)
                 if has_window:
-                    configured.add(cid)
+                    window_configured.add(cid)
+                if has_block:
+                    block_configured.add(cid)
             slot_pool_by_id[s.id] = pool
-            if configured:
-                group_scoped_calendar_ids_by_slot[s.id] = configured
-        return slot_pool_by_id, group_scoped_calendar_ids_by_slot
+            if window_configured:
+                group_scoped_window_calendar_ids_by_slot[s.id] = window_configured
+            if block_configured:
+                group_scoped_block_calendar_ids_by_slot[s.id] = block_configured
+        return (
+            slot_pool_by_id,
+            group_scoped_window_calendar_ids_by_slot,
+            group_scoped_block_calendar_ids_by_slot,
+        )
 
     def check_group_availability(
         self,
@@ -1256,23 +1579,31 @@ class CalendarGroupService:
         ``_slot_pools_with_group_scoped_flags``); a calendar WITH one is listed
         as available for a range only when that range is fully covered by at
         least one of its group-scoped windows -- narrowing only, never widening.
+
+        Group-scoped blocked time (Phase 2a) is applied AFTER base availability
+        and BEFORE the window check, per the spec resolution order: a calendar
+        with a configured block that OVERLAPS the range is excluded regardless
+        of what any window says ("blocks beat everything"). Also zero added
+        queries when unconfigured.
         """
         self._assert_initialized()
         group = self._get_group_by_id(group_id)
         ranges = list(ranges)
 
         slots = list(group.slots.all())
-        slot_pool_by_id, group_scoped_calendar_ids_by_slot = (
-            self._slot_pools_with_group_scoped_flags(slots)
-        )
+        (
+            slot_pool_by_id,
+            group_scoped_window_calendar_ids_by_slot,
+            group_scoped_block_calendar_ids_by_slot,
+        ) = self._slot_pools_with_group_scoped_flags(slots)
 
         # Self-gating early-out: only fetch expanded group-scoped spans when at
         # least one calendar anywhere in the group actually has one configured.
         group_scoped_spans_by_slot: slot_engine.GroupScopedSpansBySlot = {}
-        if group_scoped_calendar_ids_by_slot and ranges:
-            configured_slot_ids = list(group_scoped_calendar_ids_by_slot.keys())
+        if group_scoped_window_calendar_ids_by_slot and ranges:
+            configured_slot_ids = list(group_scoped_window_calendar_ids_by_slot.keys())
             configured_calendar_ids: set[int] = set()
-            for ids in group_scoped_calendar_ids_by_slot.values():
+            for ids in group_scoped_window_calendar_ids_by_slot.values():
                 configured_calendar_ids.update(ids)
             union_start = min(start for start, _ in ranges)
             union_end = max(end for _, end in ranges)
@@ -1280,6 +1611,22 @@ class CalendarGroupService:
                 self.organization.id,
                 configured_slot_ids,
                 configured_calendar_ids,
+                union_start,
+                union_end,
+            )
+
+        group_scoped_block_spans_by_slot: slot_engine.GroupScopedSpansBySlot = {}
+        if group_scoped_block_calendar_ids_by_slot and ranges:
+            configured_block_slot_ids = list(group_scoped_block_calendar_ids_by_slot.keys())
+            configured_block_calendar_ids: set[int] = set()
+            for ids in group_scoped_block_calendar_ids_by_slot.values():
+                configured_block_calendar_ids.update(ids)
+            union_start = min(start for start, _ in ranges)
+            union_end = max(end for _, end in ranges)
+            group_scoped_block_spans_by_slot = slot_engine.fetch_group_scoped_blocking_spans(
+                self.organization.id,
+                configured_block_slot_ids,
+                configured_block_calendar_ids,
                 union_start,
                 union_end,
             )
@@ -1301,19 +1648,29 @@ class CalendarGroupService:
             slot_results = []
             for s in slots:
                 base_available = slot_pool_by_id[s.id] & available_ids
-                configured_ids = group_scoped_calendar_ids_by_slot.get(s.id)
-                if not configured_ids:
+                window_configured_ids = group_scoped_window_calendar_ids_by_slot.get(s.id)
+                block_configured_ids = group_scoped_block_calendar_ids_by_slot.get(s.id)
+                if not window_configured_ids and not block_configured_ids:
                     final_available = base_available
                 else:
-                    spans_for_slot = group_scoped_spans_by_slot.get(s.id, {})
-                    final_available = {
-                        cid
-                        for cid in base_available
-                        if cid not in configured_ids
-                        or slot_engine.window_fully_covered_by_spans(
-                            spans_for_slot.get(cid, ()), start, end
-                        )
-                    }
+                    window_spans_for_slot = group_scoped_spans_by_slot.get(s.id, {})
+                    block_spans_for_slot = group_scoped_block_spans_by_slot.get(s.id, {})
+                    final_available = set()
+                    for cid in base_available:
+                        # Blocks beat everything -- checked first, before windows.
+                        if block_configured_ids and cid in block_configured_ids:
+                            blocked = any(
+                                slot_engine.intervals_overlap(span, (start, end))
+                                for span in block_spans_for_slot.get(cid, ())
+                            )
+                            if blocked:
+                                continue
+                        if window_configured_ids and cid in window_configured_ids:
+                            if not slot_engine.window_fully_covered_by_spans(
+                                window_spans_for_slot.get(cid, ()), start, end
+                            ):
+                                continue
+                        final_available.add(cid)
                 slot_results.append(
                     CalendarGroupSlotAvailability(
                         slot_id=s.id,
@@ -1910,21 +2267,30 @@ class CalendarGroupService:
         start: datetime.datetime,
         end: datetime.datetime,
     ) -> None:
-        """Reject any ``(slot_id, calendar_id)`` pair whose calendar has
-        group-scoped availability windows configured for that slot but
-        ``[start, end)`` is not fully covered by any of them (spec Acceptance 4,
-        UC-4: a caller cannot book, by naming the calendar directly, a time
-        discovery would never have offered).
+        """Reject any ``(slot_id, calendar_id)`` pair whose calendar violates a
+        group-scoped rule configured for that slot at ``[start, end)`` (spec
+        Acceptance 4, UC-4: a caller cannot book, by naming the calendar
+        directly, a time discovery would never have offered).
 
-        Mirrors ``slot_engine.calendar_free_for_window``'s intersection exactly:
-        a calendar with NO group-scoped window for a given ``(calendar, slot)``
-        pair falls through untouched -- narrowing only ever narrows what was
-        actually configured. Self-gating -- the existence check below is the
-        only extra query when nothing is configured for any of the named
-        pairs; the (fixed-cost) expanded fetch only runs when at least one pair
-        IS configured. Called from both ``create_grouped_event`` (after the
-        base-availability check) and ``reschedule_grouped_event`` (spec: every
-        enforcement surface agrees).
+        Checks BLOCKS first, then WINDOWS -- the same resolution order
+        ``slot_engine.calendar_free_for_window`` applies in discovery ("blocks
+        beat everything"): a pair with a configured group-scoped block that
+        OVERLAPS ``[start, end)`` is rejected with
+        ``GroupScopedRuleType.INSIDE_BLOCK`` before the window check even
+        runs, regardless of what any window says. A pair with no block hit is
+        then rejected with ``GroupScopedRuleType.OUTSIDE_WINDOW`` if it has a
+        configured window but ``[start, end)`` is not fully covered by any of
+        them.
+
+        A calendar with NEITHER a group-scoped block NOR window for a given
+        ``(calendar, slot)`` pair falls through untouched -- narrowing/
+        exclusion only ever applies to what was actually configured.
+        Self-gating -- the block and window existence checks are each the
+        only extra query when nothing of that kind is configured for any of
+        the named pairs; each (fixed-cost) expanded fetch only runs when at
+        least one pair IS configured for that kind. Called from both
+        ``create_grouped_event`` (after the base-availability check) and
+        ``reschedule_grouped_event`` (spec: every enforcement surface agrees).
         """
         pairs = list(slot_calendar_pairs)
         if not pairs:
@@ -1933,6 +2299,29 @@ class CalendarGroupService:
         org_id = cast(Organization, self.organization).id
         slot_ids = {slot_id for slot_id, _ in pairs}
         calendar_ids = {cid for _, cid in pairs}
+
+        # Blocks beat everything -- checked first, before windows.
+        configured_block_pairs = set(
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(org_id)
+            .filter(group_slot_fk_id__in=slot_ids, calendar_fk_id__in=calendar_ids)
+            .values_list("group_slot_fk_id", "calendar_fk_id")
+            .distinct()
+        )
+        if configured_block_pairs:
+            configured_block_slot_ids = {slot_id for slot_id, _ in configured_block_pairs}
+            configured_block_calendar_ids = {cid for _, cid in configured_block_pairs}
+            block_spans_by_slot = slot_engine.fetch_group_scoped_blocking_spans(
+                org_id, configured_block_slot_ids, configured_block_calendar_ids, start, end
+            )
+            for slot_id, calendar_id in pairs:
+                if (slot_id, calendar_id) not in configured_block_pairs:
+                    continue
+                spans = block_spans_by_slot.get(slot_id, {}).get(calendar_id, ())
+                if any(slot_engine.intervals_overlap(span, (start, end)) for span in spans):
+                    raise CalendarGroupScopedRuleViolationError(
+                        calendar_id=calendar_id, rule_type=GroupScopedRuleType.INSIDE_BLOCK
+                    )
 
         configured_pairs = set(
             AvailableTime.objects.unscoped()
@@ -2070,6 +2459,13 @@ class CalendarGroupService:
         counted toward its slot's ``required_count`` when the candidate window
         is fully covered by at least one of its group-scoped windows --
         narrowing only, never widening base availability.
+
+        Group-scoped blocked time (Phase 2a) is applied AFTER base
+        availability and BEFORE the window check (spec resolution order,
+        "blocks beat everything"): a calendar with a configured block that
+        OVERLAPS the candidate window is excluded from its slot's count
+        regardless of what any window says. Also zero added queries when
+        unconfigured.
         """
         self._assert_initialized()
         if slot_step <= datetime.timedelta(0):
@@ -2085,9 +2481,11 @@ class CalendarGroupService:
         if not slots:
             return []
 
-        slot_pool_by_id, group_scoped_calendar_ids_by_slot = (
-            self._slot_pools_with_group_scoped_flags(slots)
-        )
+        (
+            slot_pool_by_id,
+            group_scoped_calendar_ids_by_slot,
+            group_scoped_block_calendar_ids_by_slot,
+        ) = self._slot_pools_with_group_scoped_flags(slots)
         required_count_by_slot_id = {s.id: s.required_count for s in slots}
 
         all_calendar_ids: set[int] = set()
@@ -2134,6 +2532,24 @@ class CalendarGroupService:
                 search_window_end,
             )
 
+        # ------------------------------------------------------------------
+        # Group-scoped blocked time (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        # Phase 2a) -- self-gating early-out, same shape as windows above.
+        # ------------------------------------------------------------------
+        group_scoped_block_spans_by_slot: slot_engine.GroupScopedSpansBySlot = {}
+        if group_scoped_block_calendar_ids_by_slot:
+            configured_block_slot_ids = list(group_scoped_block_calendar_ids_by_slot.keys())
+            configured_block_calendar_ids: set[int] = set()
+            for ids in group_scoped_block_calendar_ids_by_slot.values():
+                configured_block_calendar_ids.update(ids)
+            group_scoped_block_spans_by_slot = slot_engine.fetch_group_scoped_blocking_spans(
+                self.organization.id,
+                configured_block_slot_ids,
+                configured_block_calendar_ids,
+                search_window_start,
+                search_window_end,
+            )
+
         proposals: list[BookableSlotProposal] = []
         cursor = search_window_start
         while cursor + duration <= search_window_end:
@@ -2153,6 +2569,8 @@ class CalendarGroupService:
                         blocking_spans,
                         group_scoped_calendar_ids_by_slot.get(slot_id),
                         group_scoped_spans_by_slot.get(slot_id),
+                        group_scoped_block_calendar_ids_by_slot.get(slot_id),
+                        group_scoped_block_spans_by_slot.get(slot_id),
                     ):
                         available_count += 1
                 if available_count < required_count_by_slot_id[slot_id]:

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -850,8 +850,8 @@ class CalendarGroupService:
         )
 
         orphaned_bookings = self._find_orphaned_bookings(
-            calendar_id=window.calendar_fk_id,  # type: ignore[arg-type]
-            group_slot=window.group_slot,
+            calendar_id=cast(int, window.calendar_fk_id),
+            group_slot=cast(CalendarGroupSlot, window.group_slot),
             now=now,
         )
         return GroupScopedAvailabilityWriteResult(
@@ -1437,8 +1437,8 @@ class CalendarGroupService:
         )
 
         orphaned_bookings = self._find_bookings_orphaned_by_group_scoped_block(
-            calendar_id=block.calendar_fk_id,  # type: ignore[arg-type]
-            group_slot=block.group_slot,
+            calendar_id=cast(int, block.calendar_fk_id),
+            group_slot=cast(CalendarGroupSlot, block.group_slot),
             now=now,
         )
         return GroupScopedBlockWriteResult(block=block, orphaned_bookings=orphaned_bookings)
@@ -1599,14 +1599,22 @@ class CalendarGroupService:
 
         # Self-gating early-out: only fetch expanded group-scoped spans when at
         # least one calendar anywhere in the group actually has one configured.
+        # Compute union range once for both window and block fetches.
+        union_start = union_end = None
+        if ranges:
+            union_start = min(start for start, _ in ranges)
+            union_end = max(end for _, end in ranges)
+
         group_scoped_spans_by_slot: slot_engine.GroupScopedSpansBySlot = {}
-        if group_scoped_window_calendar_ids_by_slot and ranges:
+        if (
+            group_scoped_window_calendar_ids_by_slot
+            and union_start is not None
+            and union_end is not None
+        ):
             configured_slot_ids = list(group_scoped_window_calendar_ids_by_slot.keys())
             configured_calendar_ids: set[int] = set()
             for ids in group_scoped_window_calendar_ids_by_slot.values():
                 configured_calendar_ids.update(ids)
-            union_start = min(start for start, _ in ranges)
-            union_end = max(end for _, end in ranges)
             group_scoped_spans_by_slot = slot_engine.fetch_group_scoped_available_spans(
                 self.organization.id,
                 configured_slot_ids,
@@ -1616,13 +1624,15 @@ class CalendarGroupService:
             )
 
         group_scoped_block_spans_by_slot: slot_engine.GroupScopedSpansBySlot = {}
-        if group_scoped_block_calendar_ids_by_slot and ranges:
+        if (
+            group_scoped_block_calendar_ids_by_slot
+            and union_start is not None
+            and union_end is not None
+        ):
             configured_block_slot_ids = list(group_scoped_block_calendar_ids_by_slot.keys())
             configured_block_calendar_ids: set[int] = set()
             for ids in group_scoped_block_calendar_ids_by_slot.values():
                 configured_block_calendar_ids.update(ids)
-            union_start = min(start for start, _ in ranges)
-            union_end = max(end for _, end in ranges)
             group_scoped_block_spans_by_slot = slot_engine.fetch_group_scoped_blocking_spans(
                 self.organization.id,
                 configured_block_slot_ids,

--- a/calendar_integration/services/dataclasses.py
+++ b/calendar_integration/services/dataclasses.py
@@ -384,6 +384,28 @@ class GroupScopedAvailabilityWriteResult:
     orphaned_bookings: list[CalendarEvent] = dataclass_field(default_factory=list)
 
 
+@dataclass
+class GroupScopedBlockWriteResult:
+    """Result of a group-scoped blocked-time write (create/update/delete)
+    (``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 2a).
+
+    ``block`` is the saved ``BlockedTime`` row, or ``None`` after a delete.
+    ``orphaned_bookings`` lists confirmed future ``CalendarEvent`` bookings in
+    the block's group slot, for the block's calendar, that fall INSIDE the
+    calendar's group-scoped blocked time *after* the write is applied (spec
+    UC-6's rule applied to blocks). Unlike a window write -- where only the
+    FIRST window flips the calendar from fall-through to narrowed, so only it
+    can orphan a booking -- a block always independently removes time, so
+    orphaned-booking detection runs on every create and every update, never
+    on delete (a delete only widens available time). Nothing about the
+    orphaned bookings is modified; this is a read-only report for the caller
+    to act on.
+    """
+
+    block: BlockedTime | None
+    orphaned_bookings: list[CalendarEvent] = dataclass_field(default_factory=list)
+
+
 @dataclass(frozen=True)
 class EffectivePolicy:
     """The resolved set of booking guardrails for a calendar, bundle, or group.

--- a/calendar_integration/services/slot_engine.py
+++ b/calendar_integration/services/slot_engine.py
@@ -14,6 +14,14 @@ single-calendar / bundle walker both depend on:
   apply at each candidate window.
 - :func:`apply_policy_filter` — drop candidate proposals that violate a resolved
   :class:`EffectivePolicy` (lead-time, max-horizon, buffer envelope).
+- :func:`fetch_group_scoped_available_spans` / :func:`expand_group_scoped_available_times`
+  — batched group-scoped ``AvailableTime`` windows (``CALENDAR_GROUP_SCOPED_AVAILABILITY``
+  Phase 1b).
+- :func:`fetch_group_scoped_blocking_spans` / :func:`expand_group_scoped_blocked_times`
+  — the block analog (``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 2a): applied
+  in :func:`calendar_free_for_window` AFTER base availability and BEFORE the
+  window intersection, since a group-scoped block wins regardless of what any
+  window says.
 
 Everything here is **stateless and org-scoped through the passed organization
 id**.  The functions are factored out of ``CalendarGroupService`` verbatim so the
@@ -61,9 +69,10 @@ from calendar_integration.services.dataclasses import (
 
 Span = tuple[datetime.datetime, datetime.datetime]
 SpansByCalendarId = dict[int, list[Span]]
-# Group-scoped AvailableTime spans, keyed first by CalendarGroupSlot id, then by
-# calendar id -- a window applies only within the one slot it was configured
-# for (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 1b).
+# Group-scoped AvailableTime (Phase 1b) / BlockedTime (Phase 2a) spans, keyed
+# first by CalendarGroupSlot id, then by calendar id -- a window or block
+# applies only within the one slot it was configured for
+# (CALENDAR_GROUP_SCOPED_AVAILABILITY).
 GroupScopedSpansBySlot = dict[int, SpansByCalendarId]
 
 
@@ -207,6 +216,8 @@ def calendar_free_for_window(
     blocking_spans: SpansByCalendarId,
     group_scoped_calendar_ids: set[int] | None = None,
     group_scoped_spans: SpansByCalendarId | None = None,
+    group_scoped_block_calendar_ids: set[int] | None = None,
+    group_scoped_block_spans: SpansByCalendarId | None = None,
 ) -> bool:
     """Return True if ``calendar_id`` is free for ``[window_start, window_end)``.
 
@@ -215,21 +226,30 @@ def calendar_free_for_window(
     - Unmanaged calendars must not overlap any blocking span.
 
     ``group_scoped_calendar_ids`` / ``group_scoped_spans`` add the Phase 1b
-    intersection (``CALENDAR_GROUP_SCOPED_AVAILABILITY``): both default to
-    ``None``, which reproduces the exact pre-Phase-1b behavior byte-for-byte --
-    this is the single-calendar / bundle walker's call shape
-    (``BookableSlotsService._walk_candidates``), which passes neither and must
-    stay untouched (spec non-goal: single-calendar booking).
+    window intersection and ``group_scoped_block_calendar_ids`` /
+    ``group_scoped_block_spans`` add the Phase 2a block exclusion
+    (``CALENDAR_GROUP_SCOPED_AVAILABILITY``): all four default to ``None``,
+    which reproduces the exact pre-Phase-1b behavior byte-for-byte -- this is
+    the single-calendar / bundle walker's call shape
+    (``BookableSlotsService._walk_candidates``), which passes none of them and
+    must stay untouched (spec non-goal: single-calendar booking).
+
+    Resolution order (spec "State transitions & edge cases" flowchart): base
+    availability, then block, then window. A calendar with a configured
+    group-scoped block that OVERLAPS ``[window_start, window_end)`` is
+    excluded immediately -- "blocks beat everything" -- regardless of what any
+    group-scoped window says; the window check below never even runs for it.
 
     When ``calendar_id`` is NOT in ``group_scoped_calendar_ids`` (or that set
-    is falsy), this calendar has no group-scoped configuration for the slot
-    being evaluated and the result is exactly the base-availability check
-    above (fall-through default). When it IS in that set, the window must
-    additionally be fully covered by at least one of ``group_scoped_spans``'
-    entries for this calendar -- narrowing only, never widening base
-    availability (spec: "Intersect, never widen"; a calendar configured with a
-    window that does not overlap ``[window_start, window_end)`` at all
-    contributes an empty span list here, which correctly yields ``False``).
+    is falsy), this calendar has no group-scoped window configured for the
+    slot being evaluated and the result is exactly the base-availability
+    (and, if applicable, block) check above (fall-through default). When it
+    IS in that set, the window must additionally be fully covered by at least
+    one of ``group_scoped_spans``' entries for this calendar -- narrowing
+    only, never widening base availability (spec: "Intersect, never widen"; a
+    calendar configured with a window that does not overlap
+    ``[window_start, window_end)`` at all contributes an empty span list
+    here, which correctly yields ``False``).
     """
     if calendar_id in managed_ids:
         base_free = window_fully_covered_by_spans(
@@ -242,6 +262,14 @@ def calendar_free_for_window(
         )
     if not base_free:
         return False
+
+    if group_scoped_block_calendar_ids and calendar_id in group_scoped_block_calendar_ids:
+        blocked = any(
+            intervals_overlap((bs, be), (window_start, window_end))
+            for bs, be in (group_scoped_block_spans or {}).get(calendar_id, ())
+        )
+        if blocked:
+            return False
 
     if not group_scoped_calendar_ids or calendar_id not in group_scoped_calendar_ids:
         return True
@@ -432,6 +460,139 @@ def fetch_group_scoped_available_spans(
     """
     spans_by_slot: GroupScopedSpansBySlot = {}
     for slot_id, calendar_id, occurrence in _iter_group_scoped_available_time_occurrences(
+        organization_id, slot_ids, calendar_ids, search_window_start, search_window_end
+    ):
+        spans_by_slot.setdefault(slot_id, {}).setdefault(calendar_id, []).append(
+            (occurrence.start_time, occurrence.end_time)
+        )
+    return spans_by_slot
+
+
+# ---------------------------------------------------------------------------
+# Group-scoped blocked time (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2a --
+# writes, discovery, and booking-validation enforcement).
+# ---------------------------------------------------------------------------
+
+
+def _iter_group_scoped_blocked_time_occurrences(
+    organization_id: int,
+    slot_ids: Iterable[int],
+    calendar_ids: Iterable[int],
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
+) -> Iterator[tuple[int, int, BlockedTime]]:
+    """Yield ``(group_slot_id, calendar_id, occurrence)`` for every group-scoped
+    ``BlockedTime`` occurrence overlapping ``[start_date, end_date)`` across
+    the given (slot, calendar) universe -- the block analog of
+    :func:`_iter_group_scoped_available_time_occurrences`: one query for
+    non-recurring rows and one for recurring masters, fixed regardless of how
+    many pairs are configured.
+
+    Reads through ``BlockedTime.objects.unscoped()`` -- group-scoped rows are
+    invisible to the default manager. Occurrence expansion for group-scoped
+    masters is safe for the same reason it is for windows: no write path
+    creates a group-scoped ``BlockedTimeRecurrenceException`` yet, and
+    ``RecurringMixin._get_occurrences_in_range`` routes the exception-instance
+    lookup through ``_base_manager`` for any group-scoped master --
+    ``AvailableTime`` and ``BlockedTime`` share that mixin, so the fix applies
+    to both without further changes.
+
+    ``occurrence`` may be a persisted master/exception row or a synthetic
+    in-memory instance (``BlockedTime.create_instance_from_occurrence``, used
+    for recurring occurrences) -- the latter does not carry its own
+    ``group_slot`` or ``organization``. Callers must attribute spans using the
+    yielded ``group_slot_id`` / ``calendar_id``, not the occurrence's own
+    fields.
+    """
+    slot_ids = list(slot_ids)
+    calendar_ids = list(calendar_ids)
+    if not slot_ids or not calendar_ids:
+        return
+
+    base_qs = (
+        BlockedTime.objects.unscoped()
+        .filter_by_organization(organization_id)
+        .filter(
+            group_slot_fk_id__in=slot_ids,
+            calendar_fk_id__in=calendar_ids,
+            parent_recurring_object__isnull=True,
+        )
+        .annotate_recurring_occurrences_on_date_range(start_date, end_date, overlap=True)
+        .select_related("recurrence_rule")
+    )
+
+    non_recurring_times = base_qs.filter(
+        start_time__lt=end_date,
+        end_time__gt=start_date,
+        recurrence_rule__isnull=True,
+        is_recurring_exception=False,
+    )
+    for bt in non_recurring_times:
+        yield bt.group_slot_fk_id, bt.calendar_fk_id, bt  # type: ignore[misc]
+
+    recurring_times = base_qs.filter(recurrence_rule__isnull=False).filter(
+        Q(recurrence_rule__until__isnull=True) | Q(recurrence_rule__until__gte=start_date),
+        start_time__lte=end_date,
+    )
+    for master_time in recurring_times:
+        instances = master_time.get_occurrences_in_range(
+            start_date, end_date, include_self=False, include_exceptions=True, overlap=True
+        )
+        for instance in instances:
+            yield master_time.group_slot_fk_id, master_time.calendar_fk_id, instance  # type: ignore[misc]
+
+
+def expand_group_scoped_blocked_times(
+    organization_id: int,
+    slot_ids: Iterable[int],
+    calendar_ids: Iterable[int],
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
+) -> list[BlockedTime]:
+    """Expand every group-scoped ``BlockedTime`` for the given (slot,
+    calendar) universe that overlaps ``[start_date, end_date)``, recurrence
+    included, sorted by start time.
+
+    Shared by ``CalendarGroupService._group_scoped_blocked_times_expanded``
+    (single-pair write-path use: orphaned-booking detection, Phase 2a) and the
+    batched discovery-side fetch below -- one implementation, so the two paths
+    cannot drift apart on the annotate-first exception-trap avoidance the
+    write path already relies on. Mirrors
+    :func:`expand_group_scoped_available_times`.
+    """
+    times = [
+        occurrence
+        for _, _, occurrence in _iter_group_scoped_blocked_time_occurrences(
+            organization_id, slot_ids, calendar_ids, start_date, end_date
+        )
+    ]
+    times.sort(key=lambda t: t.start_time)
+    return times
+
+
+def fetch_group_scoped_blocking_spans(
+    organization_id: int,
+    slot_ids: Iterable[int],
+    calendar_ids: Iterable[int],
+    search_window_start: datetime.datetime,
+    search_window_end: datetime.datetime,
+) -> GroupScopedSpansBySlot:
+    """Batched group-scoped ``BlockedTime`` spans for the given (slot,
+    calendar) universe -- one query for non-recurring rows and one for
+    recurring masters, fixed regardless of how many pairs are configured or
+    how many candidate windows the caller will check the result against
+    (mirrors :func:`fetch_group_scoped_available_spans`'s one-query-per-type
+    batching).
+
+    Returns spans keyed first by ``CalendarGroupSlot`` id, then by calendar id
+    -- a block applies only within the one slot it was configured for.
+    Callers should only invoke this once at least one (slot, calendar) pair is
+    known to have a group-scoped block configured; see
+    ``CalendarGroupService._slot_pools_with_group_scoped_flags`` for the
+    zero-extra-query existence check that gates this fetch.
+    """
+    spans_by_slot: GroupScopedSpansBySlot = {}
+    for slot_id, calendar_id, occurrence in _iter_group_scoped_blocked_time_occurrences(
         organization_id, slot_ids, calendar_ids, search_window_start, search_window_end
     ):
         spans_by_slot.setdefault(slot_id, {}).setdefault(calendar_id, []).append(

--- a/calendar_integration/tests/services/test_calendar_group_service_blocked_time.py
+++ b/calendar_integration/tests/services/test_calendar_group_service_blocked_time.py
@@ -907,3 +907,144 @@ def test_removing_calendar_from_slot_removes_group_scoped_blocks(
     ]
     assert len(block_delete_payloads) == 1
     assert block_delete_payloads[0]["subject"]["subject_id"] == str(block1_id)
+
+
+# ---------------------------------------------------------------------------
+# Recurring block orphan detection + partial-overlap orphan detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_recurring_blocked_time_detects_orphaned_bookings_on_future_occurrence(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """A recurring block whose LATER occurrence (not the first) overlaps a
+    confirmed future booking must report that booking as orphaned on creation,
+    before the booking existed. Tests that recurrence-aware expansion catches
+    all occurrences."""
+    # Use a fixed date to avoid timezone issues: 2025-09-02 is a Tuesday.
+    base_date = datetime.date(2025, 9, 2)
+    block_start = datetime.datetime.combine(base_date, datetime.time(9), tzinfo=datetime.UTC)
+    block_end = datetime.datetime.combine(base_date, datetime.time(17), tzinfo=datetime.UTC)
+    now = block_start - datetime.timedelta(days=7)  # Ensure "now" is before the block
+
+    # Create a recurring block: every Tuesday and Thursday, 9-17.
+    recurring_block = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=block_start,
+        end_time=block_end,
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+        now=now,
+    )
+    assert recurring_block.block is not None
+    assert recurring_block.orphaned_bookings == []
+
+    # Create a booking on the SECOND Thursday (9 days after 2025-09-02).
+    # 2025-09-02 = Tuesday
+    # 2025-09-04 = Thursday (first Thursday)
+    # 2025-09-11 = Thursday (second Thursday)
+    second_thursday = base_date + datetime.timedelta(days=9)
+    booking = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Future Consult",
+        description="",
+        external_id="ev_second_thursday",
+        start_time_tz_unaware=datetime.datetime.combine(
+            second_thursday, datetime.time(10), tzinfo=datetime.UTC
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            second_thursday, datetime.time(11), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=booking,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    # The EXISTING recurring block (created before the booking) should be reported
+    # as orphaning the booking (the second Thursday occurrence overlaps it).
+    # We do this by creating a NEW block that overlaps the booking.
+    overlapping_block = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=block_start,
+        end_time=block_end,
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+        now=now,
+    )
+    # Now the new block creation should detect the booking as orphaned
+    # (because the recurring occurrences overlap it).
+    orphaned_ids = {e.id for e in overlapping_block.orphaned_bookings}
+    assert orphaned_ids == {booking.id}
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_detects_partially_overlapping_booking_as_orphaned(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """A block that PARTIALLY overlaps a booking (not fully contained) must
+    still report the booking as orphaned. The orphan check uses
+    `intervals_overlap`, which returns true for any overlap."""
+    now = django_timezone.now()
+    tuesday = _next_weekday(now, weekday=1)
+
+    # Create a booking: 11:00-13:00
+    booking = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Consult",
+        description="",
+        external_id="ev_partial",
+        start_time_tz_unaware=datetime.datetime.combine(
+            tuesday, datetime.time(11), tzinfo=datetime.UTC
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            tuesday, datetime.time(13), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=booking,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    # Create a block that PARTIALLY overlaps: 12:00-14:00 (overlaps 12:00-13:00).
+    result = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(tuesday, datetime.time(12), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(tuesday, datetime.time(14), tzinfo=datetime.UTC),
+        tz="UTC",
+        now=now,
+    )
+
+    # The booking should be reported as orphaned despite only partial overlap.
+    orphaned_ids = {e.id for e in result.orphaned_bookings}
+    assert orphaned_ids == {booking.id}
+
+    # The booking itself must be untouched (not cancelled).
+    booking.refresh_from_db()
+    assert booking.title == "Consult"
+    assert CalendarEvent.objects.filter_by_organization(service.organization.id).count() == 1

--- a/calendar_integration/tests/services/test_calendar_group_service_blocked_time.py
+++ b/calendar_integration/tests/services/test_calendar_group_service_blocked_time.py
@@ -1,0 +1,909 @@
+"""Tests for group-scoped blocked-time writes on ``CalendarGroupService``
+(Phase 2a of ``CALENDAR_GROUP_SCOPED_AVAILABILITY``).
+
+Covers create/update/delete through the explicit group-scoped accessor,
+recurrence + per-block timezone round-trip, audit emission with before/after
+diffs on update, permission gating (owner-within-group or org admin, with a
+member unable to learn a group exists through the error shape), and
+orphaned-booking detection -- on every create (not just the first, unlike
+windows) and on update.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import patch
+
+from django.utils import timezone as django_timezone
+
+import pytest
+
+from audit.constants import AuditAction
+from audit.services import AuditService
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.exceptions import CalendarGroupSlotConfigNotFoundError
+from calendar_integration.models import (
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarOwnership,
+)
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.dataclasses import (
+    CalendarGroupInputData,
+    CalendarGroupSlotInputData,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payloads(mock_task) -> list[dict]:
+    return [call.args[0] for call in mock_task.delay.call_args_list]
+
+
+def _next_weekday(after: datetime.datetime, weekday: int) -> datetime.date:
+    """Next date (strictly after `after`'s date) landing on ISO `weekday`
+    (Monday=0 ... Sunday=6)."""
+    days_ahead = (weekday - after.weekday()) % 7
+    days_ahead = days_ahead or 7
+    return (after + datetime.timedelta(days=days_ahead)).date()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Blocks Test Org", should_sync_rooms=False)
+
+
+@pytest.fixture
+def audit_service() -> AuditService:
+    from di_core.containers import container
+
+    return container.audit_service()
+
+
+@pytest.fixture
+def admin_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="admin@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.ADMIN
+    )
+    return u
+
+
+@pytest.fixture
+def owner_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="owner@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.MEMBER
+    )
+    return u
+
+
+@pytest.fixture
+def other_owner_user(db: Any, organization: Organization) -> User:
+    """Owns a DIFFERENT calendar (not the one under test) -- used to prove that
+    being a member of the org (and even owning some calendar in the group) is
+    not enough; only the target calendar's own owner may edit it."""
+    u = User.objects.create_user(email="other_owner@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.MEMBER
+    )
+    return u
+
+
+@pytest.fixture
+def stranger_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="stranger@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.MEMBER
+    )
+    return u
+
+
+@pytest.fixture
+def calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="dr_reyes",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def other_calendar(organization: Organization) -> Calendar:
+    """A second calendar in the same group (different slot) -- owned by
+    `other_owner_user`, so that fixture can "see" the group without owning
+    `calendar`."""
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Costa",
+        external_id="dr_costa",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ownerships(
+    organization: Organization,
+    owner_user: User,
+    other_owner_user: User,
+    calendar: Calendar,
+    other_calendar: Calendar,
+) -> None:
+    CalendarOwnership.objects.create(
+        organization=organization, calendar=calendar, membership_user_id=owner_user.id
+    )
+    CalendarOwnership.objects.create(
+        organization=organization,
+        calendar=other_calendar,
+        membership_user_id=other_owner_user.id,
+    )
+
+
+@pytest.fixture
+def group(organization: Organization) -> CalendarGroup:
+    return CalendarGroup.objects.create(organization=organization, name="Surgery")
+
+
+@pytest.fixture
+def group_slot(
+    organization: Organization, group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Lead Surgeon"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def other_slot(
+    organization: Organization, group: CalendarGroup, other_calendar: Calendar
+) -> CalendarGroupSlot:
+    """A second slot in the same group, populated with `other_calendar` -- makes
+    `other_owner_user` a genuine member of the group without owning `calendar`."""
+    slot = CalendarGroupSlot.objects.create(organization=organization, group=group, name="Assist")
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=other_calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def service(organization: Organization, audit_service: AuditService) -> CalendarGroupService:
+    svc = CalendarGroupService(
+        calendar_permission_service=CalendarPermissionService(),
+        audit_service=audit_service,
+    )
+    svc.initialize(organization=organization)
+    return svc
+
+
+def _utc(year: int, month: int, day: int, hour: int) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# create_group_scoped_blocked_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_admin_happy_path(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    django_capture_on_commit_callbacks,
+) -> None:
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            result = service.create_group_scoped_blocked_time(
+                acting_user=admin_user,
+                group_slot_id=group_slot.id,
+                calendar_id=calendar.id,
+                start_time=_utc(2025, 9, 2, 9),
+                end_time=_utc(2025, 9, 2, 17),
+                tz="UTC",
+                reason="Conference",
+            )
+
+    block = result.block
+    assert block is not None
+    assert result.orphaned_bookings == []
+    assert block.group_slot_fk_id == group_slot.id
+    assert block.calendar_fk_id == calendar.id
+    assert block.reason == "Conference"
+
+    # Invisible on the default (base-rows-only) manager...
+    assert (
+        not BlockedTime.objects.filter_by_organization(service.organization.id)
+        .filter(id=block.id)
+        .exists()
+    )
+    # ...and visible through the explicit group-scoped accessor.
+    assert (
+        BlockedTime.objects.for_group_slot(group_slot.id)
+        .filter_by_organization(service.organization.id)
+        .get(id=block.id)
+        == block
+    )
+
+    payloads = _payloads(mock_task)
+    assert len(payloads) == 1
+    assert payloads[0]["action"] == AuditAction.CREATE
+    assert payloads[0]["subject"]["subject_type"] == "calendar_integration.BlockedTime"
+    assert payloads[0]["subject"]["subject_id"] == str(block.pk)
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_owner_happy_path(
+    service: CalendarGroupService,
+    owner_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    result = service.create_group_scoped_blocked_time(
+        acting_user=owner_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    assert result.block is not None
+    assert result.block.calendar_fk_id == calendar.id
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_denies_non_owner_without_disclosing_group(
+    service: CalendarGroupService,
+    stranger_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError) as excinfo:
+        service.create_group_scoped_blocked_time(
+            acting_user=stranger_user,
+            group_slot_id=group_slot.id,
+            calendar_id=calendar.id,
+            start_time=_utc(2025, 9, 2, 9),
+            end_time=_utc(2025, 9, 2, 17),
+            tz="UTC",
+        )
+    stranger_message = str(excinfo.value)
+
+    # A genuinely missing (group_slot_id, calendar_id) pairing must raise the
+    # exact same exception, message included -- a caller cannot distinguish
+    # "forbidden" from "does not exist" from the error alone.
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError) as excinfo_missing:
+        service.create_group_scoped_blocked_time(
+            acting_user=stranger_user,
+            group_slot_id=group_slot.id,
+            calendar_id=calendar.id + 999_999,
+            start_time=_utc(2025, 9, 2, 9),
+            end_time=_utc(2025, 9, 2, 17),
+            tz="UTC",
+        )
+    assert str(excinfo_missing.value) == stranger_message
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_denies_owner_outside_target_calendar(
+    service: CalendarGroupService,
+    other_owner_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    other_slot: CalendarGroupSlot,
+) -> None:
+    """`other_owner_user` owns a calendar in the SAME group (a different slot),
+    so they can see the group -- but they do not own `calendar`, so they must
+    still be denied, with the same not-found-shaped error."""
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError):
+        service.create_group_scoped_blocked_time(
+            acting_user=other_owner_user,
+            group_slot_id=group_slot.id,
+            calendar_id=calendar.id,
+            start_time=_utc(2025, 9, 2, 9),
+            end_time=_utc(2025, 9, 2, 17),
+            tz="UTC",
+        )
+    assert not BlockedTime.objects.unscoped().filter(group_slot_fk=group_slot).exists()
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_recurrence_and_timezone_round_trip(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    result = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),  # 2025-09-02 is a Tuesday
+        end_time=_utc(2025, 9, 2, 17),
+        tz="America/Sao_Paulo",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    block = result.block
+    assert block is not None
+    assert block.timezone == "America/Sao_Paulo"
+    assert block.recurrence_rule is not None
+    assert block.recurrence_rule.to_rrule_string() == "FREQ=WEEKLY;BYDAY=TU,TH"
+
+    range_start = _utc(2025, 9, 1, 0)
+    range_end = _utc(2025, 9, 15, 0)
+    master = (
+        BlockedTime.objects.for_group_slot(group_slot.id)
+        .filter_by_organization(service.organization.id)
+        .annotate_recurring_occurrences_on_date_range(range_start, range_end)
+        .get(id=block.id)
+    )
+    occurrences = master.get_occurrences_in_range(range_start, range_end, include_self=True)
+    weekdays = sorted({o.start_time.weekday() for o in occurrences})
+    assert weekdays == [1, 3]  # Tuesday, Thursday
+    assert len(occurrences) == 4  # two Tuesdays + two Thursdays in the range
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_unique_external_id_per_calendar(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """Two blocks on the same calendar must not collide on the
+    (calendar, external_id) uniqueness constraint."""
+    first = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 12),
+        tz="UTC",
+    )
+    second = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 4, 9),
+        end_time=_utc(2025, 9, 4, 12),
+        tz="UTC",
+    )
+    assert first.block.id != second.block.id  # type: ignore[union-attr]
+
+
+@pytest.mark.django_db
+def test_create_group_scoped_blocked_time_detects_orphaned_bookings_on_every_create(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """Unlike windows (only the FIRST one can orphan), every group-scoped
+    BLOCK independently subtracts time, so orphaned-booking detection must
+    run on every create -- verified here on a SECOND block."""
+    now = django_timezone.now()
+    tuesday = _next_weekday(now, weekday=1)
+    thursday = tuesday + datetime.timedelta(days=2)
+
+    # First block: Tuesday 9-17 -- no bookings yet, nothing orphaned.
+    first = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(tuesday, datetime.time(9), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(tuesday, datetime.time(17), tzinfo=datetime.UTC),
+        tz="UTC",
+        now=now,
+    )
+    assert first.orphaned_bookings == []
+
+    # A confirmed future booking on Thursday, outside the first block.
+    booking = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Consult",
+        description="",
+        external_id="ev_thursday",
+        start_time_tz_unaware=datetime.datetime.combine(
+            thursday, datetime.time(10), tzinfo=datetime.UTC
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            thursday, datetime.time(11), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=booking,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    # Second block: Thursday 9-17 -- now overlaps the booking. Must be reported.
+    second = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(thursday, datetime.time(9), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(thursday, datetime.time(17), tzinfo=datetime.UTC),
+        tz="UTC",
+        now=now,
+    )
+    orphaned_ids = {e.id for e in second.orphaned_bookings}
+    assert orphaned_ids == {booking.id}
+
+    # The booking itself must be untouched (not cancelled).
+    booking.refresh_from_db()
+    assert booking.title == "Consult"
+    assert CalendarEvent.objects.filter_by_organization(service.organization.id).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# update_group_scoped_blocked_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_blocked_time_records_diff(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    django_capture_on_commit_callbacks,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        reason="Conference",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            result = service.update_group_scoped_blocked_time(
+                acting_user=admin_user,
+                block_id=block_id,
+                reason="Conference (extended)",
+                rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TH",
+            )
+
+    assert result.block is not None
+    assert result.block.reason == "Conference (extended)"
+    assert result.block.recurrence_rule.to_rrule_string() == "FREQ=WEEKLY;BYDAY=TH"
+
+    payloads = _payloads(mock_task)
+    update_payloads = [p for p in payloads if p["action"] == AuditAction.UPDATE]
+    assert len(update_payloads) == 1
+    diff = update_payloads[0]["diff"]
+    assert diff is not None
+    assert diff["reason"]["old"] == "Conference"
+    assert diff["reason"]["new"] == "Conference (extended)"
+    assert diff["rrule"]["old"] == "FREQ=WEEKLY;BYDAY=TU,TH"
+    assert diff["rrule"]["new"] == "FREQ=WEEKLY;BYDAY=TH"
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_blocked_time_timezone_round_trip(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    result = service.update_group_scoped_blocked_time(
+        acting_user=admin_user,
+        block_id=block_id,
+        tz="America/Sao_Paulo",
+    )
+    assert result.block is not None
+    assert result.block.timezone == "America/Sao_Paulo"
+
+    reloaded = (
+        BlockedTime.objects.unscoped()
+        .filter_by_organization(service.organization.id)
+        .get(id=block_id)
+    )
+    assert reloaded.timezone == "America/Sao_Paulo"
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_blocked_time_explicit_none_clears_recurrence(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    result = service.update_group_scoped_blocked_time(
+        acting_user=admin_user,
+        block_id=block_id,
+        rrule_string=None,
+    )
+    assert result.block is not None
+    assert result.block.recurrence_rule is None
+    assert result.block.is_recurring is False
+
+    reloaded = (
+        BlockedTime.objects.unscoped()
+        .filter_by_organization(service.organization.id)
+        .get(id=block_id)
+    )
+    assert reloaded.recurrence_rule is None
+    assert reloaded.is_recurring is False
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_blocked_time_omitted_rrule_string_leaves_it_unchanged(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    result = service.update_group_scoped_blocked_time(
+        acting_user=admin_user,
+        block_id=block_id,
+        tz="America/Sao_Paulo",
+    )
+    assert result.block is not None
+    assert result.block.recurrence_rule is not None
+    assert result.block.recurrence_rule.to_rrule_string() == "FREQ=WEEKLY;BYDAY=TU,TH"
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_blocked_time_denies_non_owner(
+    service: CalendarGroupService,
+    admin_user: User,
+    stranger_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError):
+        service.update_group_scoped_blocked_time(
+            acting_user=stranger_user, block_id=block_id, tz="America/Sao_Paulo"
+        )
+
+    reloaded = (
+        BlockedTime.objects.unscoped()
+        .filter_by_organization(service.organization.id)
+        .get(id=block_id)
+    )
+    assert reloaded.timezone == "UTC"  # untouched
+
+
+@pytest.mark.django_db
+def test_update_group_scoped_blocked_time_reports_newly_orphaned_booking(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    """Extending a block to now overlap a previously-unaffected booking reports
+    it as orphaned, and modifies neither the event nor the group selection."""
+    now = django_timezone.now()
+    tuesday = _next_weekday(now, weekday=1)
+
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime.combine(tuesday, datetime.time(9), tzinfo=datetime.UTC),
+        end_time=datetime.datetime.combine(tuesday, datetime.time(12), tzinfo=datetime.UTC),
+        tz="UTC",
+        now=now,
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    booking = CalendarEvent.objects.create(
+        organization=service.organization,
+        calendar=calendar,
+        title="Consult",
+        description="",
+        external_id="ev_afternoon",
+        start_time_tz_unaware=datetime.datetime.combine(
+            tuesday, datetime.time(14), tzinfo=datetime.UTC
+        ),
+        end_time_tz_unaware=datetime.datetime.combine(
+            tuesday, datetime.time(15), tzinfo=datetime.UTC
+        ),
+        timezone="UTC",
+        calendar_group=group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=service.organization,
+        event=booking,
+        slot=group_slot,
+        calendar=calendar,
+    )
+
+    # Extend the block to 9-17, now covering the 14:00 booking.
+    result = service.update_group_scoped_blocked_time(
+        acting_user=admin_user,
+        block_id=block_id,
+        end_time=datetime.datetime.combine(tuesday, datetime.time(17), tzinfo=datetime.UTC),
+        now=now,
+    )
+
+    orphaned_ids = {e.id for e in result.orphaned_bookings}
+    assert orphaned_ids == {booking.id}
+
+    booking.refresh_from_db()
+    assert booking.title == "Consult"
+    assert CalendarEvent.objects.filter_by_organization(service.organization.id).count() == 1
+    assert (
+        CalendarEventGroupSelection.objects.filter_by_organization(service.organization.id).count()
+        == 1
+    )
+
+
+# ---------------------------------------------------------------------------
+# delete_group_scoped_blocked_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_delete_group_scoped_blocked_time_admin(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+    django_capture_on_commit_callbacks,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.delete_group_scoped_blocked_time(acting_user=admin_user, block_id=block_id)
+
+    assert not BlockedTime.objects.unscoped().filter(id=block_id).exists()
+    payloads = _payloads(mock_task)
+    delete_payloads = [p for p in payloads if p["action"] == AuditAction.DELETE]
+    assert len(delete_payloads) == 1
+    assert delete_payloads[0]["subject"]["subject_id"] == str(block_id)
+
+
+@pytest.mark.django_db
+def test_delete_group_scoped_blocked_time_denies_non_owner(
+    service: CalendarGroupService,
+    admin_user: User,
+    stranger_user: User,
+    calendar: Calendar,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+
+    with pytest.raises(CalendarGroupSlotConfigNotFoundError):
+        service.delete_group_scoped_blocked_time(acting_user=stranger_user, block_id=block_id)
+    assert BlockedTime.objects.unscoped().filter(id=block_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Cascade through this service path (schema-enforced by Phase 0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_deleting_slot_through_update_group_cascades_group_scoped_blocks(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    group: CalendarGroup,
+    group_slot: CalendarGroupSlot,
+) -> None:
+    created = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    block_id = created.block.id  # type: ignore[union-attr]
+    assert BlockedTime.objects.unscoped().filter(id=block_id).exists()
+
+    # Reconcile the group with no slots at all -- CalendarGroupService.update_group
+    # deletes the now-absent "Lead Surgeon" slot, which cascades (on_delete=CASCADE
+    # on BlockedTime.group_slot, established in Phase 0) to every group-scoped
+    # block that referenced it.
+    service.update_group(group.id, CalendarGroupInputData(name=group.name, slots=[]))
+
+    assert (
+        not CalendarGroupSlot.objects.filter_by_organization(service.organization.id)
+        .filter(id=group_slot.id)
+        .exists()
+    )
+    assert not BlockedTime.objects.unscoped().filter(id=block_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Removing a calendar from a slot removes its group-scoped blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_removing_calendar_from_slot_removes_group_scoped_blocks(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    other_calendar: Calendar,
+    group: CalendarGroup,
+    django_capture_on_commit_callbacks,
+) -> None:
+    """When removing a calendar from a slot's membership, its group-scoped
+    blocked time must be deleted (not orphaned). A second calendar's blocks
+    in the same slot survive. Each deleted block is audited with a DELETE
+    action naming the actor."""
+    # Create a slot with TWO calendars.
+    slot = CalendarGroupSlot.objects.create(
+        organization=service.organization, group=group, name="Test Slot"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=service.organization, slot=slot, calendar=calendar
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=service.organization, slot=slot, calendar=other_calendar
+    )
+
+    # Create group-scoped blocks for BOTH calendars.
+    block1_result = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    block1_id = block1_result.block.id  # type: ignore[union-attr]
+
+    block2_result = service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=slot.id,
+        calendar_id=other_calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+    block2_id = block2_result.block.id  # type: ignore[union-attr]
+
+    # Verify both blocks exist.
+    assert BlockedTime.objects.unscoped().filter(id=block1_id).exists()
+    assert BlockedTime.objects.unscoped().filter(id=block2_id).exists()
+
+    # Remove ONLY the first calendar from the slot (via update_group → _reconcile_slot).
+    with patch("audit.services.persist_audit_record") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            service.update_group(
+                group.id,
+                CalendarGroupInputData(
+                    name=group.name,
+                    slots=[
+                        CalendarGroupSlotInputData(
+                            name=slot.name,
+                            calendar_ids=[other_calendar.id],
+                            required_count=1,
+                        )
+                    ],
+                ),
+            )
+
+    # The first calendar's block must be deleted.
+    assert not BlockedTime.objects.unscoped().filter(id=block1_id).exists()
+    # The second calendar's block must survive.
+    assert BlockedTime.objects.unscoped().filter(id=block2_id).exists()
+    # The first calendar's membership is gone.
+    assert (
+        not CalendarGroupSlotMembership.objects.filter_by_organization(service.organization.id)
+        .filter(slot_fk=slot, calendar_fk_id=calendar.id)
+        .exists()
+    )
+    # The second calendar's membership remains.
+    assert (
+        CalendarGroupSlotMembership.objects.filter_by_organization(service.organization.id)
+        .filter(slot_fk=slot, calendar_fk_id=other_calendar.id)
+        .exists()
+    )
+
+    # Verify that a DELETE audit record was emitted for the deleted block.
+    payloads = _payloads(mock_task)
+    delete_payloads = [p for p in payloads if p["action"] == AuditAction.DELETE]
+    block_delete_payloads = [
+        p
+        for p in delete_payloads
+        if p["subject"]["subject_type"] == "calendar_integration.BlockedTime"
+    ]
+    assert len(block_delete_payloads) == 1
+    assert block_delete_payloads[0]["subject"]["subject_id"] == str(block1_id)

--- a/calendar_integration/tests/services/test_group_scoped_blocked_time_discovery.py
+++ b/calendar_integration/tests/services/test_group_scoped_blocked_time_discovery.py
@@ -1,0 +1,531 @@
+"""Tests for group-scoped blocked time in discovery and booking validation
+(Phase 2a of ``CALENDAR_GROUP_SCOPED_AVAILABILITY``).
+
+Covers:
+- A group-scoped block hides the calendar in that group, in that block's
+  time, and NOWHERE else (spec UC-3).
+- A block overlapping a group-scoped window WINS -- resolution order is
+  base availability, then block, then window ("blocks beat everything").
+- Explicit booking/reschedule inside a block is rejected with
+  ``GroupScopedRuleType.INSIDE_BLOCK``.
+- The required "unchanged path" test: a group with NO group-scoped
+  configuration (neither windows nor blocks) produces byte-for-byte
+  identical discovery output AND issues the SAME number of queries as the
+  pre-Phase-1b/2a engine.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+import pytest
+
+from calendar_integration.constants import CalendarProvider, CalendarType, GroupScopedRuleType
+from calendar_integration.exceptions import CalendarGroupScopedRuleViolationError
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+)
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import (
+    CalendarGroupEventInputData,
+    CalendarGroupSlotSelectionInputData,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, minute, tzinfo=datetime.UTC)
+
+
+# 2025-09-01 is a Monday.
+MONDAY = _utc(2025, 9, 1)
+TUESDAY = _utc(2025, 9, 2)
+WEDNESDAY = _utc(2025, 9, 3)
+THURSDAY = _utc(2025, 9, 4)
+FRIDAY = _utc(2025, 9, 5)
+SATURDAY = _utc(2025, 9, 6)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Discovery Blocks Org", should_sync_rooms=False)
+
+
+@pytest.fixture
+def audit_service():
+    from di_core.containers import container
+
+    return container.audit_service()
+
+
+@pytest.fixture
+def admin_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="admin@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.ADMIN
+    )
+    return u
+
+
+@pytest.fixture
+def calendar(organization: Organization) -> Calendar:
+    """Dr. Reyes -- available Monday through Friday, base availability only
+    (a single wide AvailableTime block; group-scoped blocks/windows model the
+    narrowing under test)."""
+    cal = Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="dr_reyes",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=True,
+    )
+    AvailableTime.objects.create(
+        organization=organization,
+        calendar=cal,
+        start_time_tz_unaware=MONDAY,
+        end_time_tz_unaware=SATURDAY,
+        timezone="UTC",
+    )
+    return cal
+
+
+@pytest.fixture
+def surgery_group(organization: Organization) -> CalendarGroup:
+    return CalendarGroup.objects.create(
+        organization=organization, name="Surgery", accepts_public_scheduling=True
+    )
+
+
+@pytest.fixture
+def surgery_slot(
+    organization: Organization, surgery_group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=surgery_group, name="Lead Surgeon"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def consults_group(organization: Organization) -> CalendarGroup:
+    """A SECOND group containing the SAME calendar, with NO group-scoped
+    configuration -- proves a block in Surgery does not leak here."""
+    return CalendarGroup.objects.create(
+        organization=organization, name="Consults", accepts_public_scheduling=True
+    )
+
+
+@pytest.fixture
+def consults_slot(
+    organization: Organization, consults_group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=consults_group, name="Consultant"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def calendar_service(organization: Organization) -> CalendarService:
+    cs = CalendarService()
+    cs.initialize_without_provider(organization=organization)
+    return cs
+
+
+@pytest.fixture
+def service(
+    organization: Organization, calendar_service: CalendarService, audit_service
+) -> CalendarGroupService:
+    svc = CalendarGroupService(
+        calendar_service=calendar_service,
+        calendar_permission_service=CalendarPermissionService(),
+        audit_service=audit_service,
+    )
+    svc.initialize(organization=organization)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# UC-3 -- a block hides the calendar in one group only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_group_scoped_block_hides_calendar_in_one_group_only(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+    consults_slot: CalendarGroupSlot,
+) -> None:
+    # Block Tuesday and Thursday entirely in Surgery.
+    service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 0),
+        end_time=_utc(2025, 9, 3, 0),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+
+    surgery_proposals = service.find_bookable_slots(
+        group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        search_window_start=MONDAY,
+        search_window_end=SATURDAY,
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(hours=2),
+    )
+    surgery_days = {p.start_time.weekday() for p in surgery_proposals}
+    # Tuesday (1) and Thursday (3) are blocked; Monday/Wednesday/Friday remain.
+    assert surgery_days == {0, 2, 4}
+
+    # The SAME calendar in the Consults group (no group-scoped config there)
+    # is unaffected -- full base availability (Mon-Fri) is offered.
+    consults_proposals = service.find_bookable_slots(
+        group_id=consults_slot.group_fk_id,  # type: ignore[arg-type]
+        search_window_start=MONDAY,
+        search_window_end=SATURDAY,
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(hours=2),
+    )
+    consults_days = {p.start_time.weekday() for p in consults_proposals}
+    assert consults_days == {0, 1, 2, 3, 4}
+
+
+@pytest.mark.django_db
+def test_check_group_availability_excludes_blocked_calendar(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+    )
+
+    blocked_range = (_utc(2025, 9, 2, 10), _utc(2025, 9, 2, 10, 30))
+    free_range = (_utc(2025, 9, 3, 10), _utc(2025, 9, 3, 10, 30))
+
+    [blocked_result, free_result] = service.check_group_availability(
+        surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        [blocked_range, free_range],
+    )
+    [blocked_slot] = blocked_result.slots
+    [free_slot] = free_result.slots
+    assert blocked_slot.available_calendar_ids == []
+    assert free_slot.available_calendar_ids == [calendar.id]
+
+
+# ---------------------------------------------------------------------------
+# Blocks beat everything: a block overlapping a window still wins.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_group_scoped_block_wins_over_overlapping_window(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    # A window covering the whole day.
+    service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 8),
+        end_time=_utc(2025, 9, 2, 18),
+        tz="UTC",
+    )
+    # A block covering the middle of the day, inside the window.
+    service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 12),
+        end_time=_utc(2025, 9, 2, 14),
+        tz="UTC",
+    )
+
+    proposals = service.find_bookable_slots(
+        group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        search_window_start=_utc(2025, 9, 2, 8),
+        search_window_end=_utc(2025, 9, 2, 18),
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(minutes=30),
+    )
+    proposal_starts = {p.start_time.hour + p.start_time.minute / 60 for p in proposals}
+
+    # The window covers 8-18; the block removes 12-14. The calendar must be
+    # offered before and after the block, but NEVER inside it -- even though
+    # the window covers that time too.
+    assert any(h < 12 for h in proposal_starts)
+    assert any(h >= 14 for h in proposal_starts)
+    assert not any(12 <= h < 14 for h in proposal_starts)
+
+    # And check_group_availability agrees.
+    inside_block_range = (_utc(2025, 9, 2, 12, 30), _utc(2025, 9, 2, 13))
+    outside_block_range = (_utc(2025, 9, 2, 9), _utc(2025, 9, 2, 9, 30))
+    [inside_result, outside_result] = service.check_group_availability(
+        surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        [inside_block_range, outside_block_range],
+    )
+    assert inside_result.slots[0].available_calendar_ids == []
+    assert outside_result.slots[0].available_calendar_ids == [calendar.id]
+
+
+@pytest.mark.django_db
+def test_create_grouped_event_rejects_calendar_inside_block_even_when_window_covers_it(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    service.create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 8),
+        end_time=_utc(2025, 9, 2, 18),
+        tz="UTC",
+    )
+    service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 12),
+        end_time=_utc(2025, 9, 2, 14),
+        tz="UTC",
+    )
+
+    with pytest.raises(CalendarGroupScopedRuleViolationError) as exc_info:
+        service.create_grouped_event(
+            CalendarGroupEventInputData(
+                title="Surgery",
+                description="",
+                start_time=_utc(2025, 9, 2, 12, 30),  # inside both window and block
+                end_time=_utc(2025, 9, 2, 13),
+                timezone="UTC",
+                group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+                slot_selections=[
+                    CalendarGroupSlotSelectionInputData(
+                        slot_id=surgery_slot.id, calendar_ids=[calendar.id]
+                    ),
+                ],
+            )
+        )
+
+    assert exc_info.value.calendar_id == calendar.id
+    assert exc_info.value.rule_type == GroupScopedRuleType.INSIDE_BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Explicit booking / reschedule inside a block is rejected.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_grouped_event_rejects_calendar_inside_group_scoped_block(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+
+    with pytest.raises(CalendarGroupScopedRuleViolationError) as exc_info:
+        service.create_grouped_event(
+            CalendarGroupEventInputData(
+                title="Surgery",
+                description="",
+                start_time=_utc(2025, 9, 2, 10),  # Tuesday -- inside the block
+                end_time=_utc(2025, 9, 2, 10, 30),
+                timezone="UTC",
+                group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+                slot_selections=[
+                    CalendarGroupSlotSelectionInputData(
+                        slot_id=surgery_slot.id, calendar_ids=[calendar.id]
+                    ),
+                ],
+            )
+        )
+
+    assert exc_info.value.calendar_id == calendar.id
+    assert exc_info.value.rule_type == GroupScopedRuleType.INSIDE_BLOCK
+    # The error names the calendar and the rule type -- never the configured
+    # block values (spec Decisions -> Errors).
+    error_msg = str(exc_info.value)
+    assert str(calendar.id) in error_msg
+    assert "inside_block" in error_msg
+
+
+@pytest.mark.django_db
+def test_create_grouped_event_allows_calendar_outside_group_scoped_block(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+
+    event = service.create_grouped_event(
+        CalendarGroupEventInputData(
+            title="Surgery",
+            description="",
+            start_time=_utc(2025, 9, 3, 10),  # Wednesday -- outside the block
+            end_time=_utc(2025, 9, 3, 10, 30),
+            timezone="UTC",
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            slot_selections=[
+                CalendarGroupSlotSelectionInputData(
+                    slot_id=surgery_slot.id, calendar_ids=[calendar.id]
+                ),
+            ],
+        )
+    )
+    assert event.calendar_fk_id == calendar.id
+
+
+@pytest.mark.django_db
+def test_reschedule_grouped_event_rejects_move_inside_group_scoped_block(
+    service: CalendarGroupService,
+    admin_user: User,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    service.create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=surgery_slot.id,
+        calendar_id=calendar.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 17),
+        tz="UTC",
+        rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+    )
+
+    event = service.create_grouped_event(
+        CalendarGroupEventInputData(
+            title="Surgery",
+            description="",
+            start_time=_utc(2025, 9, 3, 10),
+            end_time=_utc(2025, 9, 3, 10, 30),
+            timezone="UTC",
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            slot_selections=[
+                CalendarGroupSlotSelectionInputData(
+                    slot_id=surgery_slot.id, calendar_ids=[calendar.id]
+                ),
+            ],
+        )
+    )
+
+    with pytest.raises(CalendarGroupScopedRuleViolationError) as exc_info:
+        service.reschedule_grouped_event(
+            event_id=event.id,
+            start_time=_utc(2025, 9, 2, 10),  # Tuesday -- inside the block
+            end_time=_utc(2025, 9, 2, 10, 30),
+            tz="UTC",
+        )
+    assert exc_info.value.calendar_id == calendar.id
+    assert exc_info.value.rule_type == GroupScopedRuleType.INSIDE_BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Required -- unchanged path: identical output, unchanged query count.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_unconfigured_group_discovery_is_byte_for_byte_unchanged(
+    service: CalendarGroupService,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """No group-scoped window, block, or quota rule exists anywhere in the
+    group -- discovery must take the early-out before any new (Phase 1b/2a)
+    work runs.
+
+    Query counts match the Phase 1b baseline exactly (6 for
+    ``find_bookable_slots``, 5 for ``check_group_availability``) -- adding
+    the block existence flag folded it into the SAME per-slot query rather
+    than issuing a new one, so this phase adds zero queries to the
+    unconfigured path too.
+    """
+    window_start = MONDAY
+    window_end = SATURDAY
+
+    with CaptureQueriesContext(connection) as captured:
+        proposals = service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=window_start,
+            search_window_end=window_end,
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(hours=2),
+        )
+    assert len(captured.captured_queries) == 6
+    assert len(proposals) == 60
+    assert {p.start_time.weekday() for p in proposals} == {0, 1, 2, 3, 4}
+
+    range1 = (_utc(2025, 9, 2, 10), _utc(2025, 9, 2, 10, 30))
+    range2 = (_utc(2025, 9, 6, 10), _utc(2025, 9, 6, 10, 30))  # Saturday -- outside base
+    with CaptureQueriesContext(connection) as captured2:
+        result = service.check_group_availability(
+            surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            [range1, range2],
+        )
+    assert len(captured2.captured_queries) == 5
+    [r1, r2] = result
+    assert [s.available_calendar_ids for s in r1.slots] == [[calendar.id]]
+    assert [s.available_calendar_ids for s in r2.slots] == [[]]


### PR DESCRIPTION

## Summary

Phase 2a of the Calendar Group-Scoped Availability plan. A member can now block time within one group without affecting any other group, and the block wins over any window. Blocks are the negative analog of windows — `BlockedTime` rows with `group_slot` set — reusing the same recurrence machinery, audit, permissions, and early-out discipline.

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 2a. Spec use-case UC-3.

## Key decisions

- **Blocks beat everything** (spec resolution order): on all three enforcement paths (`slot_engine.calendar_free_for_window`, `check_group_availability`'s per-range loop, `_assert_calendars_within_group_scoped_windows`) a group-scoped block that overlaps the requested time excludes/rejects the calendar BEFORE the window-coverage check runs. A calendar with a full-day window but a mid-day block is not offered mid-day (verified in discovery and explicit booking). Rejection uses `GroupScopedRuleType.INSIDE_BLOCK`.
- **Every block create/update runs orphan detection** — unlike windows (where only the first-window create narrows, since windows OR together), each block independently subtracts time, so any block create or update can orphan a confirmed future booking. Delete never computes orphans (removing a block only widens). Covered including recurring blocks and partial-overlap bookings.
- **Zero-change early-out**: a second `Exists()` (`has_group_scoped_block`) folds into the same per-slot membership query already used for windows; the block-span fetch is skipped when no calendar has a block. Query counts unchanged (`find_bookable_slots` 6, `check_group_availability` 5) with byte-identical output on the unconfigured path — asserted.
- **Membership-removal cleanup**: `_reconcile_slot` now deletes and audits group-scoped blocks (as well as windows) when a calendar is removed from a slot, via a shared `_delete_group_scoped_rows_for_removed_calendars` helper.
- **Occurrence-exception safety** reuses the Phase 1b `_base_manager` guard in `RecurringMixin`; block occurrence expansion goes through a `for_group_slot`-based annotate-first path.
- `external_id` for group-scoped blocks is `group-scoped-block-{uuid4}` to satisfy `BlockedTime`'s `unique_together(calendar, external_id)`.

## Feature flag

None — self-gating (early-out); no migration. REST/public API surfaces are Phase 2b; metering blocked time is Phase 2c.

## Test plan

```bash
docker compose run --rm api uv run pytest calendar_integration/tests/services/test_calendar_group_service_blocked_time.py calendar_integration/tests/services/test_group_scoped_blocked_time_discovery.py -vs
docker compose run --rm api uv run pytest calendar_integration/tests/ -n auto
```

Covers: write lifecycle / audit / permissions / non-disclosure; block hides the calendar in that group only; block beats an overlapping window (discovery + explicit booking); recurring-block and partial-overlap orphan detection; membership-removal cascade (block deleted + audited); unconfigured-path query count + output identity.