### PR TITLE
feat(calendar): add group-scoped blocked time REST and public API surfaces

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -82,13 +82,22 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 - **Summary**: Public GraphQL `group_scoped_availability_windows` query + `batch_upsert_group_scoped_availability_windows` mutation. Batch semantics mirror the existing availability batch write exactly (all-or-nothing via own `@transaction.atomic()` + `SELECT FOR UPDATE`, NOT relying on prod-only `ATOMIC_REQUESTS`; over-limit rejects whole with byte-identical body; content-match idempotent replay for create, explicit `windowId` for update/delete). Fixed the entitlement counter `_count_availability_windows` to `unscoped().only_user_authored()` so group-scoped windows meter (composes correctly — still excludes non-user-authored rows). Public-API token auth (`OrganizationResourceAccess` + `assert_calendar_in_owner_scope`). Existing availability ops frozen (asserted). No migration.
 - **Security BLOCKER fixed (IDOR)**: update/delete now cross-check the resolved window's `calendar_fk_id == op.calendar_id` (was authorizing only by the op's own calendar, letting an owner-scoped token modify another calendar's window in the same slot via a foreign `windowId`). **Concurrency fix**: billing-root lock now taken before the idempotency content-match (concurrent UC-5 retries no longer double-create).
 
+### Phase 2a — Group-scoped blocked time: writes and enforcement ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-2a` (base: phase-1d) — **PR [#224](https://github.com/vintasoftware/vinta-schedule-api/pull/224)**
+- **Implementer model**: sonnet (plan Tier 2, stepped up per plan's "invasive resolution-order change" clause) — agent type `implementer`
+- **Reviewer model**: sonnet — no BLOCKERs; 2 test-coverage SHOULD-FIX + NITs fixed (haiku fixer)
+- **Summary**: Group-scoped blocked-time writes (create/update/delete on `CalendarGroupService`, `BlockedTime` rows with `group_slot`), mirroring Phase 1a (audit / permissions / non-disclosure / orphan detection). Slot-engine enforcement: **block beats window** on all three paths (block excludes before window-coverage runs); rejection `GroupScopedRuleType.INSIDE_BLOCK`. Every block create/update runs orphan detection (each block independently subtracts time). Zero-change early-out (second `Exists()` folded in; 6/5 query counts unchanged). `_reconcile_slot` extended via shared `_delete_group_scoped_rows_for_removed_calendars` (deletes+audits windows AND blocks on membership removal). No migration.
+
+**REFACTOR NOTE for Phase 3a**: the get / audit / create / update / delete quintet is duplicated ~1:1 between windows (Phase 1a) and blocks (Phase 2a). Phase 3a adds quota — before tripling the pattern, consider a generic model-parameterized helper (`_get_group_scoped_row(model, id)` / `_audit_group_scoped_write(model_label, ...)`). Only if it doesn't over-couple; the plan phases by concept deliberately.
+
 ## Current phase
 
-Phase 2a — Group-scoped blocked time: writes and enforcement
+Phase 2b — Blocks on the REST and public surfaces
 
 ## Remaining phases
 
-2a, 2b, 2c, 3a, 3b, 3c, 4
+2b, 2c, 3a, 3b, 3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/graphql.py
+++ b/calendar_integration/graphql.py
@@ -635,6 +635,53 @@ def group_scoped_availability_window_from_model(
     )
 
 
+@strawberry.type
+class GroupScopedBlockedTimeGraphQLType:
+    """Public API representation of one group-scoped blocked time
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+    A raw block row -- one entry per recurring master or one-off block, not
+    an expanded occurrence -- mirroring the internal REST surface's
+    ``GroupScopedBlockedTimeSerializer`` field shape.
+    """
+
+    id: int  # noqa: A003
+    calendar_id: int
+    group_slot_id: int
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    timezone: str
+    reason: str
+    rrule_string: str | None
+    is_recurring: bool
+    created: datetime.datetime
+    modified: datetime.datetime
+
+
+def group_scoped_blocked_time_from_model(
+    block: BlockedTime,
+) -> GroupScopedBlockedTimeGraphQLType:
+    """Build a :class:`GroupScopedBlockedTimeGraphQLType` from a
+    ``BlockedTime`` row.
+
+    Callers should ``select_related("recurrence_rule")`` on the source
+    queryset to avoid N+1 when building a list.
+    """
+    return GroupScopedBlockedTimeGraphQLType(
+        id=block.id,  # type: ignore[arg-type]
+        calendar_id=block.calendar_fk_id,  # type: ignore[arg-type]
+        group_slot_id=block.group_slot_fk_id,  # type: ignore[arg-type]
+        start_time=block.start_time,
+        end_time=block.end_time,
+        timezone=block.timezone,
+        reason=block.reason,
+        rrule_string=(block.recurrence_rule.to_rrule_string() if block.recurrence_rule else None),
+        is_recurring=block.is_recurring,
+        created=block.created,
+        modified=block.modified,
+    )
+
+
 @strawberry_django.type(CalendarWebhookSubscription)
 class CalendarWebhookSubscriptionGraphQLType:
     """GraphQL type for calendar webhook subscriptions."""

--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -254,3 +254,61 @@ class GroupScopedAvailabilityWindowPermission(BasePermission):
 
         view.group_slot = group_slot
         return True
+
+
+class GroupScopedBlockedTimePermission(BasePermission):
+    """Route-level group-visibility gate for the group-scoped blocked time
+    routes nested under a group's slot
+    (``calendar-groups/<group_id>/slots/<slot_id>/blocked-times/...``,
+    CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+    Identical in every respect to ``GroupScopedAvailabilityWindowPermission``
+    -- same coarse route-level gate (``can_manage_calendar_group``), same
+    non-disclosure ``Http404`` on a stranger, a cross-organization slot, or
+    a slot belonging to a different group than the one in the URL. See that
+    class's docstring for the full rationale; only the resource it guards
+    differs (blocks instead of windows).
+    """
+
+    @inject
+    def __init__(
+        self,
+        calendar_permission_service: "CalendarPermissionService | None" = Provide[
+            "calendar_permission_service"
+        ],
+    ):
+        self.calendar_permission_service = calendar_permission_service
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+        if not user.is_authenticated:
+            return False
+        membership = get_active_organization_membership(user)
+        if membership is None:
+            return False
+
+        group_id = view.kwargs.get("group_id")
+        slot_id = view.kwargs.get("slot_id")
+        if group_id is None or slot_id is None:
+            return False
+
+        try:
+            group_slot = (
+                CalendarGroupSlot.objects.filter_by_organization(membership.organization_id)
+                .select_related("group")
+                .get(id=slot_id, group_fk_id=group_id)
+            )
+        except CalendarGroupSlot.DoesNotExist:
+            raise Http404() from None
+
+        if self.calendar_permission_service is None or not (
+            self.calendar_permission_service.can_manage_calendar_group(
+                user=user, group=group_slot.group
+            )
+        ):
+            # Same not-found shape as a genuinely missing slot -- a member must
+            # not learn this group/slot exists through a distinguishable 403.
+            raise Http404()
+
+        view.group_slot = group_slot
+        return True

--- a/calendar_integration/routes.py
+++ b/calendar_integration/routes.py
@@ -9,6 +9,7 @@ from .views import (
     CalendarViewSet,
     ExternalEventChangeRequestViewSet,
     GroupScopedAvailabilityWindowViewSet,
+    GroupScopedBlockedTimeViewSet,
 )
 
 
@@ -27,6 +28,11 @@ routes: list[RouteDict] = [
         "regex": r"calendar-groups/<int:group_id>/slots/<int:slot_id>/availability-windows",
         "viewset": GroupScopedAvailabilityWindowViewSet,
         "basename": "GroupScopedAvailabilityWindows",
+    },
+    {
+        "regex": r"calendar-groups/<int:group_id>/slots/<int:slot_id>/blocked-times",
+        "viewset": GroupScopedBlockedTimeViewSet,
+        "basename": "GroupScopedBlockedTimes",
     },
     {
         "regex": r"calendar",

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -69,6 +69,7 @@ from calendar_integration.virtual_models import (
     ExternalAttendeeVirtualModel,
     ExternalEventChangeRequestVirtualModel,
     GroupScopedAvailabilityWindowVirtualModel,
+    GroupScopedBlockedTimeVirtualModel,
     RecurrenceRuleVirtualModel,
     ResourceAllocationVirtualModel,
 )
@@ -2659,6 +2660,161 @@ class GroupScopedAvailabilityWriteResultSerializer(serializers.Serializer):
             "longer fall inside the calendar's group-scoped availability after this "
             "write. Nothing about them is modified or cancelled -- act on them manually "
             "if needed."
+        ),
+    )
+
+
+class GroupScopedBlockedTimeSerializer(VirtualModelSerializer):
+    """Read representation of a group-scoped blocked time
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+    Mirrors ``GroupScopedAvailabilityWindowSerializer`` exactly, plus
+    ``reason`` -- there is no nested ``recurrence_rule`` write path here,
+    only ``rrule_string``, matching exactly what ``CalendarGroupService``'s
+    block-write methods accept, so the REST shape and the service signature
+    cannot drift apart.
+    """
+
+    calendar_id = serializers.IntegerField(source="calendar_fk_id", read_only=True)
+    group_slot_id = serializers.IntegerField(source="group_slot_fk_id", read_only=True)
+    rrule_string = serializers.SerializerMethodField(read_only=True)
+    is_recurring = serializers.SerializerMethodField(read_only=True)
+    start_time = serializers.DateTimeField(read_only=True)
+    end_time = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = BlockedTime
+        virtual_model = GroupScopedBlockedTimeVirtualModel
+        fields = (
+            "id",
+            "calendar_id",
+            "group_slot_id",
+            "start_time",
+            "end_time",
+            "timezone",
+            "reason",
+            "rrule_string",
+            "is_recurring",
+            "created",
+            "modified",
+        )
+        read_only_fields = fields
+
+    @v.hints.no_deferred_fields()
+    def get_rrule_string(self, obj: BlockedTime) -> str | None:
+        """RRULE string for the block's recurrence, or ``None`` when it doesn't recur."""
+        return obj.recurrence_rule.to_rrule_string() if obj.recurrence_rule else None
+
+    @v.hints.no_deferred_fields()
+    def get_is_recurring(self, obj: BlockedTime) -> bool:
+        return obj.is_recurring
+
+    def to_representation(self, instance):
+        """Render start_time/end_time in the block's own IANA timezone, not UTC."""
+        data = super().to_representation(instance)
+        return _localize_times_in_representation(
+            data, instance, getattr(instance, "timezone", None)
+        )
+
+
+class GroupScopedBlockedTimeCreateSerializer(serializers.Serializer):
+    """Input for creating a group-scoped blocked time.
+
+    Field names map 1:1 onto
+    ``CalendarGroupService.create_group_scoped_blocked_time``'s keyword
+    arguments (``calendar_id``, ``start_time``, ``end_time``, ``tz``,
+    ``reason``, ``rrule_string``) so the REST shape can never silently drift
+    from the service signature it delegates to.
+    """
+
+    calendar = serializers.PrimaryKeyRelatedField(
+        queryset=Calendar.original_manager.none(),
+        help_text="Calendar this block applies to. Must be a member of the target slot.",
+    )
+    start_time = serializers.DateTimeField(required=True)
+    end_time = serializers.DateTimeField(required=True)
+    timezone = serializers.CharField(required=True)
+    reason = serializers.CharField(required=False, allow_blank=True, default="")
+    rrule_string = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="RRULE string for a recurring block. Omit for a one-off block.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = (
+            self.context["request"].user if self.context and self.context.get("request") else None
+        )
+        membership = (
+            get_active_organization_membership(user) if user and user.is_authenticated else None
+        )
+        self.fields["calendar"].queryset = (
+            Calendar.objects.filter_by_organization(membership.organization_id)
+            if membership
+            else Calendar.original_manager.none()
+        )
+
+    def validate(self, attrs):
+        if attrs["start_time"] >= attrs["end_time"]:
+            raise serializers.ValidationError("start_time must be before end_time.")
+        return attrs
+
+
+class GroupScopedBlockedTimeUpdateSerializer(serializers.Serializer):
+    """Input for partially updating a group-scoped blocked time.
+
+    Every field is optional -- only provided fields change, mirroring
+    ``CalendarGroupService.update_group_scoped_blocked_time``.
+    """
+
+    start_time = serializers.DateTimeField(required=False)
+    end_time = serializers.DateTimeField(required=False)
+    timezone = serializers.CharField(required=False)
+    reason = serializers.CharField(required=False, allow_blank=True)
+    rrule_string = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="RRULE string for a recurring block. Set to null to make it non-recurring.",
+    )
+
+    def validate(self, attrs):
+        start_time = attrs.get("start_time")
+        end_time = attrs.get("end_time")
+        if start_time is not None and end_time is not None and start_time >= end_time:
+            raise serializers.ValidationError("start_time must be before end_time.")
+        return attrs
+
+
+class GroupScopedBlockOrphanedBookingSerializer(serializers.Serializer):
+    """Minimal identification of a booking a block write orphaned (spec
+    UC-6's rule applied to blocks) -- enough for an admin to act on. Nothing
+    about the booking itself is modified by the write that produced this
+    entry.
+    """
+
+    id = serializers.IntegerField(read_only=True)
+    calendar_id = serializers.IntegerField(source="calendar_fk_id", read_only=True)
+    title = serializers.CharField(read_only=True)
+    start_time = serializers.DateTimeField(read_only=True)
+    end_time = serializers.DateTimeField(read_only=True)
+
+
+class GroupScopedBlockWriteResultSerializer(serializers.Serializer):
+    """Wraps a ``GroupScopedBlockWriteResult``: the saved block plus any
+    confirmed future bookings the write orphaned. Returned by the create and
+    update actions of ``GroupScopedBlockedTimeViewSet``.
+    """
+
+    block = GroupScopedBlockedTimeSerializer(read_only=True)
+    orphaned_bookings = GroupScopedBlockOrphanedBookingSerializer(
+        many=True,
+        read_only=True,
+        help_text=(
+            "Confirmed future bookings in this slot for this block's calendar that now "
+            "fall inside the calendar's group-scoped blocked time after this write. "
+            "Nothing about them is modified or cancelled -- act on them manually if "
+            "needed."
         ),
     )
 

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -1463,6 +1463,260 @@ class CalendarGroupService:
         self._audit_group_scoped_block_write(AuditAction.DELETE, acting_user, block)
         block.delete()
 
+    def _find_matching_group_scoped_block(
+        self,
+        group_slot_id: int,
+        calendar_id: int,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        tz: str,
+        reason: str,
+        rrule_string: str | None,
+    ) -> BlockedTime | None:
+        """Find an existing group-scoped block with identical content, if any.
+
+        Backs the batch-upsert write path's idempotent ``create`` (mirrors
+        ``_find_matching_group_scoped_window``): an upstream system that
+        resends the same batch after a network timeout (spec UC-5) must land
+        on the identical final state, not accumulate duplicate rows. Matched
+        on (calendar, group slot, start_time, end_time, timezone, reason,
+        rrule). ``start_time``/``end_time`` are compared as the aware
+        instants they are -- paired with an exact ``timezone`` match this is
+        a safe point lookup, not the cross-timezone comparison
+        ``start_time_tz_unaware`` is unsafe for (see AGENTS.md).
+        """
+        organization = cast(Organization, self.organization)
+        candidates = (
+            BlockedTime.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(organization.id)
+            .filter(
+                calendar_fk_id=calendar_id,
+                start_time_tz_unaware=start_time,
+                end_time_tz_unaware=end_time,
+                timezone=tz,
+                reason=reason,
+            )
+            .select_related("recurrence_rule")
+        )
+        for candidate in candidates:
+            candidate_rrule = (
+                candidate.recurrence_rule.to_rrule_string() if candidate.recurrence_rule else None
+            )
+            if candidate_rrule == rrule_string:
+                return candidate
+        return None
+
+    @transaction.atomic()
+    def batch_upsert_group_scoped_blocked_times(
+        self,
+        group_slot_id: int,
+        operations: Iterable[dict],
+        acting_principal: "User | SystemUser",
+    ) -> list[BlockedTime]:
+        """Apply an atomic bulk-upsert batch of group-scoped blocked-time
+        create/update/delete operations within one group slot's roster
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b -- public API).
+
+        Mirrors ``batch_upsert_group_scoped_availability_windows``'s
+        transaction / idempotent-create / IDOR-cross-check structure exactly,
+        with ONE deliberate difference: blocked time is not metered yet (that
+        is Phase 2c), so this method never calls ``check_limit`` and never
+        locks the billing root -- there is no entitlement delta to protect a
+        lock against. It still calls ``check_not_restricted`` up front, like
+        every other guarded write, so a ``RESTRICTED`` organization cannot
+        write group-scoped blocks either.
+
+        * **All-or-nothing.** The whole batch runs inside one transaction
+          (this method's own ``@transaction.atomic()``, nested inside the
+          request's ``ATOMIC_REQUESTS`` transaction); every operation is
+          validated and every touched row is resolved *before* any write, so
+          a bad ``block_id`` rolls back cleanly with nothing partially
+          applied.
+        * **Idempotent create.** A ``create`` operation is an upsert, not a
+          blind insert: :meth:`_find_matching_group_scoped_block` looks for
+          an existing group-scoped block with identical content first. A
+          match is returned unchanged (no write, no audit record) rather
+          than duplicated, so replaying an identical batch (spec UC-5) lands
+          on the exact same final state.
+        * **update / delete** require ``block_id`` and act on exactly the
+          row it names, like the window batch write's ``id``-keyed
+          operations.
+
+        Authorization is split between the CALLER and this method, exactly
+        like the window batch: the caller proves each op's ``calendar_id``
+        is within the token's owner scope; this method cross-checks that an
+        update/delete op's resolved block actually belongs to that op's own
+        ``calendar_id`` and rejects the whole batch (not-found-shaped) if
+        they don't match. ``acting_principal`` is used for audit attribution
+        only.
+
+        :param operations: dicts with ``action`` (create/update/delete) and
+            ``calendar_id``; create/update also take ``start_time``,
+            ``end_time``, ``timezone``, ``reason`` (optional), ``rrule_string``
+            (optional); update/delete also take ``block_id``.
+        :param acting_principal: the ``User`` or public-API ``SystemUser``
+            this write is attributed to in the audit trail.
+        :raises CalendarGroupSlotConfigNotFoundError: a create op's
+            ``calendar_id`` is not a member of ``group_slot_id``'s roster, or
+            an update/delete op's ``block_id`` does not resolve to a
+            group-scoped block in this slot, or that block does not belong
+            to the op's own ``calendar_id``.
+        :raises ValueError: an operation's shape is invalid (unknown action,
+            missing required field).
+        :return: every group-scoped block in ``group_slot_id``'s roster (all
+            calendars) after the batch is applied.
+        """
+        self._assert_initialized()
+        organization = cast(Organization, self.organization)
+        operations = list(operations)
+
+        valid_actions = {"create", "update", "delete"}
+        for op in operations:
+            action = op.get("action")
+            if action not in valid_actions:
+                raise ValueError(f"Invalid operation action: {action}")
+            if action == "create" and (
+                "calendar_id" not in op
+                or "start_time" not in op
+                or "end_time" not in op
+                or "timezone" not in op
+            ):
+                raise ValueError(
+                    "create operation requires calendar_id, start_time, end_time, timezone"
+                )
+            if action in ("update", "delete") and "block_id" not in op:
+                raise ValueError(f"{action} operation requires block_id")
+
+        # RESTRICTED must block the batch outright, including an update-only
+        # or delete-only batch -- mirrors the window batch, minus the
+        # limit/lock machinery that exists only to protect entitlement
+        # counting, which blocks don't have yet (Phase 2c).
+        if self.entitlement_service is not None and operations:
+            self.entitlement_service.check_not_restricted(organization)
+
+        # Resolve every touched row up front (read-only): a missing/foreign
+        # block_id or a calendar not on this slot's roster fails the whole
+        # batch before anything is written.
+        blocks_by_op_id: dict[int, BlockedTime] = {}
+        for op in operations:
+            if op["action"] in ("update", "delete"):
+                block = self._get_group_scoped_block(op["block_id"])
+                if block.group_slot_fk_id != group_slot_id:
+                    raise CalendarGroupSlotConfigNotFoundError()
+                # Cross-check the resolved block against the op's OWN calendar_id --
+                # public_api's assert_calendar_in_owner_scope only proves the token owns
+                # op["calendar_id"], not that block_id actually belongs to it. Without
+                # this, a calendar-owner-scoped token could target another calendar's
+                # block in the same slot by pairing a calendar_id it owns with a
+                # block_id it doesn't. Raises the same non-disclosure exception as an
+                # unresolvable block_id so the two cases are indistinguishable.
+                if block.calendar_fk_id != op["calendar_id"]:
+                    raise CalendarGroupSlotConfigNotFoundError()
+                blocks_by_op_id[op["block_id"]] = block
+
+        memberships_by_calendar: dict[int, CalendarGroupSlotMembership] = {}
+        for op in operations:
+            if op["action"] == "create" and op["calendar_id"] not in memberships_by_calendar:
+                memberships_by_calendar[op["calendar_id"]] = self._resolve_group_scoped_membership(
+                    group_slot_id, op["calendar_id"]
+                )
+
+        # Idempotent-create resolution: match each create op against an
+        # existing group-scoped block before writing anything.
+        matched_existing: dict[int, BlockedTime] = {}
+        for i, op in enumerate(operations):
+            if op["action"] != "create":
+                continue
+            existing = self._find_matching_group_scoped_block(
+                group_slot_id=group_slot_id,
+                calendar_id=op["calendar_id"],
+                start_time=op["start_time"],
+                end_time=op["end_time"],
+                tz=op["timezone"],
+                reason=op.get("reason", ""),
+                rrule_string=op.get("rrule_string"),
+            )
+            if existing is not None:
+                matched_existing[i] = existing
+
+        for i, op in enumerate(operations):
+            action = op["action"]
+            if action == "create":
+                if i in matched_existing:
+                    continue
+                membership = memberships_by_calendar[op["calendar_id"]]
+                recurrence_rule = self._create_recurrence_rule_if_needed(op.get("rrule_string"))
+                block = BlockedTime.objects.unscoped().create(
+                    organization=organization,
+                    calendar=membership.calendar,
+                    group_slot=membership.slot,
+                    start_time_tz_unaware=op["start_time"],
+                    end_time_tz_unaware=op["end_time"],
+                    timezone=op["timezone"],
+                    reason=op.get("reason", ""),
+                    # BlockedTime enforces uniqueness on (calendar, external_id); this
+                    # write path has no natural external id, so a uuid4 guarantees no
+                    # collision with any other block -- base or group-scoped -- on the
+                    # same calendar (mirrors create_group_scoped_blocked_time).
+                    external_id=f"group-scoped-block-{uuid.uuid4()}",
+                    recurrence_rule=recurrence_rule,
+                )
+                self._audit_group_scoped_block_write(AuditAction.CREATE, acting_principal, block)
+            elif action == "update":
+                block = blocks_by_op_id[op["block_id"]]
+                before = {
+                    "start_time_tz_unaware": block.start_time_tz_unaware.isoformat(),
+                    "end_time_tz_unaware": block.end_time_tz_unaware.isoformat(),
+                    "timezone": block.timezone,
+                    "reason": block.reason,
+                    "rrule": (
+                        block.recurrence_rule.to_rrule_string() if block.recurrence_rule else None
+                    ),
+                }
+                update_fields: list[str] = []
+                if "start_time" in op:
+                    block.start_time_tz_unaware = op["start_time"]
+                    update_fields.append("start_time_tz_unaware")
+                if "end_time" in op:
+                    block.end_time_tz_unaware = op["end_time"]
+                    update_fields.append("end_time_tz_unaware")
+                if "timezone" in op:
+                    block.timezone = op["timezone"]
+                    update_fields.append("timezone")
+                if "reason" in op:
+                    block.reason = op["reason"]
+                    update_fields.append("reason")
+                if "rrule_string" in op:
+                    block.recurrence_rule = self._create_recurrence_rule_if_needed(
+                        op["rrule_string"]
+                    )
+                    update_fields.append("recurrence_rule_fk")
+                if update_fields:
+                    block.save(update_fields=[*update_fields, "modified"])
+                after = {
+                    "start_time_tz_unaware": block.start_time_tz_unaware.isoformat(),
+                    "end_time_tz_unaware": block.end_time_tz_unaware.isoformat(),
+                    "timezone": block.timezone,
+                    "reason": block.reason,
+                    "rrule": (
+                        block.recurrence_rule.to_rrule_string() if block.recurrence_rule else None
+                    ),
+                }
+                self._audit_group_scoped_block_write(
+                    AuditAction.UPDATE, acting_principal, block, diff=compute_diff(before, after)
+                )
+            elif action == "delete":
+                block = blocks_by_op_id[op["block_id"]]
+                self._audit_group_scoped_block_write(AuditAction.DELETE, acting_principal, block)
+                block.delete()
+
+        return list(
+            BlockedTime.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(organization.id)
+            .select_related("recurrence_rule")
+            .order_by("pk")
+        )
+
     # ------------------------------------------------------------------
     # Queries
     # ------------------------------------------------------------------

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -738,6 +738,7 @@ class CalendarGroupService:
         detection runs only on the first create. Nothing is cancelled.
         """
         self._assert_initialized()
+        self._check_not_restricted()
         if now is None:
             now = timezone.now()
 
@@ -805,6 +806,7 @@ class CalendarGroupService:
         the caller decides what to do with each one.
         """
         self._assert_initialized()
+        self._check_not_restricted()
         if now is None:
             now = timezone.now()
 
@@ -870,6 +872,7 @@ class CalendarGroupService:
         constraint) is a distinct action, exercised through ``update_group``.
         """
         self._assert_initialized()
+        self._check_not_restricted()
         window = self._get_group_scoped_window(window_id)
         self._authorize_group_scoped_write(acting_user, window.calendar, window.group_slot)
 
@@ -1328,6 +1331,7 @@ class CalendarGroupService:
         applied to blocks). Nothing is cancelled.
         """
         self._assert_initialized()
+        self._check_not_restricted()
         if now is None:
             now = timezone.now()
 
@@ -1387,6 +1391,7 @@ class CalendarGroupService:
         applied to blocks) -- the caller decides what to do with each one.
         """
         self._assert_initialized()
+        self._check_not_restricted()
         if now is None:
             now = timezone.now()
 
@@ -1457,6 +1462,7 @@ class CalendarGroupService:
         ``update_group``.
         """
         self._assert_initialized()
+        self._check_not_restricted()
         block = self._get_group_scoped_block(block_id)
         self._authorize_group_scoped_write(acting_user, block.calendar, block.group_slot)
 

--- a/calendar_integration/tests/test_views_group_scoped_blocked_times.py
+++ b/calendar_integration/tests/test_views_group_scoped_blocked_times.py
@@ -1,0 +1,767 @@
+"""Integration tests for the internal REST surface exposing group-scoped
+blocked times (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+Direct mirror of ``test_views_group_scoped_availability_windows.py`` for
+blocks. Covers:
+- Full lifecycle through the nested routes (create -> list -> retrieve ->
+  update -> delete), for both the calendar's owner and an org admin.
+- Route-level group-visibility gating: a stranger and the owner of a
+  *different* calendar in the same group (different slot) are both denied
+  with the exact same not-found shape -- neither can distinguish "forbidden"
+  from "does not exist".
+- Cross-organization access denied with the same not-found shape.
+- The orphaned-booking warning surfaces in the narrowing response, both on
+  create and on an update that widens the block.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from django.urls import reverse
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.factories import create_calendar_ownership
+from calendar_integration.models import (
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.factories import UserFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_client(membership: OrganizationMembership) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=membership.user)
+    return client
+
+
+def _next_weekday(after: datetime.datetime, weekday: int) -> datetime.date:
+    """Next date (strictly after `after`'s date) landing on ISO `weekday`
+    (Monday=0 ... Sunday=6)."""
+    days_ahead = (weekday - after.weekday()) % 7
+    days_ahead = days_ahead or 7
+    return (after + datetime.timedelta(days=days_ahead)).date()
+
+
+def _list_url(group_id: int, slot_id: int) -> str:
+    return reverse(
+        "api:GroupScopedBlockedTimes-list",
+        kwargs={"group_id": group_id, "slot_id": slot_id},
+    )
+
+
+def _detail_url(group_id: int, slot_id: int, pk: int) -> str:
+    return reverse(
+        "api:GroupScopedBlockedTimes-detail",
+        kwargs={"group_id": group_id, "slot_id": slot_id, "pk": pk},
+    )
+
+
+def _utc(year: int, month: int, day: int, hour: int) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization() -> Organization:
+    return baker.make(Organization, name="Blocks REST Test Org")
+
+
+@pytest.fixture
+def admin_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.ADMIN, is_active=True
+    )
+
+
+@pytest.fixture
+def owner_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def other_owner_membership(organization: Organization) -> OrganizationMembership:
+    """Owns a DIFFERENT calendar (in a different slot of the SAME group) --
+    used to prove that seeing the group is not enough to manage a calendar
+    the caller does not own."""
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def stranger_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="dr_reyes_block",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def other_calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Costa",
+        external_id="dr_costa_block",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ownerships(
+    owner_membership: OrganizationMembership,
+    other_owner_membership: OrganizationMembership,
+    calendar: Calendar,
+    other_calendar: Calendar,
+) -> None:
+    create_calendar_ownership(calendar=calendar, user=owner_membership.user)
+    create_calendar_ownership(calendar=other_calendar, user=other_owner_membership.user)
+
+
+@pytest.fixture
+def group(organization: Organization) -> CalendarGroup:
+    return CalendarGroup.objects.create(organization=organization, name="Surgery")
+
+
+@pytest.fixture
+def group_slot(
+    organization: Organization, group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Lead Surgeon"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def other_slot(
+    organization: Organization, group: CalendarGroup, other_calendar: Calendar
+) -> CalendarGroupSlot:
+    """A second slot in the same group, populated with `other_calendar` -- makes
+    `other_owner_membership`'s user a genuine member of the group without
+    owning `calendar`."""
+    slot = CalendarGroupSlot.objects.create(organization=organization, group=group, name="Assist")
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=other_calendar
+    )
+    return slot
+
+
+def _create_payload(calendar_id: int, **overrides) -> dict:
+    payload = {
+        "calendar": calendar_id,
+        "start_time": _utc(2025, 9, 2, 9).isoformat(),  # 2025-09-02 is a Tuesday
+        "end_time": _utc(2025, 9, 2, 17).isoformat(),
+        "timezone": "UTC",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedBlockedTimeLifecycle:
+    def test_full_lifecycle_as_owner(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+
+        # Create.
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(
+                calendar.id,
+                reason="On call elsewhere",
+                rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH",
+            ),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        block_data = create_response.data["block"]
+        assert block_data["calendar_id"] == calendar.id
+        assert block_data["group_slot_id"] == group_slot.id
+        assert block_data["timezone"] == "UTC"
+        assert block_data["reason"] == "On call elsewhere"
+        assert block_data["is_recurring"] is True
+        assert block_data["rrule_string"] == "FREQ=WEEKLY;BYDAY=TU,TH"
+        assert create_response.data["orphaned_bookings"] == []
+        block_id = block_data["id"]
+
+        # Invisible on the base (unscoped-from-group) manager.
+        assert (
+            not BlockedTime.objects.filter_by_organization(calendar.organization_id)
+            .filter(id=block_id)
+            .exists()
+        )
+        assert (
+            BlockedTime.objects.for_group_slot(group_slot.id)
+            .filter_by_organization(calendar.organization_id)
+            .filter(id=block_id)
+            .exists()
+        )
+
+        # List.
+        list_response = client.get(_list_url(group.id, group_slot.id))
+        assert list_response.status_code == status.HTTP_200_OK
+        ids = [b["id"] for b in list_response.data["results"]]
+        assert ids == [block_id]
+
+        # Retrieve.
+        retrieve_response = client.get(_detail_url(group.id, group_slot.id, block_id))
+        assert retrieve_response.status_code == status.HTTP_200_OK
+        assert retrieve_response.data["id"] == block_id
+
+        # Update (narrow the recurrence to Thursdays only).
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, block_id),
+            {"rrule_string": "RRULE:FREQ=WEEKLY;BYDAY=TH"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        assert update_response.data["block"]["rrule_string"] == "FREQ=WEEKLY;BYDAY=TH"
+        assert update_response.data["orphaned_bookings"] == []
+
+        # Delete.
+        delete_response = client.delete(_detail_url(group.id, group_slot.id, block_id))
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        assert not BlockedTime.objects.unscoped().filter(id=block_id).exists()
+
+        # Now invisible everywhere, including the group-scoped read path.
+        retrieve_after_delete = client.get(_detail_url(group.id, group_slot.id, block_id))
+        assert retrieve_after_delete.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_admin_can_manage_any_calendars_block(
+        self,
+        admin_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(admin_membership)
+
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        block_id = create_response.data["block"]["id"]
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, block_id), {"timezone": "America/Sao_Paulo"}
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+        assert update_response.data["block"]["timezone"] == "America/Sao_Paulo"
+
+        delete_response = client.delete(_detail_url(group.id, group_slot.id, block_id))
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_create_requires_start_before_end(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+        response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(
+                calendar.id,
+                start_time=_utc(2025, 9, 2, 17).isoformat(),
+                end_time=_utc(2025, 9, 2, 9).isoformat(),
+            ),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_put_not_allowed(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        block_id = create_response.data["block"]["id"]
+
+        response = client.put(
+            _detail_url(group.id, group_slot.id, block_id),
+            {"timezone": "America/Sao_Paulo"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_patch_null_rrule_string_clears_recurrence(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        """PATCH `{"rrule_string": null}` is the tri-state "clear" case -- it
+        must actually detach the recurrence rule, not be a silent no-op."""
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH"),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        block_id = create_response.data["block"]["id"]
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, block_id),
+            {"rrule_string": None},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        block_data = update_response.data["block"]
+        assert block_data["rrule_string"] is None
+        assert block_data["is_recurring"] is False
+
+        reloaded = (
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(calendar.organization_id)
+            .get(id=block_id)
+        )
+        assert reloaded.recurrence_rule is None
+        assert reloaded.is_recurring is False
+
+    def test_patch_omitting_rrule_string_leaves_recurrence_unchanged(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        """PATCH that never mentions `rrule_string` must leave the existing
+        recurrence untouched -- the "absent" tri-state case."""
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU,TH"),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        block_id = create_response.data["block"]["id"]
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, block_id),
+            {"timezone": "America/Sao_Paulo"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        block_data = update_response.data["block"]
+        assert block_data["is_recurring"] is True
+        assert block_data["rrule_string"] == "FREQ=WEEKLY;BYDAY=TU,TH"
+
+        reloaded = (
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(calendar.organization_id)
+            .get(id=block_id)
+        )
+        assert reloaded.recurrence_rule is not None
+        assert reloaded.is_recurring is True
+
+
+# ---------------------------------------------------------------------------
+# Non-disclosure / visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedBlockedTimeNonDisclosure:
+    def test_stranger_cannot_list_or_create(
+        self,
+        stranger_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(stranger_membership)
+
+        list_response = client.get(_list_url(group.id, group_slot.id))
+        assert list_response.status_code == status.HTTP_404_NOT_FOUND
+
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        assert create_response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_owner_of_other_calendar_in_same_group_denied_same_shape_as_stranger(
+        self,
+        other_owner_membership: OrganizationMembership,
+        stranger_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+        other_slot: CalendarGroupSlot,
+    ) -> None:
+        """`other_owner_membership`'s user owns a calendar in the SAME group (a
+        different slot), so they can see the group -- but they do not own
+        `calendar`, so writing its block must still be denied, with the exact
+        same not-found shape a genuine stranger gets."""
+        other_owner_client = _auth_client(other_owner_membership)
+        stranger_client = _auth_client(stranger_membership)
+
+        other_owner_response = other_owner_client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        stranger_response = stranger_client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+
+        assert other_owner_response.status_code == status.HTTP_404_NOT_FOUND
+        assert stranger_response.status_code == status.HTTP_404_NOT_FOUND
+        assert other_owner_response.data == stranger_response.data
+        assert not BlockedTime.objects.unscoped().filter(group_slot_fk=group_slot).exists()
+
+    def test_other_owner_can_see_and_manage_their_own_slot_in_the_group(
+        self,
+        other_owner_membership: OrganizationMembership,
+        other_calendar: Calendar,
+        group: CalendarGroup,
+        other_slot: CalendarGroupSlot,
+    ) -> None:
+        """Sanity check for the fixture setup above: `other_owner_membership`'s
+        user genuinely can manage `other_calendar`'s block in `other_slot` --
+        the denial in the sibling test is calendar-specific, not group-wide."""
+        client = _auth_client(other_owner_membership)
+        response = client.post(
+            _list_url(group.id, other_slot.id), _create_payload(other_calendar.id), format="json"
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+
+    def test_cross_organization_access_denied(
+        self,
+        owner_membership: OrganizationMembership,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        other_org = baker.make(Organization)
+        other_cal = Calendar.objects.create(
+            organization=other_org,
+            name="Other",
+            external_id="other_block",
+            provider=CalendarProvider.GOOGLE,
+        )
+        other_group = CalendarGroup.objects.create(organization=other_org, name="Other Group")
+        other_org_slot = CalendarGroupSlot.objects.create(
+            organization=other_org, group=other_group, name="Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=other_org, slot=other_org_slot, calendar=other_cal
+        )
+
+        # `owner_membership`'s user has no membership in `other_org` at all.
+        client = _auth_client(owner_membership)
+        response = client.get(_list_url(other_group.id, other_org_slot.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_slot_not_belonging_to_group_in_url_is_not_found(
+        self,
+        owner_membership: OrganizationMembership,
+        organization: Organization,
+        calendar: Calendar,
+        other_calendar: Calendar,
+    ) -> None:
+        """A slot that exists, but under a DIFFERENT group than the one named in
+        the URL, must not resolve -- same not-found shape."""
+        group_a = CalendarGroup.objects.create(organization=organization, name="A")
+        group_b = CalendarGroup.objects.create(organization=organization, name="B")
+        slot_on_b = CalendarGroupSlot.objects.create(
+            organization=organization, group=group_b, name="Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=slot_on_b, calendar=other_calendar
+        )
+        # A second slot in `group_b`, owned by the caller -- gives them genuine
+        # visibility into `group_b` without owning `slot_on_b`'s calendar.
+        callers_slot_on_b = CalendarGroupSlot.objects.create(
+            organization=organization, group=group_b, name="Caller's Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=callers_slot_on_b, calendar=calendar
+        )
+
+        client = _auth_client(owner_membership)
+        # Sanity check: the caller genuinely sees `group_b` through their own slot.
+        sanity_response = client.get(_list_url(group_b.id, callers_slot_on_b.id))
+        assert sanity_response.status_code == status.HTTP_200_OK, sanity_response.data
+
+        # `slot_on_b` belongs to `group_b`, not `group_a` -- naming `group_a` in
+        # the URL must 404 even though the caller can see `group_b`.
+        response = client.get(_list_url(group_a.id, slot_on_b.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unauthenticated_returns_401(
+        self, group: CalendarGroup, group_slot: CalendarGroupSlot
+    ) -> None:
+        client = APIClient()
+        response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Orphaned-booking warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedBlockedTimeOrphanedBookings:
+    def test_create_block_reports_orphaned_booking(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        now = datetime.datetime.now(datetime.UTC)
+        thursday = _next_weekday(now, weekday=3)
+
+        booking = CalendarEvent.objects.create(
+            organization=calendar.organization,
+            calendar=calendar,
+            title="Operation",
+            description="",
+            external_id="ev_thursday_block_rest",
+            start_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(10), tzinfo=datetime.UTC
+            ),
+            end_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(11), tzinfo=datetime.UTC
+            ),
+            timezone="UTC",
+            calendar_group=group,
+        )
+        CalendarEventGroupSelection.objects.create(
+            organization=calendar.organization,
+            event=booking,
+            slot=group_slot,
+            calendar=calendar,
+        )
+
+        client = _auth_client(owner_membership)
+        response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(
+                calendar.id,
+                start_time=datetime.datetime.combine(
+                    thursday, datetime.time(9), tzinfo=datetime.UTC
+                ).isoformat(),
+                end_time=datetime.datetime.combine(
+                    thursday, datetime.time(17), tzinfo=datetime.UTC
+                ).isoformat(),
+            ),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        orphaned = response.data["orphaned_bookings"]
+        assert len(orphaned) == 1
+        assert orphaned[0]["id"] == booking.id
+        assert orphaned[0]["calendar_id"] == calendar.id
+        assert orphaned[0]["title"] == "Operation"
+
+        # Nothing about the booking was touched.
+        booking.refresh_from_db()
+        assert booking.title == "Operation"
+
+    def test_update_widening_block_reports_orphaned_booking(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        now = datetime.datetime.now(datetime.UTC)
+        tuesday = _next_weekday(now, weekday=1)
+        thursday = tuesday + datetime.timedelta(days=2)
+
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(
+                calendar.id,
+                start_time=datetime.datetime.combine(
+                    tuesday, datetime.time(9), tzinfo=datetime.UTC
+                ).isoformat(),
+                end_time=datetime.datetime.combine(
+                    tuesday, datetime.time(17), tzinfo=datetime.UTC
+                ).isoformat(),
+                rrule_string="RRULE:FREQ=WEEKLY;BYDAY=TU",
+            ),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        block_id = create_response.data["block"]["id"]
+
+        tuesday_event = CalendarEvent.objects.create(
+            organization=calendar.organization,
+            calendar=calendar,
+            title="Tuesday Op",
+            description="",
+            external_id="ev_tuesday_block_rest",
+            start_time_tz_unaware=datetime.datetime.combine(
+                tuesday, datetime.time(10), tzinfo=datetime.UTC
+            ),
+            end_time_tz_unaware=datetime.datetime.combine(
+                tuesday, datetime.time(11), tzinfo=datetime.UTC
+            ),
+            timezone="UTC",
+            calendar_group=group,
+        )
+        CalendarEventGroupSelection.objects.create(
+            organization=calendar.organization,
+            event=tuesday_event,
+            slot=group_slot,
+            calendar=calendar,
+        )
+        thursday_event = CalendarEvent.objects.create(
+            organization=calendar.organization,
+            calendar=calendar,
+            title="Thursday Op",
+            description="",
+            external_id="ev_thursday_block_rest2",
+            start_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(10), tzinfo=datetime.UTC
+            ),
+            end_time_tz_unaware=datetime.datetime.combine(
+                thursday, datetime.time(11), tzinfo=datetime.UTC
+            ),
+            timezone="UTC",
+            calendar_group=group,
+        )
+        CalendarEventGroupSelection.objects.create(
+            organization=calendar.organization,
+            event=thursday_event,
+            slot=group_slot,
+            calendar=calendar,
+        )
+
+        # Widen the block to also cover Thursdays -- the Thursday booking now
+        # falls INSIDE the block.
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, block_id),
+            {"rrule_string": "RRULE:FREQ=WEEKLY;BYDAY=TU,TH"},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        orphaned_ids = {b["id"] for b in update_response.data["orphaned_bookings"]}
+        assert orphaned_ids == {tuesday_event.id, thursday_event.id}
+
+        # Neither booking nor its group selection was touched.
+        assert CalendarEvent.objects.filter_by_organization(calendar.organization_id).count() == 2
+        assert (
+            CalendarEventGroupSelection.objects.filter_by_organization(
+                calendar.organization_id
+            ).count()
+            == 2
+        )
+
+
+# ---------------------------------------------------------------------------
+# Query budget (bounded, must not scale with row count)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedBlockedTimeQueryBudget:
+    def test_list_query_count_is_bounded_and_does_not_scale_with_block_count(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+        django_assert_max_num_queries,
+    ) -> None:
+        """`GroupScopedBlockedTimeSerializer` never nests `calendar` (it
+        sources `calendar_id` straight from `calendar_fk_id`), so listing
+        several blocks must not eagerly pull in the general-purpose
+        `CalendarVirtualModel` sub-graph (memberships/calendar_ownerships) --
+        the query count must stay flat as the number of blocks grows."""
+        for i in range(4):
+            BlockedTime.objects.unscoped().create(
+                organization=calendar.organization,
+                calendar=calendar,
+                group_slot=group_slot,
+                start_time_tz_unaware=_utc(2025, 9, 2 + i, 9),
+                end_time_tz_unaware=_utc(2025, 9, 2 + i, 17),
+                timezone="UTC",
+                external_id=f"budget-block-{i}",
+            )
+
+        client = _auth_client(owner_membership)
+        # Generous margin over the observed ~6-7 queries -- what matters is
+        # that this bound does NOT scale with the number of blocks below.
+        with django_assert_max_num_queries(12):
+            response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 4
+
+        for i in range(4, 8):
+            BlockedTime.objects.unscoped().create(
+                organization=calendar.organization,
+                calendar=calendar,
+                group_slot=group_slot,
+                start_time_tz_unaware=_utc(2025, 9, 2 + i, 9),
+                end_time_tz_unaware=_utc(2025, 9, 2 + i, 17),
+                timezone="UTC",
+                external_id=f"budget-block-{i}",
+            )
+
+        with django_assert_max_num_queries(12):
+            response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 8

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -59,6 +59,7 @@ from calendar_integration.permissions import (
     CalendarGroupPermission,
     ExternalEventChangeRequestPermission,
     GroupScopedAvailabilityWindowPermission,
+    GroupScopedBlockedTimePermission,
 )
 from calendar_integration.serializers import (
     AvailableTimeBatchSerializer,
@@ -90,6 +91,10 @@ from calendar_integration.serializers import (
     GroupScopedAvailabilityWindowSerializer,
     GroupScopedAvailabilityWindowUpdateSerializer,
     GroupScopedAvailabilityWriteResultSerializer,
+    GroupScopedBlockedTimeCreateSerializer,
+    GroupScopedBlockedTimeSerializer,
+    GroupScopedBlockedTimeUpdateSerializer,
+    GroupScopedBlockWriteResultSerializer,
     ResourceCalendarCreateSerializer,
     UnavailableTimeWindowSerializer,
 )
@@ -1925,6 +1930,189 @@ class GroupScopedAvailabilityWindowViewSet(VintaScheduleModelViewSet):
             )
         except CalendarGroupSlotConfigNotFoundError as e:
             # Same not-found shape as a genuinely missing window -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@extend_schema(tags=["Calendar Group Scoped Blocked Times"])
+class GroupScopedBlockedTimeViewSet(VintaScheduleModelViewSet):
+    """Nested under a group's slot: manage group-scoped blocked times for
+    calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+    Phase 2b).
+
+    Direct mirror of ``GroupScopedAvailabilityWindowViewSet`` -- reads go
+    through ``BlockedTime.objects.for_group_slot(...)``, every write
+    delegates to the Phase 2a ``CalendarGroupService`` block-write methods,
+    and route visibility is gated by ``GroupScopedBlockedTimePermission``.
+    See that viewset's docstring for the full rationale; only the resource
+    it manages differs (blocks instead of windows).
+    """
+
+    permission_classes = (GroupScopedBlockedTimePermission,)
+    queryset = BlockedTime.objects.unscoped()
+    serializer_class = GroupScopedBlockedTimeSerializer
+    # PUT is intentionally unsupported: the underlying service is a partial
+    # update by design (only provided fields change), so only PATCH applies.
+    http_method_names = ("get", "post", "patch", "delete", "head", "options")
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return BlockedTime.original_manager.none()
+        membership = get_active_organization_membership(user)
+        if not membership:
+            return BlockedTime.original_manager.none()
+        slot_id = self.kwargs.get("slot_id")
+        return (
+            super()
+            .get_queryset()
+            .filter_by_organization(membership.organization_id)
+            .for_group_slot(slot_id)
+            # `GroupScopedBlockedTimeVirtualModel` doesn't know about `recurrence_rule`
+            # under the "rrule_string" name our serializer exposes it as -- select it
+            # explicitly so `GroupScopedBlockedTimeSerializer.get_rrule_string` doesn't
+            # N+1 on the way to `recurrence_rule.to_rrule_string()`.
+            .select_related("recurrence_rule")
+        )
+
+    @extend_schema(
+        summary="Create a group-scoped blocked time",
+        description=(
+            "Creates a group-scoped blocked time for a calendar within a group slot's "
+            "roster. Confirmed future bookings in that group for that calendar that "
+            "now fall INSIDE the block are returned in `orphaned_bookings`; nothing "
+            "about them is modified."
+        ),
+        request=GroupScopedBlockedTimeCreateSerializer,
+        responses={201: GroupScopedBlockWriteResultSerializer},
+    )
+    @inject
+    def create(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        serializer = GroupScopedBlockedTimeCreateSerializer(
+            data=request.data, context=self.get_serializer_context()
+        )
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            # Unreachable in practice -- `GroupScopedBlockedTimePermission`
+            # already requires an active membership -- but narrows the type for
+            # mypy and fails closed rather than crashing on `None.organization`.
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            result = calendar_group_service.create_group_scoped_blocked_time(
+                acting_user=request.user,
+                group_slot_id=self.kwargs["slot_id"],
+                calendar_id=data["calendar"].id,
+                start_time=data["start_time"],
+                end_time=data["end_time"],
+                tz=data["timezone"],
+                reason=data.get("reason", ""),
+                rrule_string=data.get("rrule_string"),
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing block -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+
+        response_serializer = GroupScopedBlockWriteResultSerializer(
+            result, context=self.get_serializer_context()
+        )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        summary="Update a group-scoped blocked time",
+        description=(
+            "Partial update -- only provided fields change. Confirmed future bookings "
+            "that now fall inside the block are returned in `orphaned_bookings`; "
+            "nothing about them is modified."
+        ),
+        request=GroupScopedBlockedTimeUpdateSerializer,
+        responses={200: GroupScopedBlockWriteResultSerializer},
+    )
+    @inject
+    def partial_update(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        instance = self.get_object()
+        serializer = GroupScopedBlockedTimeUpdateSerializer(
+            data=request.data, partial=True, context=self.get_serializer_context()
+        )
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        # `rrule_string` is tri-state: absent from `validated_data` (DRF drops
+        # optional fields not present in the request via SkipField) means
+        # "leave the recurrence alone"; present and `None` means "clear it";
+        # present and a string means "set/replace it". `.get()` would collapse
+        # the first two cases -- checking membership is required to tell them
+        # apart.
+        # mypy: _UNCHANGED is object() but the service accepts it as the sentinel
+        # for "str | None"; suppress the mismatch, matching the service's own annotation.
+        rrule_string: str | None = (  # type: ignore[assignment]
+            data["rrule_string"] if "rrule_string" in data else _UNCHANGED  # type: ignore[assignment]
+        )
+        try:
+            result = calendar_group_service.update_group_scoped_blocked_time(
+                acting_user=request.user,
+                block_id=instance.id,
+                start_time=data.get("start_time"),
+                end_time=data.get("end_time"),
+                tz=data.get("timezone"),
+                reason=data.get("reason"),
+                rrule_string=rrule_string,
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing block -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+
+        response_serializer = GroupScopedBlockWriteResultSerializer(
+            result, context=self.get_serializer_context()
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Delete a group-scoped blocked time",
+        description="Deletes the block (a recurring block is one row -- deletes the whole series).",
+        responses={204: None},
+    )
+    @inject
+    def destroy(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        instance = self.get_object()
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            calendar_group_service.delete_group_scoped_blocked_time(
+                acting_user=request.user, block_id=instance.id
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing block -- no message
             # leaked that would distinguish "forbidden" from "does not exist".
             raise Http404 from e
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/calendar_integration/virtual_models.py
+++ b/calendar_integration/virtual_models.py
@@ -172,6 +172,27 @@ class GroupScopedAvailabilityWindowVirtualModel(v.VirtualModel):
         model = AvailableTime
 
 
+class GroupScopedBlockedTimeVirtualModel(v.VirtualModel):
+    """Virtual model for ``GroupScopedBlockedTimeSerializer``
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+    Mirrors ``GroupScopedAvailabilityWindowVirtualModel`` exactly, for the
+    same reason: the serializer sources ``calendar_id``/``group_slot_id``
+    from the raw FK columns and never nests a ``calendar`` field, so no
+    sub-field is declared here for it -- avoids pulling in
+    ``CalendarVirtualModel``'s eager memberships/calendar_ownerships graph,
+    which this serializer never reads. ``rrule_string``/``is_recurring`` are
+    ``no_deferred_fields()``-hinted ``SerializerMethodField``s that read
+    ``recurrence_rule`` directly; the view selects that relation explicitly
+    (``.select_related("recurrence_rule")`` in
+    ``GroupScopedBlockedTimeViewSet.get_queryset``) since it isn't exposed
+    under a matching field name here for the optimizer to infer.
+    """
+
+    class Meta:
+        model = BlockedTime
+
+
 class ExternalEventChangeRequestVirtualModel(v.VirtualModel):
     """Virtual model for ``ExternalEventChangeRequest`` serialization.
 

--- a/payments/tests/services/test_restricted_enforcement.py
+++ b/payments/tests/services/test_restricted_enforcement.py
@@ -35,17 +35,31 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from calendar_integration.constants import CalendarProvider, CalendarType
-from calendar_integration.models import AvailableTime, Calendar, CalendarEvent, CalendarGroup
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarEvent,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+)
 from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_service import CalendarService
 from calendar_integration.services.dataclasses import CalendarEventInputData, CalendarGroupInputData
-from organizations.models import Organization, OrganizationInvitation, OrganizationMembership
+from organizations.models import (
+    Organization,
+    OrganizationInvitation,
+    OrganizationMembership,
+    OrganizationRole,
+)
 from payments.billing_constants import BillingInterval, BillingState, LimitedResource, LimitKind
 from payments.exceptions import OverLimitError
 from payments.models import BillingPlan, PlanLimit, Subscription, SubscriptionPlanLimit
 from payments.services.entitlement_service import EntitlementService
 from payments.services.subscription_service import SubscriptionService
 from public_api.models import SystemUser
+from users.models import User
 from webhooks.constants import WebhookEventType
 from webhooks.models import WebhookConfiguration
 from webhooks.services.webhook_service import WebhookService
@@ -204,6 +218,142 @@ def _delete_calendar_group(organization: Organization) -> None:
     service = CalendarGroupService()
     service.initialize(organization=organization)
     service.delete_group(group.id)
+
+
+def _group_scoped_membership(
+    organization: Organization,
+) -> tuple[CalendarGroupSlot, Calendar, User]:
+    """A minimal (calendar, group slot) roster entry plus an org admin
+    authorized to write its group-scoped config -- mirrors the fixture shape
+    in ``test_calendar_group_service_blocked_time.py`` /
+    ``test_calendar_group_service_availability_windows.py``. An org admin
+    (rather than a calendar owner) is used so the probe needs no
+    ``CalendarOwnership`` row -- ``can_manage_group_scoped_calendar_config``
+    grants org admins unconditionally.
+    """
+    from users.factories import UserFactory
+
+    admin_user = UserFactory().create_user()
+    baker.make(
+        OrganizationMembership,
+        user=admin_user,
+        organization=organization,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+    calendar = baker.make(
+        Calendar,
+        organization=organization,
+        calendar_type=CalendarType.PERSONAL,
+        provider=CalendarProvider.GOOGLE,
+        manage_available_windows=True,
+    )
+    group = baker.make(CalendarGroup, organization=organization)
+    # ``CalendarGroupSlot.group`` / ``CalendarGroupSlotMembership.slot`` /
+    # ``.calendar`` are ``OrganizationForeignKey`` (a composite ``ForeignObject``,
+    # not a plain ``ForeignKey``) -- model-bakery cannot auto-generate that field
+    # type, so these two rows are created directly through the manager, exactly
+    # as ``test_calendar_group_service_blocked_time.py``'s fixtures do.
+    group_slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Restricted-guard slot"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=group_slot, calendar=calendar
+    )
+    return group_slot, calendar, admin_user
+
+
+def _group_scoped_service(organization: Organization) -> CalendarGroupService:
+    service = CalendarGroupService()
+    service.initialize(organization=organization)
+    return service
+
+
+def _create_group_scoped_availability_window(organization: Organization) -> None:
+    group_slot, calendar, admin_user = _group_scoped_membership(organization)
+    _group_scoped_service(organization).create_group_scoped_availability_window(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime(2030, 1, 1, 9, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2030, 1, 1, 17, 0, tzinfo=datetime.UTC),
+        tz="UTC",
+    )
+
+
+def _update_group_scoped_availability_window(organization: Organization) -> None:
+    group_slot, calendar, admin_user = _group_scoped_membership(organization)
+    window = baker.make(
+        AvailableTime,
+        organization=organization,
+        calendar=calendar,
+        group_slot=group_slot,
+        timezone="UTC",
+    )
+    _group_scoped_service(organization).update_group_scoped_availability_window(
+        acting_user=admin_user,
+        window_id=window.id,
+        tz="America/Sao_Paulo",
+    )
+
+
+def _delete_group_scoped_availability_window(organization: Organization) -> None:
+    group_slot, calendar, admin_user = _group_scoped_membership(organization)
+    window = baker.make(
+        AvailableTime,
+        organization=organization,
+        calendar=calendar,
+        group_slot=group_slot,
+        timezone="UTC",
+    )
+    _group_scoped_service(organization).delete_group_scoped_availability_window(
+        acting_user=admin_user,
+        window_id=window.id,
+    )
+
+
+def _create_group_scoped_blocked_time(organization: Organization) -> None:
+    group_slot, calendar, admin_user = _group_scoped_membership(organization)
+    _group_scoped_service(organization).create_group_scoped_blocked_time(
+        acting_user=admin_user,
+        group_slot_id=group_slot.id,
+        calendar_id=calendar.id,
+        start_time=datetime.datetime(2030, 1, 1, 9, 0, tzinfo=datetime.UTC),
+        end_time=datetime.datetime(2030, 1, 1, 17, 0, tzinfo=datetime.UTC),
+        tz="UTC",
+        reason="Restricted-guard block",
+    )
+
+
+def _update_group_scoped_blocked_time(organization: Organization) -> None:
+    group_slot, calendar, admin_user = _group_scoped_membership(organization)
+    block = baker.make(
+        BlockedTime,
+        organization=organization,
+        calendar=calendar,
+        group_slot=group_slot,
+        timezone="UTC",
+    )
+    _group_scoped_service(organization).update_group_scoped_blocked_time(
+        acting_user=admin_user,
+        block_id=block.id,
+        reason="Renamed (restricted-guard)",
+    )
+
+
+def _delete_group_scoped_blocked_time(organization: Organization) -> None:
+    group_slot, calendar, admin_user = _group_scoped_membership(organization)
+    block = baker.make(
+        BlockedTime,
+        organization=organization,
+        calendar=calendar,
+        group_slot=group_slot,
+        timezone="UTC",
+    )
+    _group_scoped_service(organization).delete_group_scoped_blocked_time(
+        acting_user=admin_user,
+        block_id=block.id,
+    )
 
 
 def _create_webhook_configuration(organization: Organization) -> None:
@@ -451,6 +601,27 @@ RESTRICTED_WRITE_PROBES: dict[str, WriteProbe] = {
 }
 
 
+#: Group-scoped single-write probes (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+#: These six ``CalendarGroupService`` methods are NOT tied to a ``LimitedResource``
+#: ceiling -- they call ``_check_not_restricted()`` directly, never ``check_limit``
+#: -- so they cannot live in ``RESTRICTED_WRITE_PROBES`` (keyed exhaustively against
+#: ``LimitedResource.values`` by ``test_every_limited_resource_has_a_create_probe``).
+#: Kept in a sibling registry, driven by ``TestRestrictedOrganizationBlocksGroupScopedWrites``
+#: below, so the same real-guarded-method proof applies to them.
+GROUP_SCOPED_WRITE_PROBES: dict[str, WriteProbe] = {
+    "group_scoped_availability_windows": WriteProbe(
+        create=_create_group_scoped_availability_window,
+        update=_update_group_scoped_availability_window,
+        delete=_delete_group_scoped_availability_window,
+    ),
+    "group_scoped_blocked_times": WriteProbe(
+        create=_create_group_scoped_blocked_time,
+        update=_update_group_scoped_blocked_time,
+        delete=_delete_group_scoped_blocked_time,
+    ),
+}
+
+
 #: The guarded update/delete **service-level** methods behind the restricted write
 #: guard, enumerated explicitly and checked against the code by
 #: ``TestRestrictedWriteProbeCoverage`` so a rename or removal fails CI instead of
@@ -469,6 +640,15 @@ GUARDED_MUTATING_SERVICE_METHODS: list[tuple[type, str]] = [
     (CalendarGroupService, "delete_group"),
     (WebhookService, "update_configuration"),
     (WebhookService, "delete_configuration"),
+    # Group-scoped single-write methods (Phase 2b): none call check_limit, so
+    # (unlike the base creates above) their create half is guarded the same
+    # way as update/delete -- all six belong here, not just update/delete.
+    (CalendarGroupService, "create_group_scoped_availability_window"),
+    (CalendarGroupService, "update_group_scoped_availability_window"),
+    (CalendarGroupService, "delete_group_scoped_availability_window"),
+    (CalendarGroupService, "create_group_scoped_blocked_time"),
+    (CalendarGroupService, "update_group_scoped_blocked_time"),
+    (CalendarGroupService, "delete_group_scoped_blocked_time"),
 ]
 
 
@@ -486,6 +666,28 @@ def _probe_ids() -> list[str]:
 def _probe_params() -> list[tuple[str, Callable[[Organization], None]]]:
     params = []
     for resource_key, probe in RESTRICTED_WRITE_PROBES.items():
+        params.append((resource_key, probe.create))
+        if probe.update is not None:
+            params.append((resource_key, probe.update))
+        if probe.delete is not None:
+            params.append((resource_key, probe.delete))
+    return params
+
+
+def _group_scoped_probe_ids() -> list[str]:
+    ids = []
+    for resource_key, probe in GROUP_SCOPED_WRITE_PROBES.items():
+        ids.append(f"{resource_key}-create")
+        if probe.update is not None:
+            ids.append(f"{resource_key}-update")
+        if probe.delete is not None:
+            ids.append(f"{resource_key}-delete")
+    return ids
+
+
+def _group_scoped_probe_params() -> list[tuple[str, Callable[[Organization], None]]]:
+    params = []
+    for resource_key, probe in GROUP_SCOPED_WRITE_PROBES.items():
         params.append((resource_key, probe.create))
         if probe.update is not None:
             params.append((resource_key, probe.update))
@@ -572,6 +774,43 @@ class TestRestrictedOrganizationBlocksEveryWrite:
         """``GRACE`` is never write-blocked, only ``RESTRICTED`` is. A ``GRACE``
         organization with an unlimited plan keeps writing normally. Escalation
         is the dunning ladder, not a write block."""
+        organization = _organization_with_billing_state(BillingState.GRACE)
+
+        action(organization)  # must not raise
+
+
+@pytest.mark.django_db
+class TestRestrictedOrganizationBlocksGroupScopedWrites:
+    """Sibling of ``TestRestrictedOrganizationBlocksEveryWrite`` for the six
+    group-scoped single-write ``CalendarGroupService`` methods (Phase 2b) --
+    kept separate because they are not ``LimitedResource``-keyed (see
+    ``GROUP_SCOPED_WRITE_PROBES``), but proven with the exact same shape:
+    drive the real guarded method against a RESTRICTED org and assert it is
+    blocked."""
+
+    @pytest.mark.parametrize(
+        "resource_key,action", _group_scoped_probe_params(), ids=_group_scoped_probe_ids()
+    )
+    def test_restricted_blocks(self, resource_key, action):
+        organization = _organization_with_billing_state(BillingState.RESTRICTED)
+
+        with pytest.raises(OverLimitError) as exc_info:
+            action(organization)
+
+        assert exc_info.value.remedy == "resolve_billing"
+
+    @pytest.mark.parametrize(
+        "resource_key,action", _group_scoped_probe_params(), ids=_group_scoped_probe_ids()
+    )
+    def test_active_is_unaffected(self, resource_key, action):
+        organization = _organization_with_billing_state(BillingState.ACTIVE)
+
+        action(organization)  # must not raise
+
+    @pytest.mark.parametrize(
+        "resource_key,action", _group_scoped_probe_params(), ids=_group_scoped_probe_ids()
+    )
+    def test_grace_is_unaffected(self, resource_key, action):
         organization = _organization_with_billing_state(BillingState.GRACE)
 
         action(organization)  # must not raise

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -70,6 +70,14 @@ class PublicAPIResources(TextChoices):
         "batch_upsert_group_scoped_availability_windows",
         "Batch Upsert Group-Scoped Availability Windows",
     )
+    GROUP_SCOPED_BLOCKED_TIMES = (
+        "group_scoped_blocked_times",
+        "Group-Scoped Blocked Times",
+    )
+    BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES = (
+        "batch_upsert_group_scoped_blocked_times",
+        "Batch Upsert Group-Scoped Blocked Times",
+    )
 
 
 PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
@@ -89,5 +97,7 @@ PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
         PublicAPIResources.BATCH_UPDATE_AVAILABILITY_WINDOWS,
         PublicAPIResources.GROUP_SCOPED_AVAILABILITY_WINDOWS,
         PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS,
+        PublicAPIResources.GROUP_SCOPED_BLOCKED_TIMES,
+        PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES,
     ]
 )

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -34,8 +34,10 @@ from calendar_integration.graphql import (
     DeleteBookingPolicyInput,
     DeleteBookingPolicyResult,
     GroupScopedAvailabilityWindowGraphQLType,
+    GroupScopedBlockedTimeGraphQLType,
     UpdateBookingPolicyInput,
     group_scoped_availability_window_from_model,
+    group_scoped_blocked_time_from_model,
 )
 from calendar_integration.models import BookingPolicy, Calendar, CalendarEvent, CalendarGroup
 from calendar_integration.mutations import (
@@ -538,6 +540,60 @@ class BatchUpsertGroupScopedAvailabilityWindowsResult:
     success: bool
     error_message: str | None = None
     windows: list[GroupScopedAvailabilityWindowGraphQLType]
+
+
+@strawberry.input
+class GroupScopedBlockedTimeOperationInput:
+    """A single create/update/delete operation in a batch group-scoped
+    blocked-time upsert (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+    Mirrors ``GroupScopedAvailabilityWindowOperationInput`` exactly, plus
+    ``reason``. ``calendarId`` is required on every operation (not only
+    ``create``) so the owner-scope guard can be applied per-operation before
+    any service call.
+
+    For action='create': calendarId, startTime, endTime, and timezone are
+    required; reason and rruleString are optional. An identical create
+    (same calendar, group slot, start/end time, timezone, reason, and rrule
+    as an existing block) is a no-op — replaying the same batch never
+    duplicates a block (spec UC-5).
+    For action='update': blockId is required; other fields are optional
+    (only provided fields change).
+    For action='delete': blockId is required; no other fields are needed.
+    """
+
+    action: str
+    calendar_id: int
+    block_id: int | None = None
+    start_time: datetime.datetime | None = None
+    end_time: datetime.datetime | None = None
+    timezone: str | None = None
+    reason: str | None = None
+    rrule_string: str | None = None
+
+
+@strawberry.input
+class BatchGroupScopedBlockedTimesInput:
+    """Input for applying an atomic batch of group-scoped blocked-time
+    operations within one group slot's roster."""
+
+    organization_id: int
+    group_slot_id: int
+    operations: list[GroupScopedBlockedTimeOperationInput]
+
+
+@strawberry.type
+class BatchUpsertGroupScopedBlockedTimesResult:
+    """Result of the batchUpsertGroupScopedBlockedTimes mutation.
+
+    On success, ``blockedTimes`` contains every group-scoped block in the
+    group slot's roster (all calendars) after the batch is applied. On
+    failure, ``blockedTimes`` is an empty list and nothing was written.
+    """
+
+    success: bool
+    error_message: str | None = None
+    blocked_times: list[GroupScopedBlockedTimeGraphQLType]
 
 
 @strawberry.input
@@ -2161,6 +2217,137 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         return BatchUpsertGroupScopedAvailabilityWindowsResult(
             success=True,
             windows=[group_scoped_availability_window_from_model(w) for w in windows],
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def batch_upsert_group_scoped_blocked_times(
+        self,
+        info: strawberry.Info,
+        input: BatchGroupScopedBlockedTimesInput,  # noqa: A002
+    ) -> BatchUpsertGroupScopedBlockedTimesResult:
+        """Apply an atomic create/update/delete batch of group-scoped blocked
+        times within one group slot's roster
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+        Direct mirror of ``batchUpsertGroupScopedAvailabilityWindows`` -- same
+        validation, owner-scope, and IDOR cross-check structure -- with ONE
+        deliberate difference: blocked time is not metered yet (that is
+        Phase 2c), so this mutation never surfaces an ``OverLimitError`` for
+        a plan-limit ceiling; ``CalendarGroupService.batch_upsert_group_scoped_blocked_times``
+        still enforces ``check_not_restricted`` (a ``RESTRICTED`` billing
+        root still blocks the write), but there is no delta/limit check.
+
+        The token's OrganizationResourceAccess must include the
+        BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES resource.
+        """
+        _valid_actions = {"create", "update", "delete"}
+
+        org = info.context.request.public_api_organization
+        if not org:
+            return BatchUpsertGroupScopedBlockedTimesResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                blocked_times=[],
+            )
+        if input.organization_id != org.id:
+            return BatchUpsertGroupScopedBlockedTimesResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                blocked_times=[],
+            )
+
+        # Validate all operations before touching anything -- fail fast, no writes.
+        for op_input in input.operations:
+            if op_input.action not in _valid_actions:
+                return BatchUpsertGroupScopedBlockedTimesResult(
+                    success=False,
+                    error_message=f"Invalid operation action: {op_input.action}",
+                    blocked_times=[],
+                )
+            if op_input.action == "create" and (
+                op_input.start_time is None
+                or op_input.end_time is None
+                or op_input.timezone is None
+            ):
+                return BatchUpsertGroupScopedBlockedTimesResult(
+                    success=False,
+                    error_message="create operation requires startTime, endTime, and timezone",
+                    blocked_times=[],
+                )
+            if op_input.action in ("update", "delete") and op_input.block_id is None:
+                return BatchUpsertGroupScopedBlockedTimesResult(
+                    success=False,
+                    error_message=f"{op_input.action} operation requires blockId",
+                    blocked_times=[],
+                )
+
+        # Owner-scope guard per operation's calendarId -- reveals nothing about
+        # existence for a calendar outside a scoped token's owner set. Checked
+        # for EVERY operation up front, so a cross-owner op anywhere in the
+        # batch rejects the whole thing before any service call. This only
+        # proves the token owns op.calendarId; it does NOT prove that an
+        # update/delete op's blockId actually resolves to that calendar --
+        # CalendarGroupService.batch_upsert_group_scoped_blocked_times
+        # cross-checks that itself (block.calendar_fk_id == op.calendar_id)
+        # before applying anything, so a token can't pair a calendarId it owns
+        # with a blockId belonging to a different calendar.
+        request: PublicApiHttpRequest = info.context.request
+        system_user = request.public_api_system_user
+        try:
+            for op_input in input.operations:
+                assert_calendar_in_owner_scope(system_user, org, op_input.calendar_id)
+        except Calendar.DoesNotExist:
+            return BatchUpsertGroupScopedBlockedTimesResult(
+                success=False, error_message="Calendar not found.", blocked_times=[]
+            )
+
+        ops: list[dict[str, object]] = []
+        for op_input in input.operations:
+            op: dict[str, object] = {"action": op_input.action, "calendar_id": op_input.calendar_id}
+            if op_input.block_id is not None:
+                op["block_id"] = op_input.block_id
+            if op_input.start_time is not None:
+                op["start_time"] = op_input.start_time
+            if op_input.end_time is not None:
+                op["end_time"] = op_input.end_time
+            if op_input.timezone is not None:
+                op["timezone"] = op_input.timezone
+            if op_input.reason is not None:
+                op["reason"] = op_input.reason
+            if op_input.rrule_string is not None:
+                op["rrule_string"] = op_input.rrule_string
+            ops.append(op)
+
+        deps = get_calendar_mutation_dependencies()
+        deps.calendar_group_service.initialize(organization=org)
+
+        if system_user is None:
+            return BatchUpsertGroupScopedBlockedTimesResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                blocked_times=[],
+            )
+
+        try:
+            blocks = deps.calendar_group_service.batch_upsert_group_scoped_blocked_times(
+                group_slot_id=input.group_slot_id,
+                operations=ops,
+                acting_principal=system_user,
+            )
+        except OverLimitError as exc:
+            raise_over_limit_graphql_error(exc)
+        except CalendarGroupSlotConfigNotFoundError:
+            return BatchUpsertGroupScopedBlockedTimesResult(
+                success=False, error_message="Group slot not found.", blocked_times=[]
+            )
+        except (CalendarIntegrationError, ValueError, DjangoValidationError) as e:
+            return BatchUpsertGroupScopedBlockedTimesResult(
+                success=False, error_message=str(e), blocked_times=[]
+            )
+
+        return BatchUpsertGroupScopedBlockedTimesResult(
+            success=True,
+            blocked_times=[group_scoped_blocked_time_from_model(b) for b in blocks],
         )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -72,6 +72,10 @@ class OrganizationResourceAccess(BasePermission):
         "batchUpsertGroupScopedAvailabilityWindows": (
             PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS
         ),
+        "groupScopedBlockedTimes": PublicAPIResources.GROUP_SCOPED_BLOCKED_TIMES,
+        "batchUpsertGroupScopedBlockedTimes": (
+            PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES
+        ),
         "createBlockedTime": PublicAPIResources.CREATE_BLOCKED_TIME,
         "updateBlockedTime": PublicAPIResources.UPDATE_BLOCKED_TIME,
         "deleteBlockedTime": PublicAPIResources.DELETE_BLOCKED_TIME,

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -36,9 +36,11 @@ from calendar_integration.graphql import (
     CalendarWebhookSubscriptionGraphQLType,
     ExternalEventChangeRequestGraphQLType,
     GroupScopedAvailabilityWindowGraphQLType,
+    GroupScopedBlockedTimeGraphQLType,
     UnavailableTimeWindowGraphQLType,
     WebhookSubscriptionStatusGraphQLType,
     group_scoped_availability_window_from_model,
+    group_scoped_blocked_time_from_model,
 )
 from calendar_integration.models import (
     AvailableTime,
@@ -1006,6 +1008,45 @@ class Query:
 
         windows = _slice_qs(qs.order_by("pk"), offset, limit)
         return [group_scoped_availability_window_from_model(w) for w in windows]
+
+    @strawberry.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def group_scoped_blocked_times(
+        self,
+        info: strawberry.Info,
+        group_slot_id: int,
+        calendar_id: int | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[GroupScopedBlockedTimeGraphQLType]:
+        """List group-scoped blocked times for a group slot's roster.
+
+        Returns raw block rows (one per recurring master or one-off block,
+        not expanded occurrences) -- mirrors the internal REST surface's
+        list shape (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b). Optionally
+        filtered to a single calendar in the slot's roster.
+        """
+        org = _get_org(info)
+
+        qs = (
+            BlockedTime.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(org.id)
+            .select_related("recurrence_rule")
+        )
+
+        # Owner-scope: for scoped tokens, only return blocks on calendars in
+        # the token owner's set.
+        request: PublicApiHttpRequest = info.context.request
+        system_user = request.public_api_system_user
+        if system_user is not None:
+            allowed_ids = scoped_calendar_ids(system_user, org)
+            if allowed_ids is not None:
+                qs = qs.filter(calendar_fk__in=allowed_ids)
+
+        if calendar_id is not None:
+            qs = qs.filter(calendar_fk_id=calendar_id)
+
+        blocks = _slice_qs(qs.order_by("pk"), offset, limit)
+        return [group_scoped_blocked_time_from_model(b) for b in blocks]
 
     @strawberry_django.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
     def child_organizations(

--- a/public_api/tests/test_group_scoped_blocked_times.py
+++ b/public_api/tests/test_group_scoped_blocked_times.py
@@ -423,6 +423,93 @@ class TestGroupScopedBlockedTimesPublicAPI:
             "Replaying an identical batch must not create a duplicate block."
         )
 
+    def test_reason_participates_in_the_idempotent_create_match_key(self):
+        """``reason`` is part of ``_find_matching_group_scoped_block``'s match
+        key (calendar, group slot, start, end, timezone, reason, rrule). A
+        ``create`` op with the SAME reason as an already-persisted block
+        matches it (no-op); a ``create`` op with the SAME (calendar, slot,
+        start, end, timezone) but a DIFFERENT reason must NOT match -- it is
+        a genuinely distinct block and must persist as its own row. If
+        ``reason`` were dropped from that filter, both ops below would match
+        the same pre-existing row and only one row would remain."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        existing = BlockedTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=end,
+            timezone="UTC",
+            reason="Conference",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            # Identical to `existing`, including reason -- matches,
+                            # no new row.
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "startTime": start.isoformat(),
+                            "endTime": end.isoformat(),
+                            "timezone": "UTC",
+                            "reason": "Conference",
+                        },
+                        {
+                            # Same (calendar, slot, start, end, timezone) as
+                            # `existing`, but a DIFFERENT reason -- must NOT match;
+                            # persists as its own distinct row.
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "startTime": start.isoformat(),
+                            "endTime": end.isoformat(),
+                            "timezone": "UTC",
+                            "reason": "On call elsewhere",
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert result["success"] is True
+
+        # Two distinct rows: `existing` (matched, unchanged) + the new
+        # different-reason block. Not one -- which is what would happen if
+        # `reason` were dropped from the idempotent-create match key and the
+        # second op collapsed into `existing` too.
+        assert len(result["blockedTimes"]) == 2
+        reasons = {block["reason"] for block in result["blockedTimes"]}
+        assert reasons == {"Conference", "On call elsewhere"}
+
+        rows = (
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+        )
+        assert rows.count() == 2
+        assert rows.filter(id=existing.id).exists()
+
     # ------------------------------------------------------------------
     # batchUpsertGroupScopedBlockedTimes -- RESTRICTED billing root still blocks
     # ------------------------------------------------------------------

--- a/public_api/tests/test_group_scoped_blocked_times.py
+++ b/public_api/tests/test_group_scoped_blocked_times.py
@@ -1,0 +1,958 @@
+"""Integration tests for the public GraphQL surface of group-scoped
+blocked times (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+Direct mirror of ``test_group_scoped_availability_windows.py`` for blocks.
+Covers ``groupScopedBlockedTimes`` (query) and
+``batchUpsertGroupScopedBlockedTimes`` (batch-upsert mutation): batch apply,
+idempotent replay (identical final state, no duplicates), cross-organization
+scoping, and the IDOR window/calendar cross-check. Blocked time is NOT
+metered yet (Phase 2c does that), so there is no over-limit test here --
+instead, a ``RESTRICTED`` billing root is asserted to still block the batch
+(the one guard that DOES apply pre-metering).
+"""
+
+import datetime
+import uuid
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType
+from calendar_integration.models import (
+    BlockedTime,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarOwnership,
+)
+from organizations.models import Organization, OrganizationMembership
+from payments.billing_constants import BillingState
+from payments.models import Subscription
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+GROUP_SCOPED_BLOCKED_TIMES_QUERY = """
+query GroupScopedBlockedTimes($groupSlotId: Int!, $calendarId: Int) {
+    groupScopedBlockedTimes(groupSlotId: $groupSlotId, calendarId: $calendarId) {
+        id
+        calendarId
+        groupSlotId
+        startTime
+        endTime
+        timezone
+        reason
+        rruleString
+        isRecurring
+    }
+}
+"""
+
+BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION = """
+mutation BatchUpsertGroupScopedBlockedTimes($input: BatchGroupScopedBlockedTimesInput!) {
+    batchUpsertGroupScopedBlockedTimes(input: $input) {
+        success
+        errorMessage
+        blockedTimes {
+            id
+            calendarId
+            groupSlotId
+            startTime
+            endTime
+            timezone
+            reason
+            rruleString
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestGroupScopedBlockedTimesPublicAPI:
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _setup_org(self) -> Organization:
+        return baker.make(Organization, name="Test Org")
+
+    def _make_org_wide_system_user(self, org, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_owner_with_calendar(self, org: Organization):
+        """Create a user, their active membership, and a calendar they own.
+
+        Returns (user, membership, calendar).
+        """
+        from django.contrib.auth import get_user_model
+
+        user_model = get_user_model()
+        unique = uuid.uuid4().hex[:8]
+        owner = baker.make(user_model, email=f"owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = Calendar.objects.create(
+            organization=org,
+            name=f"Calendar {unique}",
+            external_id=f"cal-{unique}",
+            provider=CalendarProvider.GOOGLE,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+        )
+        CalendarOwnership.objects.create(
+            organization=org, calendar=calendar, membership_user_id=owner.id
+        )
+        return owner, membership, calendar
+
+    def _make_calendar(self, org: Organization) -> Calendar:
+        unique = uuid.uuid4().hex[:8]
+        return Calendar.objects.create(
+            organization=org,
+            name=f"Calendar {unique}",
+            external_id=f"cal-{unique}",
+            provider=CalendarProvider.GOOGLE,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+        )
+
+    def _make_group_slot(self, org: Organization, *calendars: Calendar) -> CalendarGroupSlot:
+        group = CalendarGroup.objects.create(organization=org, name="Surgery")
+        slot = CalendarGroupSlot.objects.create(organization=org, group=group, name="Lead")
+        for calendar in calendars:
+            CalendarGroupSlotMembership.objects.create(
+                organization=org, slot=slot, calendar=calendar
+            )
+        return slot
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def _restrict_organization(self, organization: Organization) -> None:
+        """Flip ``organization``'s (auto-provisioned, unlimited) subscription to
+        RESTRICTED in place -- applied AFTER any setup (e.g. system-user-token
+        creation) that itself goes through a guarded, limit-checked path, so
+        that setup is not blocked by the very state under test."""
+        Subscription.objects.filter(organization=organization).update(
+            billing_state=BillingState.RESTRICTED
+        )
+
+    # ------------------------------------------------------------------
+    # groupScopedBlockedTimes -- query
+    # ------------------------------------------------------------------
+
+    def test_query_returns_group_scoped_blocks_for_the_slot(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org,
+            [
+                PublicAPIResources.GROUP_SCOPED_BLOCKED_TIMES,
+                PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES,
+            ],
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        block = BlockedTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=end,
+            timezone="UTC",
+            reason="On call elsewhere",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+
+        response = self._post(
+            GROUP_SCOPED_BLOCKED_TIMES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        blocks = data["data"]["groupScopedBlockedTimes"]
+        assert len(blocks) == 1
+        assert blocks[0]["id"] == block.id
+        assert blocks[0]["calendarId"] == calendar.id
+        assert blocks[0]["groupSlotId"] == slot.id
+        assert blocks[0]["timezone"] == "UTC"
+        assert blocks[0]["reason"] == "On call elsewhere"
+
+    def test_query_cross_organization_scoping_returns_empty(self):
+        """A group slot belonging to another organization is invisible."""
+        org_a = self._setup_org()
+        org_b = self._setup_org()
+        calendar_b = self._make_calendar(org_b)
+        slot_b = self._make_group_slot(org_b, calendar_b)
+
+        BlockedTime.objects.unscoped().create(
+            organization=org_b,
+            calendar=calendar_b,
+            group_slot=slot_b,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org_a, [PublicAPIResources.GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        response = self._post(
+            GROUP_SCOPED_BLOCKED_TIMES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot_b.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        assert data["data"]["groupScopedBlockedTimes"] == []
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedBlockedTimes -- apply
+    # ------------------------------------------------------------------
+
+    def test_batch_upsert_applies_mixed_operations(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        existing = BlockedTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+        to_delete = BlockedTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 2, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 2, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+
+        create_start = datetime.datetime(2026, 10, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        create_end = datetime.datetime(2026, 10, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        new_start = datetime.datetime(2026, 11, 1, 8, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 1, 16, 0, 0, tzinfo=datetime.UTC)
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "startTime": create_start.isoformat(),
+                            "endTime": create_end.isoformat(),
+                            "timezone": "UTC",
+                            "reason": "Conference",
+                        },
+                        {
+                            "action": "update",
+                            "calendarId": calendar.id,
+                            "blockId": existing.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                        },
+                        {
+                            "action": "delete",
+                            "calendarId": calendar.id,
+                            "blockId": to_delete.id,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert result["success"] is True
+        assert result["errorMessage"] is None
+        # Final roster state: the updated row + the newly created row (deleted row gone).
+        assert len(result["blockedTimes"]) == 2
+
+        existing.refresh_from_db()
+        assert existing.start_time_tz_unaware == new_start
+        assert existing.end_time_tz_unaware == new_end
+        assert not (
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(id=to_delete.id)
+            .exists()
+        )
+
+        remaining = BlockedTime.objects.for_group_slot(slot.id).filter_by_organization(org.id)
+        assert remaining.count() == 2
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedBlockedTimes -- idempotent replay
+    # ------------------------------------------------------------------
+
+    def test_identical_replay_is_a_no_op(self):
+        """Replaying an identical create-only batch (spec UC-5) lands on the
+        same final state instead of duplicating rows."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        variables = {
+            "input": {
+                "organizationId": org.id,
+                "groupSlotId": slot.id,
+                "operations": [
+                    {
+                        "action": "create",
+                        "calendarId": calendar.id,
+                        "startTime": start.isoformat(),
+                        "endTime": end.isoformat(),
+                        "timezone": "UTC",
+                        "reason": "Conference",
+                    },
+                ],
+            }
+        }
+
+        first = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            variables,
+        )
+        assert first.status_code == 200
+        first_result = first.json()["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert first_result["success"] is True
+        assert len(first_result["blockedTimes"]) == 1
+        first_block_id = first_result["blockedTimes"][0]["id"]
+
+        rows_after_first = (
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+        )
+        assert rows_after_first == 1
+
+        second = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            variables,
+        )
+        assert second.status_code == 200
+        second_result = second.json()["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert second_result["success"] is True
+
+        # Same final state: one row, same id, no duplicate created.
+        assert len(second_result["blockedTimes"]) == 1
+        assert second_result["blockedTimes"][0]["id"] == first_block_id
+        rows_after_replay = (
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+        )
+        assert rows_after_replay == 1, (
+            "Replaying an identical batch must not create a duplicate block."
+        )
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedBlockedTimes -- RESTRICTED billing root still blocks
+    # ------------------------------------------------------------------
+
+    def test_restricted_organization_batch_rejected_wholesale(self):
+        """Blocked time is not metered yet (Phase 2c), so there is no
+        plan-limit ceiling to hit here -- but the general RESTRICTED-billing-
+        root guard every other guarded write goes through must still apply.
+        Nothing is created."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+        # Restrict AFTER the system-user token is created -- token creation is
+        # itself a guarded, limit-checked path that a RESTRICTED billing root
+        # would also block.
+        self._restrict_organization(org)
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "startTime": datetime.datetime(
+                                2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "endTime": datetime.datetime(
+                                2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["errors"]) == 1
+        extensions = data["errors"][0]["extensions"]
+        assert extensions["code"] == "limit_exceeded"
+        assert extensions["remedy"] == "resolve_billing"
+        assert (
+            BlockedTime.objects.for_group_slot(slot.id).filter_by_organization(org.id).count() == 0
+        ), "A RESTRICTED organization's batch must create nothing."
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedBlockedTimes -- cross-organization scoping
+    # ------------------------------------------------------------------
+
+    def test_cross_organization_group_slot_is_rejected(self):
+        org_a = self._setup_org()
+        org_b = self._setup_org()
+        calendar_b = self._make_calendar(org_b)
+        slot_b = self._make_group_slot(org_b, calendar_b)
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org_a.id,
+                    "groupSlotId": slot_b.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar_b.id,
+                            "startTime": datetime.datetime(
+                                2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "endTime": datetime.datetime(
+                                2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert result["success"] is False
+        assert result["blockedTimes"] == []
+        assert (
+            not BlockedTime.objects.for_group_slot(slot_b.id)
+            .filter_by_organization(org_b.id)
+            .filter(calendar_fk_id=calendar_b.id, timezone="UTC")
+            .exists()
+        )
+
+    def test_cross_owner_scoped_token_rejected_wholesale(self):
+        """A scoped token may not write group-scoped blocks on a calendar it
+        does not own -- same not-found shape as a genuinely missing calendar,
+        and nothing is written."""
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_b)
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar_b.id,
+                            "startTime": datetime.datetime(
+                                2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "endTime": datetime.datetime(
+                                2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Calendar not found."
+        assert (
+            BlockedTime.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedBlockedTimes -- IDOR (block/calendar cross-check
+    # on update/delete)
+    # ------------------------------------------------------------------
+
+    def test_update_with_block_from_another_calendar_rejected_wholesale(self):
+        """A calendar-owner-scoped token pairs a calendarId it owns with a
+        blockId belonging to a DIFFERENT calendar in the same slot's roster.
+        assert_calendar_in_owner_scope alone would let this through (it only
+        checks ownership of calendarId) -- the service must ALSO reject
+        because the resolved block does not belong to that calendar. Whole
+        batch fails, not-found shape, nothing changes."""
+        org = self._setup_org()
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_a, calendar_b)
+
+        foreign_block = BlockedTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar_b,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        new_start = datetime.datetime(2026, 11, 1, 8, 0, 0, tzinfo=datetime.UTC)
+        new_end = datetime.datetime(2026, 11, 1, 16, 0, 0, tzinfo=datetime.UTC)
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            # calendarId the token owns...
+                            "calendarId": calendar_a.id,
+                            # ...but blockId belongs to calendar_b.
+                            "blockId": foreign_block.id,
+                            "startTime": new_start.isoformat(),
+                            "endTime": new_end.isoformat(),
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["blockedTimes"] == []
+
+        foreign_block.refresh_from_db()
+        assert foreign_block.start_time_tz_unaware != new_start
+        assert foreign_block.end_time_tz_unaware != new_end
+        assert foreign_block.calendar_fk_id == calendar_b.id
+
+    def test_delete_with_block_from_another_calendar_rejected_wholesale(self):
+        """Same IDOR as the update case above, but for a delete op: the
+        foreign block must still exist, unmodified, afterward."""
+        org = self._setup_org()
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_a, calendar_b)
+
+        foreign_block = BlockedTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar_b,
+            group_slot=slot,
+            start_time_tz_unaware=datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC),
+            end_time_tz_unaware=datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC),
+            timezone="UTC",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "delete",
+                            # calendarId the token owns, blockId belongs to calendar_b.
+                            "calendarId": calendar_a.id,
+                            "blockId": foreign_block.id,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["blockedTimes"] == []
+
+        assert (
+            BlockedTime.objects.unscoped()
+            .filter_by_organization(org.id)
+            .filter(id=foreign_block.id)
+            .exists()
+        ), "The foreign block must NOT be deleted by a batch it was never authorized for."
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedBlockedTimes -- create outside the slot's roster
+    # ------------------------------------------------------------------
+
+    def test_create_with_calendar_outside_slot_roster_rejected_wholesale(self):
+        """A create op's calendarId is a calendar the token owns/can access, but
+        it is not a member of the target groupSlotId's roster -- rejected with
+        the not-found shape, nothing created."""
+        org = self._setup_org()
+        roster_calendar = self._make_calendar(org)
+        outside_calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, roster_calendar)
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": outside_calendar.id,
+                            "startTime": datetime.datetime(
+                                2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "endTime": datetime.datetime(
+                                2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC
+                            ).isoformat(),
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedBlockedTimes"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["blockedTimes"] == []
+        assert (
+            BlockedTime.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=outside_calendar.id)
+            .count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
+    # Anonymous / unauthorized access -- query and mutation
+    # ------------------------------------------------------------------
+
+    def test_query_anonymous_request_denied(self):
+        """No Authorization header -- the standard auth error, no data leaked."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+
+        response = self.client.post(
+            "/graphql/",
+            data={
+                "query": GROUP_SCOPED_BLOCKED_TIMES_QUERY,
+                "variables": {"groupSlotId": slot.id, "calendarId": None},
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+
+    def test_mutation_anonymous_request_denied(self):
+        """No Authorization header on the mutation -- the standard auth error,
+        no write applied."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+
+        response = self.client.post(
+            "/graphql/",
+            data={
+                "query": BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+                "variables": {
+                    "input": {
+                        "organizationId": org.id,
+                        "groupSlotId": slot.id,
+                        "operations": [
+                            {
+                                "action": "create",
+                                "calendarId": calendar.id,
+                                "startTime": "2026-09-01T09:00:00Z",
+                                "endTime": "2026-09-01T17:00:00Z",
+                                "timezone": "UTC",
+                            }
+                        ],
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert (
+            BlockedTime.objects.for_group_slot(slot.id).filter_by_organization(org.id).count() == 0
+        )
+
+    def test_query_token_without_resource_grant_denied(self):
+        """An authenticated token that lacks the GROUP_SCOPED_BLOCKED_TIMES
+        resource grant is denied."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        # Grant an unrelated resource only.
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        response = self._post(
+            GROUP_SCOPED_BLOCKED_TIMES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_mutation_token_without_resource_grant_denied(self):
+        """An authenticated token that lacks the
+        BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES resource grant is denied, and
+        nothing is written."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        # Grant an unrelated resource only.
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "startTime": "2026-09-01T09:00:00Z",
+                            "endTime": "2026-09-01T17:00:00Z",
+                            "timezone": "UTC",
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+        assert (
+            BlockedTime.objects.for_group_slot(slot.id).filter_by_organization(org.id).count() == 0
+        )
+
+    # ------------------------------------------------------------------
+    # Existing availability window operations are unchanged (no-regression)
+    # ------------------------------------------------------------------
+
+    def test_existing_group_scoped_availability_windows_query_shape_unchanged(self):
+        """Byte-for-byte shape check: the frozen groupScopedAvailabilityWindows
+        query's response is unaffected by this phase's additions."""
+        from calendar_integration.models import AvailableTime
+
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.GROUP_SCOPED_AVAILABILITY_WINDOWS]
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        window = AvailableTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=end,
+            timezone="UTC",
+        )
+
+        query = """
+        query GroupScopedAvailabilityWindows($groupSlotId: Int!, $calendarId: Int) {
+            groupScopedAvailabilityWindows(groupSlotId: $groupSlotId, calendarId: $calendarId) {
+                id
+                calendarId
+                groupSlotId
+                startTime
+                endTime
+                timezone
+                rruleString
+                isRecurring
+            }
+        }
+        """
+        response = self._post(
+            query,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        windows = data["data"]["groupScopedAvailabilityWindows"]
+        assert len(windows) == 1
+        assert windows[0]["id"] == window.id

--- a/schema.yml
+++ b/schema.yml
@@ -5852,6 +5852,555 @@ paths:
       responses:
         '204':
           description: No response body
+  /calendar-groups/{group_id}/slots/{slot_id}/blocked-times/:
+    get:
+      operationId: calendar_groups_slots_blocked_times_list
+      description: |-
+        Nested under a group's slot: manage group-scoped blocked times for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 2b).
+
+        Direct mirror of ``GroupScopedAvailabilityWindowViewSet`` -- reads go
+        through ``BlockedTime.objects.for_group_slot(...)``, every write
+        delegates to the Phase 2a ``CalendarGroupService`` block-write methods,
+        and route visibility is gated by ``GroupScopedBlockedTimePermission``.
+        See that viewset's docstring for the full rationale; only the resource
+        it manages differs (blocks instead of windows).
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGroupScopedBlockedTimeList'
+          description: ''
+    post:
+      operationId: calendar_groups_slots_blocked_times_create
+      description: Creates a group-scoped blocked time for a calendar within a group
+        slot's roster. Confirmed future bookings in that group for that calendar that
+        now fall INSIDE the block are returned in `orphaned_bookings`; nothing about
+        them is modified.
+      summary: Create a group-scoped blocked time
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupScopedBlockedTimeCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GroupScopedBlockedTimeCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GroupScopedBlockedTimeCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedBlockWriteResult'
+          description: ''
+  /calendar-groups/{group_id}/slots/{slot_id}/blocked-times{format}:
+    get:
+      operationId: calendar_groups_slots_blocked_times_formatted_list
+      description: |-
+        Nested under a group's slot: manage group-scoped blocked times for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 2b).
+
+        Direct mirror of ``GroupScopedAvailabilityWindowViewSet`` -- reads go
+        through ``BlockedTime.objects.for_group_slot(...)``, every write
+        delegates to the Phase 2a ``CalendarGroupService`` block-write methods,
+        and route visibility is gated by ``GroupScopedBlockedTimePermission``.
+        See that viewset's docstring for the full rationale; only the resource
+        it manages differs (blocks instead of windows).
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGroupScopedBlockedTimeList'
+          description: ''
+    post:
+      operationId: calendar_groups_slots_blocked_times_formatted_create
+      description: Creates a group-scoped blocked time for a calendar within a group
+        slot's roster. Confirmed future bookings in that group for that calendar that
+        now fall INSIDE the block are returned in `orphaned_bookings`; nothing about
+        them is modified.
+      summary: Create a group-scoped blocked time
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupScopedBlockedTimeCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GroupScopedBlockedTimeCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GroupScopedBlockedTimeCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedBlockWriteResult'
+          description: ''
+  /calendar-groups/{group_id}/slots/{slot_id}/blocked-times/{id}/:
+    get:
+      operationId: calendar_groups_slots_blocked_times_retrieve
+      description: |-
+        Nested under a group's slot: manage group-scoped blocked times for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 2b).
+
+        Direct mirror of ``GroupScopedAvailabilityWindowViewSet`` -- reads go
+        through ``BlockedTime.objects.for_group_slot(...)``, every write
+        delegates to the Phase 2a ``CalendarGroupService`` block-write methods,
+        and route visibility is gated by ``GroupScopedBlockedTimePermission``.
+        See that viewset's docstring for the full rationale; only the resource
+        it manages differs (blocks instead of windows).
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedBlockedTime'
+          description: ''
+    patch:
+      operationId: calendar_groups_slots_blocked_times_partial_update
+      description: Partial update -- only provided fields change. Confirmed future
+        bookings that now fall inside the block are returned in `orphaned_bookings`;
+        nothing about them is modified.
+      summary: Update a group-scoped blocked time
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedBlockedTimeUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedBlockedTimeUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedBlockedTimeUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedBlockWriteResult'
+          description: ''
+    delete:
+      operationId: calendar_groups_slots_blocked_times_destroy
+      description: Deletes the block (a recurring block is one row -- deletes the
+        whole series).
+      summary: Delete a group-scoped blocked time
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /calendar-groups/{group_id}/slots/{slot_id}/blocked-times/{id}{format}:
+    get:
+      operationId: calendar_groups_slots_blocked_times_formatted_retrieve
+      description: |-
+        Nested under a group's slot: manage group-scoped blocked times for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 2b).
+
+        Direct mirror of ``GroupScopedAvailabilityWindowViewSet`` -- reads go
+        through ``BlockedTime.objects.for_group_slot(...)``, every write
+        delegates to the Phase 2a ``CalendarGroupService`` block-write methods,
+        and route visibility is gated by ``GroupScopedBlockedTimePermission``.
+        See that viewset's docstring for the full rationale; only the resource
+        it manages differs (blocks instead of windows).
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedBlockedTime'
+          description: ''
+    patch:
+      operationId: calendar_groups_slots_blocked_times_formatted_partial_update
+      description: Partial update -- only provided fields change. Confirmed future
+        bookings that now fall inside the block are returned in `orphaned_bookings`;
+        nothing about them is modified.
+      summary: Update a group-scoped blocked time
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedBlockedTimeUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedBlockedTimeUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedBlockedTimeUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedBlockWriteResult'
+          description: ''
+    delete:
+      operationId: calendar_groups_slots_blocked_times_formatted_destroy
+      description: Deletes the block (a recurring block is one row -- deletes the
+        whole series).
+      summary: Delete a group-scoped blocked time
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Blocked Times
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /calendar-groups/{id}/:
     get:
       operationId: calendar_groups_retrieve
@@ -13920,6 +14469,8 @@ components:
       - bookable_slots
       - group_scoped_availability_windows
       - batch_upsert_group_scoped_availability_windows
+      - group_scoped_blocked_times
+      - batch_upsert_group_scoped_blocked_times
       type: string
       description: |-
         * `calendar_event` - Calendar Event
@@ -13968,6 +14519,8 @@ components:
         * `bookable_slots` - Bookable Slots
         * `group_scoped_availability_windows` - Group-Scoped Availability Windows
         * `batch_upsert_group_scoped_availability_windows` - Batch Upsert Group-Scoped Availability Windows
+        * `group_scoped_blocked_times` - Group-Scoped Blocked Times
+        * `batch_upsert_group_scoped_blocked_times` - Batch Upsert Group-Scoped Blocked Times
     AvailableTime:
       type: object
       description: Serializer for AvailableTime model with recurring support.
@@ -15561,6 +16114,159 @@ components:
       required:
       - orphaned_bookings
       - window
+    GroupScopedBlockOrphanedBooking:
+      type: object
+      description: |-
+        Minimal identification of a booking a block write orphaned (spec
+        UC-6's rule applied to blocks) -- enough for an admin to act on. Nothing
+        about the booking itself is modified by the write that produced this
+        entry.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        calendar_id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+        start_time:
+          type: string
+          format: date-time
+          readOnly: true
+        end_time:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - calendar_id
+      - end_time
+      - id
+      - start_time
+      - title
+    GroupScopedBlockWriteResult:
+      type: object
+      description: |-
+        Wraps a ``GroupScopedBlockWriteResult``: the saved block plus any
+        confirmed future bookings the write orphaned. Returned by the create and
+        update actions of ``GroupScopedBlockedTimeViewSet``.
+      properties:
+        block:
+          allOf:
+          - $ref: '#/components/schemas/GroupScopedBlockedTime'
+          readOnly: true
+        orphaned_bookings:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupScopedBlockOrphanedBooking'
+          readOnly: true
+          description: Confirmed future bookings in this slot for this block's calendar
+            that now fall inside the calendar's group-scoped blocked time after this
+            write. Nothing about them is modified or cancelled -- act on them manually
+            if needed.
+      required:
+      - block
+      - orphaned_bookings
+    GroupScopedBlockedTime:
+      type: object
+      description: |-
+        Read representation of a group-scoped blocked time
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 2b).
+
+        Mirrors ``GroupScopedAvailabilityWindowSerializer`` exactly, plus
+        ``reason`` -- there is no nested ``recurrence_rule`` write path here,
+        only ``rrule_string``, matching exactly what ``CalendarGroupService``'s
+        block-write methods accept, so the REST shape and the service signature
+        cannot drift apart.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        calendar_id:
+          type: integer
+          readOnly: true
+        group_slot_id:
+          type: integer
+          readOnly: true
+        start_time:
+          type: string
+          format: date-time
+          readOnly: true
+        end_time:
+          type: string
+          format: date-time
+          readOnly: true
+        timezone:
+          type: string
+          readOnly: true
+        reason:
+          type: string
+          readOnly: true
+        rrule_string:
+          type: string
+          nullable: true
+          description: RRULE string for the block's recurrence, or ``None`` when it
+            doesn't recur.
+          readOnly: true
+        is_recurring:
+          type: boolean
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - calendar_id
+      - created
+      - end_time
+      - group_slot_id
+      - id
+      - is_recurring
+      - modified
+      - reason
+      - rrule_string
+      - start_time
+      - timezone
+    GroupScopedBlockedTimeCreate:
+      type: object
+      description: |-
+        Input for creating a group-scoped blocked time.
+
+        Field names map 1:1 onto
+        ``CalendarGroupService.create_group_scoped_blocked_time``'s keyword
+        arguments (``calendar_id``, ``start_time``, ``end_time``, ``tz``,
+        ``reason``, ``rrule_string``) so the REST shape can never silently drift
+        from the service signature it delegates to.
+      properties:
+        calendar:
+          type: integer
+          description: Calendar this block applies to. Must be a member of the target
+            slot.
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        timezone:
+          type: string
+        reason:
+          type: string
+          default: ''
+        rrule_string:
+          type: string
+          nullable: true
+          description: RRULE string for a recurring block. Omit for a one-off block.
+      required:
+      - calendar
+      - end_time
+      - start_time
+      - timezone
     MyMembership:
       type: object
       description: |-
@@ -16162,6 +16868,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GroupScopedAvailabilityWindow'
+    PaginatedGroupScopedBlockedTimeList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupScopedBlockedTime'
     PaginatedOrganizationInvitationList:
       type: object
       required:
@@ -16782,6 +17511,29 @@ components:
           type: string
           nullable: true
           description: RRULE string for a recurring window. Set to null to make it
+            non-recurring.
+    PatchedGroupScopedBlockedTimeUpdate:
+      type: object
+      description: |-
+        Input for partially updating a group-scoped blocked time.
+
+        Every field is optional -- only provided fields change, mirroring
+        ``CalendarGroupService.update_group_scoped_blocked_time``.
+      properties:
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        timezone:
+          type: string
+        reason:
+          type: string
+        rrule_string:
+          type: string
+          nullable: true
+          description: RRULE string for a recurring block. Set to null to make it
             non-recurring.
     PatchedOrganization:
       type: object


### PR DESCRIPTION

## Summary

Phase 2b of the Calendar Group-Scoped Availability plan. Group-scoped blocks now have full parity with windows on both the internal REST surface and the public GraphQL API — a direct mirror of Phases 1c and 1d applied to blocks.

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 2b. Spec use-case UC-3.

## Key decisions

- **REST** (`.../calendar-groups/{group_id}/slots/{slot_id}/blocked-times/`): mirrors the window viewset — route-level group-visibility gating with byte-identical `Http404` non-disclosure (stranger / cross-org / other-calendar-owner / mismatched-slot all indistinguishable), tri-state recurrence editing (`_UNCHANGED` sentinel), a narrow virtual model + bounded-query test, and the orphaned-booking warning in the write response.
- **Public API**: new `group_scoped_blocked_times` query + `batch_upsert_group_scoped_blocked_times` mutation mirroring the window batch — all-or-nothing, content-match idempotent replay (the match key additionally includes `reason`, which windows lack), cross-org scoping, and the IDOR calendar-match cross-check on update/delete (rejects a foreign `blockId` paired with an owned `calendarId`).
- **Blocks are NOT metered here** (that is Phase 2c) — so the block batch does not call `check_limit`/`lock_billing_root`. It still calls `check_not_restricted`, so a RESTRICTED billing root is blocked wholesale.
- **Restriction-bypass fix (security)**: this phase also fixed a pre-existing gap — the single-write group-scoped methods (create/update/delete for BOTH windows and blocks) did not call `_check_not_restricted()`, so a RESTRICTED org could write through the REST viewsets, bypassing the billing block enforced elsewhere. All six methods now enforce it, and a new `GROUP_SCOPED_WRITE_PROBES` registry + `TestRestrictedOrganizationBlocksGroupScopedWrites` in `payments/tests/services/test_restricted_enforcement.py` exercises the guard so CI catches regressions. (The window-method fix rides here rather than amending the earlier window PRs — the cleaner trade-off than rebasing the whole stack; reviewers should note it lands in this PR.)

## Feature flag

None — new routes/operations; existing window + availability operations unchanged; schema purely additive (752 insertions, 0 deletions); no migration.

## Known follow-up (out of scope, flagged)

Single-write REST *creates* (`create_group_scoped_availability_window` / `_blocked_time`) do not call `check_limit`, so the availability-window plan limit is enforced only on the batch (public API) path, not on one-at-a-time REST creation. This appears consistent with the existing base-availability behavior; noted for a future consistency pass.

## Test plan

```bash
docker compose run --rm api uv run pytest calendar_integration/tests/test_views_group_scoped_blocked_times.py public_api/tests/test_group_scoped_blocked_times.py -vs
docker compose run --rm api uv run pytest payments/tests/services/test_restricted_enforcement.py -vs
docker compose run --rm api uv run pytest calendar_integration/tests/ public_api/tests/ payments/tests/ -n auto
```

Covers: REST + public API CRUD parity; non-disclosure identical-shape; IDOR calendar-match on update/delete; idempotent replay incl. `reason`-distinguishes; cross-org scoping; bounded list queries; RESTRICTED org blocked on every single-write and batch path.