### PR TITLE
feat(calendar): enforce group-scoped quota in discovery and booking

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -108,13 +108,23 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 - **Reviewer model**: sonnet — CLEAN (no BLOCKER / SHOULD-FIX / NIT)
 - **Summary**: `_count_availability_windows` now sums user-authored availability windows + blocked time (base + group-scoped, both `unscoped()`). Added `BlockedTimeQuerySet.only_user_authored` (faithful translation — `BlockedTime` shares `RecurringMixin` and the same generic recurrence machinery, so `exception_for`/`bulk_modification_parent`/`is_recurring_exception` have identical semantics; exceptions/splits don't inflate). Over-limit uses the existing `OverLimitError` path; the limit-warning notification picks up blocked-time usage automatically via `get_current_usage`. Open Question 2 resolved (no field gap). No migration.
 
+### Phase 3a — Quota model and period-counting function ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-3a` (base: phase-2c) — **PR [#227](https://github.com/vintasoftware/vinta-schedule-api/pull/227)**
+- **Implementer model**: sonnet (plan Tier 3) — agent type `migration-author`
+- **Reviewer model**: sonnet — 1 BLOCKER (quota cap-bypass via per-event timezone bucketing) fixed (sonnet fixer)
+- **Summary**: `CalendarGroupSlotQuotaRule` model (slot, calendar, period `QuotaPeriod` day/week/month, cap; unique per (calendar,slot,period); cascade on slot deletion; membership-removal cleanup wired into `_reconcile_slot`). Versioned Postgres `calculate_calendar_group_quota_period_counts` + JSON wrapper counting live bookings made through the group (via `CalendarEventGroupSelection`; cancelled = deleted event; reschedule re-buckets on read). Migrations `0043`/`0044` reverse cleanly. `GetCalendarGroupQuotaPeriodCountsJSON` wrapper (`Value()`-wraps string args).
+- **BLOCKER fixed (quota bypass)**: bucketing now uses a single consistent UTC frame (was per-event booker-supplied `ce.timezone`, which let a per-period cap be exceeded by varying the booking timezone). Matches the plan's timezone-less function signature. Local-timezone quota alignment deferred (no canonical calendar tz field in schema). Regression test added.
+
+**CARRY-FORWARD for Phase 3b**: quota periods are measured in **UTC** (documented v1 simplification). Phase 3b's discovery/booking lookup MUST bucket the candidate booking's time in the SAME UTC frame the counting function uses, so the candidate's period matches the counted period. Do NOT reintroduce per-event/local timezone bucketing on the candidate side.
+
 ## Current phase
 
-Phase 3a — Quota model and period-counting function
+Phase 3b — Quota in discovery and booking validation
 
 ## Remaining phases
 
-3a, 3b, 3c, 4
+3b, 3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/constants.py
+++ b/calendar_integration/constants.py
@@ -111,13 +111,14 @@ class GroupScopedRuleType(TextChoices):
 
     Named exactly as the spec requires them surfaced to a caller: outside
     window, inside block, quota consumed -- never the configured values
-    themselves. ``OUTSIDE_WINDOW`` is enforced as of Phase 1b and
-    ``INSIDE_BLOCK`` as of Phase 2a; ``QUOTA_CONSUMED`` is reserved for
-    Phase 3b.
+    themselves (e.g. the cap or current count). ``OUTSIDE_WINDOW`` is
+    enforced as of Phase 1b, ``INSIDE_BLOCK`` as of Phase 2a, and
+    ``QUOTA_CONSUMED`` as of Phase 3b.
     """
 
     OUTSIDE_WINDOW = "outside_window", "Outside window"
     INSIDE_BLOCK = "inside_block", "Inside block"
+    QUOTA_CONSUMED = "quota_consumed", "Quota consumed"
 
 
 class QuotaPeriod(TextChoices):

--- a/calendar_integration/exceptions.py
+++ b/calendar_integration/exceptions.py
@@ -360,8 +360,10 @@ class CalendarGroupScopedRuleViolationError(CalendarGroupError):
     callers can build a structured error response -- never the configured
     rule values themselves (spec Decisions -> Errors: enough for an admin to
     act on, without leaking roster detail to external bookers on public
-    links). ``OUTSIDE_WINDOW`` is raised as of Phase 1b and ``INSIDE_BLOCK``
-    as of Phase 2a; ``QUOTA_CONSUMED`` is reserved for Phase 3b.
+    links). ``OUTSIDE_WINDOW`` is raised as of Phase 1b, ``INSIDE_BLOCK`` as
+    of Phase 2a, and ``QUOTA_CONSUMED`` as of Phase 3b -- naming only the
+    quota rule that was violated, never its configured cap or the calendar's
+    current count.
     """
 
     def __init__(

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -1758,35 +1758,39 @@ class CalendarGroupService:
 
     def _slot_pools_with_group_scoped_flags(
         self, slots: Iterable[CalendarGroupSlot]
-    ) -> tuple[dict[int, set[int]], dict[int, set[int]], dict[int, set[int]]]:
-        """Build the (slot_id -> calendar_id pool) map, folding in two per-row
-        ``EXISTS`` subqueries flagging which pool calendars have ANY
-        group-scoped availability window, and ANY group-scoped blocked time,
-        configured for that slot (regardless of whether either overlaps a
-        caller's search window).
+    ) -> tuple[dict[int, set[int]], dict[int, set[int]], dict[int, set[int]], dict[int, set[int]]]:
+        """Build the (slot_id -> calendar_id pool) map, folding in three
+        per-row ``EXISTS`` subqueries flagging which pool calendars have ANY
+        group-scoped availability window, ANY group-scoped blocked time, and
+        ANY group-scoped quota rule configured for that slot (regardless of
+        whether any of them overlaps a caller's search window).
 
-        This is the Phase 1b (windows) / Phase 2a (blocks) self-gating
-        early-out mechanism (``CALENDAR_GROUP_SCOPED_AVAILABILITY``): both
-        ``EXISTS`` clauses are folded into the SAME per-slot membership query
-        every caller of this method already issued before Phase 1b, so an
-        unconfigured group costs exactly as many round trips as it did before
-        either phase -- zero added queries. Only when the returned "window
-        configured" or "block configured" map is non-empty for a slot does the
-        caller go on to fetch the actual group-scoped spans (a fixed,
-        non-per-candidate number of additional queries -- see
+        This is the Phase 1b (windows) / Phase 2a (blocks) / Phase 3b (quota)
+        self-gating early-out mechanism (``CALENDAR_GROUP_SCOPED_AVAILABILITY``):
+        all three ``EXISTS`` clauses are folded into the SAME per-slot
+        membership query every caller of this method already issued before
+        Phase 1b, so an unconfigured group costs exactly as many round trips
+        as it did before any of the three phases -- zero added queries. Only
+        when the returned "window configured", "block configured", or "quota
+        configured" map is non-empty for a slot does the caller go on to
+        fetch the actual group-scoped spans / rules (a fixed, non-per-candidate
+        number of additional queries -- see
         ``slot_engine.fetch_group_scoped_available_spans`` /
-        ``slot_engine.fetch_group_scoped_blocking_spans``).
+        ``slot_engine.fetch_group_scoped_blocking_spans`` /
+        ``slot_engine.fetch_group_scoped_quota_rules``).
 
         Returns ``(slot_pool_by_id, group_scoped_window_calendar_ids_by_slot,
-        group_scoped_block_calendar_ids_by_slot)``. The second and third
-        mappings each omit a slot entirely when nothing in its pool is
-        configured, so ``bool(...)`` on either alone tells a caller whether
-        ANY group-scoped window / block exists anywhere in the group.
+        group_scoped_block_calendar_ids_by_slot,
+        group_scoped_quota_calendar_ids_by_slot)``. The second, third, and
+        fourth mappings each omit a slot entirely when nothing in its pool is
+        configured, so ``bool(...)`` on any alone tells a caller whether ANY
+        group-scoped window / block / quota rule exists anywhere in the group.
         """
         org_id = cast(Organization, self.organization).id
         slot_pool_by_id: dict[int, set[int]] = {}
         group_scoped_window_calendar_ids_by_slot: dict[int, set[int]] = {}
         group_scoped_block_calendar_ids_by_slot: dict[int, set[int]] = {}
+        group_scoped_quota_calendar_ids_by_slot: dict[int, set[int]] = {}
         for s in slots:
             rows = (
                 CalendarGroupSlotMembership.objects.filter_by_organization(org_id)
@@ -1802,27 +1806,43 @@ class CalendarGroupService:
                         .filter_by_organization(org_id)
                         .filter(calendar_fk_id=OuterRef("calendar_fk_id"), group_slot_fk_id=s.id)
                     ),
+                    has_group_scoped_quota=Exists(
+                        CalendarGroupSlotQuotaRule.objects.filter_by_organization(org_id).filter(
+                            calendar_fk_id=OuterRef("calendar_fk_id"), group_slot_fk_id=s.id
+                        )
+                    ),
                 )
-                .values_list("calendar_fk_id", "has_group_scoped_window", "has_group_scoped_block")
+                .values_list(
+                    "calendar_fk_id",
+                    "has_group_scoped_window",
+                    "has_group_scoped_block",
+                    "has_group_scoped_quota",
+                )
             )
             pool: set[int] = set()
             window_configured: set[int] = set()
             block_configured: set[int] = set()
-            for cid, has_window, has_block in rows:
+            quota_configured: set[int] = set()
+            for cid, has_window, has_block, has_quota in rows:
                 pool.add(cid)
                 if has_window:
                     window_configured.add(cid)
                 if has_block:
                     block_configured.add(cid)
+                if has_quota:
+                    quota_configured.add(cid)
             slot_pool_by_id[s.id] = pool
             if window_configured:
                 group_scoped_window_calendar_ids_by_slot[s.id] = window_configured
             if block_configured:
                 group_scoped_block_calendar_ids_by_slot[s.id] = block_configured
+            if quota_configured:
+                group_scoped_quota_calendar_ids_by_slot[s.id] = quota_configured
         return (
             slot_pool_by_id,
             group_scoped_window_calendar_ids_by_slot,
             group_scoped_block_calendar_ids_by_slot,
+            group_scoped_quota_calendar_ids_by_slot,
         )
 
     def check_group_availability(
@@ -1850,6 +1870,16 @@ class CalendarGroupService:
         with a configured block that OVERLAPS the range is excluded regardless
         of what any window says ("blocks beat everything"). Also zero added
         queries when unconfigured.
+
+        Group-scoped quota rules (Phase 3b) are checked LAST, after base
+        availability, block, and window all pass: a calendar with a
+        configured quota rule whose cap is already met for the period the
+        range's start falls into is excluded, regardless of what any window
+        says. Also zero added queries when unconfigured -- see
+        ``slot_engine.fetch_group_scoped_quota_period_counts`` for the
+        query-count discipline (one counting query per ``(slot, period)``
+        combination actually configured, covering every range passed to this
+        call, never one per range).
         """
         self._assert_initialized()
         group = self._get_group_by_id(group_id)
@@ -1860,11 +1890,12 @@ class CalendarGroupService:
             slot_pool_by_id,
             group_scoped_window_calendar_ids_by_slot,
             group_scoped_block_calendar_ids_by_slot,
+            group_scoped_quota_calendar_ids_by_slot,
         ) = self._slot_pools_with_group_scoped_flags(slots)
 
         # Self-gating early-out: only fetch expanded group-scoped spans when at
         # least one calendar anywhere in the group actually has one configured.
-        # Compute union range once for both window and block fetches.
+        # Compute union range once for the window, block, and quota fetches.
         union_start = union_end = None
         if ranges:
             union_start = min(start for start, _ in ranges)
@@ -1906,6 +1937,41 @@ class CalendarGroupService:
                 union_end,
             )
 
+        group_scoped_quota_rules_by_slot: slot_engine.GroupScopedQuotaRulesBySlot = {}
+        group_scoped_quota_counts_by_slot: slot_engine.GroupScopedQuotaCountsBySlot = {}
+        org = cast(Organization, self.organization)
+        week_start = org.week_start
+        if (
+            group_scoped_quota_calendar_ids_by_slot
+            and union_start is not None
+            and union_end is not None
+        ):
+            configured_quota_slot_ids = list(group_scoped_quota_calendar_ids_by_slot.keys())
+            configured_quota_calendar_ids: set[int] = set()
+            for ids in group_scoped_quota_calendar_ids_by_slot.values():
+                configured_quota_calendar_ids.update(ids)
+            quota_rules = slot_engine.fetch_group_scoped_quota_rules(
+                org.id, configured_quota_slot_ids, configured_quota_calendar_ids
+            )
+            group_scoped_quota_rules_by_slot = slot_engine.group_quota_rules_by_slot(quota_rules)
+            # Widen to the full period boundaries touched by any range's
+            # start -- the literal `[union_start, union_end)` union of the
+            # requested ranges can start AFTER a period's own start (e.g. a
+            # Wednesday range inside a Monday-start week), which would
+            # silently undercount earlier live bookings in that same period.
+            # See `slot_engine.quota_covering_range`'s docstring.
+            covering_range = slot_engine.quota_covering_range(
+                (start for start, _ in ranges),
+                {rule.period for rule in quota_rules},
+                week_start,
+            )
+            if covering_range is not None:
+                group_scoped_quota_counts_by_slot = (
+                    slot_engine.fetch_group_scoped_quota_period_counts(
+                        org.id, quota_rules, week_start, *covering_range
+                    )
+                )
+
         calendar_qs_method = (
             "only_calendars_available_in_ranges_with_bulk_modifications"
             if with_bulk_modifications
@@ -1925,11 +1991,18 @@ class CalendarGroupService:
                 base_available = slot_pool_by_id[s.id] & available_ids
                 window_configured_ids = group_scoped_window_calendar_ids_by_slot.get(s.id)
                 block_configured_ids = group_scoped_block_calendar_ids_by_slot.get(s.id)
-                if not window_configured_ids and not block_configured_ids:
+                quota_configured_ids = group_scoped_quota_calendar_ids_by_slot.get(s.id)
+                if (
+                    not window_configured_ids
+                    and not block_configured_ids
+                    and not quota_configured_ids
+                ):
                     final_available = base_available
                 else:
                     window_spans_for_slot = group_scoped_spans_by_slot.get(s.id, {})
                     block_spans_for_slot = group_scoped_block_spans_by_slot.get(s.id, {})
+                    quota_rules_for_slot = group_scoped_quota_rules_by_slot.get(s.id, {})
+                    quota_counts_for_slot = group_scoped_quota_counts_by_slot.get(s.id, {})
                     final_available = set()
                     for cid in base_available:
                         # Blocks beat everything -- checked first, before windows.
@@ -1944,6 +2017,21 @@ class CalendarGroupService:
                             if not slot_engine.window_fully_covered_by_spans(
                                 window_spans_for_slot.get(cid, ()), start, end
                             ):
+                                continue
+                        # Quota is checked LAST, after block and window both pass.
+                        if quota_configured_ids and cid in quota_configured_ids:
+                            over_quota = False
+                            for rule in quota_rules_for_slot.get(cid, ()):
+                                period_start = slot_engine.quota_period_start_utc(
+                                    start, rule.period, week_start
+                                )
+                                count = quota_counts_for_slot.get((cid, rule.period), {}).get(
+                                    period_start, 0
+                                )
+                                if count >= rule.cap:
+                                    over_quota = True
+                                    break
+                            if over_quota:
                                 continue
                         final_available.add(cid)
                 slot_results.append(
@@ -2303,6 +2391,21 @@ class CalendarGroupService:
         ``CalendarEventGroupSelection``) -- every enforcement surface must
         agree, so a narrowed calendar cannot dodge the window it would have
         been rejected for at booking time simply by rescheduling instead.
+        Group-scoped blocks (Phase 2a) and quota rules (Phase 3b) are checked
+        the same way.
+
+        Known v1 limitation on quota specifically: the count used to validate
+        the NEW period is the live count as of THIS event's still-unmoved
+        ``CalendarEvent`` row (the reschedule write happens after this
+        check), which still includes this event's own booking if it already
+        falls in the SAME target period (e.g. moving a booking from 9am to
+        2pm on the same day, under a daily cap already at its limit) -- such
+        a same-period, no-net-change reschedule can be rejected even though
+        it does not actually consume additional quota. This mirrors the
+        counting function's derive-on-read design (Phase 3a) rather than
+        excluding the event under reschedule from its own count, and is
+        accepted for v1 the same way the non-primary base-availability gap
+        above is.
         """
         self._assert_initialized()
         # Checked explicitly and first, for the same reason as
@@ -2547,25 +2650,31 @@ class CalendarGroupService:
         Acceptance 4, UC-4: a caller cannot book, by naming the calendar
         directly, a time discovery would never have offered).
 
-        Checks BLOCKS first, then WINDOWS -- the same resolution order
+        Checks BLOCKS, then WINDOWS, then QUOTA -- the same resolution order
         ``slot_engine.calendar_free_for_window`` applies in discovery ("blocks
-        beat everything"): a pair with a configured group-scoped block that
-        OVERLAPS ``[start, end)`` is rejected with
+        beat everything", quota last): a pair with a configured group-scoped
+        block that OVERLAPS ``[start, end)`` is rejected with
         ``GroupScopedRuleType.INSIDE_BLOCK`` before the window check even
-        runs, regardless of what any window says. A pair with no block hit is
-        then rejected with ``GroupScopedRuleType.OUTSIDE_WINDOW`` if it has a
-        configured window but ``[start, end)`` is not fully covered by any of
-        them.
+        runs, regardless of what any window or quota rule says. A pair with
+        no block hit is then rejected with ``GroupScopedRuleType.OUTSIDE_WINDOW``
+        if it has a configured window but ``[start, end)`` is not fully
+        covered by any of them. Only once BOTH pass does a pair with a
+        configured quota rule get rejected with
+        ``GroupScopedRuleType.QUOTA_CONSUMED`` when ANY of its rules (e.g. a
+        daily AND a weekly cap) has no headroom left for the period
+        ``start`` falls into -- ALL of a calendar's quota rules must have
+        headroom, mirroring discovery's "every rule must pass".
 
-        A calendar with NEITHER a group-scoped block NOR window for a given
-        ``(calendar, slot)`` pair falls through untouched -- narrowing/
-        exclusion only ever applies to what was actually configured.
-        Self-gating -- the block and window existence checks are each the
-        only extra query when nothing of that kind is configured for any of
-        the named pairs; each (fixed-cost) expanded fetch only runs when at
-        least one pair IS configured for that kind. Called from both
-        ``create_grouped_event`` (after the base-availability check) and
-        ``reschedule_grouped_event`` (spec: every enforcement surface agrees).
+        A calendar with NEITHER a group-scoped block, window, NOR quota rule
+        for a given ``(calendar, slot)`` pair falls through untouched --
+        narrowing/exclusion only ever applies to what was actually
+        configured. Self-gating -- the block, window, and quota existence
+        checks are each the only extra query when nothing of that kind is
+        configured for any of the named pairs; each (fixed-cost) expanded
+        fetch only runs when at least one pair IS configured for that kind.
+        Called from both ``create_grouped_event`` (after the
+        base-availability check) and ``reschedule_grouped_event`` (spec:
+        every enforcement surface agrees).
         """
         pairs = list(slot_calendar_pairs)
         if not pairs:
@@ -2575,7 +2684,7 @@ class CalendarGroupService:
         slot_ids = {slot_id for slot_id, _ in pairs}
         calendar_ids = {cid for _, cid in pairs}
 
-        # Blocks beat everything -- checked first, before windows.
+        # Blocks beat everything -- checked first, before windows and quota.
         configured_block_pairs = set(
             BlockedTime.objects.unscoped()
             .filter_by_organization(org_id)
@@ -2605,21 +2714,55 @@ class CalendarGroupService:
             .values_list("group_slot_fk_id", "calendar_fk_id")
             .distinct()
         )
-        if not configured_pairs:
+        if configured_pairs:
+            configured_slot_ids = {slot_id for slot_id, _ in configured_pairs}
+            configured_calendar_ids = {cid for _, cid in configured_pairs}
+            spans_by_slot = slot_engine.fetch_group_scoped_available_spans(
+                org_id, configured_slot_ids, configured_calendar_ids, start, end
+            )
+
+            for slot_id, calendar_id in pairs:
+                if (slot_id, calendar_id) not in configured_pairs:
+                    continue
+                spans = spans_by_slot.get(slot_id, {}).get(calendar_id, ())
+                if not slot_engine.window_fully_covered_by_spans(spans, start, end):
+                    raise CalendarGroupScopedRuleViolationError(calendar_id=calendar_id)
+
+        # Quota is checked LAST, after block and window both pass.
+        configured_quota_rules = slot_engine.fetch_group_scoped_quota_rules(
+            org_id, slot_ids, calendar_ids
+        )
+        if not configured_quota_rules:
             return
 
-        configured_slot_ids = {slot_id for slot_id, _ in configured_pairs}
-        configured_calendar_ids = {cid for _, cid in configured_pairs}
-        spans_by_slot = slot_engine.fetch_group_scoped_available_spans(
-            org_id, configured_slot_ids, configured_calendar_ids, start, end
+        quota_rules_by_slot = slot_engine.group_quota_rules_by_slot(configured_quota_rules)
+        week_start = cast(Organization, self.organization).week_start
+        # Widen to the full period boundaries the candidate's own start falls
+        # into -- `[start, end)` is typically much narrower than a day/week/
+        # month bucket, which would otherwise silently undercount an earlier
+        # live booking in that same period. See
+        # `slot_engine.quota_covering_range`'s docstring.
+        covering_range = slot_engine.quota_covering_range(
+            (start,), {rule.period for rule in configured_quota_rules}, week_start
         )
+        quota_counts_by_slot: slot_engine.GroupScopedQuotaCountsBySlot = {}
+        if covering_range is not None:
+            quota_counts_by_slot = slot_engine.fetch_group_scoped_quota_period_counts(
+                org_id, configured_quota_rules, week_start, *covering_range
+            )
 
         for slot_id, calendar_id in pairs:
-            if (slot_id, calendar_id) not in configured_pairs:
+            rules = quota_rules_by_slot.get(slot_id, {}).get(calendar_id, ())
+            if not rules:
                 continue
-            spans = spans_by_slot.get(slot_id, {}).get(calendar_id, ())
-            if not slot_engine.window_fully_covered_by_spans(spans, start, end):
-                raise CalendarGroupScopedRuleViolationError(calendar_id=calendar_id)
+            counts_for_slot = quota_counts_by_slot.get(slot_id, {})
+            for rule in rules:
+                period_start = slot_engine.quota_period_start_utc(start, rule.period, week_start)
+                count = counts_for_slot.get((calendar_id, rule.period), {}).get(period_start, 0)
+                if count >= rule.cap:
+                    raise CalendarGroupScopedRuleViolationError(
+                        calendar_id=calendar_id, rule_type=GroupScopedRuleType.QUOTA_CONSUMED
+                    )
 
     def _create_non_primary_blocked_times(
         self,
@@ -2741,6 +2884,16 @@ class CalendarGroupService:
         OVERLAPS the candidate window is excluded from its slot's count
         regardless of what any window says. Also zero added queries when
         unconfigured.
+
+        Group-scoped quota rules (``CALENDAR_GROUP_SCOPED_AVAILABILITY``
+        Phase 3b) are checked LAST, after base availability, block, and
+        window all pass: a calendar with a configured quota rule at or over
+        its cap for the period a candidate window's start falls into is
+        excluded from its slot's count, regardless of what any window says.
+        The counting call (see ``slot_engine.fetch_group_scoped_quota_period_counts``)
+        is issued ONCE per ``(slot, period)`` combination actually
+        configured, covering the WHOLE search window -- never once per
+        candidate. Also zero added queries when unconfigured.
         """
         self._assert_initialized()
         if slot_step <= datetime.timedelta(0):
@@ -2760,6 +2913,7 @@ class CalendarGroupService:
             slot_pool_by_id,
             group_scoped_calendar_ids_by_slot,
             group_scoped_block_calendar_ids_by_slot,
+            group_scoped_quota_calendar_ids_by_slot,
         ) = self._slot_pools_with_group_scoped_flags(slots)
         required_count_by_slot_id = {s.id: s.required_count for s in slots}
 
@@ -2825,6 +2979,52 @@ class CalendarGroupService:
                 search_window_end,
             )
 
+        # ------------------------------------------------------------------
+        # Group-scoped quota rules (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase
+        # 3b) -- self-gating early-out, same shape as windows/blocks above.
+        # ------------------------------------------------------------------
+        # `group_scoped_quota_calendar_ids_by_slot` was already computed above
+        # by folding a THIRD EXISTS() subquery into the SAME per-slot
+        # membership query -- zero added round trips. Only when at least one
+        # calendar anywhere in the group actually has a quota rule configured
+        # do we pay for the fixed, non-per-candidate counting fetch below --
+        # ONE query per (slot, period) combination actually configured,
+        # covering the WHOLE search window in one shot (see
+        # `slot_engine.fetch_group_scoped_quota_period_counts`). The number of
+        # counting queries is a function of the roster/config, never of how
+        # many candidate windows the loop below will check the result
+        # against.
+        org = cast(Organization, self.organization)
+        week_start = org.week_start
+        group_scoped_quota_rules_by_slot: slot_engine.GroupScopedQuotaRulesBySlot = {}
+        group_scoped_quota_counts_by_slot: slot_engine.GroupScopedQuotaCountsBySlot = {}
+        if group_scoped_quota_calendar_ids_by_slot:
+            configured_quota_slot_ids = list(group_scoped_quota_calendar_ids_by_slot.keys())
+            configured_quota_calendar_ids: set[int] = set()
+            for ids in group_scoped_quota_calendar_ids_by_slot.values():
+                configured_quota_calendar_ids.update(ids)
+            quota_rules = slot_engine.fetch_group_scoped_quota_rules(
+                org.id, configured_quota_slot_ids, configured_quota_calendar_ids
+            )
+            group_scoped_quota_rules_by_slot = slot_engine.group_quota_rules_by_slot(quota_rules)
+            # Widen to the full period boundaries touched by the search
+            # window's own edges -- `search_window_start` need not itself sit
+            # on a period boundary (e.g. a Wednesday-to-Friday search window
+            # under a Monday-start weekly rule), which would otherwise
+            # silently undercount live bookings made earlier in that same
+            # period. See `slot_engine.quota_covering_range`'s docstring.
+            covering_range = slot_engine.quota_covering_range(
+                (search_window_start, search_window_end),
+                {rule.period for rule in quota_rules},
+                week_start,
+            )
+            if covering_range is not None:
+                group_scoped_quota_counts_by_slot = (
+                    slot_engine.fetch_group_scoped_quota_period_counts(
+                        org.id, quota_rules, week_start, *covering_range
+                    )
+                )
+
         proposals: list[BookableSlotProposal] = []
         cursor = search_window_start
         while cursor + duration <= search_window_end:
@@ -2846,6 +3046,10 @@ class CalendarGroupService:
                         group_scoped_spans_by_slot.get(slot_id),
                         group_scoped_block_calendar_ids_by_slot.get(slot_id),
                         group_scoped_block_spans_by_slot.get(slot_id),
+                        group_scoped_quota_calendar_ids_by_slot.get(slot_id),
+                        group_scoped_quota_rules_by_slot.get(slot_id),
+                        group_scoped_quota_counts_by_slot.get(slot_id),
+                        week_start,
                     ):
                         available_count += 1
                 if available_count < required_count_by_slot_id[slot_id]:

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -2394,18 +2394,17 @@ class CalendarGroupService:
         Group-scoped blocks (Phase 2a) and quota rules (Phase 3b) are checked
         the same way.
 
-        Known v1 limitation on quota specifically: the count used to validate
-        the NEW period is the live count as of THIS event's still-unmoved
-        ``CalendarEvent`` row (the reschedule write happens after this
-        check), which still includes this event's own booking if it already
-        falls in the SAME target period (e.g. moving a booking from 9am to
-        2pm on the same day, under a daily cap already at its limit) -- such
-        a same-period, no-net-change reschedule can be rejected even though
-        it does not actually consume additional quota. This mirrors the
-        counting function's derive-on-read design (Phase 3a) rather than
-        excluding the event under reschedule from its own count, and is
-        accepted for v1 the same way the non-primary base-availability gap
-        above is.
+        Quota self-exclusion: the count used to validate the NEW period is
+        the live count as of THIS event's still-unmoved ``CalendarEvent`` row
+        (the reschedule write happens after this check), which would
+        otherwise still include this event's own booking if it already falls
+        in the SAME target period (e.g. moving a booking from 9am to 2pm on
+        the same day, under a daily cap already at its limit). To avoid
+        rejecting such a same-period, no-net-change reschedule,
+        ``_assert_calendars_within_group_scoped_windows`` is passed this
+        event's CURRENT (pre-move) start time and subtracts 1 from a rule's
+        looked-up count whenever that old period matches the candidate's
+        period -- see that method's docstring for the full rationale.
         """
         self._assert_initialized()
         # Checked explicitly and first, for the same reason as
@@ -2457,7 +2456,12 @@ class CalendarGroupService:
             .filter(event_fk=event)
             .values_list("slot_fk_id", "calendar_fk_id")
         )
-        self._assert_calendars_within_group_scoped_windows(selection_pairs, start_time, end_time)
+        self._assert_calendars_within_group_scoped_windows(
+            selection_pairs,
+            start_time,
+            end_time,
+            rescheduling_event_old_start=event.start_time,
+        )
 
         # Build the update input preserving all non-time details so that only
         # RESCHEDULE permission is required (same approach as the single-calendar path).
@@ -2644,6 +2648,7 @@ class CalendarGroupService:
         slot_calendar_pairs: Iterable[tuple[int, int]],
         start: datetime.datetime,
         end: datetime.datetime,
+        rescheduling_event_old_start: datetime.datetime | None = None,
     ) -> None:
         """Reject any ``(slot_id, calendar_id)`` pair whose calendar violates a
         group-scoped rule configured for that slot at ``[start, end)`` (spec
@@ -2675,6 +2680,18 @@ class CalendarGroupService:
         Called from both ``create_grouped_event`` (after the
         base-availability check) and ``reschedule_grouped_event`` (spec:
         every enforcement surface agrees).
+
+        ``rescheduling_event_old_start``: only passed by
+        ``reschedule_grouped_event``, as the event-being-moved's CURRENT
+        (pre-move) start time. The live count fetched for quota purposes
+        still includes that event's own still-unmoved booking row. When its
+        old period matches the candidate's period, this method subtracts 1
+        from the looked-up count before comparing to the cap so a same-period
+        (no net quota change) reschedule is not rejected purely because it
+        sees its own row. A fresh ``create_grouped_event`` call never passes
+        this (there is no prior row to exclude), and discovery
+        (``calendar_free_for_window`` / ``check_group_availability``) never
+        calls this method at all -- both are therefore unaffected.
         """
         pairs = list(slot_calendar_pairs)
         if not pairs:
@@ -2759,6 +2776,21 @@ class CalendarGroupService:
             for rule in rules:
                 period_start = slot_engine.quota_period_start_utc(start, rule.period, week_start)
                 count = counts_for_slot.get((calendar_id, rule.period), {}).get(period_start, 0)
+                # Self-exclusion for reschedules: the fetched count above
+                # already includes the event-being-moved's OWN still-present
+                # row. If its old (pre-move) period is the SAME period the
+                # candidate falls into, subtract 1 so we're comparing "does
+                # this booking exceed the cap for OTHERS" rather than
+                # double-counting the event against itself. If the old period
+                # differs (a reschedule across a period boundary), the event
+                # is NOT part of this period's count, so no adjustment is
+                # made and a full period still correctly rejects.
+                if rescheduling_event_old_start is not None:
+                    old_period_start = slot_engine.quota_period_start_utc(
+                        rescheduling_event_old_start, rule.period, week_start
+                    )
+                    if old_period_start == period_start:
+                        count -= 1
                 if count >= rule.cap:
                     raise CalendarGroupScopedRuleViolationError(
                         calendar_id=calendar_id, rule_type=GroupScopedRuleType.QUOTA_CONSUMED

--- a/calendar_integration/services/slot_engine.py
+++ b/calendar_integration/services/slot_engine.py
@@ -895,6 +895,10 @@ def fetch_group_scoped_quota_period_counts(
             bucket_counts: QuotaPeriodBucketCounts = {}
             for bucket in buckets or ():
                 period_start = datetime.datetime.fromisoformat(bucket["period_start"])
+                # ``bucket["period_end"]`` is intentionally unused here -- only
+                # ``period_start`` (the lookup key) and ``booking_count`` are
+                # needed on the Python side; callers derive any end boundary
+                # they need via `quota_period_end_utc`.
                 bucket_counts[period_start] = bucket["booking_count"]
             counts_by_slot.setdefault(slot_id, {})[(calendar_id, period)] = bucket_counts
     return counts_by_slot

--- a/calendar_integration/services/slot_engine.py
+++ b/calendar_integration/services/slot_engine.py
@@ -22,6 +22,16 @@ single-calendar / bundle walker both depend on:
   in :func:`calendar_free_for_window` AFTER base availability and BEFORE the
   window intersection, since a group-scoped block wins regardless of what any
   window says.
+- :func:`fetch_group_scoped_quota_rules` / :func:`fetch_group_scoped_quota_period_counts`
+  / :func:`quota_period_start_utc` — the quota analog
+  (``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 3b): applied in
+  :func:`calendar_free_for_window` LAST, after base availability, block, and
+  window all pass. The counting call (``GetCalendarGroupQuotaPeriodCountsJSON``,
+  Phase 3a) is issued ONCE per ``(group_slot, period)`` combination actually
+  configured, covering the WHOLE search window in one shot; each candidate
+  then only does an in-memory dict lookup keyed by the period its start time
+  falls into (:func:`quota_period_start_utc`, which mirrors the SQL function's
+  UTC bucketing exactly) -- no query inside the per-candidate loop.
 
 Everything here is **stateless and org-scoped through the passed organization
 id**.  The functions are factored out of ``CalendarGroupService`` verbatim so the
@@ -52,19 +62,24 @@ Boundary semantics (decided once, applied consistently):
 
 import datetime
 from collections.abc import Iterable, Iterator
+from typing import NamedTuple
 
 from django.db.models import Q
 
+from calendar_integration.constants import QuotaPeriod
+from calendar_integration.database_functions import GetCalendarGroupQuotaPeriodCountsJSON
 from calendar_integration.models import (
     AvailableTime,
     BlockedTime,
     Calendar,
     CalendarEvent,
+    CalendarGroupSlotQuotaRule,
 )
 from calendar_integration.services.dataclasses import (
     BookableSlotProposal,
     EffectivePolicy,
 )
+from organizations.models import WeekStart
 
 
 Span = tuple[datetime.datetime, datetime.datetime]
@@ -74,6 +89,35 @@ SpansByCalendarId = dict[int, list[Span]]
 # applies only within the one slot it was configured for
 # (CALENDAR_GROUP_SCOPED_AVAILABILITY).
 GroupScopedSpansBySlot = dict[int, SpansByCalendarId]
+
+
+class GroupScopedQuotaRule(NamedTuple):
+    """One ``CalendarGroupSlotQuotaRule`` row, flattened for the discovery /
+    booking-validation lookup (``CALENDAR_GROUP_SCOPED_AVAILABILITY`` Phase 3b).
+    A calendar may have several of these for the same ``(slot_id, calendar_id)``
+    -- one per period -- and ALL of them must have headroom (spec: "at most 1 a
+    day AND 3 a week" is two rules, both enforced).
+    """
+
+    slot_id: int
+    calendar_id: int
+    period: str
+    cap: int
+
+
+# Quota rules for a (slot, calendar) pair -- there can be more than one (e.g.
+# a daily rule AND a weekly rule), all of which must pass.
+QuotaRulesByCalendar = dict[int, list[GroupScopedQuotaRule]]
+# Quota rules, keyed first by CalendarGroupSlot id, then by calendar id --
+# mirrors GroupScopedSpansBySlot's shape.
+GroupScopedQuotaRulesBySlot = dict[int, QuotaRulesByCalendar]
+# Live-booking counts per period bucket for one (calendar, period) pair within
+# a slot: {period_start (UTC) -> booking_count}. Only periods with >= 1 live
+# booking appear (the SQL function only returns non-empty buckets); a period
+# absent from this dict has a count of 0.
+QuotaPeriodBucketCounts = dict[datetime.datetime, int]
+# Counts keyed first by CalendarGroupSlot id, then by (calendar_id, period).
+GroupScopedQuotaCountsBySlot = dict[int, dict[tuple[int, str], QuotaPeriodBucketCounts]]
 
 
 def intervals_overlap(a: Span, b: Span) -> bool:
@@ -218,6 +262,10 @@ def calendar_free_for_window(
     group_scoped_spans: SpansByCalendarId | None = None,
     group_scoped_block_calendar_ids: set[int] | None = None,
     group_scoped_block_spans: SpansByCalendarId | None = None,
+    group_scoped_quota_calendar_ids: set[int] | None = None,
+    group_scoped_quota_rules: QuotaRulesByCalendar | None = None,
+    group_scoped_quota_counts: dict[tuple[int, str], QuotaPeriodBucketCounts] | None = None,
+    week_start: str = WeekStart.MONDAY,
 ) -> bool:
     """Return True if ``calendar_id`` is free for ``[window_start, window_end)``.
 
@@ -226,30 +274,48 @@ def calendar_free_for_window(
     - Unmanaged calendars must not overlap any blocking span.
 
     ``group_scoped_calendar_ids`` / ``group_scoped_spans`` add the Phase 1b
-    window intersection and ``group_scoped_block_calendar_ids`` /
-    ``group_scoped_block_spans`` add the Phase 2a block exclusion
-    (``CALENDAR_GROUP_SCOPED_AVAILABILITY``): all four default to ``None``,
-    which reproduces the exact pre-Phase-1b behavior byte-for-byte -- this is
-    the single-calendar / bundle walker's call shape
+    window intersection, ``group_scoped_block_calendar_ids`` /
+    ``group_scoped_block_spans`` add the Phase 2a block exclusion, and
+    ``group_scoped_quota_calendar_ids`` / ``group_scoped_quota_rules`` /
+    ``group_scoped_quota_counts`` add the Phase 3b quota cap
+    (``CALENDAR_GROUP_SCOPED_AVAILABILITY``): all default to ``None``, which
+    reproduces the exact pre-Phase-1b behavior byte-for-byte -- this is the
+    single-calendar / bundle walker's call shape
     (``BookableSlotsService._walk_candidates``), which passes none of them and
     must stay untouched (spec non-goal: single-calendar booking).
 
     Resolution order (spec "State transitions & edge cases" flowchart): base
-    availability, then block, then window. A calendar with a configured
+    availability, then block, then window, then quota -- QUOTA IS CHECKED
+    LAST, after everything else passes. A calendar with a configured
     group-scoped block that OVERLAPS ``[window_start, window_end)`` is
     excluded immediately -- "blocks beat everything" -- regardless of what any
-    group-scoped window says; the window check below never even runs for it.
+    group-scoped window or quota rule says; the window and quota checks below
+    never even run for it.
 
     When ``calendar_id`` is NOT in ``group_scoped_calendar_ids`` (or that set
     is falsy), this calendar has no group-scoped window configured for the
-    slot being evaluated and the result is exactly the base-availability
-    (and, if applicable, block) check above (fall-through default). When it
-    IS in that set, the window must additionally be fully covered by at least
-    one of ``group_scoped_spans``' entries for this calendar -- narrowing
-    only, never widening base availability (spec: "Intersect, never widen"; a
-    calendar configured with a window that does not overlap
-    ``[window_start, window_end)`` at all contributes an empty span list
-    here, which correctly yields ``False``).
+    slot being evaluated and the window step is a no-op (fall-through
+    default). When it IS in that set, the window must additionally be fully
+    covered by at least one of ``group_scoped_spans``' entries for this
+    calendar -- narrowing only, never widening base availability (spec:
+    "Intersect, never widen"; a calendar configured with a window that does
+    not overlap ``[window_start, window_end)`` at all contributes an empty
+    span list here, which correctly yields ``False``).
+
+    Quota (Phase 3b): when ``calendar_id`` is NOT in
+    ``group_scoped_quota_calendar_ids`` (or that set is falsy), the quota step
+    is a no-op -- same self-gating fall-through as windows and blocks. When it
+    IS in that set, EVERY rule in ``group_scoped_quota_rules[calendar_id]``
+    must have headroom (spec: "at most 1 a day AND 3 a week" is two rules,
+    both enforced) -- one rule at/over its cap for the period
+    ``window_start`` falls into rejects the candidate. The period a candidate
+    falls into is computed by :func:`quota_period_start_utc`, which mirrors
+    the counting SQL function's UTC bucketing exactly so the candidate side
+    and the counted side always agree on which bucket a time belongs to. No
+    query happens here -- ``group_scoped_quota_counts`` was already fetched
+    once for the whole search window by the caller
+    (:func:`fetch_group_scoped_quota_period_counts`); this is a pure
+    in-memory dict lookup.
     """
     if calendar_id in managed_ids:
         base_free = window_fully_covered_by_spans(
@@ -271,12 +337,24 @@ def calendar_free_for_window(
         if blocked:
             return False
 
-    if not group_scoped_calendar_ids or calendar_id not in group_scoped_calendar_ids:
-        return True
+    if group_scoped_calendar_ids and calendar_id in group_scoped_calendar_ids:
+        if not window_fully_covered_by_spans(
+            (group_scoped_spans or {}).get(calendar_id, ()), window_start, window_end
+        ):
+            return False
 
-    return window_fully_covered_by_spans(
-        (group_scoped_spans or {}).get(calendar_id, ()), window_start, window_end
-    )
+    if group_scoped_quota_calendar_ids and calendar_id in group_scoped_quota_calendar_ids:
+        for rule in (group_scoped_quota_rules or {}).get(calendar_id, ()):
+            period_start = quota_period_start_utc(window_start, rule.period, week_start)
+            count = (
+                (group_scoped_quota_counts or {})
+                .get((calendar_id, rule.period), {})
+                .get(period_start, 0)
+            )
+            if count >= rule.cap:
+                return False
+
+    return True
 
 
 def apply_policy_filter(
@@ -599,3 +677,224 @@ def fetch_group_scoped_blocking_spans(
             (occurrence.start_time, occurrence.end_time)
         )
     return spans_by_slot
+
+
+# ---------------------------------------------------------------------------
+# Group-scoped quota rules (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3b --
+# discovery + booking-validation enforcement). The rule model and the
+# per-period counting SQL function/wrapper were added in Phase 3a; nothing
+# read them until now.
+# ---------------------------------------------------------------------------
+
+
+def fetch_group_scoped_quota_rules(
+    organization_id: int,
+    slot_ids: Iterable[int],
+    calendar_ids: Iterable[int],
+) -> list[GroupScopedQuotaRule]:
+    """Every ``CalendarGroupSlotQuotaRule`` row for the given (slot, calendar)
+    universe -- ONE query, fixed regardless of how many candidate windows the
+    caller will check the result against. Callers should only invoke this
+    once at least one (slot, calendar) pair is known to have a quota rule
+    configured; see ``CalendarGroupService._slot_pools_with_group_scoped_flags``
+    for the zero-extra-query existence check that gates this fetch.
+    """
+    slot_ids = list(slot_ids)
+    calendar_ids = list(calendar_ids)
+    if not slot_ids or not calendar_ids:
+        return []
+    return [
+        GroupScopedQuotaRule(
+            slot_id=row["group_slot_fk_id"],
+            calendar_id=row["calendar_fk_id"],
+            period=row["period"],
+            cap=row["cap"],
+        )
+        for row in (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(organization_id)
+            .filter(group_slot_fk_id__in=slot_ids, calendar_fk_id__in=calendar_ids)
+            .values("group_slot_fk_id", "calendar_fk_id", "period", "cap")
+        )
+    ]
+
+
+def group_quota_rules_by_slot(
+    rules: Iterable[GroupScopedQuotaRule],
+) -> GroupScopedQuotaRulesBySlot:
+    """Reshape a flat list of :class:`GroupScopedQuotaRule` into
+    ``{slot_id: {calendar_id: [rules]}}`` -- the shape
+    :func:`calendar_free_for_window` consumes per slot, mirroring
+    ``GroupScopedSpansBySlot``.
+    """
+    by_slot: GroupScopedQuotaRulesBySlot = {}
+    for rule in rules:
+        by_slot.setdefault(rule.slot_id, {}).setdefault(rule.calendar_id, []).append(rule)
+    return by_slot
+
+
+def quota_period_start_utc(
+    instant: datetime.datetime, period: str, week_start: str
+) -> datetime.datetime:
+    """Return the UTC start of the fixed calendar period (day / week / month)
+    that ``instant`` falls into -- the Python-side mirror of
+    ``calculate_calendar_group_quota_period_counts``'s bucketing (Phase 3a
+    SQL), so a candidate time and a counted booking with the same real instant
+    always land in the SAME bucket.
+
+    Bucketing happens in ONE consistent frame -- UTC -- regardless of
+    ``instant``'s own tzinfo (naive instants are treated as already being in
+    UTC, matching how ``CalendarEvent.start_time`` -- a true UTC instant -- is
+    truncated ``AT TIME ZONE 'UTC'`` on the SQL side). This is the same
+    documented v1 decision the counting function carries: no canonical
+    calendar-level timezone exists in this schema, so per-event/per-candidate
+    timezones must never be allowed to split or bypass a quota bucket.
+
+    Week buckets honor ``week_start`` (``organizations.models.WeekStart``):
+    a Monday start truncates to the ISO Monday on/before ``instant``; a Sunday
+    start truncates to the Sunday on/before ``instant`` (mirrors the SQL
+    function's ``date_trunc('week', ts + 1 day) - 1 day`` shift).
+    """
+    if instant.tzinfo is None:
+        instant_utc = instant.replace(tzinfo=datetime.UTC)
+    else:
+        instant_utc = instant.astimezone(datetime.UTC)
+    midnight = instant_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    if period == QuotaPeriod.DAY:
+        return midnight
+    if period == QuotaPeriod.MONTH:
+        return midnight.replace(day=1)
+
+    # Week period: `datetime.weekday()` is Monday=0 .. Sunday=6.
+    if week_start == WeekStart.SUNDAY:
+        days_since_period_start = (midnight.weekday() + 1) % 7
+    else:
+        days_since_period_start = midnight.weekday()
+    return midnight - datetime.timedelta(days=days_since_period_start)
+
+
+def quota_period_end_utc(period_start: datetime.datetime, period: str) -> datetime.datetime:
+    """Return the (exclusive) end of the fixed calendar period that starts at
+    ``period_start`` (itself expected to already be a value returned by
+    :func:`quota_period_start_utc`). Companion to that function -- together
+    they give the ``[period_start, period_end)`` bounds one period bucket
+    covers, used by callers that need to fetch counts for a specific booking
+    time rather than a whole discovery search window (see
+    :func:`quota_covering_range`).
+    """
+    if period == QuotaPeriod.DAY:
+        return period_start + datetime.timedelta(days=1)
+    if period == QuotaPeriod.WEEK:
+        return period_start + datetime.timedelta(days=7)
+    # Month: `period_start` always has day=1 (from `quota_period_start_utc`).
+    if period_start.month == 12:
+        return period_start.replace(year=period_start.year + 1, month=1)
+    return period_start.replace(month=period_start.month + 1)
+
+
+def quota_covering_range(
+    instants: Iterable[datetime.datetime],
+    periods: Iterable[str],
+    week_start: str,
+) -> tuple[datetime.datetime, datetime.datetime] | None:
+    """Return a ``[range_start, range_end)`` that fully covers, for EVERY
+    ``instant`` and EVERY ``period`` type, the whole quota-period bucket that
+    instant falls into -- not just the instant itself.
+
+    This matters for any caller whose "search window" is narrower than a
+    quota period (e.g. booking/reschedule validation checks a single
+    candidate ``[start, end)``, and ``check_group_availability`` checks
+    discrete, possibly far-apart ranges): if the counting query's range were
+    just ``[instant, instant)``-ish, an EARLIER live booking in the SAME
+    period (e.g. one made at 9am when the candidate being validated is at
+    2pm the same day) would fall outside the fetched range and be silently
+    undercounted, letting a calendar already at its cap slip through. Widening
+    to the full period boundary is what makes the count agree with what
+    discovery would have shown for the same period, regardless of which
+    single instant a caller happens to be asking about.
+
+    Returns ``None`` when either iterable is empty (nothing to cover).
+    """
+    starts: list[datetime.datetime] = []
+    ends: list[datetime.datetime] = []
+    periods = list(periods)
+    for instant in instants:
+        for period in periods:
+            period_start = quota_period_start_utc(instant, period, week_start)
+            starts.append(period_start)
+            ends.append(quota_period_end_utc(period_start, period))
+    if not starts:
+        return None
+    return min(starts), max(ends)
+
+
+def fetch_group_scoped_quota_period_counts(
+    organization_id: int,
+    rules: Iterable[GroupScopedQuotaRule],
+    week_start: str,
+    search_window_start: datetime.datetime,
+    search_window_end: datetime.datetime,
+) -> GroupScopedQuotaCountsBySlot:
+    """Live-booking counts, bucketed by period, for every ``(slot, calendar,
+    period)`` combination present in ``rules``, covering the WHOLE
+    ``[search_window_start, search_window_end)`` range in one shot per
+    combination.
+
+    **Callers MUST pass a range that fully covers every quota-period bucket
+    they intend to look up afterward** -- not just the literal candidate
+    time(s) under evaluation. A range narrower than a period bucket silently
+    undercounts (an earlier live booking in the same period, outside the
+    passed range, is invisible to the SQL function's ``WHERE ce.start_time >=
+    p_range_start AND ce.start_time < p_range_end`` filter). Discovery
+    (``find_bookable_slots``) naturally satisfies this because its search
+    window spans many candidates already; callers validating a single instant
+    or a handful of scattered ranges (booking/reschedule validation,
+    ``check_group_availability``) MUST widen first via
+    :func:`quota_covering_range`.
+
+    **Query-count discipline (the headline risk of this phase):** issues
+    exactly ONE query per distinct ``(slot_id, period)`` pair present in
+    ``rules`` -- NOT one per calendar and NOT one per candidate time. Calendar
+    ids sharing a ``(slot_id, period)`` are folded into a single annotated
+    ``Calendar`` queryset (``GetCalendarGroupQuotaPeriodCountsJSON`` evaluates
+    once per matched row, inside ONE SQL round trip -- the Phase 3a function
+    only accepts one calendar id as a positional argument, but that argument
+    becomes a per-row column reference when annotating a multi-row queryset,
+    so a whole roster shares one query). In the common case (one slot, one or
+    two period types configured) this is 1-2 queries total for the entire
+    discovery call, independent of how many candidate slots the caller will
+    check the result against afterward -- that check is a pure in-memory dict
+    lookup (see :func:`quota_period_start_utc` /
+    :func:`calendar_free_for_window`).
+    """
+    calendar_ids_by_slot_period: dict[tuple[int, str], set[int]] = {}
+    for rule in rules:
+        calendar_ids_by_slot_period.setdefault((rule.slot_id, rule.period), set()).add(
+            rule.calendar_id
+        )
+
+    counts_by_slot: GroupScopedQuotaCountsBySlot = {}
+    for (slot_id, period), calendar_ids in calendar_ids_by_slot_period.items():
+        rows = (
+            Calendar.objects.filter_by_organization(organization_id)
+            .filter(id__in=calendar_ids)
+            .annotate(
+                quota_period_counts=GetCalendarGroupQuotaPeriodCountsJSON(
+                    "id",
+                    slot_id,
+                    organization_id,
+                    period,
+                    week_start,
+                    search_window_start,
+                    search_window_end,
+                )
+            )
+            .values_list("id", "quota_period_counts")
+        )
+        for calendar_id, buckets in rows:
+            bucket_counts: QuotaPeriodBucketCounts = {}
+            for bucket in buckets or ():
+                period_start = datetime.datetime.fromisoformat(bucket["period_start"])
+                bucket_counts[period_start] = bucket["booking_count"]
+            counts_by_slot.setdefault(slot_id, {})[(calendar_id, period)] = bucket_counts
+    return counts_by_slot

--- a/calendar_integration/tests/services/test_group_scoped_quota_discovery.py
+++ b/calendar_integration/tests/services/test_group_scoped_quota_discovery.py
@@ -29,6 +29,7 @@ import pytest
 from calendar_integration.constants import (
     CalendarProvider,
     CalendarType,
+    EventManagementPermissions,
     GroupScopedRuleType,
     QuotaPeriod,
 )
@@ -42,6 +43,7 @@ from calendar_integration.models import (
     CalendarGroup,
     CalendarGroupSlot,
     CalendarGroupSlotMembership,
+    CalendarManagementToken,
 )
 from calendar_integration.services.calendar_group_service import CalendarGroupService
 from calendar_integration.services.calendar_permission_service import CalendarPermissionService
@@ -50,7 +52,7 @@ from calendar_integration.services.dataclasses import (
     CalendarGroupEventInputData,
     CalendarGroupSlotSelectionInputData,
 )
-from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from organizations.models import Organization, OrganizationMembership, OrganizationRole, WeekStart
 from users.models import Profile, User
 
 
@@ -192,6 +194,74 @@ def service(
     )
     svc.initialize(organization=organization)
     return svc
+
+
+@pytest.fixture
+def reschedule_admin_user(organization: Organization) -> User:
+    """A real ``User`` identity (not the anonymous/public path the other
+    fixtures use) -- needed only by the reschedule self-exclusion tests below,
+    which must exercise the FULL ``reschedule_grouped_event`` write path
+    (through ``CalendarService.update_event``'s permission check), not just
+    the quota gate."""
+    u = User.objects.create_user(email="quota-reschedule-admin@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.ADMIN
+    )
+    return u
+
+
+@pytest.fixture
+def reschedule_calendar_service(
+    organization: Organization, reschedule_admin_user: User, calendar: Calendar
+) -> CalendarService:
+    """A ``CalendarService`` authenticated as ``reschedule_admin_user``, with a
+    calendar-level ``CalendarManagementToken`` pre-minted so
+    ``CalendarEventService.create_event``'s ``initialize_with_user`` call
+    succeeds for the grouped booking's primary create (no permissions need to
+    be attached to this token -- ``create_grouped_event`` sets
+    ``group_authorized=True`` on the underlying create, which bypasses the
+    per-calendar scheduling permission check)."""
+    CalendarManagementToken.objects.create(
+        organization=organization,
+        calendar_fk=calendar,
+        membership_user_id=reschedule_admin_user.id,
+        token_hash=f"quota-reschedule-cal-{uuid.uuid4()}",
+    )
+    cs = CalendarService()
+    cs.initialize_without_provider(user_or_token=reschedule_admin_user, organization=organization)
+    return cs
+
+
+@pytest.fixture
+def reschedule_service(
+    organization: Organization, reschedule_calendar_service: CalendarService, audit_service
+) -> CalendarGroupService:
+    svc = CalendarGroupService(
+        calendar_service=reschedule_calendar_service,
+        calendar_permission_service=CalendarPermissionService(),
+        audit_service=audit_service,
+    )
+    svc.initialize(organization=organization)
+    return svc
+
+
+def _grant_reschedule_permission(
+    organization: Organization, user: User, event: CalendarEvent
+) -> CalendarManagementToken:
+    """Mint an event-scoped token with RESCHEDULE so
+    ``CalendarEventService.update_event``'s ``can_perform_update`` check
+    passes for a subsequent ``reschedule_grouped_event`` call on ``event``."""
+    token = CalendarManagementToken.objects.create(
+        organization=organization,
+        event_fk=event,
+        membership_user_id=user.id,
+        token_hash=f"quota-reschedule-evt-{uuid.uuid4()}",
+    )
+    token.permissions.create(
+        organization=organization, permission=EventManagementPermissions.RESCHEDULE
+    )
+    return token
 
 
 def _seed_booking(
@@ -467,6 +537,12 @@ def test_create_grouped_event_rejects_calendar_over_quota(
     error_msg = str(exc_info.value)
     assert str(calendar.id) in error_msg
     assert "quota_consumed" in error_msg
+    # The configured cap (1) must NOT leak into the message either -- strip
+    # out the calendar id occurrence first so a coincidental digit overlap
+    # between the cap and the (DB-assigned) calendar id can't mask a
+    # regression that actually embeds the cap.
+    message_without_calendar_id = error_msg.replace(str(calendar.id), "")
+    assert "1" not in message_without_calendar_id
 
 
 @pytest.mark.django_db
@@ -487,6 +563,325 @@ def test_create_grouped_event_allows_calendar_under_quota(
     _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 1, 9))
     event = _book_via_service(service, surgery_slot, calendar, _utc(2025, 9, 1, 14))
     assert event.calendar_fk_id == calendar.id
+
+
+# ---------------------------------------------------------------------------
+# Reschedule self-exclusion: the event-being-moved's own still-present
+# booking row must not count against itself when validating the reschedule.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_reschedule_same_day_at_daily_cap_succeeds(
+    reschedule_service: CalendarGroupService,
+    reschedule_admin_user: User,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """Daily cap=1, one booking at 09:00. Rescheduling THAT SAME booking to
+    14:00 the same day must succeed: the candidate period (Sep 1) is the
+    booking's own old period, so its own row must be excluded from the count
+    used to validate the new time -- it isn't consuming any additional quota,
+    just moving within the same period."""
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.DAY,
+        cap=1,
+    )
+    event = _book_via_service(reschedule_service, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+    _grant_reschedule_permission(organization, reschedule_admin_user, event)
+
+    rescheduled = reschedule_service.reschedule_grouped_event(
+        event_id=event.id,
+        start_time=_utc(2025, 9, 1, 14),
+        end_time=_utc(2025, 9, 1, 14, 30),
+        tz="UTC",
+    )
+    assert rescheduled.start_time == _utc(2025, 9, 1, 14)
+
+
+@pytest.mark.django_db
+def test_reschedule_across_boundary_into_full_period_rejected(
+    reschedule_service: CalendarGroupService,
+    reschedule_admin_user: User,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """Daily cap=1. The event under reschedule lives on Sep 1; Sep 2 already
+    has its OWN (different) booking at the cap. Moving the Sep 1 event INTO
+    Sep 2 must be rejected -- the old period (Sep 1) differs from the
+    candidate period (Sep 2), so no self-exclusion applies and Sep 2's count
+    (from the other booking) is evaluated as-is."""
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.DAY,
+        cap=1,
+    )
+    event = _book_via_service(reschedule_service, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+    _grant_reschedule_permission(organization, reschedule_admin_user, event)
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 2, 9))
+
+    with pytest.raises(CalendarGroupScopedRuleViolationError) as exc_info:
+        reschedule_service.reschedule_grouped_event(
+            event_id=event.id,
+            start_time=_utc(2025, 9, 2, 14),
+            end_time=_utc(2025, 9, 2, 14, 30),
+            tz="UTC",
+        )
+    assert exc_info.value.calendar_id == calendar.id
+    assert exc_info.value.rule_type == GroupScopedRuleType.QUOTA_CONSUMED
+
+
+@pytest.mark.django_db
+def test_reschedule_across_boundary_into_period_with_headroom_succeeds(
+    reschedule_service: CalendarGroupService,
+    reschedule_admin_user: User,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """Daily cap=1. The event under reschedule lives on Sep 1; Sep 2 has no
+    other bookings. Moving the Sep 1 event into Sep 2 must succeed -- the old
+    period differs from the candidate period (no self-exclusion needed), and
+    Sep 2's count (0) is under the cap."""
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.DAY,
+        cap=1,
+    )
+    event = _book_via_service(reschedule_service, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+    _grant_reschedule_permission(organization, reschedule_admin_user, event)
+
+    rescheduled = reschedule_service.reschedule_grouped_event(
+        event_id=event.id,
+        start_time=_utc(2025, 9, 2, 9),
+        end_time=_utc(2025, 9, 2, 9, 30),
+        tz="UTC",
+    )
+    assert rescheduled.start_time == _utc(2025, 9, 2, 9)
+
+
+# ---------------------------------------------------------------------------
+# Sunday week start -- exercises the shift-truncate-shift bucketing branch a
+# default-Monday fixture never hits.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_weekly_quota_with_sunday_week_start_hides_calendar_across_boundary(
+    service: CalendarGroupService,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """Sunday week start: the week containing Sunday 2025-09-07 runs
+    [Sep 7 - Sep 13]. Two bookings inside that Sunday-started week (one on
+    the Sunday itself, one on the following Monday) at cap=2 must hide the
+    calendar for the REST of that week, while the calendar remains offered on
+    Sep 6 (the last day of the PRECEDING Sunday-started week, [Aug 31 - Sep
+    6]) -- a boundary a Monday-week-start fixture never straddles the same
+    way."""
+    organization = calendar.organization
+    organization.week_start = WeekStart.SUNDAY
+    organization.save(update_fields=["week_start"])
+
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=2,
+    )
+    # Sunday 2025-09-07 and Monday 2025-09-08 are in the SAME Sunday-started
+    # week [Sep 7 - Sep 13].
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 7, 9))
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 8, 9))
+
+    # Sep 9 (Tuesday) is still inside the now-capped [Sep 7 - Sep 13] week.
+    still_in_capped_week = service.check_group_availability(
+        surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        [(_utc(2025, 9, 9, 10), _utc(2025, 9, 9, 10, 30))],
+    )
+    assert still_in_capped_week[0].slots[0].available_calendar_ids == []
+
+    # Sep 6 (Saturday) is the last day of the PRECEDING Sunday-started week
+    # [Aug 31 - Sep 6] -- untouched by the cap.
+    preceding_week = service.check_group_availability(
+        surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        [(_utc(2025, 9, 6, 10), _utc(2025, 9, 6, 10, 30))],
+    )
+    assert preceding_week[0].slots[0].available_calendar_ids == [calendar.id]
+
+
+# ---------------------------------------------------------------------------
+# Monthly quota rule, bookings across a month boundary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_monthly_quota_hides_calendar_across_month_boundary(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    # The `calendar` fixture's base AvailableTime block only runs through
+    # 2025-09-29 -- extend it into October so base availability isn't the
+    # bottleneck for the October assertion below (mirrors the fixture's own
+    # single-wide-block approach).
+    AvailableTime.objects.create(
+        organization=organization,
+        calendar=calendar,
+        start_time_tz_unaware=_utc(2025, 9, 29),
+        end_time_tz_unaware=_utc(2025, 10, 3),
+        timezone="UTC",
+    )
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.MONTH,
+        cap=2,
+    )
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 5, 9))
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 20, 9))
+
+    # Still September -- at cap, hidden.
+    september_result = service.check_group_availability(
+        surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        [(_utc(2025, 9, 25, 10), _utc(2025, 9, 25, 10, 30))],
+    )
+    assert september_result[0].slots[0].available_calendar_ids == []
+
+    # October -- a fresh month bucket, no bookings yet, offered again.
+    october_result = service.check_group_availability(
+        surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        [(_utc(2025, 10, 1, 10), _utc(2025, 10, 1, 10, 30))],
+    )
+    assert october_result[0].slots[0].available_calendar_ids == [calendar.id]
+
+
+# ---------------------------------------------------------------------------
+# Python/SQL bucketing pin test -- the Python-side `quota_period_start_utc`
+# and the SQL `get_calendar_group_quota_period_counts_json` function must
+# always bucket the SAME instant into the SAME period, or the count fetched
+# via SQL will silently disagree with the period the Python side looks it up
+# under.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_python_and_sql_bucketing_agree_on_period_start(
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    from calendar_integration.database_functions import GetCalendarGroupQuotaPeriodCountsJSON
+    from calendar_integration.services import slot_engine
+
+    seed_instants = [
+        _utc(2025, 9, 3, 9),  # mid-week Wednesday
+        _utc(2025, 9, 7, 23, 30),  # Sunday, near midnight
+        _utc(2025, 9, 30, 9),  # end of month
+    ]
+    for instant in seed_instants:
+        _seed_booking(organization, surgery_group, surgery_slot, calendar, instant)
+
+    range_start = _utc(2025, 8, 25)
+    range_end = _utc(2025, 10, 5)
+
+    for period, week_start in (
+        (QuotaPeriod.DAY, WeekStart.MONDAY),
+        (QuotaPeriod.WEEK, WeekStart.MONDAY),
+        (QuotaPeriod.WEEK, WeekStart.SUNDAY),
+        (QuotaPeriod.MONTH, WeekStart.MONDAY),
+    ):
+        row = (
+            Calendar.objects.filter_by_organization(organization.id)
+            .filter(id=calendar.id)
+            .annotate(
+                quota_counts=GetCalendarGroupQuotaPeriodCountsJSON(
+                    "id",
+                    surgery_slot.id,
+                    organization.id,
+                    period,
+                    week_start,
+                    range_start,
+                    range_end,
+                )
+            )
+            .values_list("quota_counts", flat=True)
+            .first()
+        )
+        sql_period_starts = {
+            datetime.datetime.fromisoformat(bucket["period_start"]) for bucket in (row or ())
+        }
+
+        expected_period_starts = {
+            slot_engine.quota_period_start_utc(instant, period, week_start)
+            for instant in seed_instants
+        }
+
+        assert sql_period_starts == expected_period_starts, (period, week_start)
+
+
+# ---------------------------------------------------------------------------
+# `check_group_availability` quota-counting query count is fixed per
+# configured (slot, period) combination, not per range.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_check_group_availability_quota_query_count_independent_of_range_count(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=3,
+    )
+
+    few_ranges = [(_utc(2025, 9, 1, 9), _utc(2025, 9, 1, 9, 30))]
+    many_ranges = [
+        (
+            WEEK1_MONDAY + datetime.timedelta(minutes=5 * i),
+            WEEK1_MONDAY + datetime.timedelta(minutes=5 * i + 30),
+        )
+        for i in range(200)
+    ]
+
+    with CaptureQueriesContext(connection) as few:
+        service.check_group_availability(
+            surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            few_ranges,
+        )
+    with CaptureQueriesContext(connection) as many:
+        service.check_group_availability(
+            surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            many_ranges,
+        )
+
+    few_quota_queries = _quota_query_count(few)
+    many_quota_queries = _quota_query_count(many)
+    assert few_quota_queries == 1
+    assert many_quota_queries == 1
+    assert few_quota_queries == many_quota_queries
 
 
 # ---------------------------------------------------------------------------

--- a/calendar_integration/tests/services/test_group_scoped_quota_discovery.py
+++ b/calendar_integration/tests/services/test_group_scoped_quota_discovery.py
@@ -1,0 +1,654 @@
+"""Tests for group-scoped quota rules in discovery and booking validation
+(Phase 3b of ``CALENDAR_GROUP_SCOPED_AVAILABILITY``).
+
+Covers:
+- A calendar at its cap is hidden from discovery for that period and
+  reappears the FOLLOWING period (spec UC-2, Acceptance 5's setup).
+- Cancelling a booking frees quota immediately, with no further action
+  (Acceptance 5).
+- Two rules (daily AND weekly) on the same calendar are BOTH enforced.
+- Explicit booking past the cap is rejected with
+  ``GroupScopedRuleType.QUOTA_CONSUMED``.
+- The headline risk this phase exists to guard against: the quota-counting
+  query count is a FIXED function of the roster/config (bounded by the
+  number of distinct ``(slot, period)`` combinations actually configured),
+  never a function of how many candidate times discovery walks.
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from typing import Any
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+import pytest
+
+from calendar_integration.constants import (
+    CalendarProvider,
+    CalendarType,
+    GroupScopedRuleType,
+    QuotaPeriod,
+)
+from calendar_integration.exceptions import CalendarGroupScopedRuleViolationError
+from calendar_integration.factories import create_group_slot_quota_rule
+from calendar_integration.models import (
+    AvailableTime,
+    Calendar,
+    CalendarEvent,
+    CalendarEventGroupSelection,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+)
+from calendar_integration.services.calendar_group_service import CalendarGroupService
+from calendar_integration.services.calendar_permission_service import CalendarPermissionService
+from calendar_integration.services.calendar_service import CalendarService
+from calendar_integration.services.dataclasses import (
+    CalendarGroupEventInputData,
+    CalendarGroupSlotSelectionInputData,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.models import Profile, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+QUOTA_COUNTING_FUNCTION = "get_calendar_group_quota_period_counts_json"
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, minute, tzinfo=datetime.UTC)
+
+
+# 2025-09-01 is a Monday. Weeks: [Sep 1-7], [Sep 8-14], [Sep 15-21].
+WEEK1_MONDAY = _utc(2025, 9, 1)
+WEEK1_TUESDAY = _utc(2025, 9, 2)
+WEEK1_WEDNESDAY = _utc(2025, 9, 3)
+WEEK1_SATURDAY = _utc(2025, 9, 6)
+WEEK2_MONDAY = _utc(2025, 9, 8)
+WEEK2_SATURDAY = _utc(2025, 9, 13)
+
+
+def _quota_query_count(captured: CaptureQueriesContext) -> int:
+    return sum(1 for q in captured.captured_queries if QUOTA_COUNTING_FUNCTION in q["sql"])
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization(db: Any) -> Organization:
+    return Organization.objects.create(name="Quota Discovery Org", should_sync_rooms=False)
+
+
+@pytest.fixture
+def audit_service():
+    from di_core.containers import container
+
+    return container.audit_service()
+
+
+@pytest.fixture
+def admin_user(db: Any, organization: Organization) -> User:
+    u = User.objects.create_user(email="quota-admin@example.com", password="pass")
+    Profile.objects.create(user=u)
+    OrganizationMembership.objects.create(
+        user=u, organization=organization, role=OrganizationRole.ADMIN
+    )
+    return u
+
+
+@pytest.fixture
+def calendar(organization: Organization) -> Calendar:
+    """Dr. Reyes -- available every day for several weeks (a single wide
+    AvailableTime block); base availability is never the bottleneck under
+    test here, only quota. MANAGED (``manage_available_windows=True``), so
+    base availability derives purely from ``AvailableTime`` coverage -- the
+    existing bookings created below never conflict with each other or with
+    later candidates on base-availability grounds, letting the tests isolate
+    the quota gate."""
+    cal = Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="dr_reyes_quota",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=True,
+    )
+    AvailableTime.objects.create(
+        organization=organization,
+        calendar=cal,
+        start_time_tz_unaware=WEEK1_MONDAY,
+        end_time_tz_unaware=_utc(2025, 9, 29),
+        timezone="UTC",
+    )
+    return cal
+
+
+@pytest.fixture
+def other_calendar(organization: Organization) -> Calendar:
+    cal = Calendar.objects.create(
+        organization=organization,
+        name="Dr. Costa",
+        external_id="dr_costa_quota",
+        provider=CalendarProvider.INTERNAL,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+        accepts_public_scheduling=True,
+    )
+    AvailableTime.objects.create(
+        organization=organization,
+        calendar=cal,
+        start_time_tz_unaware=WEEK1_MONDAY,
+        end_time_tz_unaware=_utc(2025, 9, 29),
+        timezone="UTC",
+    )
+    return cal
+
+
+@pytest.fixture
+def surgery_group(organization: Organization) -> CalendarGroup:
+    return CalendarGroup.objects.create(
+        organization=organization, name="Surgery", accepts_public_scheduling=True
+    )
+
+
+@pytest.fixture
+def surgery_slot(
+    organization: Organization, surgery_group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=surgery_group, name="Lead Surgeon"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def calendar_service(organization: Organization) -> CalendarService:
+    cs = CalendarService()
+    cs.initialize_without_provider(organization=organization)
+    return cs
+
+
+@pytest.fixture
+def service(
+    organization: Organization, calendar_service: CalendarService, audit_service
+) -> CalendarGroupService:
+    svc = CalendarGroupService(
+        calendar_service=calendar_service,
+        calendar_permission_service=CalendarPermissionService(),
+        audit_service=audit_service,
+    )
+    svc.initialize(organization=organization)
+    return svc
+
+
+def _seed_booking(
+    organization: Organization,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+    calendar: Calendar,
+    start: datetime.datetime,
+    duration_minutes: int = 30,
+) -> CalendarEvent:
+    """Directly create a LIVE booking "made through" `surgery_slot` -- a
+    ``CalendarEvent`` plus its ``CalendarEventGroupSelection`` link, exactly
+    what ``CalendarGroupService.create_grouped_event`` would persist for a
+    single-calendar slot selection (mirrors the Phase 3a counting-function
+    test helper). Used to seed MULTIPLE pre-existing bookings without going
+    through the full booking write pipeline, whose ``CalendarEvent.external_id``
+    is server-generated and left blank (globally unique, INTERNAL provider,
+    no write adapter under ``initialize_without_provider``) -- going through
+    ``create_grouped_event`` more than once per test would collide on that
+    constraint. The REJECTION/ACCEPTANCE tests below still exercise the real
+    write path via ``create_grouped_event`` (only ONE successful write each).
+    """
+    end = start + datetime.timedelta(minutes=duration_minutes)
+    event = CalendarEvent.objects.create(
+        organization=organization,
+        calendar=calendar,
+        title="Surgery",
+        external_id=f"quota-seed-{uuid.uuid4()}",
+        start_time_tz_unaware=start,
+        end_time_tz_unaware=end,
+        timezone="UTC",
+        calendar_group=surgery_group,
+    )
+    CalendarEventGroupSelection.objects.create(
+        organization=organization, event=event, slot=surgery_slot, calendar=calendar
+    )
+    return event
+
+
+def _book_via_service(
+    service: CalendarGroupService,
+    surgery_slot: CalendarGroupSlot,
+    calendar: Calendar,
+    start: datetime.datetime,
+    duration_minutes: int = 30,
+):
+    """Book through the real write path (``create_grouped_event``) -- used
+    for the tests that exercise booking-time validation itself, never more
+    than once per test (see ``_seed_booking``'s docstring)."""
+    return service.create_grouped_event(
+        CalendarGroupEventInputData(
+            title="Surgery",
+            description="",
+            start_time=start,
+            end_time=start + datetime.timedelta(minutes=duration_minutes),
+            timezone="UTC",
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            slot_selections=[
+                CalendarGroupSlotSelectionInputData(
+                    slot_id=surgery_slot.id, calendar_ids=[calendar.id]
+                ),
+            ],
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# UC-2 / Acceptance 5 (setup) -- capped calendar hidden for the period, offered
+# again the following period.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_capped_calendar_hidden_for_period_and_offered_next_period(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=3,
+    )
+
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 2, 9))
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 3, 9))
+
+    week1_proposals = service.find_bookable_slots(
+        group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        search_window_start=WEEK1_MONDAY,
+        search_window_end=WEEK1_SATURDAY,
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(hours=2),
+    )
+    assert week1_proposals == []
+
+    week2_proposals = service.find_bookable_slots(
+        group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        search_window_start=WEEK2_MONDAY,
+        search_window_end=WEEK2_SATURDAY,
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(hours=2),
+    )
+    assert len(week2_proposals) > 0
+    assert {p.start_time.weekday() for p in week2_proposals} == {0, 1, 2, 3, 4}
+
+
+@pytest.mark.django_db
+def test_check_group_availability_excludes_capped_calendar(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=1,
+    )
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+
+    capped_range = (_utc(2025, 9, 2, 10), _utc(2025, 9, 2, 10, 30))
+    free_range = (_utc(2025, 9, 8, 10), _utc(2025, 9, 8, 10, 30))  # next week
+
+    [capped_result, free_result] = service.check_group_availability(
+        surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        [capped_range, free_range],
+    )
+    assert capped_result.slots[0].available_calendar_ids == []
+    assert free_result.slots[0].available_calendar_ids == [calendar.id]
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 5 -- cancelling a booking frees quota immediately.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_cancelling_booking_frees_quota_with_no_further_action(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=3,
+    )
+
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 2, 9))
+    third = _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 3, 9))
+
+    assert (
+        service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=WEEK1_MONDAY,
+            search_window_end=WEEK1_SATURDAY,
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(hours=2),
+        )
+        == []
+    )
+
+    # Cancelling a grouped booking deletes the CalendarEvent row (mirrors
+    # CalendarGroupService.cancel_grouped_event, which this test bypasses to
+    # avoid needing a fully-permissioned actor -- the fixtures here have no
+    # user or public-scheduling token attached to the calendar_service, so
+    # the real write-path permission check would reject the delete for
+    # reasons unrelated to quota). The CASCADE on
+    # CalendarEventGroupSelection.event_fk removes the group-selection link
+    # too, so the counting function sees one fewer live booking -- exactly
+    # what cancel_grouped_event's own deletion of the primary event achieves.
+    third.delete()
+
+    proposals_after_cancel = service.find_bookable_slots(
+        group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        search_window_start=WEEK1_MONDAY,
+        search_window_end=WEEK1_SATURDAY,
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(hours=2),
+    )
+    assert len(proposals_after_cancel) > 0
+
+
+# ---------------------------------------------------------------------------
+# Two rules (daily AND weekly) both enforced.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_daily_and_weekly_rules_both_enforced(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """A calendar under its weekly cap but at its daily cap is not offered
+    THAT day, but is offered other days in the week."""
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.DAY,
+        cap=1,
+    )
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=5,
+    )
+
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, WEEK1_MONDAY.replace(hour=9))
+
+    proposals = service.find_bookable_slots(
+        group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+        search_window_start=WEEK1_MONDAY,
+        search_window_end=WEEK1_SATURDAY,
+        duration=datetime.timedelta(minutes=30),
+        slot_step=datetime.timedelta(hours=2),
+    )
+    days_offered = {p.start_time.weekday() for p in proposals}
+    # Monday (0) is at its daily cap -- absent. Tuesday-Friday (1-4) are
+    # under both caps -- present. The weekly cap (5) is never hit.
+    assert 0 not in days_offered
+    assert days_offered == {1, 2, 3, 4}
+
+
+# ---------------------------------------------------------------------------
+# Explicit booking past the cap is rejected with QUOTA_CONSUMED.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_grouped_event_rejects_calendar_over_quota(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.DAY,
+        cap=1,
+    )
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+
+    with pytest.raises(CalendarGroupScopedRuleViolationError) as exc_info:
+        _book_via_service(service, surgery_slot, calendar, _utc(2025, 9, 1, 14))
+
+    assert exc_info.value.calendar_id == calendar.id
+    assert exc_info.value.rule_type == GroupScopedRuleType.QUOTA_CONSUMED
+    # The error names the calendar and the rule type -- never the configured
+    # cap or current count (spec Decisions -> Errors).
+    error_msg = str(exc_info.value)
+    assert str(calendar.id) in error_msg
+    assert "quota_consumed" in error_msg
+
+
+@pytest.mark.django_db
+def test_create_grouped_event_allows_calendar_under_quota(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_group: CalendarGroup,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.DAY,
+        cap=2,
+    )
+    _seed_booking(organization, surgery_group, surgery_slot, calendar, _utc(2025, 9, 1, 9))
+    event = _book_via_service(service, surgery_slot, calendar, _utc(2025, 9, 1, 14))
+    assert event.calendar_fk_id == calendar.id
+
+
+# ---------------------------------------------------------------------------
+# Headline risk: quota-counting query count is independent of candidate
+# count, and bounded by (slot, period) combinations actually configured --
+# never by roster size or candidate count.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_quota_query_count_independent_of_candidate_count(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=3,
+    )
+
+    # FEW candidates: 2-hour steps over a single day.
+    with CaptureQueriesContext(connection) as few:
+        few_proposals = service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=WEEK1_MONDAY,
+            search_window_end=WEEK1_TUESDAY,
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(hours=2),
+        )
+
+    # MANY candidates: 5-minute steps over three weeks -- orders of magnitude
+    # more candidate windows than the FEW case above.
+    with CaptureQueriesContext(connection) as many:
+        many_proposals = service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=WEEK1_MONDAY,
+            search_window_end=_utc(2025, 9, 22),
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(minutes=5),
+        )
+
+    assert len(many_proposals) > len(few_proposals) * 50  # sanity: MANY more candidates
+
+    few_quota_queries = _quota_query_count(few)
+    many_quota_queries = _quota_query_count(many)
+    assert few_quota_queries == 1
+    assert many_quota_queries == 1
+    assert few_quota_queries == many_quota_queries
+
+    # The TOTAL query count (not just the quota-counting slice) is also
+    # identical -- discovery does not issue one round trip per candidate for
+    # ANY of its fetches, quota included.
+    assert len(few.captured_queries) == len(many.captured_queries)
+
+
+@pytest.mark.django_db
+def test_quota_query_count_bounded_by_period_combinations_not_calendar_count(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    other_calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """Two calendars sharing the SAME (slot, period) -- the counting call is
+    ONE annotated query covering both, not one per calendar."""
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=surgery_slot, calendar=other_calendar
+    )
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=3,
+    )
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=other_calendar,
+        period=QuotaPeriod.WEEK,
+        cap=3,
+    )
+
+    with CaptureQueriesContext(connection) as captured:
+        service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=WEEK1_MONDAY,
+            search_window_end=WEEK1_SATURDAY,
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(hours=2),
+        )
+    assert _quota_query_count(captured) == 1
+
+
+@pytest.mark.django_db
+def test_quota_query_count_scales_with_distinct_periods_not_candidates(
+    service: CalendarGroupService,
+    organization: Organization,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    """One calendar with TWO period types configured (day + week) -- TWO
+    counting queries, bounded by the distinct period types actually
+    configured, still independent of candidate count."""
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.DAY,
+        cap=1,
+    )
+    create_group_slot_quota_rule(
+        organization=organization,
+        group_slot=surgery_slot,
+        calendar=calendar,
+        period=QuotaPeriod.WEEK,
+        cap=5,
+    )
+
+    with CaptureQueriesContext(connection) as few:
+        service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=WEEK1_MONDAY,
+            search_window_end=WEEK1_TUESDAY,
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(hours=2),
+        )
+    with CaptureQueriesContext(connection) as many:
+        service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=WEEK1_MONDAY,
+            search_window_end=WEEK1_SATURDAY,
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(minutes=5),
+        )
+    assert _quota_query_count(few) == 2
+    assert _quota_query_count(many) == 2
+
+
+# ---------------------------------------------------------------------------
+# Required -- unchanged path: identical output, unchanged query count (no
+# quota-counting query issued at all when nothing is configured).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_unconfigured_group_issues_no_quota_counting_query(
+    service: CalendarGroupService,
+    calendar: Calendar,
+    surgery_slot: CalendarGroupSlot,
+) -> None:
+    with CaptureQueriesContext(connection) as captured:
+        proposals = service.find_bookable_slots(
+            group_id=surgery_slot.group_fk_id,  # type: ignore[arg-type]
+            search_window_start=WEEK1_MONDAY,
+            search_window_end=WEEK1_SATURDAY,
+            duration=datetime.timedelta(minutes=30),
+            slot_step=datetime.timedelta(hours=2),
+        )
+    assert len(proposals) > 0
+    assert _quota_query_count(captured) == 0


### PR DESCRIPTION

## Summary

Phase 3b of the Calendar Group-Scoped Availability plan. A calendar that has consumed its quota for a period stops being offered for that period and is rejected if named directly. Quota is the last filter in the resolution order (base → block → window → quota).

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 3b. Spec use-cases UC-2 and the quota half of UC-4; Acceptance scenario 5.

## Key decisions

- **One counting query per discovery, independent of candidate count** (the headline perf risk): the counting call is batched by `(slot, period)` and issued once per distinct configured `(slot, period)` combination — never inside the per-candidate loop. Results are bucketed into an in-memory lookup consulted per candidate. Asserted: 1 quota query for a few vs ~50× candidates; 1 for two calendars sharing a `(slot, week)`; 2 for a day+week pair; 0 unconfigured. A `check_group_availability` test asserts 1 quota query across 200 ranges.
- **Self-gating**: a third `Exists()` folds into the existing per-slot membership query; the counting call is skipped entirely when no quota rule exists. The unconfigured discovery path is byte-for-byte unchanged (6/5 query counts hold).
- **UTC bucketing matches Phase 3a**: `quota_period_start_utc` reimplements the SQL function's exact bucketing (day/month truncation; Monday/Sunday week via shift-truncate-shift). A pin test runs the real SQL function and asserts its `period_start` equals the Python bucket for the same instants across day / week-Monday / week-Sunday / month, so the two implementations can't drift.
- **`quota_covering_range`**: the counting range is widened to the full period boundaries the candidate touches (per period type), so a live booking earlier in the same period — outside a narrow candidate range — is still counted (fixes an undercount that would otherwise let a cap be bypassed).
- **All rules must pass**: every consulting site checks all of a calendar's quota rules (daily AND weekly) and excludes/rejects if any is at/over cap.
- **Reschedule self-exclusion**: rescheduling a booking within the period it already occupies does not consume additional quota — the event being moved is subtracted from its own period's count (reschedule path only; fresh creates and discovery unaffected). Without this, a `cap=1` calendar could never reschedule same-day. Reschedule across a boundary into a full period is still correctly rejected.
- **Released on cancel** (Acceptance 5): counts are derived on read, so cancelling a booking frees quota with no further action.
- **Error shape**: `QUOTA_CONSUMED` names the calendar + rule type, not the configured cap.

## Feature flag

None — self-gating; no migration.

## Test plan

```bash
docker compose run --rm api uv run pytest calendar_integration/tests/services/test_group_scoped_quota_discovery.py -vs
docker compose run --rm api uv run pytest calendar_integration/tests/ -n auto
```

Covers: at-cap hidden + offered next period; cancel releases; daily AND weekly both enforced; explicit booking past cap rejected (QUOTA_CONSUMED, cap not leaked); reschedule self-exclusion (same-day at cap succeeds; across-boundary into full period rejected); Sunday-week and month bucketing; Python/SQL bucketing agreement; quota query count independent of candidate/range count; unconfigured path unchanged with no quota query.