### PR TITLE
feat(calendar): add group-scoped quota rule REST and public API surfaces

### DIFF
--- a/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
+++ b/ai-plans/TRACKING_CALENDAR_GROUP_SCOPED_AVAILABILITY.md
@@ -118,13 +118,21 @@ Phase 0 branches off `plan-calendar-group-scoped-availability`; each later phase
 
 **CARRY-FORWARD for Phase 3b**: quota periods are measured in **UTC** (documented v1 simplification). Phase 3b's discovery/booking lookup MUST bucket the candidate booking's time in the SAME UTC frame the counting function uses, so the candidate's period matches the counted period. Do NOT reintroduce per-event/local timezone bucketing on the candidate side.
 
+### Phase 3b — Quota in discovery and booking validation ✅
+
+- **Branch**: `plan/calendar-group-scoped-availability/phase-3b` (base: phase-3a) — **PR [#228](https://github.com/vintasoftware/vinta-schedule-api/pull/228)**
+- **Implementer model**: sonnet (plan Tier 3) — agent type `implementer`
+- **Reviewer model**: opus (plan Tier-4 override) — no BLOCKERs; 1 SHOULD-FIX (reschedule self-exclusion) + coverage gaps + NITs fixed (sonnet fixer)
+- **Summary**: Quota wired into discovery + booking/reschedule. **One counting query per discovery, independent of candidate count** (batched by `(slot,period)`; asserted 1 for few vs ~50× candidates, 0 unconfigured; `check_group_availability` 1 across 200 ranges). Third `Exists()` folded into the membership query (self-gating; 6/5 counts hold). `quota_period_start_utc` mirrors the SQL bucketing (pin test prevents drift). `quota_covering_range` prevents same-period undercount. Quota checked LAST; all rules must pass. `QUOTA_CONSUMED` error (cap not leaked). Cancel releases quota on read. No migration.
+- **SHOULD-FIX fixed (reschedule)**: the event being rescheduled is self-excluded from its own period's quota count, so a `cap=1` calendar can reschedule same-day (was universally rejected). Reschedule across a boundary into a full period still correctly rejected.
+
 ## Current phase
 
-Phase 3b — Quota in discovery and booking validation
+Phase 3c — Quota rules on the REST and public surfaces
 
 ## Remaining phases
 
-3b, 3c, 4
+3c, 4
 
 ## Deferred phases
 

--- a/calendar_integration/graphql.py
+++ b/calendar_integration/graphql.py
@@ -15,6 +15,7 @@ from calendar_integration.models import (
     CalendarEventGroupSelection,
     CalendarGroup,
     CalendarGroupSlot,
+    CalendarGroupSlotQuotaRule,
     CalendarOwnership,
     CalendarWebhookEvent,
     CalendarWebhookSubscription,
@@ -679,6 +680,43 @@ def group_scoped_blocked_time_from_model(
         is_recurring=block.is_recurring,
         created=block.created,
         modified=block.modified,
+    )
+
+
+@strawberry.type
+class GroupScopedQuotaRuleGraphQLType:
+    """Public API representation of one group-scoped quota rule
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+    Simpler than ``GroupScopedAvailabilityWindowGraphQLType``/
+    ``GroupScopedBlockedTimeGraphQLType``: quota rules are non-recurring (no
+    ``rruleString``, no ``timezone``, no time range) -- just the period and
+    the cap, mirroring the internal REST surface's
+    ``GroupScopedQuotaRuleSerializer`` field shape.
+    """
+
+    id: int  # noqa: A003
+    calendar_id: int
+    group_slot_id: int
+    period: str
+    cap: int
+    created: datetime.datetime
+    modified: datetime.datetime
+
+
+def group_scoped_quota_rule_from_model(
+    rule: CalendarGroupSlotQuotaRule,
+) -> GroupScopedQuotaRuleGraphQLType:
+    """Build a :class:`GroupScopedQuotaRuleGraphQLType` from a
+    ``CalendarGroupSlotQuotaRule`` row."""
+    return GroupScopedQuotaRuleGraphQLType(
+        id=rule.id,  # type: ignore[arg-type]
+        calendar_id=rule.calendar_fk_id,  # type: ignore[arg-type]
+        group_slot_id=rule.group_slot_fk_id,  # type: ignore[arg-type]
+        period=rule.period,
+        cap=rule.cap,
+        created=rule.created,
+        modified=rule.modified,
     )
 
 

--- a/calendar_integration/permissions.py
+++ b/calendar_integration/permissions.py
@@ -312,3 +312,62 @@ class GroupScopedBlockedTimePermission(BasePermission):
 
         view.group_slot = group_slot
         return True
+
+
+class GroupScopedQuotaRulePermission(BasePermission):
+    """Route-level group-visibility gate for the group-scoped quota rule
+    routes nested under a group's slot
+    (``calendar-groups/<group_id>/slots/<slot_id>/quota-rules/...``,
+    CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+    Identical in every respect to ``GroupScopedAvailabilityWindowPermission``/
+    ``GroupScopedBlockedTimePermission`` -- same coarse route-level gate
+    (``can_manage_calendar_group``), same non-disclosure ``Http404`` on a
+    stranger, a cross-organization slot, or a slot belonging to a different
+    group than the one in the URL. See ``GroupScopedAvailabilityWindowPermission``'s
+    docstring for the full rationale; only the resource it guards differs
+    (quota rules instead of windows).
+    """
+
+    @inject
+    def __init__(
+        self,
+        calendar_permission_service: "CalendarPermissionService | None" = Provide[
+            "calendar_permission_service"
+        ],
+    ):
+        self.calendar_permission_service = calendar_permission_service
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+        if not user.is_authenticated:
+            return False
+        membership = get_active_organization_membership(user)
+        if membership is None:
+            return False
+
+        group_id = view.kwargs.get("group_id")
+        slot_id = view.kwargs.get("slot_id")
+        if group_id is None or slot_id is None:
+            return False
+
+        try:
+            group_slot = (
+                CalendarGroupSlot.objects.filter_by_organization(membership.organization_id)
+                .select_related("group")
+                .get(id=slot_id, group_fk_id=group_id)
+            )
+        except CalendarGroupSlot.DoesNotExist:
+            raise Http404() from None
+
+        if self.calendar_permission_service is None or not (
+            self.calendar_permission_service.can_manage_calendar_group(
+                user=user, group=group_slot.group
+            )
+        ):
+            # Same not-found shape as a genuinely missing slot -- a member must
+            # not learn this group/slot exists through a distinguishable 403.
+            raise Http404()
+
+        view.group_slot = group_slot
+        return True

--- a/calendar_integration/routes.py
+++ b/calendar_integration/routes.py
@@ -10,6 +10,7 @@ from .views import (
     ExternalEventChangeRequestViewSet,
     GroupScopedAvailabilityWindowViewSet,
     GroupScopedBlockedTimeViewSet,
+    GroupScopedQuotaRuleViewSet,
 )
 
 
@@ -33,6 +34,11 @@ routes: list[RouteDict] = [
         "regex": r"calendar-groups/<int:group_id>/slots/<int:slot_id>/blocked-times",
         "viewset": GroupScopedBlockedTimeViewSet,
         "basename": "GroupScopedBlockedTimes",
+    },
+    {
+        "regex": r"calendar-groups/<int:group_id>/slots/<int:slot_id>/quota-rules",
+        "viewset": GroupScopedQuotaRuleViewSet,
+        "basename": "GroupScopedQuotaRules",
     },
     {
         "regex": r"calendar",

--- a/calendar_integration/serializers.py
+++ b/calendar_integration/serializers.py
@@ -10,7 +10,12 @@ from allauth.socialaccount.models import SocialAccount
 from dependency_injector.wiring import Provide, inject
 from rest_framework import serializers
 
-from calendar_integration.constants import CalendarProvider, CalendarType, CalendarVisibility
+from calendar_integration.constants import (
+    CalendarProvider,
+    CalendarType,
+    CalendarVisibility,
+    QuotaPeriod,
+)
 from calendar_integration.exceptions import (
     CalendarGroupError,
     CalendarIntegrationError,
@@ -27,6 +32,7 @@ from calendar_integration.models import (
     CalendarGroup,
     CalendarGroupSlot,
     CalendarGroupSlotMembership,
+    CalendarGroupSlotQuotaRule,
     CalendarOwnership,
     CalendarSync,
     ChildrenCalendarRelationship,
@@ -70,6 +76,7 @@ from calendar_integration.virtual_models import (
     ExternalEventChangeRequestVirtualModel,
     GroupScopedAvailabilityWindowVirtualModel,
     GroupScopedBlockedTimeVirtualModel,
+    GroupScopedQuotaRuleVirtualModel,
     RecurrenceRuleVirtualModel,
     ResourceAllocationVirtualModel,
 )
@@ -2817,6 +2824,87 @@ class GroupScopedBlockWriteResultSerializer(serializers.Serializer):
             "needed."
         ),
     )
+
+
+class GroupScopedQuotaRuleSerializer(VirtualModelSerializer):
+    """Read representation of a group-scoped quota rule
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+    Simpler than ``GroupScopedAvailabilityWindowSerializer``/
+    ``GroupScopedBlockedTimeSerializer``: quota rules are non-recurring (no
+    ``rrule_string``, no ``timezone``, no time range) -- just the period and
+    the cap, matching exactly what ``CalendarGroupService``'s quota-write
+    methods accept, so the REST shape and the service signature cannot drift
+    apart.
+    """
+
+    calendar_id = serializers.IntegerField(source="calendar_fk_id", read_only=True)
+    group_slot_id = serializers.IntegerField(source="group_slot_fk_id", read_only=True)
+
+    class Meta:
+        model = CalendarGroupSlotQuotaRule
+        virtual_model = GroupScopedQuotaRuleVirtualModel
+        fields = (
+            "id",
+            "calendar_id",
+            "group_slot_id",
+            "period",
+            "cap",
+            "created",
+            "modified",
+        )
+        read_only_fields = fields
+
+
+class GroupScopedQuotaRuleCreateSerializer(serializers.Serializer):
+    """Input for creating a group-scoped quota rule.
+
+    Field names map 1:1 onto
+    ``CalendarGroupService.create_group_scoped_quota_rule``'s keyword
+    arguments (``calendar_id``, ``period``, ``cap``) so the REST shape can
+    never silently drift from the service signature it delegates to.
+    """
+
+    calendar = serializers.PrimaryKeyRelatedField(
+        queryset=Calendar.original_manager.none(),
+        help_text="Calendar this quota rule applies to. Must be a member of the target slot.",
+    )
+    period = serializers.ChoiceField(
+        choices=QuotaPeriod.choices,
+        help_text="Fixed calendar period the cap applies to (day, week, or month).",
+    )
+    cap = serializers.IntegerField(
+        min_value=1,
+        help_text=(
+            "Maximum number of live bookings made through this group slot the "
+            "calendar may hold within one period."
+        ),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = (
+            self.context["request"].user if self.context and self.context.get("request") else None
+        )
+        membership = (
+            get_active_organization_membership(user) if user and user.is_authenticated else None
+        )
+        self.fields["calendar"].queryset = (
+            Calendar.objects.filter_by_organization(membership.organization_id)
+            if membership
+            else Calendar.original_manager.none()
+        )
+
+
+class GroupScopedQuotaRuleUpdateSerializer(serializers.Serializer):
+    """Input for partially updating a group-scoped quota rule.
+
+    Every field is optional -- only provided fields change, mirroring
+    ``CalendarGroupService.update_group_scoped_quota_rule``.
+    """
+
+    period = serializers.ChoiceField(choices=QuotaPeriod.choices, required=False)
+    cap = serializers.IntegerField(min_value=1, required=False)
 
 
 class CalendarGroupSlotSerializer(VirtualModelSerializer):

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Annotated, cast
 
 from django.core.exceptions import PermissionDenied
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Exists, OuterRef, QuerySet
 from django.utils import timezone
 
@@ -12,7 +12,12 @@ from dependency_injector.wiring import Provide, inject
 
 from audit.constants import AuditAction
 from audit.diff import compute_diff
-from calendar_integration.constants import CalendarProvider, CalendarType, GroupScopedRuleType
+from calendar_integration.constants import (
+    CalendarProvider,
+    CalendarType,
+    GroupScopedRuleType,
+    QuotaPeriod,
+)
 from calendar_integration.exceptions import (
     BookingPolicyViolationError,
     CalendarGroupHasFutureEventsError,
@@ -1725,6 +1730,397 @@ class CalendarGroupService:
             BlockedTime.objects.for_group_slot(group_slot_id)
             .filter_by_organization(organization.id)
             .select_related("recurrence_rule")
+            .order_by("pk")
+        )
+
+    # ------------------------------------------------------------------
+    # Group-scoped quota rules (Phase 3a model / Phase 3c writes of
+    # CALENDAR_GROUP_SCOPED_AVAILABILITY)
+    # ------------------------------------------------------------------
+
+    def _get_group_scoped_quota_rule(self, rule_id: int) -> CalendarGroupSlotQuotaRule:
+        """Fetch a group-scoped ``CalendarGroupSlotQuotaRule`` by id, scoped to
+        this org.
+
+        Unlike ``_get_group_scoped_window``/``_get_group_scoped_block``, there
+        is no ``unscoped()``/default-exclude split to navigate here -- every
+        ``CalendarGroupSlotQuotaRule`` row is group-scoped by construction
+        (there is no "base" quota rule), so the default manager already
+        returns the right rows.
+        """
+        org_id = cast(Organization, self.organization).id
+        try:
+            return (
+                CalendarGroupSlotQuotaRule.objects.filter_by_organization(org_id)
+                .select_related("group_slot", "calendar")
+                .get(id=rule_id)
+            )
+        except CalendarGroupSlotQuotaRule.DoesNotExist:
+            raise CalendarGroupSlotConfigNotFoundError() from None
+
+    def _audit_group_scoped_quota_rule_write(
+        self,
+        action: str,
+        acting_user: "User | SystemUser",
+        subject_instance: CalendarGroupSlotQuotaRule,
+        diff: dict | None = None,
+    ) -> None:
+        """Emit an audit record for a group-scoped quota-rule write.
+
+        Mirrors ``_audit_group_scoped_block_write``/``_audit_group_scoped_availability_write``:
+        the acting principal is taken explicitly (this write path is reachable
+        without a bound ``calendar_service``), and this is a no-op when no
+        ``audit_service`` / ``organization`` is bound.
+        """
+        if self.audit_service is None or self.organization is None:
+            return
+        self.audit_service.record(
+            organization_id=self.organization.id,
+            action=action,
+            actor=self.audit_service.actor_from_user_or_token(acting_user, self.organization.id),
+            subject=self.audit_service.subject_from_instance(subject_instance),
+            diff=diff,
+        )
+
+    def _find_matching_group_scoped_quota_rule(
+        self,
+        group_slot_id: int,
+        calendar_id: int,
+        period: str,
+        cap: int,
+    ) -> CalendarGroupSlotQuotaRule | None:
+        """Find an existing group-scoped quota rule with identical content, if any.
+
+        Backs the batch-upsert write path's idempotent ``create`` (mirrors
+        ``_find_matching_group_scoped_block``): replaying the same batch
+        (spec UC-5) must land on the identical final state, not attempt to
+        insert a duplicate and trip the (calendar, slot, period) unique
+        constraint. Matched on (calendar, group slot, period, cap) -- a
+        ``create`` naming the SAME period but a DIFFERENT cap is deliberately
+        NOT a match, so it falls through to the real insert and surfaces the
+        unique-constraint violation as a validation error rather than
+        silently keeping the old cap.
+        """
+        organization = cast(Organization, self.organization)
+        return (
+            CalendarGroupSlotQuotaRule.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(organization.id)
+            .filter(calendar_fk_id=calendar_id, period=period, cap=cap)
+            .first()
+        )
+
+    @transaction.atomic()
+    def create_group_scoped_quota_rule(
+        self,
+        acting_user: User,
+        group_slot_id: int,
+        calendar_id: int,
+        period: str,
+        cap: int,
+    ) -> CalendarGroupSlotQuotaRule:
+        """Create a group-scoped quota rule capping ``calendar_id``'s live
+        bookings made through ``group_slot_id`` within one ``period``.
+
+        Permission-gated identically to windows and blocks: ``acting_user``
+        must own the calendar or be an org admin (see
+        ``CalendarPermissionService.can_manage_group_scoped_calendar_config``).
+
+        Unlike windows and blocks, quota rules are NOT metered (spec: "Windows
+        and blocks both consume the limit; quota rules do not") -- only
+        ``_check_not_restricted()`` guards this write, never ``check_limit``.
+        There is also no orphaned-booking report: a quota rule caps FUTURE
+        bookings, it does not narrow or remove time from already-confirmed
+        ones, so nothing here can retroactively orphan a booking the way a
+        window or block write can.
+
+        :raises CalendarGroupValidationError: ``cap`` is not a positive
+            integer, or a rule for ``(calendar_id, group_slot_id, period)``
+            already exists (the model's unique constraint) -- surfaced as a
+            validation error, never an unhandled ``IntegrityError``.
+        """
+        self._assert_initialized()
+        self._check_not_restricted()
+        if cap < 1:
+            raise CalendarGroupValidationError("cap must be at least 1.")
+        if period not in QuotaPeriod.values:
+            raise CalendarGroupValidationError(f"Invalid period: {period!r}.")
+
+        organization = cast(Organization, self.organization)
+        membership = self._resolve_group_scoped_membership(group_slot_id, calendar_id)
+        self._authorize_group_scoped_write(acting_user, membership.calendar, membership.slot)
+
+        try:
+            # Nested atomic() opens a savepoint scoped to just this insert, so
+            # catching the IntegrityError below rolls back only the failed
+            # insert -- not the whole request transaction (ATOMIC_REQUESTS)
+            # nor this method's own outer @transaction.atomic().
+            with transaction.atomic():
+                rule = CalendarGroupSlotQuotaRule.objects.create(
+                    organization=organization,
+                    group_slot=membership.slot,
+                    calendar=membership.calendar,
+                    period=period,
+                    cap=cap,
+                )
+        except IntegrityError as e:
+            raise CalendarGroupValidationError(
+                f"A quota rule for period {period!r} already exists for this calendar and slot."
+            ) from e
+
+        self._audit_group_scoped_quota_rule_write(AuditAction.CREATE, acting_user, rule)
+        return rule
+
+    @transaction.atomic()
+    def update_group_scoped_quota_rule(
+        self,
+        acting_user: User,
+        rule_id: int,
+        period: str | None = None,
+        cap: int | None = None,
+    ) -> CalendarGroupSlotQuotaRule:
+        """Partially update a group-scoped quota rule (only provided fields
+        change -- mirrors ``update_group_scoped_blocked_time``).
+
+        :raises CalendarGroupValidationError: ``cap`` is not a positive
+            integer, or the update would collide with another rule already
+            covering ``(calendar, slot, period)``.
+        """
+        self._assert_initialized()
+        self._check_not_restricted()
+        if cap is not None and cap < 1:
+            raise CalendarGroupValidationError("cap must be at least 1.")
+        if period is not None and period not in QuotaPeriod.values:
+            raise CalendarGroupValidationError(f"Invalid period: {period!r}.")
+
+        rule = self._get_group_scoped_quota_rule(rule_id)
+        self._authorize_group_scoped_write(acting_user, rule.calendar, rule.group_slot)
+
+        before = {"period": rule.period, "cap": rule.cap}
+
+        update_fields: list[str] = []
+        if period is not None:
+            rule.period = period
+            update_fields.append("period")
+        if cap is not None:
+            rule.cap = cap
+            update_fields.append("cap")
+
+        if update_fields:
+            try:
+                # See create_group_scoped_quota_rule -- nested atomic() scopes
+                # the savepoint to just this save.
+                with transaction.atomic():
+                    rule.save(update_fields=[*update_fields, "modified"])
+            except IntegrityError as e:
+                raise CalendarGroupValidationError(
+                    f"A quota rule for period {rule.period!r} already exists for this "
+                    "calendar and slot."
+                ) from e
+
+        after = {"period": rule.period, "cap": rule.cap}
+        self._audit_group_scoped_quota_rule_write(
+            AuditAction.UPDATE, acting_user, rule, diff=compute_diff(before, after)
+        )
+        return rule
+
+    @transaction.atomic()
+    def delete_group_scoped_quota_rule(self, acting_user: User, rule_id: int) -> None:
+        """Delete a group-scoped quota rule.
+
+        Mirrors ``delete_group_scoped_blocked_time``/``delete_group_scoped_availability_window``:
+        no orphaned-booking report is computed (deleting a quota rule only
+        WIDENS future bookability, and quota never narrows already-confirmed
+        bookings in the first place).
+        """
+        self._assert_initialized()
+        self._check_not_restricted()
+        rule = self._get_group_scoped_quota_rule(rule_id)
+        self._authorize_group_scoped_write(acting_user, rule.calendar, rule.group_slot)
+
+        self._audit_group_scoped_quota_rule_write(AuditAction.DELETE, acting_user, rule)
+        rule.delete()
+
+    @transaction.atomic()
+    def batch_upsert_group_scoped_quota_rules(
+        self,
+        group_slot_id: int,
+        operations: Iterable[dict],
+        acting_principal: "User | SystemUser",
+    ) -> list[CalendarGroupSlotQuotaRule]:
+        """Apply an atomic bulk-upsert batch of group-scoped quota-rule
+        create/update/delete operations within one group slot's roster
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c -- public API).
+
+        Direct mirror of ``batch_upsert_group_scoped_blocked_times``'s
+        transaction / idempotent-create / IDOR-cross-check structure -- same
+        two deliberate differences from the window batch: quota rules are not
+        metered (never ``check_limit``, never locks the billing root), but it
+        still calls ``check_not_restricted`` up front so a ``RESTRICTED``
+        organization cannot write group-scoped quota rules either.
+
+        * **All-or-nothing.** The whole batch runs inside one transaction.
+        * **Idempotent create.** A ``create`` op is an upsert:
+          :meth:`_find_matching_group_scoped_quota_rule` looks for an existing
+          rule with identical content (calendar, slot, period, cap) first. A
+          match is returned unchanged; a genuine content difference on an
+          already-used period falls through to the real insert and surfaces
+          the unique-constraint violation as :class:`CalendarGroupValidationError`,
+          never an unhandled ``IntegrityError``.
+        * **update / delete** require ``rule_id`` and act on exactly the row
+          it names.
+
+        Authorization is split between the CALLER and this method, exactly
+        like the block batch: the caller proves each op's ``calendar_id`` is
+        within the token's owner scope; this method cross-checks that an
+        update/delete op's resolved rule actually belongs to that op's own
+        ``calendar_id`` and rejects the whole batch (not-found-shaped) if
+        they don't match.
+
+        :param operations: dicts with ``action`` (create/update/delete) and
+            ``calendar_id``; create also takes ``period`` and ``cap``;
+            update takes ``rule_id`` plus optional ``period``/``cap``;
+            delete takes ``rule_id``.
+        :param acting_principal: the ``User`` or public-API ``SystemUser``
+            this write is attributed to in the audit trail.
+        :raises CalendarGroupSlotConfigNotFoundError: a create op's
+            ``calendar_id`` is not a member of ``group_slot_id``'s roster, or
+            an update/delete op's ``rule_id`` does not resolve to a
+            group-scoped quota rule in this slot, or that rule does not
+            belong to the op's own ``calendar_id``.
+        :raises CalendarGroupValidationError: a ``cap`` is not a positive
+            integer, or a create/update collides with the unique
+            (calendar, slot, period) constraint.
+        :raises ValueError: an operation's shape is invalid (unknown action,
+            missing required field).
+        :return: every group-scoped quota rule in ``group_slot_id``'s roster
+            (all calendars) after the batch is applied.
+        """
+        self._assert_initialized()
+        organization = cast(Organization, self.organization)
+        operations = list(operations)
+
+        valid_actions = {"create", "update", "delete"}
+        for op in operations:
+            action = op.get("action")
+            if action not in valid_actions:
+                raise ValueError(f"Invalid operation action: {action}")
+            if action == "create" and (
+                "calendar_id" not in op or "period" not in op or "cap" not in op
+            ):
+                raise ValueError("create operation requires calendar_id, period, cap")
+            if action in ("update", "delete") and "rule_id" not in op:
+                raise ValueError(f"{action} operation requires rule_id")
+            if "cap" in op and op["cap"] is not None and op["cap"] < 1:
+                raise CalendarGroupValidationError("cap must be at least 1.")
+            if (
+                "period" in op
+                and op["period"] is not None
+                and op["period"] not in QuotaPeriod.values
+            ):
+                raise CalendarGroupValidationError(f"Invalid period: {op['period']!r}.")
+
+        # RESTRICTED must block the batch outright, mirrors the block batch,
+        # minus the limit/lock machinery that exists only to protect
+        # entitlement counting, which quota rules don't have (spec: unmetered).
+        if self.entitlement_service is not None and operations:
+            self.entitlement_service.check_not_restricted(organization)
+
+        # Resolve every touched row up front (read-only): a missing/foreign
+        # rule_id or a calendar not on this slot's roster fails the whole
+        # batch before anything is written.
+        rules_by_op_id: dict[int, CalendarGroupSlotQuotaRule] = {}
+        for op in operations:
+            if op["action"] in ("update", "delete"):
+                rule = self._get_group_scoped_quota_rule(op["rule_id"])
+                if rule.group_slot_fk_id != group_slot_id:
+                    raise CalendarGroupSlotConfigNotFoundError()
+                # Cross-check the resolved rule against the op's OWN calendar_id --
+                # mirrors the block batch's IDOR guard: a calendar-owner-scoped
+                # token could otherwise pair a calendar_id it owns with a
+                # rule_id it doesn't, targeting another calendar's quota rule
+                # in the same slot.
+                if rule.calendar_fk_id != op["calendar_id"]:
+                    raise CalendarGroupSlotConfigNotFoundError()
+                rules_by_op_id[op["rule_id"]] = rule
+
+        memberships_by_calendar: dict[int, CalendarGroupSlotMembership] = {}
+        for op in operations:
+            if op["action"] == "create" and op["calendar_id"] not in memberships_by_calendar:
+                memberships_by_calendar[op["calendar_id"]] = self._resolve_group_scoped_membership(
+                    group_slot_id, op["calendar_id"]
+                )
+
+        # Idempotent-create resolution: match each create op against an
+        # existing group-scoped quota rule before writing anything.
+        matched_existing: dict[int, CalendarGroupSlotQuotaRule] = {}
+        for i, op in enumerate(operations):
+            if op["action"] != "create":
+                continue
+            existing = self._find_matching_group_scoped_quota_rule(
+                group_slot_id=group_slot_id,
+                calendar_id=op["calendar_id"],
+                period=op["period"],
+                cap=op["cap"],
+            )
+            if existing is not None:
+                matched_existing[i] = existing
+
+        for i, op in enumerate(operations):
+            action = op["action"]
+            if action == "create":
+                if i in matched_existing:
+                    continue
+                membership = memberships_by_calendar[op["calendar_id"]]
+                try:
+                    with transaction.atomic():
+                        rule = CalendarGroupSlotQuotaRule.objects.create(
+                            organization=organization,
+                            group_slot=membership.slot,
+                            calendar=membership.calendar,
+                            period=op["period"],
+                            cap=op["cap"],
+                        )
+                except IntegrityError as e:
+                    raise CalendarGroupValidationError(
+                        f"A quota rule for period {op['period']!r} already exists for "
+                        f"calendar {op['calendar_id']} in this slot."
+                    ) from e
+                self._audit_group_scoped_quota_rule_write(
+                    AuditAction.CREATE, acting_principal, rule
+                )
+            elif action == "update":
+                rule = rules_by_op_id[op["rule_id"]]
+                before = {"period": rule.period, "cap": rule.cap}
+                update_fields: list[str] = []
+                if "period" in op:
+                    rule.period = op["period"]
+                    update_fields.append("period")
+                if "cap" in op:
+                    rule.cap = op["cap"]
+                    update_fields.append("cap")
+                if update_fields:
+                    try:
+                        with transaction.atomic():
+                            rule.save(update_fields=[*update_fields, "modified"])
+                    except IntegrityError as e:
+                        raise CalendarGroupValidationError(
+                            f"A quota rule for period {rule.period!r} already exists for "
+                            "this calendar and slot."
+                        ) from e
+                after = {"period": rule.period, "cap": rule.cap}
+                self._audit_group_scoped_quota_rule_write(
+                    AuditAction.UPDATE, acting_principal, rule, diff=compute_diff(before, after)
+                )
+            elif action == "delete":
+                rule = rules_by_op_id[op["rule_id"]]
+                self._audit_group_scoped_quota_rule_write(
+                    AuditAction.DELETE, acting_principal, rule
+                )
+                rule.delete()
+
+        return list(
+            CalendarGroupSlotQuotaRule.objects.for_group_slot(group_slot_id)
+            .filter_by_organization(organization.id)
             .order_by("pk")
         )
 

--- a/calendar_integration/services/calendar_group_service.py
+++ b/calendar_integration/services/calendar_group_service.py
@@ -212,6 +212,18 @@ class CalendarGroupService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+    @staticmethod
+    def _is_quota_uniqueness_constraint_violation(e: IntegrityError) -> bool:
+        """Check if an IntegrityError is the (group_slot, calendar, period) unique
+        constraint violation on CalendarGroupSlotQuotaRule.
+
+        Returns True if the error message contains the unique constraint name,
+        False otherwise. Non-uniqueness constraint violations should be re-raised,
+        not converted to a validation error.
+        """
+        constraint_name = "calendargroupslotquotarule_unique_slot_calendar_period"
+        return constraint_name in str(e)
+
     def _get_group_by_id(self, group_id: int) -> CalendarGroup:
         self._assert_initialized()
         return CalendarGroup.objects.filter_by_organization(self.organization.id).get(id=group_id)
@@ -1863,9 +1875,11 @@ class CalendarGroupService:
                     cap=cap,
                 )
         except IntegrityError as e:
-            raise CalendarGroupValidationError(
-                f"A quota rule for period {period!r} already exists for this calendar and slot."
-            ) from e
+            if self._is_quota_uniqueness_constraint_violation(e):
+                raise CalendarGroupValidationError(
+                    f"A quota rule for period {period!r} already exists for this calendar and slot."
+                ) from e
+            raise
 
         self._audit_group_scoped_quota_rule_write(AuditAction.CREATE, acting_user, rule)
         return rule
@@ -1912,10 +1926,12 @@ class CalendarGroupService:
                 with transaction.atomic():
                     rule.save(update_fields=[*update_fields, "modified"])
             except IntegrityError as e:
-                raise CalendarGroupValidationError(
-                    f"A quota rule for period {rule.period!r} already exists for this "
-                    "calendar and slot."
-                ) from e
+                if self._is_quota_uniqueness_constraint_violation(e):
+                    raise CalendarGroupValidationError(
+                        f"A quota rule for period {rule.period!r} already exists for this "
+                        "calendar and slot."
+                    ) from e
+                raise
 
         after = {"period": rule.period, "cap": rule.cap}
         self._audit_group_scoped_quota_rule_write(
@@ -2081,10 +2097,12 @@ class CalendarGroupService:
                             cap=op["cap"],
                         )
                 except IntegrityError as e:
-                    raise CalendarGroupValidationError(
-                        f"A quota rule for period {op['period']!r} already exists for "
-                        f"calendar {op['calendar_id']} in this slot."
-                    ) from e
+                    if self._is_quota_uniqueness_constraint_violation(e):
+                        raise CalendarGroupValidationError(
+                            f"A quota rule for period {op['period']!r} already exists for "
+                            f"calendar {op['calendar_id']} in this slot."
+                        ) from e
+                    raise
                 self._audit_group_scoped_quota_rule_write(
                     AuditAction.CREATE, acting_principal, rule
                 )
@@ -2103,10 +2121,12 @@ class CalendarGroupService:
                         with transaction.atomic():
                             rule.save(update_fields=[*update_fields, "modified"])
                     except IntegrityError as e:
-                        raise CalendarGroupValidationError(
-                            f"A quota rule for period {rule.period!r} already exists for "
-                            "this calendar and slot."
-                        ) from e
+                        if self._is_quota_uniqueness_constraint_violation(e):
+                            raise CalendarGroupValidationError(
+                                f"A quota rule for period {rule.period!r} already exists for "
+                                "this calendar and slot."
+                            ) from e
+                        raise
                 after = {"period": rule.period, "cap": rule.cap}
                 self._audit_group_scoped_quota_rule_write(
                     AuditAction.UPDATE, acting_principal, rule, diff=compute_diff(before, after)

--- a/calendar_integration/tests/test_views_group_scoped_quota_rules.py
+++ b/calendar_integration/tests/test_views_group_scoped_quota_rules.py
@@ -296,6 +296,65 @@ class TestGroupScopedQuotaRuleLifecycle:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_create_with_invalid_period(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        """A create with an invalid period value (not in QuotaPeriod.values)
+        must be rejected as a 400 validation error, nothing created."""
+        client = _auth_client(owner_membership)
+        response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, period="invalid"),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        # Nothing was created.
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(
+                calendar.organization_id
+            ).count()
+            == 0
+        )
+
+    def test_patch_requires_positive_cap(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        """Mirrors test_create_requires_positive_cap: a PATCH setting cap=0
+        or cap < 1 must be rejected as a 400 validation error."""
+        client = _auth_client(owner_membership)
+
+        # Create a rule first.
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, cap=3),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+        rule_id = create_response.data["id"]
+
+        # Try to PATCH it with cap=0.
+        patch_response = client.patch(
+            _detail_url(group.id, group_slot.id, rule_id),
+            {"cap": 0},
+            format="json",
+        )
+        assert patch_response.status_code == status.HTTP_400_BAD_REQUEST
+
+        # The rule's cap should remain unchanged.
+        rule = CalendarGroupSlotQuotaRule.objects.filter_by_organization(
+            calendar.organization_id
+        ).get(id=rule_id)
+        assert rule.cap == 3
+
     def test_put_not_allowed(
         self,
         owner_membership: OrganizationMembership,

--- a/calendar_integration/tests/test_views_group_scoped_quota_rules.py
+++ b/calendar_integration/tests/test_views_group_scoped_quota_rules.py
@@ -1,0 +1,615 @@
+"""Integration tests for the internal REST surface exposing group-scoped
+quota rules (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+Direct mirror of ``test_views_group_scoped_blocked_times.py`` for quota
+rules, minus the recurrence/orphaned-booking machinery (quota rules are
+non-recurring and never narrow already-confirmed bookings). Covers:
+- Full lifecycle through the nested routes (create -> list -> retrieve ->
+  update -> delete), for both the calendar's owner and an org admin.
+- Multiple rules per (calendar, slot) -- day and week coexisting.
+- The (calendar, slot, period) uniqueness constraint surfaced as a 400
+  validation error, never an unhandled IntegrityError/500.
+- Route-level group-visibility gating: a stranger and the owner of a
+  *different* calendar in the same group (different slot) are both denied
+  with the exact same not-found shape.
+- Cross-organization access denied with the same not-found shape.
+- No entitlement check gates quota-rule creation (unmetered).
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from django.urls import reverse
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType, QuotaPeriod
+from calendar_integration.factories import create_calendar_ownership
+from calendar_integration.models import (
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarGroupSlotQuotaRule,
+)
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from users.factories import UserFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_client(membership: OrganizationMembership) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=membership.user)
+    return client
+
+
+def _list_url(group_id: int, slot_id: int) -> str:
+    return reverse(
+        "api:GroupScopedQuotaRules-list",
+        kwargs={"group_id": group_id, "slot_id": slot_id},
+    )
+
+
+def _detail_url(group_id: int, slot_id: int, pk: int) -> str:
+    return reverse(
+        "api:GroupScopedQuotaRules-detail",
+        kwargs={"group_id": group_id, "slot_id": slot_id, "pk": pk},
+    )
+
+
+def _utc(year: int, month: int, day: int, hour: int) -> datetime.datetime:
+    return datetime.datetime(year, month, day, hour, 0, tzinfo=datetime.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def organization() -> Organization:
+    return baker.make(Organization, name="Quota REST Test Org")
+
+
+@pytest.fixture
+def admin_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.ADMIN, is_active=True
+    )
+
+
+@pytest.fixture
+def owner_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def other_owner_membership(organization: Organization) -> OrganizationMembership:
+    """Owns a DIFFERENT calendar (in a different slot of the SAME group) --
+    used to prove that seeing the group is not enough to manage a calendar
+    the caller does not own."""
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def stranger_membership(organization: Organization) -> OrganizationMembership:
+    user = UserFactory().create_user()
+    return OrganizationMembership.objects.create(
+        user=user, organization=organization, role=OrganizationRole.MEMBER, is_active=True
+    )
+
+
+@pytest.fixture
+def calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Reyes",
+        external_id="dr_reyes_quota",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture
+def other_calendar(organization: Organization) -> Calendar:
+    return Calendar.objects.create(
+        organization=organization,
+        name="Dr. Costa",
+        external_id="dr_costa_quota",
+        provider=CalendarProvider.GOOGLE,
+        calendar_type=CalendarType.PERSONAL,
+        manage_available_windows=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _ownerships(
+    owner_membership: OrganizationMembership,
+    other_owner_membership: OrganizationMembership,
+    calendar: Calendar,
+    other_calendar: Calendar,
+) -> None:
+    create_calendar_ownership(calendar=calendar, user=owner_membership.user)
+    create_calendar_ownership(calendar=other_calendar, user=other_owner_membership.user)
+
+
+@pytest.fixture
+def group(organization: Organization) -> CalendarGroup:
+    return CalendarGroup.objects.create(organization=organization, name="Surgery")
+
+
+@pytest.fixture
+def group_slot(
+    organization: Organization, group: CalendarGroup, calendar: Calendar
+) -> CalendarGroupSlot:
+    slot = CalendarGroupSlot.objects.create(
+        organization=organization, group=group, name="Lead Surgeon"
+    )
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=calendar
+    )
+    return slot
+
+
+@pytest.fixture
+def other_slot(
+    organization: Organization, group: CalendarGroup, other_calendar: Calendar
+) -> CalendarGroupSlot:
+    """A second slot in the same group, populated with `other_calendar` -- makes
+    `other_owner_membership`'s user a genuine member of the group without
+    owning `calendar`."""
+    slot = CalendarGroupSlot.objects.create(organization=organization, group=group, name="Assist")
+    CalendarGroupSlotMembership.objects.create(
+        organization=organization, slot=slot, calendar=other_calendar
+    )
+    return slot
+
+
+def _create_payload(calendar_id: int, **overrides) -> dict:
+    payload = {
+        "calendar": calendar_id,
+        "period": QuotaPeriod.WEEK,
+        "cap": 3,
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedQuotaRuleLifecycle:
+    def test_full_lifecycle_as_owner(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+
+        # Create.
+        create_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id),
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        rule_data = create_response.data
+        assert rule_data["calendar_id"] == calendar.id
+        assert rule_data["group_slot_id"] == group_slot.id
+        assert rule_data["period"] == QuotaPeriod.WEEK
+        assert rule_data["cap"] == 3
+        rule_id = rule_data["id"]
+
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(calendar.organization_id)
+            .filter(id=rule_id)
+            .exists()
+        )
+
+        # List.
+        list_response = client.get(_list_url(group.id, group_slot.id))
+        assert list_response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in list_response.data["results"]]
+        assert ids == [rule_id]
+
+        # Retrieve.
+        retrieve_response = client.get(_detail_url(group.id, group_slot.id, rule_id))
+        assert retrieve_response.status_code == status.HTTP_200_OK
+        assert retrieve_response.data["id"] == rule_id
+
+        # Update (raise the cap).
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, rule_id),
+            {"cap": 5},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.data
+        assert update_response.data["cap"] == 5
+        assert update_response.data["period"] == QuotaPeriod.WEEK
+
+        # Delete.
+        delete_response = client.delete(_detail_url(group.id, group_slot.id, rule_id))
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        assert not CalendarGroupSlotQuotaRule.objects.filter(id=rule_id).exists()
+
+        # Now invisible everywhere, including the group-scoped read path.
+        retrieve_after_delete = client.get(_detail_url(group.id, group_slot.id, rule_id))
+        assert retrieve_after_delete.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_admin_can_manage_any_calendars_quota_rule(
+        self,
+        admin_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(admin_membership)
+
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED, create_response.data
+        rule_id = create_response.data["id"]
+
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, rule_id), {"cap": 10}, format="json"
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+        assert update_response.data["cap"] == 10
+
+        delete_response = client.delete(_detail_url(group.id, group_slot.id, rule_id))
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_create_requires_positive_cap(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+        response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, cap=0),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_put_not_allowed(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        rule_id = create_response.data["id"]
+
+        response = client.put(
+            _detail_url(group.id, group_slot.id, rule_id),
+            {"cap": 5},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_day_and_week_rules_coexist_for_same_calendar_and_slot(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        """Multiple rules per (calendar, slot) are allowed and ALL must pass
+        -- e.g. "at most 1 a day AND 3 a week" -- as long as each names a
+        DIFFERENT period."""
+        client = _auth_client(owner_membership)
+
+        day_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, period=QuotaPeriod.DAY, cap=1),
+            format="json",
+        )
+        assert day_response.status_code == status.HTTP_201_CREATED, day_response.data
+
+        week_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, period=QuotaPeriod.WEEK, cap=3),
+            format="json",
+        )
+        assert week_response.status_code == status.HTTP_201_CREATED, week_response.data
+
+        list_response = client.get(_list_url(group.id, group_slot.id))
+        assert list_response.status_code == status.HTTP_200_OK
+        periods = {r["period"] for r in list_response.data["results"]}
+        assert periods == {QuotaPeriod.DAY, QuotaPeriod.WEEK}
+
+
+# ---------------------------------------------------------------------------
+# Uniqueness -> validation error, not a server error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedQuotaRuleUniqueness:
+    def test_create_duplicate_period_for_same_calendar_and_slot_is_validation_error(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+
+        first_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, period=QuotaPeriod.WEEK, cap=3),
+            format="json",
+        )
+        assert first_response.status_code == status.HTTP_201_CREATED, first_response.data
+
+        second_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, period=QuotaPeriod.WEEK, cap=5),
+            format="json",
+        )
+        assert second_response.status_code == status.HTTP_400_BAD_REQUEST, second_response.data
+        assert "non_field_errors" in second_response.data
+
+        # Nothing extra was written -- exactly the one rule from the first create.
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(
+                calendar.organization_id
+            ).count()
+            == 1
+        )
+
+    def test_update_colliding_with_existing_period_is_validation_error(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(owner_membership)
+
+        day_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, period=QuotaPeriod.DAY, cap=1),
+            format="json",
+        )
+        assert day_response.status_code == status.HTTP_201_CREATED, day_response.data
+        day_rule_id = day_response.data["id"]
+
+        week_response = client.post(
+            _list_url(group.id, group_slot.id),
+            _create_payload(calendar.id, period=QuotaPeriod.WEEK, cap=3),
+            format="json",
+        )
+        assert week_response.status_code == status.HTTP_201_CREATED, week_response.data
+
+        # Updating the DAY rule to WEEK collides with the existing WEEK rule.
+        update_response = client.patch(
+            _detail_url(group.id, group_slot.id, day_rule_id),
+            {"period": QuotaPeriod.WEEK},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_400_BAD_REQUEST, update_response.data
+        assert "non_field_errors" in update_response.data
+
+        # The DAY rule kept its original period -- the failed update did not
+        # partially apply.
+        reloaded = CalendarGroupSlotQuotaRule.objects.filter_by_organization(
+            calendar.organization_id
+        ).get(id=day_rule_id)
+        assert reloaded.period == QuotaPeriod.DAY
+
+
+# ---------------------------------------------------------------------------
+# Non-disclosure / visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedQuotaRuleNonDisclosure:
+    def test_stranger_cannot_list_or_create(
+        self,
+        stranger_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(stranger_membership)
+
+        list_response = client.get(_list_url(group.id, group_slot.id))
+        assert list_response.status_code == status.HTTP_404_NOT_FOUND
+
+        create_response = client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        assert create_response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_owner_of_other_calendar_in_same_group_denied_same_shape_as_stranger(
+        self,
+        other_owner_membership: OrganizationMembership,
+        stranger_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+        other_slot: CalendarGroupSlot,
+    ) -> None:
+        other_owner_client = _auth_client(other_owner_membership)
+        stranger_client = _auth_client(stranger_membership)
+
+        other_owner_response = other_owner_client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+        stranger_response = stranger_client.post(
+            _list_url(group.id, group_slot.id), _create_payload(calendar.id), format="json"
+        )
+
+        assert other_owner_response.status_code == status.HTTP_404_NOT_FOUND
+        assert stranger_response.status_code == status.HTTP_404_NOT_FOUND
+        assert other_owner_response.data == stranger_response.data
+        assert not CalendarGroupSlotQuotaRule.objects.filter(group_slot_fk=group_slot).exists()
+
+    def test_other_owner_can_see_and_manage_their_own_slot_in_the_group(
+        self,
+        other_owner_membership: OrganizationMembership,
+        other_calendar: Calendar,
+        group: CalendarGroup,
+        other_slot: CalendarGroupSlot,
+    ) -> None:
+        client = _auth_client(other_owner_membership)
+        response = client.post(
+            _list_url(group.id, other_slot.id), _create_payload(other_calendar.id), format="json"
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+
+    def test_cross_organization_access_denied(
+        self,
+        owner_membership: OrganizationMembership,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+    ) -> None:
+        other_org = baker.make(Organization)
+        other_cal = Calendar.objects.create(
+            organization=other_org,
+            name="Other",
+            external_id="other_quota",
+            provider=CalendarProvider.GOOGLE,
+        )
+        other_group = CalendarGroup.objects.create(organization=other_org, name="Other Group")
+        other_org_slot = CalendarGroupSlot.objects.create(
+            organization=other_org, group=other_group, name="Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=other_org, slot=other_org_slot, calendar=other_cal
+        )
+
+        # `owner_membership`'s user has no membership in `other_org` at all.
+        client = _auth_client(owner_membership)
+        response = client.get(_list_url(other_group.id, other_org_slot.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_slot_not_belonging_to_group_in_url_is_not_found(
+        self,
+        owner_membership: OrganizationMembership,
+        organization: Organization,
+        calendar: Calendar,
+        other_calendar: Calendar,
+    ) -> None:
+        group_a = CalendarGroup.objects.create(organization=organization, name="A")
+        group_b = CalendarGroup.objects.create(organization=organization, name="B")
+        slot_on_b = CalendarGroupSlot.objects.create(
+            organization=organization, group=group_b, name="Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=slot_on_b, calendar=other_calendar
+        )
+        callers_slot_on_b = CalendarGroupSlot.objects.create(
+            organization=organization, group=group_b, name="Caller's Slot"
+        )
+        CalendarGroupSlotMembership.objects.create(
+            organization=organization, slot=callers_slot_on_b, calendar=calendar
+        )
+
+        client = _auth_client(owner_membership)
+        sanity_response = client.get(_list_url(group_b.id, callers_slot_on_b.id))
+        assert sanity_response.status_code == status.HTTP_200_OK, sanity_response.data
+
+        response = client.get(_list_url(group_a.id, slot_on_b.id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unauthenticated_returns_401(
+        self, group: CalendarGroup, group_slot: CalendarGroupSlot
+    ) -> None:
+        client = APIClient()
+        response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Query budget (bounded, must not scale with row count)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGroupScopedQuotaRuleQueryBudget:
+    def test_list_query_count_is_bounded_and_does_not_scale_with_rule_count(
+        self,
+        owner_membership: OrganizationMembership,
+        calendar: Calendar,
+        group: CalendarGroup,
+        group_slot: CalendarGroupSlot,
+        django_assert_max_num_queries,
+    ) -> None:
+        """`GroupScopedQuotaRuleSerializer` never nests `calendar` (it sources
+        `calendar_id` straight from `calendar_fk_id`), so listing several
+        rules must not eagerly pull in the general-purpose
+        `CalendarVirtualModel` sub-graph -- the query count must stay flat as
+        the number of rules grows. Row count is grown by adding more
+        calendars to the SAME slot's roster (each with one quota rule) rather
+        than more periods, since the model's (calendar, slot, period) unique
+        constraint caps periods at three per calendar."""
+
+        def _add_calendar_with_rule(index: int) -> None:
+            extra_calendar = Calendar.objects.create(
+                organization=calendar.organization,
+                name=f"Dr. Extra {index}",
+                external_id=f"dr_extra_quota_{index}",
+                provider=CalendarProvider.GOOGLE,
+                calendar_type=CalendarType.PERSONAL,
+            )
+            CalendarGroupSlotMembership.objects.create(
+                organization=calendar.organization, slot=group_slot, calendar=extra_calendar
+            )
+            CalendarGroupSlotQuotaRule.objects.create(
+                organization=calendar.organization,
+                group_slot=group_slot,
+                calendar=extra_calendar,
+                period=QuotaPeriod.WEEK,
+                cap=1,
+            )
+
+        for i in range(4):
+            _add_calendar_with_rule(i)
+
+        client = _auth_client(owner_membership)
+        # Generous margin over the observed query count -- what matters is
+        # that this bound does NOT scale with the number of rules below.
+        with django_assert_max_num_queries(12):
+            response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 4
+
+        for i in range(4, 8):
+            _add_calendar_with_rule(i)
+
+        with django_assert_max_num_queries(12):
+            response = client.get(_list_url(group.id, group_slot.id))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 8

--- a/calendar_integration/views.py
+++ b/calendar_integration/views.py
@@ -30,6 +30,7 @@ from calendar_integration.constants import (
 from calendar_integration.exceptions import (
     CalendarGroupError,
     CalendarGroupSlotConfigNotFoundError,
+    CalendarGroupValidationError,
     CalendarIntegrationError,
     ChangeRequestIneligibleError,
     ChangeRequestNotPendingError,
@@ -49,6 +50,7 @@ from calendar_integration.models import (
     Calendar,
     CalendarEvent,
     CalendarGroup,
+    CalendarGroupSlotQuotaRule,
     CalendarOwnership,
     ExternalEventChangeRequest,
 )
@@ -60,6 +62,7 @@ from calendar_integration.permissions import (
     ExternalEventChangeRequestPermission,
     GroupScopedAvailabilityWindowPermission,
     GroupScopedBlockedTimePermission,
+    GroupScopedQuotaRulePermission,
 )
 from calendar_integration.serializers import (
     AvailableTimeBatchSerializer,
@@ -95,6 +98,9 @@ from calendar_integration.serializers import (
     GroupScopedBlockedTimeSerializer,
     GroupScopedBlockedTimeUpdateSerializer,
     GroupScopedBlockWriteResultSerializer,
+    GroupScopedQuotaRuleCreateSerializer,
+    GroupScopedQuotaRuleSerializer,
+    GroupScopedQuotaRuleUpdateSerializer,
     ResourceCalendarCreateSerializer,
     UnavailableTimeWindowSerializer,
 )
@@ -2113,6 +2119,179 @@ class GroupScopedBlockedTimeViewSet(VintaScheduleModelViewSet):
             )
         except CalendarGroupSlotConfigNotFoundError as e:
             # Same not-found shape as a genuinely missing block -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@extend_schema(tags=["Calendar Group Scoped Quota Rules"])
+class GroupScopedQuotaRuleViewSet(VintaScheduleModelViewSet):
+    """Nested under a group's slot: manage group-scoped quota rules for
+    calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+    Phase 3c).
+
+    Mirrors ``GroupScopedAvailabilityWindowViewSet``/``GroupScopedBlockedTimeViewSet``
+    exactly -- reads go through
+    ``CalendarGroupSlotQuotaRule.objects.for_group_slot(...)``, every write
+    delegates to the Phase 3c ``CalendarGroupService`` quota-write methods,
+    and route visibility is gated by ``GroupScopedQuotaRulePermission``. The
+    resource is simpler than windows/blocks: quota rules are non-recurring
+    (no ``rrule_string``/``timezone``/time range) and unmetered (no
+    entitlement ``check_limit`` gates their creation -- only
+    ``check_not_restricted``, like blocks). There is also no
+    orphaned-booking report: a quota rule caps FUTURE bookings and never
+    narrows already-confirmed ones, so the create/update responses return the
+    saved rule directly rather than a write-result wrapper.
+
+    The uniqueness constraint on (calendar, slot, period) is surfaced here as
+    a 400 validation error (``CalendarGroupValidationError`` -> DRF
+    ``ValidationError``), never an unhandled ``IntegrityError``/500.
+    """
+
+    permission_classes = (GroupScopedQuotaRulePermission,)
+    queryset = CalendarGroupSlotQuotaRule.objects.all()
+    serializer_class = GroupScopedQuotaRuleSerializer
+    # PUT is intentionally unsupported: the underlying service is a partial
+    # update by design (only provided fields change), so only PATCH applies.
+    http_method_names = ("get", "post", "patch", "delete", "head", "options")
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return CalendarGroupSlotQuotaRule.objects.none()
+        membership = get_active_organization_membership(user)
+        if not membership:
+            return CalendarGroupSlotQuotaRule.objects.none()
+        slot_id = self.kwargs.get("slot_id")
+        return (
+            super()
+            .get_queryset()
+            .filter_by_organization(membership.organization_id)
+            .for_group_slot(slot_id)
+        )
+
+    @extend_schema(
+        summary="Create a group-scoped quota rule",
+        description=(
+            "Creates a group-scoped quota rule capping a calendar's live bookings "
+            "made through a group slot within a fixed period. Not metered -- no "
+            "entitlement limit gates this write."
+        ),
+        request=GroupScopedQuotaRuleCreateSerializer,
+        responses={201: GroupScopedQuotaRuleSerializer},
+    )
+    @inject
+    def create(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        serializer = GroupScopedQuotaRuleCreateSerializer(
+            data=request.data, context=self.get_serializer_context()
+        )
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            # Unreachable in practice -- `GroupScopedQuotaRulePermission`
+            # already requires an active membership -- but narrows the type for
+            # mypy and fails closed rather than crashing on `None.organization`.
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            rule = calendar_group_service.create_group_scoped_quota_rule(
+                acting_user=request.user,
+                group_slot_id=self.kwargs["slot_id"],
+                calendar_id=data["calendar"].id,
+                period=data["period"],
+                cap=data["cap"],
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing rule -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+        except CalendarGroupValidationError as e:
+            # The (calendar, slot, period) unique constraint -- surfaced as a
+            # validation error, never an unhandled IntegrityError/500.
+            raise ValidationError({"non_field_errors": [str(e)]}) from e
+
+        response_serializer = GroupScopedQuotaRuleSerializer(
+            rule, context=self.get_serializer_context()
+        )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        summary="Update a group-scoped quota rule",
+        description="Partial update -- only provided fields change.",
+        request=GroupScopedQuotaRuleUpdateSerializer,
+        responses={200: GroupScopedQuotaRuleSerializer},
+    )
+    @inject
+    def partial_update(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        instance = self.get_object()
+        serializer = GroupScopedQuotaRuleUpdateSerializer(
+            data=request.data, partial=True, context=self.get_serializer_context()
+        )
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            rule = calendar_group_service.update_group_scoped_quota_rule(
+                acting_user=request.user,
+                rule_id=instance.id,
+                period=data.get("period"),
+                cap=data.get("cap"),
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing rule -- no message
+            # leaked that would distinguish "forbidden" from "does not exist".
+            raise Http404 from e
+        except CalendarGroupValidationError as e:
+            # The (calendar, slot, period) unique constraint -- surfaced as a
+            # validation error, never an unhandled IntegrityError/500.
+            raise ValidationError({"non_field_errors": [str(e)]}) from e
+
+        response_serializer = GroupScopedQuotaRuleSerializer(
+            rule, context=self.get_serializer_context()
+        )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Delete a group-scoped quota rule",
+        responses={204: None},
+    )
+    @inject
+    def destroy(
+        self,
+        request,
+        *args,
+        calendar_group_service: Annotated[CalendarGroupService, Provide["calendar_group_service"]],
+        **kwargs,
+    ):
+        instance = self.get_object()
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise Http404
+        calendar_group_service.initialize(organization=membership.organization)
+        try:
+            calendar_group_service.delete_group_scoped_quota_rule(
+                acting_user=request.user, rule_id=instance.id
+            )
+        except CalendarGroupSlotConfigNotFoundError as e:
+            # Same not-found shape as a genuinely missing rule -- no message
             # leaked that would distinguish "forbidden" from "does not exist".
             raise Http404 from e
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/calendar_integration/virtual_models.py
+++ b/calendar_integration/virtual_models.py
@@ -9,6 +9,7 @@ from calendar_integration.models import (
     CalendarGroup,
     CalendarGroupSlot,
     CalendarGroupSlotMembership,
+    CalendarGroupSlotQuotaRule,
     CalendarOwnership,
     EventAttendance,
     EventExternalAttendance,
@@ -191,6 +192,23 @@ class GroupScopedBlockedTimeVirtualModel(v.VirtualModel):
 
     class Meta:
         model = BlockedTime
+
+
+class GroupScopedQuotaRuleVirtualModel(v.VirtualModel):
+    """Virtual model for ``GroupScopedQuotaRuleSerializer``
+    (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+    Simpler than ``GroupScopedAvailabilityWindowVirtualModel``/
+    ``GroupScopedBlockedTimeVirtualModel``: a quota rule has no recurrence and
+    no time range, so there is no ``recurrence_rule``/``parent_recurring_object``
+    to fetch. The serializer sources ``calendar_id``/``group_slot_id`` from the
+    raw FK columns and never nests a ``calendar`` field, so no sub-field is
+    declared here either -- avoids pulling in ``CalendarVirtualModel``'s eager
+    memberships/calendar_ownerships graph, which this serializer never reads.
+    """
+
+    class Meta:
+        model = CalendarGroupSlotQuotaRule
 
 
 class ExternalEventChangeRequestVirtualModel(v.VirtualModel):

--- a/public_api/constants.py
+++ b/public_api/constants.py
@@ -78,6 +78,14 @@ class PublicAPIResources(TextChoices):
         "batch_upsert_group_scoped_blocked_times",
         "Batch Upsert Group-Scoped Blocked Times",
     )
+    GROUP_SCOPED_QUOTA_RULES = (
+        "group_scoped_quota_rules",
+        "Group-Scoped Quota Rules",
+    )
+    BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES = (
+        "batch_upsert_group_scoped_quota_rules",
+        "Batch Upsert Group-Scoped Quota Rules",
+    )
 
 
 PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
@@ -99,5 +107,7 @@ PROVIDER_SCOPED_RESOURCES: frozenset[str] = frozenset(
         PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_AVAILABILITY_WINDOWS,
         PublicAPIResources.GROUP_SCOPED_BLOCKED_TIMES,
         PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES,
+        PublicAPIResources.GROUP_SCOPED_QUOTA_RULES,
+        PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES,
     ]
 )

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -35,9 +35,11 @@ from calendar_integration.graphql import (
     DeleteBookingPolicyResult,
     GroupScopedAvailabilityWindowGraphQLType,
     GroupScopedBlockedTimeGraphQLType,
+    GroupScopedQuotaRuleGraphQLType,
     UpdateBookingPolicyInput,
     group_scoped_availability_window_from_model,
     group_scoped_blocked_time_from_model,
+    group_scoped_quota_rule_from_model,
 )
 from calendar_integration.models import BookingPolicy, Calendar, CalendarEvent, CalendarGroup
 from calendar_integration.mutations import (
@@ -594,6 +596,60 @@ class BatchUpsertGroupScopedBlockedTimesResult:
     success: bool
     error_message: str | None = None
     blocked_times: list[GroupScopedBlockedTimeGraphQLType]
+
+
+@strawberry.input
+class GroupScopedQuotaRuleOperationInput:
+    """A single create/update/delete operation in a batch group-scoped
+    quota-rule upsert (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+    Simpler than ``GroupScopedBlockedTimeOperationInput``: quota rules are
+    non-recurring and have no time range, so there is no ``startTime``/
+    ``endTime``/``timezone``/``rruleString`` -- just ``period`` and ``cap``.
+    ``calendarId`` is required on every operation (not only ``create``) so
+    the owner-scope guard can be applied per-operation before any service
+    call.
+
+    For action='create': calendarId, period, and cap are required. An
+    identical create (same calendar, group slot, period, and cap as an
+    existing rule) is a no-op — replaying the same batch never duplicates a
+    rule (spec UC-5). A create naming an ALREADY-USED period with a
+    DIFFERENT cap is rejected as a validation error (the model's unique
+    constraint on (calendar, slot, period)), never an unhandled server error.
+    For action='update': ruleId is required; period and/or cap are optional
+    (only provided fields change).
+    For action='delete': ruleId is required; no other fields are needed.
+    """
+
+    action: str
+    calendar_id: int
+    rule_id: int | None = None
+    period: str | None = None
+    cap: int | None = None
+
+
+@strawberry.input
+class BatchGroupScopedQuotaRulesInput:
+    """Input for applying an atomic batch of group-scoped quota-rule
+    operations within one group slot's roster."""
+
+    organization_id: int
+    group_slot_id: int
+    operations: list[GroupScopedQuotaRuleOperationInput]
+
+
+@strawberry.type
+class BatchUpsertGroupScopedQuotaRulesResult:
+    """Result of the batchUpsertGroupScopedQuotaRules mutation.
+
+    On success, ``quotaRules`` contains every group-scoped quota rule in the
+    group slot's roster (all calendars) after the batch is applied. On
+    failure, ``quotaRules`` is an empty list and nothing was written.
+    """
+
+    success: bool
+    error_message: str | None = None
+    quota_rules: list[GroupScopedQuotaRuleGraphQLType]
 
 
 @strawberry.input
@@ -2348,6 +2404,138 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         return BatchUpsertGroupScopedBlockedTimesResult(
             success=True,
             blocked_times=[group_scoped_blocked_time_from_model(b) for b in blocks],
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def batch_upsert_group_scoped_quota_rules(
+        self,
+        info: strawberry.Info,
+        input: BatchGroupScopedQuotaRulesInput,  # noqa: A002
+    ) -> BatchUpsertGroupScopedQuotaRulesResult:
+        """Apply an atomic create/update/delete batch of group-scoped quota
+        rules within one group slot's roster
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+        Direct mirror of ``batchUpsertGroupScopedBlockedTimes`` -- same
+        validation, owner-scope, and IDOR cross-check structure -- with two
+        deliberate differences: quota rules are non-recurring (no
+        startTime/endTime/timezone/rruleString, just period and cap) and are
+        NOT metered (spec: "Windows and blocks both consume the limit; quota
+        rules do not") -- this mutation never surfaces an ``OverLimitError``,
+        and ``CalendarGroupService.batch_upsert_group_scoped_quota_rules``
+        still enforces ``check_not_restricted`` (a ``RESTRICTED`` billing
+        root still blocks the write) but there is no delta/limit check.
+
+        The (calendar, slot, period) uniqueness constraint is surfaced as a
+        clean ``success=False`` result (``CalendarGroupValidationError`` ->
+        the ``CalendarIntegrationError`` branch below), never an unhandled
+        server error.
+
+        The token's OrganizationResourceAccess must include the
+        BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES resource.
+        """
+        _valid_actions = {"create", "update", "delete"}
+
+        org = info.context.request.public_api_organization
+        if not org:
+            return BatchUpsertGroupScopedQuotaRulesResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                quota_rules=[],
+            )
+        if input.organization_id != org.id:
+            return BatchUpsertGroupScopedQuotaRulesResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                quota_rules=[],
+            )
+
+        # Validate all operations before touching anything -- fail fast, no writes.
+        for op_input in input.operations:
+            if op_input.action not in _valid_actions:
+                return BatchUpsertGroupScopedQuotaRulesResult(
+                    success=False,
+                    error_message=f"Invalid operation action: {op_input.action}",
+                    quota_rules=[],
+                )
+            if op_input.action == "create" and (op_input.period is None or op_input.cap is None):
+                return BatchUpsertGroupScopedQuotaRulesResult(
+                    success=False,
+                    error_message="create operation requires period and cap",
+                    quota_rules=[],
+                )
+            if op_input.action in ("update", "delete") and op_input.rule_id is None:
+                return BatchUpsertGroupScopedQuotaRulesResult(
+                    success=False,
+                    error_message=f"{op_input.action} operation requires ruleId",
+                    quota_rules=[],
+                )
+
+        # Owner-scope guard per operation's calendarId -- reveals nothing about
+        # existence for a calendar outside a scoped token's owner set. Checked
+        # for EVERY operation up front, so a cross-owner op anywhere in the
+        # batch rejects the whole thing before any service call. This only
+        # proves the token owns op.calendarId; it does NOT prove that an
+        # update/delete op's ruleId actually resolves to that calendar --
+        # CalendarGroupService.batch_upsert_group_scoped_quota_rules
+        # cross-checks that itself (rule.calendar_fk_id == op.calendar_id)
+        # before applying anything, so a token can't pair a calendarId it owns
+        # with a ruleId belonging to a different calendar.
+        request: PublicApiHttpRequest = info.context.request
+        system_user = request.public_api_system_user
+        try:
+            for op_input in input.operations:
+                assert_calendar_in_owner_scope(system_user, org, op_input.calendar_id)
+        except Calendar.DoesNotExist:
+            return BatchUpsertGroupScopedQuotaRulesResult(
+                success=False, error_message="Calendar not found.", quota_rules=[]
+            )
+
+        ops: list[dict[str, object]] = []
+        for op_input in input.operations:
+            op: dict[str, object] = {"action": op_input.action, "calendar_id": op_input.calendar_id}
+            if op_input.rule_id is not None:
+                op["rule_id"] = op_input.rule_id
+            if op_input.period is not None:
+                op["period"] = op_input.period
+            if op_input.cap is not None:
+                op["cap"] = op_input.cap
+            ops.append(op)
+
+        deps = get_calendar_mutation_dependencies()
+        deps.calendar_group_service.initialize(organization=org)
+
+        if system_user is None:
+            return BatchUpsertGroupScopedQuotaRulesResult(
+                success=False,
+                error_message="Organization not found in request context.",
+                quota_rules=[],
+            )
+
+        try:
+            rules = deps.calendar_group_service.batch_upsert_group_scoped_quota_rules(
+                group_slot_id=input.group_slot_id,
+                operations=ops,
+                acting_principal=system_user,
+            )
+        except OverLimitError as exc:
+            # Not a plan-limit ceiling (quota rules are unmetered) -- this is
+            # `check_not_restricted`'s RESTRICTED-billing-root guard, which
+            # raises the same `OverLimitError` subclass and renders through
+            # the same GraphQL error shape every other guarded write uses.
+            raise_over_limit_graphql_error(exc)
+        except CalendarGroupSlotConfigNotFoundError:
+            return BatchUpsertGroupScopedQuotaRulesResult(
+                success=False, error_message="Group slot not found.", quota_rules=[]
+            )
+        except (CalendarIntegrationError, ValueError, DjangoValidationError) as e:
+            return BatchUpsertGroupScopedQuotaRulesResult(
+                success=False, error_message=str(e), quota_rules=[]
+            )
+
+        return BatchUpsertGroupScopedQuotaRulesResult(
+            success=True,
+            quota_rules=[group_scoped_quota_rule_from_model(r) for r in rules],
         )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated, OrganizationResourceAccess])

--- a/public_api/permissions.py
+++ b/public_api/permissions.py
@@ -76,6 +76,10 @@ class OrganizationResourceAccess(BasePermission):
         "batchUpsertGroupScopedBlockedTimes": (
             PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_BLOCKED_TIMES
         ),
+        "groupScopedQuotaRules": PublicAPIResources.GROUP_SCOPED_QUOTA_RULES,
+        "batchUpsertGroupScopedQuotaRules": (
+            PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES
+        ),
         "createBlockedTime": PublicAPIResources.CREATE_BLOCKED_TIME,
         "updateBlockedTime": PublicAPIResources.UPDATE_BLOCKED_TIME,
         "deleteBlockedTime": PublicAPIResources.DELETE_BLOCKED_TIME,

--- a/public_api/queries.py
+++ b/public_api/queries.py
@@ -37,10 +37,12 @@ from calendar_integration.graphql import (
     ExternalEventChangeRequestGraphQLType,
     GroupScopedAvailabilityWindowGraphQLType,
     GroupScopedBlockedTimeGraphQLType,
+    GroupScopedQuotaRuleGraphQLType,
     UnavailableTimeWindowGraphQLType,
     WebhookSubscriptionStatusGraphQLType,
     group_scoped_availability_window_from_model,
     group_scoped_blocked_time_from_model,
+    group_scoped_quota_rule_from_model,
 )
 from calendar_integration.models import (
     AvailableTime,
@@ -48,6 +50,7 @@ from calendar_integration.models import (
     Calendar,
     CalendarEvent,
     CalendarGroup,
+    CalendarGroupSlotQuotaRule,
     CalendarManagementToken,
     ExternalEventChangeRequest,
 )
@@ -1047,6 +1050,42 @@ class Query:
 
         blocks = _slice_qs(qs.order_by("pk"), offset, limit)
         return [group_scoped_blocked_time_from_model(b) for b in blocks]
+
+    @strawberry.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
+    def group_scoped_quota_rules(
+        self,
+        info: strawberry.Info,
+        group_slot_id: int,
+        calendar_id: int | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[GroupScopedQuotaRuleGraphQLType]:
+        """List group-scoped quota rules for a group slot's roster.
+
+        Mirrors the internal REST surface's list shape
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c). Optionally filtered to
+        a single calendar in the slot's roster.
+        """
+        org = _get_org(info)
+
+        qs = CalendarGroupSlotQuotaRule.objects.for_group_slot(
+            group_slot_id
+        ).filter_by_organization(org.id)
+
+        # Owner-scope: for scoped tokens, only return rules on calendars in
+        # the token owner's set.
+        request: PublicApiHttpRequest = info.context.request
+        system_user = request.public_api_system_user
+        if system_user is not None:
+            allowed_ids = scoped_calendar_ids(system_user, org)
+            if allowed_ids is not None:
+                qs = qs.filter(calendar_fk__in=allowed_ids)
+
+        if calendar_id is not None:
+            qs = qs.filter(calendar_fk_id=calendar_id)
+
+        rules = _slice_qs(qs.order_by("pk"), offset, limit)
+        return [group_scoped_quota_rule_from_model(r) for r in rules]
 
     @strawberry_django.field(permission_classes=[IsAuthenticated, OrganizationResourceAccess])
     def child_organizations(

--- a/public_api/tests/test_group_scoped_quota_rules.py
+++ b/public_api/tests/test_group_scoped_quota_rules.py
@@ -1,0 +1,1079 @@
+"""Integration tests for the public GraphQL surface of group-scoped quota
+rules (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+Direct mirror of ``test_group_scoped_blocked_times.py`` for quota rules,
+minus the recurrence/reason machinery (quota rules are non-recurring and
+have no time range -- just a period and a cap). Covers
+``groupScopedQuotaRules`` (query) and ``batchUpsertGroupScopedQuotaRules``
+(batch-upsert mutation): batch apply, idempotent replay (identical final
+state, no duplicates), the (calendar, slot, period) uniqueness constraint
+surfaced as a clean ``success=False`` result rather than a server error,
+cross-organization scoping, and the IDOR rule/calendar cross-check. Quota
+rules are NOT metered (spec: "Windows and blocks both consume the limit;
+quota rules do not"), so there is no over-limit test here -- instead, a
+``RESTRICTED`` billing root is asserted to still block the batch (the one
+guard that DOES apply to an unmetered resource).
+"""
+
+import datetime
+import uuid
+
+import pytest
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from calendar_integration.constants import CalendarProvider, CalendarType, QuotaPeriod
+from calendar_integration.models import (
+    Calendar,
+    CalendarGroup,
+    CalendarGroupSlot,
+    CalendarGroupSlotMembership,
+    CalendarGroupSlotQuotaRule,
+    CalendarOwnership,
+)
+from organizations.models import Organization, OrganizationMembership
+from payments.billing_constants import BillingState
+from payments.models import Subscription
+from public_api.constants import PublicAPIResources
+from public_api.models import ResourceAccess
+from public_api.services import PublicAPIAuthService
+
+
+GROUP_SCOPED_QUOTA_RULES_QUERY = """
+query GroupScopedQuotaRules($groupSlotId: Int!, $calendarId: Int) {
+    groupScopedQuotaRules(groupSlotId: $groupSlotId, calendarId: $calendarId) {
+        id
+        calendarId
+        groupSlotId
+        period
+        cap
+    }
+}
+"""
+
+BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION = """
+mutation BatchUpsertGroupScopedQuotaRules($input: BatchGroupScopedQuotaRulesInput!) {
+    batchUpsertGroupScopedQuotaRules(input: $input) {
+        success
+        errorMessage
+        quotaRules {
+            id
+            calendarId
+            groupSlotId
+            period
+            cap
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+class TestGroupScopedQuotaRulesPublicAPI:
+    def setup_method(self):
+        self.client = APIClient()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _setup_org(self) -> Organization:
+        return baker.make(Organization, name="Test Org")
+
+    def _make_org_wide_system_user(self, org, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"org_wide_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_scoped_system_user(self, org, membership, resources):
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name=f"scoped_token_{uuid.uuid4().hex[:8]}",
+            organization=org,
+            scoped_to_membership=membership,
+        )
+        for resource in resources:
+            baker.make(ResourceAccess, system_user=system_user, resource_name=resource)
+        return system_user, token, auth_service
+
+    def _make_owner_with_calendar(self, org: Organization):
+        """Create a user, their active membership, and a calendar they own.
+
+        Returns (user, membership, calendar).
+        """
+        from django.contrib.auth import get_user_model
+
+        user_model = get_user_model()
+        unique = uuid.uuid4().hex[:8]
+        owner = baker.make(user_model, email=f"owner_{unique}@example.com")
+        membership = baker.make(
+            OrganizationMembership, user=owner, organization=org, is_active=True
+        )
+        calendar = Calendar.objects.create(
+            organization=org,
+            name=f"Calendar {unique}",
+            external_id=f"cal-{unique}",
+            provider=CalendarProvider.GOOGLE,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+        )
+        CalendarOwnership.objects.create(
+            organization=org, calendar=calendar, membership_user_id=owner.id
+        )
+        return owner, membership, calendar
+
+    def _make_calendar(self, org: Organization) -> Calendar:
+        unique = uuid.uuid4().hex[:8]
+        return Calendar.objects.create(
+            organization=org,
+            name=f"Calendar {unique}",
+            external_id=f"cal-{unique}",
+            provider=CalendarProvider.GOOGLE,
+            calendar_type=CalendarType.PERSONAL,
+            manage_available_windows=True,
+        )
+
+    def _make_group_slot(self, org: Organization, *calendars: Calendar) -> CalendarGroupSlot:
+        group = CalendarGroup.objects.create(organization=org, name="Surgery")
+        slot = CalendarGroupSlot.objects.create(organization=org, group=group, name="Lead")
+        for calendar in calendars:
+            CalendarGroupSlotMembership.objects.create(
+                organization=org, slot=slot, calendar=calendar
+            )
+        return slot
+
+    def _post(self, query, system_user, token, auth_service, variables):
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            return self.client.post(
+                "/graphql/",
+                data={"query": query, "variables": variables},
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+    def _restrict_organization(self, organization: Organization) -> None:
+        """Flip ``organization``'s (auto-provisioned, unlimited) subscription to
+        RESTRICTED in place -- applied AFTER any setup (e.g. system-user-token
+        creation) that itself goes through a guarded, limit-checked path, so
+        that setup is not blocked by the very state under test."""
+        Subscription.objects.filter(organization=organization).update(
+            billing_state=BillingState.RESTRICTED
+        )
+
+    # ------------------------------------------------------------------
+    # groupScopedQuotaRules -- query
+    # ------------------------------------------------------------------
+
+    def test_query_returns_group_scoped_quota_rules_for_the_slot(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org,
+            [
+                PublicAPIResources.GROUP_SCOPED_QUOTA_RULES,
+                PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES,
+            ],
+        )
+
+        rule = CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            period=QuotaPeriod.WEEK,
+            cap=3,
+        )
+
+        response = self._post(
+            GROUP_SCOPED_QUOTA_RULES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        rules = data["data"]["groupScopedQuotaRules"]
+        assert len(rules) == 1
+        assert rules[0]["id"] == rule.id
+        assert rules[0]["calendarId"] == calendar.id
+        assert rules[0]["groupSlotId"] == slot.id
+        assert rules[0]["period"] == QuotaPeriod.WEEK
+        assert rules[0]["cap"] == 3
+
+    def test_query_cross_organization_scoping_returns_empty(self):
+        """A group slot belonging to another organization is invisible."""
+        org_a = self._setup_org()
+        org_b = self._setup_org()
+        calendar_b = self._make_calendar(org_b)
+        slot_b = self._make_group_slot(org_b, calendar_b)
+
+        CalendarGroupSlotQuotaRule.objects.create(
+            organization=org_b,
+            calendar=calendar_b,
+            group_slot=slot_b,
+            period=QuotaPeriod.WEEK,
+            cap=3,
+        )
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org_a, [PublicAPIResources.GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            GROUP_SCOPED_QUOTA_RULES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot_b.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        assert data["data"]["groupScopedQuotaRules"] == []
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- apply
+    # ------------------------------------------------------------------
+
+    def test_batch_upsert_applies_mixed_operations(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        existing = CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            period=QuotaPeriod.WEEK,
+            cap=3,
+        )
+        to_delete = CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            period=QuotaPeriod.DAY,
+            cap=1,
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": QuotaPeriod.MONTH,
+                            "cap": 10,
+                        },
+                        {
+                            "action": "update",
+                            "calendarId": calendar.id,
+                            "ruleId": existing.id,
+                            "cap": 5,
+                        },
+                        {
+                            "action": "delete",
+                            "calendarId": calendar.id,
+                            "ruleId": to_delete.id,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is True
+        assert result["errorMessage"] is None
+        # Final roster state: the updated row + the newly created row (deleted row gone).
+        assert len(result["quotaRules"]) == 2
+
+        existing.refresh_from_db()
+        assert existing.cap == 5
+        assert not (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(id=to_delete.id)
+            .exists()
+        )
+
+        remaining = CalendarGroupSlotQuotaRule.objects.for_group_slot(
+            slot.id
+        ).filter_by_organization(org.id)
+        assert remaining.count() == 2
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- idempotent replay
+    # ------------------------------------------------------------------
+
+    def test_identical_replay_is_a_no_op(self):
+        """Replaying an identical create-only batch (spec UC-5) lands on the
+        same final state instead of duplicating rows."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        variables = {
+            "input": {
+                "organizationId": org.id,
+                "groupSlotId": slot.id,
+                "operations": [
+                    {
+                        "action": "create",
+                        "calendarId": calendar.id,
+                        "period": QuotaPeriod.WEEK,
+                        "cap": 3,
+                    },
+                ],
+            }
+        }
+
+        first = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            variables,
+        )
+        assert first.status_code == 200
+        first_result = first.json()["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert first_result["success"] is True
+        assert len(first_result["quotaRules"]) == 1
+        first_rule_id = first_result["quotaRules"][0]["id"]
+
+        rows_after_first = (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+        )
+        assert rows_after_first == 1
+
+        second = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            variables,
+        )
+        assert second.status_code == 200
+        second_result = second.json()["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert second_result["success"] is True
+
+        # Same final state: one row, same id, no duplicate created.
+        assert len(second_result["quotaRules"]) == 1
+        assert second_result["quotaRules"][0]["id"] == first_rule_id
+        rows_after_replay = (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+        )
+        assert rows_after_replay == 1, (
+            "Replaying an identical batch must not create a duplicate quota rule."
+        )
+
+    def test_cap_participates_in_the_idempotent_create_match_key(self):
+        """``cap`` is part of the idempotent-create match key (calendar,
+        group slot, period, cap). A ``create`` op naming the SAME period but
+        a DIFFERENT cap must NOT match the existing rule -- it falls through
+        to a real insert and trips the (calendar, slot, period) unique
+        constraint, surfaced as a validation error rather than silently
+        keeping the old cap."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        existing = CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            period=QuotaPeriod.WEEK,
+            cap=3,
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": QuotaPeriod.WEEK,
+                            "cap": 5,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["quotaRules"] == []
+
+        existing.refresh_from_db()
+        assert existing.cap == 3
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+            == 1
+        )
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- uniqueness -> validation error
+    # ------------------------------------------------------------------
+
+    def test_create_duplicate_period_is_surfaced_as_a_clean_failure_not_a_server_error(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            period=QuotaPeriod.DAY,
+            cap=1,
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": QuotaPeriod.DAY,
+                            "cap": 2,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # A clean GraphQL-level "no", not an unhandled server error at the
+        # transport level.
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["errorMessage"]
+        assert result["quotaRules"] == []
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id)
+            .count()
+            == 1
+        )
+
+    def test_update_colliding_with_existing_period_is_surfaced_as_a_clean_failure(self):
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        day_rule = CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            period=QuotaPeriod.DAY,
+            cap=1,
+        )
+        CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            period=QuotaPeriod.WEEK,
+            cap=3,
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            "calendarId": calendar.id,
+                            "ruleId": day_rule.id,
+                            "period": QuotaPeriod.WEEK,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["quotaRules"] == []
+
+        day_rule.refresh_from_db()
+        assert day_rule.period == QuotaPeriod.DAY
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- RESTRICTED billing root still blocks
+    # ------------------------------------------------------------------
+
+    def test_restricted_organization_batch_rejected_wholesale(self):
+        """Quota rules are unmetered, so there is no plan-limit ceiling to hit
+        here -- but the general RESTRICTED-billing-root guard every other
+        guarded write goes through must still apply. Nothing is created."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+        # Restrict AFTER the system-user token is created -- token creation is
+        # itself a guarded, limit-checked path that a RESTRICTED billing root
+        # would also block.
+        self._restrict_organization(org)
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": QuotaPeriod.WEEK,
+                            "cap": 3,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["errors"]) == 1
+        extensions = data["errors"][0]["extensions"]
+        assert extensions["code"] == "limit_exceeded"
+        assert extensions["remedy"] == "resolve_billing"
+        assert (
+            CalendarGroupSlotQuotaRule.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .count()
+            == 0
+        ), "A RESTRICTED organization's batch must create nothing."
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- cross-organization scoping
+    # ------------------------------------------------------------------
+
+    def test_cross_organization_group_slot_is_rejected(self):
+        org_a = self._setup_org()
+        org_b = self._setup_org()
+        calendar_b = self._make_calendar(org_b)
+        slot_b = self._make_group_slot(org_b, calendar_b)
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org_a.id,
+                    "groupSlotId": slot_b.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar_b.id,
+                            "period": QuotaPeriod.WEEK,
+                            "cap": 3,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["quotaRules"] == []
+        assert (
+            not CalendarGroupSlotQuotaRule.objects.for_group_slot(slot_b.id)
+            .filter_by_organization(org_b.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .exists()
+        )
+
+    def test_cross_owner_scoped_token_rejected_wholesale(self):
+        """A scoped token may not write group-scoped quota rules on a
+        calendar it does not own -- same not-found shape as a genuinely
+        missing calendar, and nothing is written."""
+        org = self._setup_org()
+        _owner_a, membership_a, _calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_b)
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar_b.id,
+                            "period": QuotaPeriod.WEEK,
+                            "cap": 3,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Calendar not found."
+        assert (
+            CalendarGroupSlotQuotaRule.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar_b.id)
+            .count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- IDOR (rule/calendar cross-check
+    # on update/delete)
+    # ------------------------------------------------------------------
+
+    def test_update_with_rule_from_another_calendar_rejected_wholesale(self):
+        """A calendar-owner-scoped token pairs a calendarId it owns with a
+        ruleId belonging to a DIFFERENT calendar in the same slot's roster.
+        assert_calendar_in_owner_scope alone would let this through (it only
+        checks ownership of calendarId) -- the service must ALSO reject
+        because the resolved rule does not belong to that calendar. Whole
+        batch fails, not-found shape, nothing changes."""
+        org = self._setup_org()
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_a, calendar_b)
+
+        foreign_rule = CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar_b,
+            group_slot=slot,
+            period=QuotaPeriod.WEEK,
+            cap=3,
+        )
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "update",
+                            # calendarId the token owns...
+                            "calendarId": calendar_a.id,
+                            # ...but ruleId belongs to calendar_b.
+                            "ruleId": foreign_rule.id,
+                            "cap": 10,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["quotaRules"] == []
+
+        foreign_rule.refresh_from_db()
+        assert foreign_rule.cap == 3
+        assert foreign_rule.calendar_fk_id == calendar_b.id
+
+    def test_delete_with_rule_from_another_calendar_rejected_wholesale(self):
+        """Same IDOR as the update case above, but for a delete op: the
+        foreign rule must still exist, unmodified, afterward."""
+        org = self._setup_org()
+        _owner_a, membership_a, calendar_a = self._make_owner_with_calendar(org)
+        _owner_b, _membership_b, calendar_b = self._make_owner_with_calendar(org)
+        slot = self._make_group_slot(org, calendar_a, calendar_b)
+
+        foreign_rule = CalendarGroupSlotQuotaRule.objects.create(
+            organization=org,
+            calendar=calendar_b,
+            group_slot=slot,
+            period=QuotaPeriod.WEEK,
+            cap=3,
+        )
+
+        system_user_a, token_a, auth_service_a = self._make_scoped_system_user(
+            org, membership_a, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user_a,
+            token_a,
+            auth_service_a,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "delete",
+                            # calendarId the token owns, ruleId belongs to calendar_b.
+                            "calendarId": calendar_a.id,
+                            "ruleId": foreign_rule.id,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["quotaRules"] == []
+
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(id=foreign_rule.id)
+            .exists()
+        ), "The foreign rule must NOT be deleted by a batch it was never authorized for."
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- create outside the slot's roster
+    # ------------------------------------------------------------------
+
+    def test_create_with_calendar_outside_slot_roster_rejected_wholesale(self):
+        """A create op's calendarId is a calendar the token owns/can access, but
+        it is not a member of the target groupSlotId's roster -- rejected with
+        the not-found shape, nothing created."""
+        org = self._setup_org()
+        roster_calendar = self._make_calendar(org)
+        outside_calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, roster_calendar)
+
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": outside_calendar.id,
+                            "period": QuotaPeriod.WEEK,
+                            "cap": 3,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["errorMessage"] == "Group slot not found."
+        assert result["quotaRules"] == []
+        assert (
+            CalendarGroupSlotQuotaRule.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .filter(calendar_fk_id=outside_calendar.id)
+            .count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
+    # Anonymous / unauthorized access -- query and mutation
+    # ------------------------------------------------------------------
+
+    def test_query_anonymous_request_denied(self):
+        """No Authorization header -- the standard auth error, no data leaked."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+
+        response = self.client.post(
+            "/graphql/",
+            data={
+                "query": GROUP_SCOPED_QUOTA_RULES_QUERY,
+                "variables": {"groupSlotId": slot.id, "calendarId": None},
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+
+    def test_mutation_anonymous_request_denied(self):
+        """No Authorization header on the mutation -- the standard auth error,
+        no write applied."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+
+        response = self.client.post(
+            "/graphql/",
+            data={
+                "query": BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+                "variables": {
+                    "input": {
+                        "organizationId": org.id,
+                        "groupSlotId": slot.id,
+                        "operations": [
+                            {
+                                "action": "create",
+                                "calendarId": calendar.id,
+                                "period": QuotaPeriod.WEEK,
+                                "cap": 3,
+                            }
+                        ],
+                    }
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert (
+            CalendarGroupSlotQuotaRule.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .count()
+            == 0
+        )
+
+    def test_query_token_without_resource_grant_denied(self):
+        """An authenticated token that lacks the GROUP_SCOPED_QUOTA_RULES
+        resource grant is denied."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        # Grant an unrelated resource only.
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            GROUP_SCOPED_QUOTA_RULES_QUERY,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+
+    def test_mutation_token_without_resource_grant_denied(self):
+        """An authenticated token that lacks the
+        BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES resource grant is denied, and
+        nothing is written."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        # Grant an unrelated resource only.
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": QuotaPeriod.WEEK,
+                            "cap": 3,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert "don't have access" in str(data["errors"]).lower()
+        assert (
+            CalendarGroupSlotQuotaRule.objects.for_group_slot(slot.id)
+            .filter_by_organization(org.id)
+            .count()
+            == 0
+        )
+
+    # ------------------------------------------------------------------
+    # Existing block operations are unchanged (no-regression)
+    # ------------------------------------------------------------------
+
+    def test_existing_group_scoped_blocked_times_query_shape_unchanged(self):
+        """Byte-for-byte shape check: the pre-existing groupScopedBlockedTimes
+        query's response is unaffected by this phase's additions."""
+        from calendar_integration.models import BlockedTime
+
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.GROUP_SCOPED_BLOCKED_TIMES]
+        )
+
+        start = datetime.datetime(2026, 9, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        end = datetime.datetime(2026, 9, 1, 17, 0, 0, tzinfo=datetime.UTC)
+        block = BlockedTime.objects.unscoped().create(
+            organization=org,
+            calendar=calendar,
+            group_slot=slot,
+            start_time_tz_unaware=start,
+            end_time_tz_unaware=end,
+            timezone="UTC",
+            external_id=f"block-{uuid.uuid4()}",
+        )
+
+        query = """
+        query GroupScopedBlockedTimes($groupSlotId: Int!, $calendarId: Int) {
+            groupScopedBlockedTimes(groupSlotId: $groupSlotId, calendarId: $calendarId) {
+                id
+                calendarId
+                groupSlotId
+                startTime
+                endTime
+                timezone
+                reason
+                rruleString
+                isRecurring
+            }
+        }
+        """
+        response = self._post(
+            query,
+            system_user,
+            token,
+            auth_service,
+            {"groupSlotId": slot.id, "calendarId": None},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        blocks = data["data"]["groupScopedBlockedTimes"]
+        assert len(blocks) == 1
+        assert blocks[0]["id"] == block.id

--- a/public_api/tests/test_group_scoped_quota_rules.py
+++ b/public_api/tests/test_group_scoped_quota_rules.py
@@ -455,6 +455,68 @@ class TestGroupScopedQuotaRulesPublicAPI:
         )
 
     # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- atomicity on mid-batch failure
+    # ------------------------------------------------------------------
+
+    def test_batch_atomicity_rolls_back_all_ops_on_later_collision(self):
+        """When a later operation in a batch collides on the uniqueness
+        constraint, the entire batch is rolled back (all-or-nothing semantics).
+        Specifically, op1 creates a rule for period=DAY, then op2 tries to create
+        another with the same period (collision), which should fail; both op1
+        (created) and op2 (attempted) must be rolled back.
+        """
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": QuotaPeriod.DAY,
+                            "cap": 1,
+                        },
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": QuotaPeriod.DAY,
+                            "cap": 2,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        # The batch must fail cleanly (not a 500).
+        assert result["success"] is False
+        assert result["errorMessage"]
+        assert result["quotaRules"] == []
+        # CRITICAL: zero rules exist for this (calendar, slot) -- op1 was ALSO
+        # rolled back, proving the outer transaction rolled back everything.
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id, group_slot_fk_id=slot.id)
+            .count()
+            == 0
+        ), "Batch atomicity: all operations must be rolled back on mid-batch collision."
+
+    # ------------------------------------------------------------------
     # batchUpsertGroupScopedQuotaRules -- uniqueness -> validation error
     # ------------------------------------------------------------------
 
@@ -564,6 +626,57 @@ class TestGroupScopedQuotaRulesPublicAPI:
 
         day_rule.refresh_from_db()
         assert day_rule.period == QuotaPeriod.DAY
+
+    # ------------------------------------------------------------------
+    # batchUpsertGroupScopedQuotaRules -- invalid period value
+    # ------------------------------------------------------------------
+
+    def test_batch_create_with_invalid_period_is_validation_error(self):
+        """A batch create operation with an invalid period value (not in
+        QuotaPeriod.values) must be rejected as a clean validation failure
+        (success=False), not a 500."""
+        org = self._setup_org()
+        calendar = self._make_calendar(org)
+        slot = self._make_group_slot(org, calendar)
+        system_user, token, auth_service = self._make_org_wide_system_user(
+            org, [PublicAPIResources.BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES]
+        )
+
+        response = self._post(
+            BATCH_UPSERT_GROUP_SCOPED_QUOTA_RULES_MUTATION,
+            system_user,
+            token,
+            auth_service,
+            {
+                "input": {
+                    "organizationId": org.id,
+                    "groupSlotId": slot.id,
+                    "operations": [
+                        {
+                            "action": "create",
+                            "calendarId": calendar.id,
+                            "period": "invalid",
+                            "cap": 3,
+                        },
+                    ],
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("errors", []) == []
+        result = data["data"]["batchUpsertGroupScopedQuotaRules"]
+        assert result["success"] is False
+        assert result["errorMessage"]
+        assert result["quotaRules"] == []
+        # Nothing created.
+        assert (
+            CalendarGroupSlotQuotaRule.objects.filter_by_organization(org.id)
+            .filter(calendar_fk_id=calendar.id, group_slot_fk_id=slot.id)
+            .count()
+            == 0
+        )
 
     # ------------------------------------------------------------------
     # batchUpsertGroupScopedQuotaRules -- RESTRICTED billing root still blocks

--- a/schema.yml
+++ b/schema.yml
@@ -6401,6 +6401,627 @@ paths:
       responses:
         '204':
           description: No response body
+  /calendar-groups/{group_id}/slots/{slot_id}/quota-rules/:
+    get:
+      operationId: calendar_groups_slots_quota_rules_list
+      description: |-
+        Nested under a group's slot: manage group-scoped quota rules for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 3c).
+
+        Mirrors ``GroupScopedAvailabilityWindowViewSet``/``GroupScopedBlockedTimeViewSet``
+        exactly -- reads go through
+        ``CalendarGroupSlotQuotaRule.objects.for_group_slot(...)``, every write
+        delegates to the Phase 3c ``CalendarGroupService`` quota-write methods,
+        and route visibility is gated by ``GroupScopedQuotaRulePermission``. The
+        resource is simpler than windows/blocks: quota rules are non-recurring
+        (no ``rrule_string``/``timezone``/time range) and unmetered (no
+        entitlement ``check_limit`` gates their creation -- only
+        ``check_not_restricted``, like blocks). There is also no
+        orphaned-booking report: a quota rule caps FUTURE bookings and never
+        narrows already-confirmed ones, so the create/update responses return the
+        saved rule directly rather than a write-result wrapper.
+
+        The uniqueness constraint on (calendar, slot, period) is surfaced here as
+        a 400 validation error (``CalendarGroupValidationError`` -> DRF
+        ``ValidationError``), never an unhandled ``IntegrityError``/500.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGroupScopedQuotaRuleList'
+          description: ''
+    post:
+      operationId: calendar_groups_slots_quota_rules_create
+      description: Creates a group-scoped quota rule capping a calendar's live bookings
+        made through a group slot within a fixed period. Not metered -- no entitlement
+        limit gates this write.
+      summary: Create a group-scoped quota rule
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupScopedQuotaRuleCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GroupScopedQuotaRuleCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GroupScopedQuotaRuleCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedQuotaRule'
+          description: ''
+  /calendar-groups/{group_id}/slots/{slot_id}/quota-rules{format}:
+    get:
+      operationId: calendar_groups_slots_quota_rules_formatted_list
+      description: |-
+        Nested under a group's slot: manage group-scoped quota rules for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 3c).
+
+        Mirrors ``GroupScopedAvailabilityWindowViewSet``/``GroupScopedBlockedTimeViewSet``
+        exactly -- reads go through
+        ``CalendarGroupSlotQuotaRule.objects.for_group_slot(...)``, every write
+        delegates to the Phase 3c ``CalendarGroupService`` quota-write methods,
+        and route visibility is gated by ``GroupScopedQuotaRulePermission``. The
+        resource is simpler than windows/blocks: quota rules are non-recurring
+        (no ``rrule_string``/``timezone``/time range) and unmetered (no
+        entitlement ``check_limit`` gates their creation -- only
+        ``check_not_restricted``, like blocks). There is also no
+        orphaned-booking report: a quota rule caps FUTURE bookings and never
+        narrows already-confirmed ones, so the create/update responses return the
+        saved rule directly rather than a write-result wrapper.
+
+        The uniqueness constraint on (calendar, slot, period) is surfaced here as
+        a 400 validation error (``CalendarGroupValidationError`` -> DRF
+        ``ValidationError``), never an unhandled ``IntegrityError``/500.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGroupScopedQuotaRuleList'
+          description: ''
+    post:
+      operationId: calendar_groups_slots_quota_rules_formatted_create
+      description: Creates a group-scoped quota rule capping a calendar's live bookings
+        made through a group slot within a fixed period. Not metered -- no entitlement
+        limit gates this write.
+      summary: Create a group-scoped quota rule
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupScopedQuotaRuleCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GroupScopedQuotaRuleCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GroupScopedQuotaRuleCreate'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedQuotaRule'
+          description: ''
+  /calendar-groups/{group_id}/slots/{slot_id}/quota-rules/{id}/:
+    get:
+      operationId: calendar_groups_slots_quota_rules_retrieve
+      description: |-
+        Nested under a group's slot: manage group-scoped quota rules for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 3c).
+
+        Mirrors ``GroupScopedAvailabilityWindowViewSet``/``GroupScopedBlockedTimeViewSet``
+        exactly -- reads go through
+        ``CalendarGroupSlotQuotaRule.objects.for_group_slot(...)``, every write
+        delegates to the Phase 3c ``CalendarGroupService`` quota-write methods,
+        and route visibility is gated by ``GroupScopedQuotaRulePermission``. The
+        resource is simpler than windows/blocks: quota rules are non-recurring
+        (no ``rrule_string``/``timezone``/time range) and unmetered (no
+        entitlement ``check_limit`` gates their creation -- only
+        ``check_not_restricted``, like blocks). There is also no
+        orphaned-booking report: a quota rule caps FUTURE bookings and never
+        narrows already-confirmed ones, so the create/update responses return the
+        saved rule directly rather than a write-result wrapper.
+
+        The uniqueness constraint on (calendar, slot, period) is surfaced here as
+        a 400 validation error (``CalendarGroupValidationError`` -> DRF
+        ``ValidationError``), never an unhandled ``IntegrityError``/500.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedQuotaRule'
+          description: ''
+    patch:
+      operationId: calendar_groups_slots_quota_rules_partial_update
+      description: Partial update -- only provided fields change.
+      summary: Update a group-scoped quota rule
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedQuotaRuleUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedQuotaRuleUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedQuotaRuleUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedQuotaRule'
+          description: ''
+    delete:
+      operationId: calendar_groups_slots_quota_rules_destroy
+      description: |-
+        Nested under a group's slot: manage group-scoped quota rules for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 3c).
+
+        Mirrors ``GroupScopedAvailabilityWindowViewSet``/``GroupScopedBlockedTimeViewSet``
+        exactly -- reads go through
+        ``CalendarGroupSlotQuotaRule.objects.for_group_slot(...)``, every write
+        delegates to the Phase 3c ``CalendarGroupService`` quota-write methods,
+        and route visibility is gated by ``GroupScopedQuotaRulePermission``. The
+        resource is simpler than windows/blocks: quota rules are non-recurring
+        (no ``rrule_string``/``timezone``/time range) and unmetered (no
+        entitlement ``check_limit`` gates their creation -- only
+        ``check_not_restricted``, like blocks). There is also no
+        orphaned-booking report: a quota rule caps FUTURE bookings and never
+        narrows already-confirmed ones, so the create/update responses return the
+        saved rule directly rather than a write-result wrapper.
+
+        The uniqueness constraint on (calendar, slot, period) is surfaced here as
+        a 400 validation error (``CalendarGroupValidationError`` -> DRF
+        ``ValidationError``), never an unhandled ``IntegrityError``/500.
+      summary: Delete a group-scoped quota rule
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /calendar-groups/{group_id}/slots/{slot_id}/quota-rules/{id}{format}:
+    get:
+      operationId: calendar_groups_slots_quota_rules_formatted_retrieve
+      description: |-
+        Nested under a group's slot: manage group-scoped quota rules for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 3c).
+
+        Mirrors ``GroupScopedAvailabilityWindowViewSet``/``GroupScopedBlockedTimeViewSet``
+        exactly -- reads go through
+        ``CalendarGroupSlotQuotaRule.objects.for_group_slot(...)``, every write
+        delegates to the Phase 3c ``CalendarGroupService`` quota-write methods,
+        and route visibility is gated by ``GroupScopedQuotaRulePermission``. The
+        resource is simpler than windows/blocks: quota rules are non-recurring
+        (no ``rrule_string``/``timezone``/time range) and unmetered (no
+        entitlement ``check_limit`` gates their creation -- only
+        ``check_not_restricted``, like blocks). There is also no
+        orphaned-booking report: a quota rule caps FUTURE bookings and never
+        narrows already-confirmed ones, so the create/update responses return the
+        saved rule directly rather than a write-result wrapper.
+
+        The uniqueness constraint on (calendar, slot, period) is surfaced here as
+        a 400 validation error (``CalendarGroupValidationError`` -> DRF
+        ``ValidationError``), never an unhandled ``IntegrityError``/500.
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedQuotaRule'
+          description: ''
+    patch:
+      operationId: calendar_groups_slots_quota_rules_formatted_partial_update
+      description: Partial update -- only provided fields change.
+      summary: Update a group-scoped quota rule
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedQuotaRuleUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedQuotaRuleUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGroupScopedQuotaRuleUpdate'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupScopedQuotaRule'
+          description: ''
+    delete:
+      operationId: calendar_groups_slots_quota_rules_formatted_destroy
+      description: |-
+        Nested under a group's slot: manage group-scoped quota rules for
+        calendars in that slot's roster (CALENDAR_GROUP_SCOPED_AVAILABILITY
+        Phase 3c).
+
+        Mirrors ``GroupScopedAvailabilityWindowViewSet``/``GroupScopedBlockedTimeViewSet``
+        exactly -- reads go through
+        ``CalendarGroupSlotQuotaRule.objects.for_group_slot(...)``, every write
+        delegates to the Phase 3c ``CalendarGroupService`` quota-write methods,
+        and route visibility is gated by ``GroupScopedQuotaRulePermission``. The
+        resource is simpler than windows/blocks: quota rules are non-recurring
+        (no ``rrule_string``/``timezone``/time range) and unmetered (no
+        entitlement ``check_limit`` gates their creation -- only
+        ``check_not_restricted``, like blocks). There is also no
+        orphaned-booking report: a quota rule caps FUTURE bookings and never
+        narrows already-confirmed ones, so the create/update responses return the
+        saved rule directly rather than a write-result wrapper.
+
+        The uniqueness constraint on (calendar, slot, period) is surfaced here as
+        a 400 validation error (``CalendarGroupValidationError`` -> DRF
+        ``ValidationError``), never an unhandled ``IntegrityError``/500.
+      summary: Delete a group-scoped quota rule
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      - in: path
+        name: format
+        schema:
+          type: string
+          enum:
+          - .json
+        required: true
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: slot_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Calendar Group Scoped Quota Rules
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /calendar-groups/{id}/:
     get:
       operationId: calendar_groups_retrieve
@@ -14471,6 +15092,8 @@ components:
       - batch_upsert_group_scoped_availability_windows
       - group_scoped_blocked_times
       - batch_upsert_group_scoped_blocked_times
+      - group_scoped_quota_rules
+      - batch_upsert_group_scoped_quota_rules
       type: string
       description: |-
         * `calendar_event` - Calendar Event
@@ -14521,6 +15144,8 @@ components:
         * `batch_upsert_group_scoped_availability_windows` - Batch Upsert Group-Scoped Availability Windows
         * `group_scoped_blocked_times` - Group-Scoped Blocked Times
         * `batch_upsert_group_scoped_blocked_times` - Batch Upsert Group-Scoped Blocked Times
+        * `group_scoped_quota_rules` - Group-Scoped Quota Rules
+        * `batch_upsert_group_scoped_quota_rules` - Batch Upsert Group-Scoped Quota Rules
     AvailableTime:
       type: object
       description: Serializer for AvailableTime model with recurring support.
@@ -16267,6 +16892,91 @@ components:
       - end_time
       - start_time
       - timezone
+    GroupScopedQuotaRule:
+      type: object
+      description: |-
+        Read representation of a group-scoped quota rule
+        (CALENDAR_GROUP_SCOPED_AVAILABILITY Phase 3c).
+
+        Simpler than ``GroupScopedAvailabilityWindowSerializer``/
+        ``GroupScopedBlockedTimeSerializer``: quota rules are non-recurring (no
+        ``rrule_string``, no ``timezone``, no time range) -- just the period and
+        the cap, matching exactly what ``CalendarGroupService``'s quota-write
+        methods accept, so the REST shape and the service signature cannot drift
+        apart.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        calendar_id:
+          type: integer
+          readOnly: true
+        group_slot_id:
+          type: integer
+          readOnly: true
+        period:
+          allOf:
+          - $ref: '#/components/schemas/PeriodEnum'
+          readOnly: true
+          description: |-
+            Fixed calendar period the cap applies to (day, week, or month).
+
+            * `day` - Day
+            * `week` - Week
+            * `month` - Month
+        cap:
+          type: integer
+          readOnly: true
+          description: Maximum number of live bookings made through this group slot
+            a calendar may hold within one period. Must be at least 1.
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - calendar_id
+      - cap
+      - created
+      - group_slot_id
+      - id
+      - modified
+      - period
+    GroupScopedQuotaRuleCreate:
+      type: object
+      description: |-
+        Input for creating a group-scoped quota rule.
+
+        Field names map 1:1 onto
+        ``CalendarGroupService.create_group_scoped_quota_rule``'s keyword
+        arguments (``calendar_id``, ``period``, ``cap``) so the REST shape can
+        never silently drift from the service signature it delegates to.
+      properties:
+        calendar:
+          type: integer
+          description: Calendar this quota rule applies to. Must be a member of the
+            target slot.
+        period:
+          allOf:
+          - $ref: '#/components/schemas/PeriodEnum'
+          description: |-
+            Fixed calendar period the cap applies to (day, week, or month).
+
+            * `day` - Day
+            * `week` - Week
+            * `month` - Month
+        cap:
+          type: integer
+          minimum: 1
+          description: Maximum number of live bookings made through this group slot
+            the calendar may hold within one period.
+      required:
+      - calendar
+      - cap
+      - period
     MyMembership:
       type: object
       description: |-
@@ -16891,6 +17601,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GroupScopedBlockedTime'
+    PaginatedGroupScopedQuotaRuleList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupScopedQuotaRule'
     PaginatedOrganizationInvitationList:
       type: object
       required:
@@ -17535,6 +18268,19 @@ components:
           nullable: true
           description: RRULE string for a recurring block. Set to null to make it
             non-recurring.
+    PatchedGroupScopedQuotaRuleUpdate:
+      type: object
+      description: |-
+        Input for partially updating a group-scoped quota rule.
+
+        Every field is optional -- only provided fields change, mirroring
+        ``CalendarGroupService.update_group_scoped_quota_rule``.
+      properties:
+        period:
+          $ref: '#/components/schemas/PeriodEnum'
+        cap:
+          type: integer
+          minimum: 1
     PatchedOrganization:
       type: object
       description: |-
@@ -17723,6 +18469,16 @@ components:
       description: |-
         * `monthly` - Monthly
         * `annual` - Annual
+    PeriodEnum:
+      enum:
+      - day
+      - week
+      - month
+      type: string
+      description: |-
+        * `day` - Day
+        * `week` - Week
+        * `month` - Month
     PlanEntitlement:
       type: object
       properties:


### PR DESCRIPTION

## Summary

Phase 3c of the Calendar Group-Scoped Availability plan — completes the quota concept and the whole feature's surface work. Quota rules are now manageable and readable everywhere windows and blocks are: a nested REST viewset and a public GraphQL query + batch-upsert mutation, mirroring the block surfaces (Phase 2b) minus the recurrence concepts (quota rules carry only `period` and `cap`).

## Plan reference

`ai-plans/2026-08-05-CALENDAR_GROUP_SCOPED_AVAILABILITY_IMPLEMENTATION_PLAN.md` — Phase 3c. Spec use-case UC-2.

## Key decisions

- **Full parity with block/window surfaces**, minus recurrence: route-level group-visibility gating, byte-identical `Http404` non-disclosure (stranger / cross-org / other-calendar-owner / mismatched slot), IDOR calendar-match on batch update/delete, bounded list queries (narrow virtual model), and the `check_not_restricted` guard.
- **Not metered** (Guiding Decisions): quota-rule creation calls `check_not_restricted` (a RESTRICTED billing root is still blocked) but NO `check_limit`/entitlement gate — quota rules don't consume the availability-window limit.
- **Uniqueness → validation error, not a 500**: the `(calendar, slot, period)` `UniqueConstraint` is caught inside a nested `transaction.atomic()` **savepoint** (so the caught `IntegrityError` rolls back only that savepoint, not the request transaction) and re-raised as `CalendarGroupValidationError` → HTTP 400 (REST) / clean `success=False` (public API). The catch is scoped to the specific constraint name (`calendargroupslotquotarule_unique_slot_calendar_period`); any other `IntegrityError` re-raises rather than mis-reporting as a duplicate. `cap >= 1` and a valid `period` are validated ahead of the DB too.
- **Batch is all-or-nothing**: a later op colliding on uniqueness fails the whole batch and rolls back earlier ops (tested — zero rows remain). Content-match idempotency keys on `cap`, and two rules with the same period but different cap correctly collide on the uniqueness constraint.
- **No write-result wrapper**: quota rules can't orphan an existing booking (they cap future creation, not existing time), so create/update return the plain rule — deliberately dropping the orphaned-booking field windows/blocks carry.
- New quota write service methods (`create/update/delete_group_scoped_quota_rule`, `batch_upsert_group_scoped_quota_rules`) were added, mirroring the block write methods.

## Feature flag

None — new routes/operations; existing window/block/availability operations unchanged; schema purely additive (756 insertions, 0 deletions); no migration.

## Follow-up (out of scope, tracked)

The get/authorize/audit/create/update/delete/batch service sextet is now duplicated a third time (windows, blocks, quota). A shared model-parameterized helper is justified as a post-merge refactor (a task has been chipped for it) — deliberately not done here to avoid churning the already-reviewed per-concept code in open PRs.

## Test plan

```bash
docker compose run --rm api uv run pytest calendar_integration/tests/test_views_group_scoped_quota_rules.py public_api/tests/test_group_scoped_quota_rules.py -vs
docker compose run --rm api uv run pytest calendar_integration/tests/ public_api/tests/ -n auto
```

Covers: REST + public API CRUD parity; multiple rules per calendar/slot (day + week coexist); uniqueness surfaced as a validation error on both surfaces (not a 500); batch atomicity under a mid-batch collision; invalid period and cap < 1 rejected as validation errors; non-disclosure identical shape; IDOR calendar-match; bounded list queries; cross-org scoping; RESTRICTED org blocked; quota creation is unmetered.