### PR TITLE
feat(payments): meter blocked time toward the availability window limit

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -91,13 +91,23 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 
 **REFACTOR NOTE for Phase 3a**: the get / audit / create / update / delete quintet is duplicated ~1:1 between windows (Phase 1a) and blocks (Phase 2a). Phase 3a adds quota — before tripling the pattern, consider a generic model-parameterized helper (`_get_group_scoped_row(model, id)` / `_audit_group_scoped_write(model_label, ...)`). Only if it doesn't over-couple; the plan phases by concept deliberately.
 
+### Phase 2b — Blocks on the REST and public surfaces ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-2b` (base: phase-2a) — **PR [#225](https://github.com/vintasoftware/vinta-schedule-api/pull/225)**
+- **Implementer model**: sonnet (plan Tier 2, stepped up given the 1c haiku failure) — agent type `implementer`
+- **Reviewer model**: sonnet — 2 BLOCKERs (restriction bypass + test-registry gap) + 1 SHOULD-FIX, all fixed (sonnet fixer)
+- **Summary**: Full REST + public API parity for blocks, mirroring windows (Phase 1c/1d). Route `.../slots/{slot_id}/blocked-times/`; non-disclosure identical `Http404`; IDOR calendar-match on batch update/delete; tri-state rrule; bounded queries; content-match idempotency (key includes `reason`). Blocks unmetered (2c does that) but `check_not_restricted`-guarded. Schema additive; no migration.
+- **Security BLOCKER fixed (restriction bypass)**: all six single-write group-scoped methods (window + block create/update/delete) now call `_check_not_restricted()` — previously a RESTRICTED org could write via the REST viewsets. New `GROUP_SCOPED_WRITE_PROBES` registry + test class in `test_restricted_enforcement.py` so CI catches it.
+
+**FOLLOW-UP NOTE (metering enforcement on single-write creates)**: single-write REST creates don't call `check_limit`, so the AVAILABILITY_WINDOWS limit is enforced only on the batch (public API) path. Appears consistent with existing base-availability behavior. Phase 2c owns the metering *counter* (what counts); whether single-write REST create should also *enforce* the limit is a separate consistency question — flag if Phase 2c's work makes it trivial to close.
+
 ## Current phase
 
-Phase 2b — Blocks on the REST and public surfaces
+Phase 2c — Meter all blocked time
 
 ## Remaining phases
 
-2b, 2c, 3a, 3b, 3c, 4
+2c, 3a, 3b, 3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/querysets.py
+++ b/calendar_integration/querysets.py
@@ -778,6 +778,44 @@ class BlockedTimeQuerySet(
     Custom QuerySet for BlockedTime model to handle specific queries.
     """
 
+    def only_user_authored(self) -> "BlockedTimeQuerySet":
+        """Exclude rows the recurrence machinery derived from another row.
+
+        Direct translation of ``AvailableTimeQuerySet.only_user_authored`` --
+        ``BlockedTime`` shares ``RecurringMixin`` with ``AvailableTime``, so
+        every field this filters on (``exception_for``,
+        ``bulk_modification_parent``, ``is_recurring_exception``) exists on
+        ``BlockedTime`` with the identical name and the identical meaning:
+
+        * ``AvailabilityService.create_recurring_blocked_time_exception`` inserts a
+          standalone row for a modified occurrence and links it back through
+          ``BlockedTimeRecurrenceException.modified_blocked_time`` (reverse accessor
+          ``exception_for``), also flagging it ``is_recurring_exception``.
+        * ``create_recurring_blocked_time_bulk_modification`` inserts a continuation
+          row for the remainder of a split series, linked by
+          ``bulk_modification_parent``.
+
+        Counting those as separate blocks over-reports usage for the same reason
+        ``AvailableTimeQuerySet.only_user_authored`` documents: one blocked time the
+        user created can end up as several ``BlockedTime`` rows. Every caller that
+        wants "how many blocked times did this organization author" (the billing
+        usage counter above all, once blocked time is metered -- see
+        ``payments.services.entitlement_service._count_availability_windows``) wants
+        this queryset, not a bare ``filter(...)``.
+
+        Known gap: identical to ``AvailableTimeQuerySet.only_user_authored``'s --
+        editing or cancelling the first occurrence of a series truncates the master
+        row and creates a fresh series row with no link back to it, which is still
+        counted and compounds on every subsequent first-occurrence edit or cancel.
+        See that method's docstring for the full explanation; it applies here
+        unchanged since both models share the same recurrence machinery.
+        """
+        return self.filter(
+            exception_for__isnull=True,
+            bulk_modification_parent__isnull=True,
+            is_recurring_exception=False,
+        )
+
     def annotate_recurring_occurrences_on_date_range(
         self, start: datetime.datetime, end: datetime.datetime, max_occurrences=10000, overlap=False
     ):

--- a/calendar_integration/tests/services/test_calendar_limits.py
+++ b/calendar_integration/tests/services/test_calendar_limits.py
@@ -20,7 +20,13 @@ import pytest
 from model_bakery import baker
 
 from calendar_integration.constants import CalendarType
-from calendar_integration.models import AvailableTime, Calendar, CalendarGroup
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+)
 from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_service import CalendarService
 from calendar_integration.services.dataclasses import CalendarGroupInputData
@@ -282,6 +288,92 @@ class TestCreateAvailableTimeLimit:
             end_time=end,
             timezone="UTC",
             bypass_limits=True,
+        )
+
+        assert available_time.pk is not None
+
+
+@pytest.mark.django_db
+class TestBlockedTimeCountsTowardTheAvailabilityWindowLimit:
+    """Phase 2c: blocked time and availability windows share one
+    ``availability_windows`` ceiling. Blocked-time creation itself is not guarded
+    (unchanged by this phase -- see ``AvailabilityService.create_blocked_time``),
+    but existing blocked time now counts toward the same ceiling an availability
+    window creation is checked against, so an organization that has only ever
+    authored blocked time can already be at its ceiling the first time it tries to
+    create an availability window. It hits the *existing* over-limit path, not a
+    new one.
+    """
+
+    def test_existing_base_blocked_time_blocks_further_window_creation(self):
+        organization = _organization_with_limit(LimitedResource.AVAILABILITY_WINDOWS, 1)
+        calendar = _calendar_managing_windows(organization)
+        baker.make(BlockedTime, organization=organization, calendar=calendar, timezone="UTC")
+
+        service = CalendarService()
+        service.initialize_without_provider(organization=organization)
+
+        start = datetime.datetime(2026, 1, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 1, 1, 17, 0, tzinfo=datetime.UTC)
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.create_available_time(
+                calendar=calendar, start_time=start, end_time=end, timezone="UTC"
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.AVAILABILITY_WINDOWS
+        assert exc_info.value.current_usage == 1
+        assert exc_info.value.limit == 1
+        assert not AvailableTime.objects.filter(
+            organization=organization, calendar=calendar
+        ).exists()
+
+    def test_existing_group_scoped_blocked_time_blocks_further_window_creation(self):
+        """Group-scoped blocks are invisible to ``BlockedTime.objects`` (the default
+        manager) but must still be counted -- the metering rule is "every time
+        window an organization authors", regardless of scope."""
+        organization = _organization_with_limit(LimitedResource.AVAILABILITY_WINDOWS, 1)
+        calendar = _calendar_managing_windows(organization)
+        group = baker.make(CalendarGroup, organization=organization)
+        slot = baker.make(CalendarGroupSlot, organization=organization, group=group)
+        baker.make(
+            BlockedTime,
+            organization=organization,
+            calendar=calendar,
+            timezone="UTC",
+            group_slot=slot,
+        )
+
+        service = CalendarService()
+        service.initialize_without_provider(organization=organization)
+
+        start = datetime.datetime(2026, 1, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 1, 1, 17, 0, tzinfo=datetime.UTC)
+
+        with pytest.raises(OverLimitError) as exc_info:
+            service.create_available_time(
+                calendar=calendar, start_time=start, end_time=end, timezone="UTC"
+            )
+
+        assert exc_info.value.resource_key == LimitedResource.AVAILABILITY_WINDOWS
+        assert exc_info.value.current_usage == 1
+        assert not AvailableTime.objects.filter(
+            organization=organization, calendar=calendar
+        ).exists()
+
+    def test_headroom_left_after_blocked_time_still_allows_a_window(self):
+        organization = _organization_with_limit(LimitedResource.AVAILABILITY_WINDOWS, 2)
+        calendar = _calendar_managing_windows(organization)
+        baker.make(BlockedTime, organization=organization, calendar=calendar, timezone="UTC")
+
+        service = CalendarService()
+        service.initialize_without_provider(organization=organization)
+
+        start = datetime.datetime(2026, 1, 1, 9, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 1, 1, 17, 0, tzinfo=datetime.UTC)
+
+        available_time = service.create_available_time(
+            calendar=calendar, start_time=start, end_time=end, timezone="UTC"
         )
 
         assert available_time.pk is not None

--- a/payments/services/entitlement_service.py
+++ b/payments/services/entitlement_service.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from django.db.models import Sum
 
 from calendar_integration.constants import CalendarType
-from calendar_integration.models import AvailableTime, Calendar, CalendarGroup
+from calendar_integration.models import AvailableTime, BlockedTime, Calendar, CalendarGroup
 from organizations.models import Organization, OrganizationInvitation, OrganizationMembership
 from payments.billing_constants import (
     BillingState,
@@ -118,29 +118,37 @@ def _count_calendar_groups(context: UsageContext) -> int:
 
 
 def _count_availability_windows(context: UsageContext) -> int:
-    """Availability windows the organization actually authored.
+    """Every time window the organization actually authored — availability
+    windows and blocked time alike, positive or negative.
 
-    Not every ``AvailableTime`` row is a window somebody created: editing one
-    occurrence of a recurring window, or splitting a series, *inserts* extra rows
-    (see ``AvailableTimeQuerySet.only_user_authored`` for the full list and the one
-    residual gap). Counting those would over-report — an organization with a limit
-    of 5 that created 3 recurring windows and edited 3 occurrences would read as 6
-    and be blocked below its real usage, which the rollout's "nobody is blocked as
-    a consequence of the rollout itself" rule forbids.
+    Not every ``AvailableTime``/``BlockedTime`` row is a window somebody created:
+    editing one occurrence of a recurring window, or splitting a series, *inserts*
+    extra rows (see ``AvailableTimeQuerySet.only_user_authored`` /
+    ``BlockedTimeQuerySet.only_user_authored`` for the full list and the one
+    residual gap each carries). Counting those would over-report — an organization
+    with a limit of 5 that created 3 recurring windows and edited 3 occurrences
+    would read as 6 and be blocked below its real usage, which the rollout's
+    "nobody is blocked as a consequence of the rollout itself" rule forbids.
 
-    Reads through ``unscoped()`` (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 0/1d):
-    ``AvailableTime.objects`` — the default manager — excludes group-scoped rows
-    (``group_slot`` set) by design, so counting through it would under-report and
-    let group-scoped windows bypass the plan limit entirely. The spec's metering
-    rule is "every time window an organization authors is metered" regardless of
-    scope, so base and group-scoped rows are counted together here.
+    Reads through ``unscoped()`` on both models
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 0/1d/2c): the default manager on
+    each excludes group-scoped rows (``group_slot`` set) by design, so counting
+    through it would under-report and let group-scoped windows and blocks bypass
+    the plan limit entirely. The spec's metering rule is "every time window an
+    organization authors is metered" regardless of scope or sign, so base and
+    group-scoped rows of both models are counted together here (Phase 2c: blocked
+    time was not metered before this and now is, for every organization at once
+    — see that phase's rollout note on why this is a billing-rule change made
+    deliberately, not incidentally).
     """
-    return (
-        AvailableTime.objects.unscoped()
-        .only_user_authored()
-        .filter(organization_id__in=context.organization_ids)
-        .count()
+    organization_filter = {"organization_id__in": context.organization_ids}
+    availability_windows = (
+        AvailableTime.objects.unscoped().only_user_authored().filter(**organization_filter).count()
     )
+    blocked_times = (
+        BlockedTime.objects.unscoped().only_user_authored().filter(**organization_filter).count()
+    )
+    return availability_windows + blocked_times
 
 
 def _count_webhook_subscriptions(context: UsageContext) -> int:

--- a/payments/tests/services/test_usage_counters.py
+++ b/payments/tests/services/test_usage_counters.py
@@ -20,10 +20,17 @@ from typing import Any
 from django.utils import timezone
 
 import pytest
+from model_bakery import baker
 
 from audit.services import AuditService
 from calendar_integration.constants import CalendarProvider
-from calendar_integration.models import AvailableTime, Calendar
+from calendar_integration.models import (
+    AvailableTime,
+    BlockedTime,
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+)
 from calendar_integration.services.availability_service import AvailabilityService
 from calendar_integration.services.calendar_service_context import CalendarServiceContext
 from calendar_integration.services.recurrence_manager import RecurrenceManager
@@ -244,6 +251,218 @@ class TestAvailabilityWindowCounter:
                 end_time=_utc(2025, 7, 1, hour + 1),
                 timezone="UTC",
             )
+
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 2
+        )
+
+
+@pytest.mark.django_db
+class TestBlockedTimeCounter:
+    """Phase 2c: blocked time is metered on the same ``availability_windows``
+    counter as availability windows, base and group-scoped rows alike.
+
+    Mirrors ``TestAvailabilityWindowCounter`` exactly -- the two models share
+    ``RecurringMixin``, so the same recurrence-derived-row defect and the same
+    ``only_user_authored`` fix apply to both.
+    """
+
+    def test_a_plain_block_counts_once(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        availability_service.create_blocked_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 1, 10),
+            end_time=_utc(2025, 7, 1, 12),
+            timezone="UTC",
+        )
+
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 1
+        )
+
+    def test_a_recurring_block_counts_once_regardless_of_its_occurrences(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        availability_service.create_blocked_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 1, 10),
+            end_time=_utc(2025, 7, 1, 12),
+            timezone="UTC",
+            rrule_string="RRULE:FREQ=DAILY;COUNT=10",
+        )
+
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 1
+        )
+
+    def test_editing_one_occurrence_does_not_inflate_the_block_count(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        """``create_recurring_blocked_time_exception`` implements "edit this one
+        occurrence" by *inserting a second row*, exactly like its availability-window
+        counterpart. Counting every ``BlockedTime`` row would over-report."""
+        parent = availability_service.create_blocked_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 1, 10),
+            end_time=_utc(2025, 7, 1, 12),
+            timezone="UTC",
+            rrule_string="RRULE:FREQ=DAILY;COUNT=10",
+        )
+
+        availability_service.create_recurring_blocked_time_exception(
+            parent_blocked_time=parent,
+            exception_date=datetime.date(2025, 7, 3),
+            modified_start_time=_utc(2025, 7, 3, 14),
+            modified_end_time=_utc(2025, 7, 3, 16),
+            is_cancelled=False,
+        )
+
+        # The extra row genuinely exists -- this is not a test that passes because
+        # the edit did nothing.
+        assert BlockedTime.objects.filter(organization_id=organization.pk).count() > 1, (
+            "Expected the modified occurrence to have inserted a derived row."
+        )
+
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 1
+        ), (
+            "A block whose occurrence was edited must still count as one block. "
+            "The counter is counting recurrence-derived rows."
+        )
+
+    def test_cancelling_one_occurrence_does_not_inflate_the_block_count(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        parent = availability_service.create_blocked_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 1, 10),
+            end_time=_utc(2025, 7, 1, 12),
+            timezone="UTC",
+            rrule_string="RRULE:FREQ=DAILY;COUNT=10",
+        )
+
+        availability_service.create_recurring_blocked_time_exception(
+            parent_blocked_time=parent,
+            exception_date=datetime.date(2025, 7, 3),
+            is_cancelled=True,
+        )
+
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 1
+        )
+
+    def test_splitting_a_series_does_not_inflate_the_block_count(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        """A bulk modification splits the series and inserts a continuation row,
+        linked by ``bulk_modification_parent``. Still one block to the user."""
+        parent = availability_service.create_blocked_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 1, 10),
+            end_time=_utc(2025, 7, 1, 12),
+            timezone="UTC",
+            rrule_string="RRULE:FREQ=DAILY;COUNT=10",
+        )
+
+        availability_service.create_recurring_blocked_time_bulk_modification(
+            parent_blocked_time=parent,
+            modification_start_date=_utc(2025, 7, 5, 10),
+            modified_start_time_offset=datetime.timedelta(hours=4),
+            modified_end_time_offset=datetime.timedelta(hours=4),
+        )
+
+        assert BlockedTime.objects.filter(organization_id=organization.pk).count() > 1, (
+            "Expected the bulk modification to have inserted a continuation row."
+        )
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 1
+        )
+
+    def test_two_independent_blocks_count_twice(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        for hour in (10, 14):
+            availability_service.create_blocked_time(
+                calendar=managed_calendar,
+                start_time=_utc(2025, 7, 1, hour),
+                end_time=_utc(2025, 7, 1, hour + 1),
+                timezone="UTC",
+            )
+
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 2
+        )
+
+    def test_group_scoped_blocks_count_alongside_base_blocks(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        """``BlockedTime.objects`` (the default manager) excludes group-scoped rows
+        by design (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 0). The counter must
+        read through ``unscoped()`` or a group-scoped block would bypass metering
+        entirely -- the spec's rule is "every time window is metered" regardless of
+        scope."""
+        availability_service.create_blocked_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 1, 10),
+            end_time=_utc(2025, 7, 1, 12),
+            timezone="UTC",
+        )
+        group = baker.make(CalendarGroup, organization=organization)
+        slot = baker.make(CalendarGroupSlot, organization=organization, group=group)
+        baker.make(
+            BlockedTime,
+            organization=organization,
+            calendar=managed_calendar,
+            timezone="UTC",
+            group_slot=slot,
+        )
+
+        assert (
+            entitlement_service.get_current_usage(
+                organization, LimitedResource.AVAILABILITY_WINDOWS
+            )
+            == 2
+        )
+
+    def test_availability_windows_and_blocked_time_count_together(
+        self, entitlement_service, availability_service, managed_calendar, organization
+    ):
+        """The one shared ``availability_windows`` ceiling covers both models -- one
+        rule for every authored time window, positive or negative (Phase 2c)."""
+        availability_service.create_available_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 1, 10),
+            end_time=_utc(2025, 7, 1, 12),
+            timezone="UTC",
+        )
+        availability_service.create_blocked_time(
+            calendar=managed_calendar,
+            start_time=_utc(2025, 7, 2, 10),
+            end_time=_utc(2025, 7, 2, 12),
+            timezone="UTC",
+        )
 
         assert (
             entitlement_service.get_current_usage(

--- a/payments/tests/services/test_usage_warning_service.py
+++ b/payments/tests/services/test_usage_warning_service.py
@@ -204,6 +204,49 @@ class TestApproachingThreshold:
         warning = LimitWarningNotification.objects.get(subscription=subscription)
         assert warning.level == LimitWarningLevel.REACHED
 
+    def test_blocked_time_pushes_the_availability_window_warning_to_fire(
+        self, service, organization, subscription
+    ):
+        """Phase 2c: blocked time is now folded into the ``availability_windows``
+        counter this warning reads (``EntitlementService.get_current_usage`` ->
+        ``_count_availability_windows``), so an organization that has only ever
+        authored blocked time -- never an availability window -- can already be at
+        or past the threshold. Proves the push side picks up the rule change with
+        no changes of its own: it reads the same counter enforcement does."""
+        from calendar_integration.constants import CalendarType
+        from calendar_integration.models import BlockedTime, Calendar
+
+        _make_limit(subscription, LimitedResource.AVAILABILITY_WINDOWS, 10)
+        calendar = baker.make(
+            Calendar,
+            organization=organization,
+            calendar_type=CalendarType.RESOURCE,
+            manage_available_windows=True,
+        )
+        # 8 of 10 (80%) -- exactly the approaching threshold, and every unit of
+        # usage here is blocked time, not a single availability window.
+        for i in range(8):
+            baker.make(
+                BlockedTime,
+                organization=organization,
+                calendar=calendar,
+                timezone="UTC",
+                external_id=f"blocked-{i}",
+            )
+
+        with freeze_time(FREEZE_START):
+            service.check_subscription(subscription)
+
+        service.notification_service.create_notification.assert_called_once()
+        call = service.notification_service.create_notification.call_args
+        assert call.kwargs["context_name"] == "approaching_limit_context"
+        assert call.kwargs["context_kwargs"]["resource_key"] == LimitedResource.AVAILABILITY_WINDOWS
+        assert call.kwargs["context_kwargs"]["current_usage"] == 8
+
+        warning = LimitWarningNotification.objects.get(subscription=subscription)
+        assert warning.level == LimitWarningLevel.APPROACHING
+        assert warning.resource_key == LimitedResource.AVAILABILITY_WINDOWS
+
 
 @pytest.mark.django_db
 class TestDebounce:


### PR DESCRIPTION

## Summary

Phase 2c of the Calendar Group-Scoped Availability plan. A billing rule change: all blocked time — base and group-scoped — now counts toward the availability-window plan limit, alongside availability windows. One rule holds: every time window an organization authors is metered, positive or negative.

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 2c. No spec use-case (billing rule required by the "Metering" decision).

## Key decisions

- **Not self-gating** (Guiding Decisions → "Metering rollout"): this changes the counter's meaning for every organization, not just configured ones. It ships now because the product is pre-customer, so no installed base is affected — the change that would be breaking later is free now. Kept in its own phase for reviewability and independent revert.
- **The counter** (`_count_availability_windows`) now returns `AvailableTime.objects.unscoped().only_user_authored().filter(org).count() + BlockedTime.objects.unscoped().only_user_authored().filter(org).count()` — base + group-scoped rows of both models, all user-authored. Disjoint tables, no double-count.
- **Open Question 2 resolved**: `BlockedTimeQuerySet.only_user_authored` was added as a faithful translation of the availability version. `BlockedTime` shares `RecurringMixin` with `AvailableTime`, and its exceptions/splits are created through the *same generic recurrence machinery*, so the filter fields (`exception_for`, `bulk_modification_parent`, `is_recurring_exception`) exist with identical semantics — recurrence exceptions and series splits do not inflate the count. The one residual "first-occurrence edit" gap is identical to (and no worse than) the availability counter's existing gap.
- **Existing over-limit path**: an org over the combined limit hits the same `OverLimitError` / over-limit response as before — no new error type. The `UsageWarningService` "approaching/reached" push notification needs no change; it reads `get_current_usage`, which feeds from this counter, so blocked-time usage drives the warning automatically.
- **No new metering on blocked-time creation itself** — blocked time is not `check_limit`-guarded on create (not in scope / not in the touch list); existing blocked time occupies the shared ceiling, so the next window-creation attempt hits the existing over-limit path.

## Feature flag

None. No migration. Touch list: `payments/services/entitlement_service.py`, `calendar_integration/querysets.py` (+ tests).

## Test plan

```bash
docker compose run --rm api uv run pytest payments/tests/services/test_usage_counters.py payments/tests/services/test_usage_warning_service.py -vs
docker compose run --rm api uv run pytest calendar_integration/tests/services/test_calendar_limits.py -vs
docker compose run --rm api uv run pytest payments/tests/ calendar_integration/tests/ -n auto
```

Covers: counter includes base + group-scoped blocked time; recurrence exceptions / series splits (driven through the real recurrence services) do NOT inflate the count; an org over the new limit hits the existing over-limit path; the limit-warning notification fires from blocked-time-only usage.