### PR TITLE
fix(organizations): add REST endpoint for branding logo upload signing

### DIFF
--- a/organizations/permissions.py
+++ b/organizations/permissions.py
@@ -3,8 +3,14 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated
 
 from dependency_injector.wiring import Provide, inject
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission
 
+from organizations.exceptions import (
+    BrandingEntitlementRequiredError,
+    OrganizationHasParentBrandingError,
+    OrganizationSlugRequiredForBrandingError,
+)
 from organizations.models import (
     Organization,
     OrganizationInvitation,
@@ -170,6 +176,31 @@ def evaluate_branding_write_gate(organization: Organization | None) -> BrandingW
     if not organization.slug:
         return BrandingWriteGateReason.NO_SLUG
     return BrandingWriteGateReason.OK
+
+
+BRANDING_GATE_EXCEPTIONS: dict[BrandingWriteGateReason, type[PermissionDenied]] = {
+    BrandingWriteGateReason.HAS_PARENT: OrganizationHasParentBrandingError,
+    BrandingWriteGateReason.NOT_ENTITLED: BrandingEntitlementRequiredError,
+    BrandingWriteGateReason.NO_SLUG: OrganizationSlugRequiredForBrandingError,
+}
+
+
+def check_branding_read_eligibility(organization: Organization | None) -> None:
+    """Two-condition branding **eligibility** gate (parentless, entitled),
+    shared by every branding read-adjacent surface: ``OrganizationBrandingView.get``
+    and ``OrganizationBrandingLogoUploadParamsView.post`` (``organizations/views.py``).
+
+    Derives its reason from ``evaluate_branding_write_gate`` but admits
+    ``NO_SLUG`` -- a slug-less eligible organization must still be able to see
+    the branding page and upload a logo (the frontend uploads a logo on
+    file-picker change, before the slug/branding write on form submit). Raises
+    the matching ``PermissionDenied`` subclass on the first failed condition;
+    a no-op when the gate admits the organization.
+    """
+    reason = evaluate_branding_write_gate(organization)
+    if reason in (BrandingWriteGateReason.OK, BrandingWriteGateReason.NO_SLUG):
+        return
+    raise BRANDING_GATE_EXCEPTIONS[reason]()
 
 
 def user_administers_branding_eligible_organization(user: "User | None") -> bool:

--- a/organizations/routes.py
+++ b/organizations/routes.py
@@ -3,6 +3,7 @@ from django.urls import path
 from common.types import RouteDict
 
 from .views import (
+    OrganizationBrandingLogoUploadParamsView,
     OrganizationBrandingView,
     OrganizationInvitationViewSet,
     OrganizationLogoDeliveryView,
@@ -38,6 +39,11 @@ routes: list[RouteDict] = [
 # Non-viewset routes (APIViews) — URL patterns to register with Django URL conf
 extra_patterns = [
     path("branding/", OrganizationBrandingView.as_view(), name="branding"),
+    path(
+        "branding/logo-upload-params/",
+        OrganizationBrandingLogoUploadParamsView.as_view(),
+        name="branding-logo-upload-params",
+    ),
     # Unauthenticated -- keyed on the organization's public slug, never an object
     # key. See OrganizationLogoDeliveryView's docstring.
     path(

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -571,3 +571,26 @@ class OrganizationBrandingSerializer(serializers.ModelSerializer):
         except DjangoValidationError as exc:
             raise serializers.ValidationError(exc.messages) from exc
         return value
+
+
+class OrganizationBrandingLogoUploadParamsRequestSerializer(serializers.Serializer):
+    """Request body for ``OrganizationBrandingLogoUploadParamsView``. Mirrors
+    ``users.serializers.ProfilePictureUploadParamsRequestSerializer``."""
+
+    file_name = serializers.CharField()
+    file_type = serializers.CharField()
+    file_size = serializers.IntegerField(min_value=1)
+
+
+class OrganizationBrandingLogoUploadParamsSerializer(serializers.Serializer):
+    """Response body for ``OrganizationBrandingLogoUploadParamsView`` — the same
+    shape ``organizations.branding_logo.sign_branding_logo_upload`` and the
+    GraphQL ``create_branding_logo_upload`` mutation return."""
+
+    object_key = serializers.CharField()
+    access_key_id = serializers.CharField(allow_null=True)
+    session_token = serializers.CharField(allow_null=True)
+    region = serializers.CharField(allow_null=True)
+    bucket = serializers.CharField(allow_null=True)
+    endpoint = serializers.CharField(allow_null=True)
+    acl = serializers.CharField()

--- a/organizations/tests/test_branding_logo_upload_params.py
+++ b/organizations/tests/test_branding_logo_upload_params.py
@@ -1,0 +1,217 @@
+import json
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from organizations.models import Organization, OrganizationMembership, OrganizationRole
+from organizations.tests.test_branding_rest import _make_unentitled_org
+
+
+User = get_user_model()
+
+UPLOAD_PARAMS_URL = "/branding/logo-upload-params/"
+
+
+def assert_response_status_code(response, expected_status_code):
+    assert response.status_code == expected_status_code, (
+        f"The status error {response.status_code} != {expected_status_code}\n"
+        f"Response Payload: {json.dumps(response.json() if hasattr(response, 'json') and callable(response.json) else str(response.content))}"
+    )
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def user():
+    return baker.make(User)
+
+
+@pytest.fixture
+def eligible_org():
+    """Parentless, entitled (suite's autouse default subscription), slugged org."""
+    return baker.make(Organization, can_invite_organizations=False, slug="eligible-org")
+
+
+@pytest.fixture
+def no_slug_org():
+    """Parentless and entitled, but no slug -- logo upload must still be admitted
+    (uploads happen before the slug/branding write on form submit)."""
+    return baker.make(Organization, can_invite_organizations=False, parent=None)
+
+
+@pytest.fixture
+def parented_org(eligible_org):
+    return baker.make(Organization, parent=eligible_org, slug="child-org")
+
+
+@pytest.fixture
+def eligible_org_admin(user, eligible_org):
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=eligible_org,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def eligible_org_member(eligible_org):
+    member = baker.make(User)
+    baker.make(
+        OrganizationMembership,
+        user=member,
+        organization=eligible_org,
+        role=OrganizationRole.MEMBER,
+        is_active=True,
+    )
+    return member
+
+
+@pytest.fixture
+def no_slug_org_admin(user, no_slug_org):
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=no_slug_org,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def parented_org_admin(user, parented_org):
+    return baker.make(
+        OrganizationMembership,
+        user=user,
+        organization=parented_org,
+        role=OrganizationRole.ADMIN,
+        is_active=True,
+    )
+
+
+VALID_PAYLOAD = {"file_name": "logo.png", "file_type": "image/png", "file_size": 1024}
+
+
+@pytest.mark.django_db
+class TestOrganizationBrandingLogoUploadParamsView:
+    def test_admin_of_eligible_org_gets_signed_params(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        data = response.json()
+        assert data["object_key"]
+        assert data["acl"]
+
+    def test_admin_of_a_no_slug_org_still_gets_signed_params(
+        self, client, user, no_slug_org, no_slug_org_admin
+    ):
+        """Logo upload uses the two-condition eligibility gate, not the
+        three-condition write gate -- a slug-less-but-otherwise-eligible org
+        must still be able to upload a logo (the slug/branding write happens
+        later, on form submit)."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(no_slug_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+    def test_non_admin_member_returns_403(self, client, eligible_org, eligible_org_member):
+        client.force_authenticate(eligible_org_member)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_of_a_parented_org_returns_403(
+        self, client, user, parented_org, parented_org_admin
+    ):
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(parented_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    @pytest.mark.no_auto_subscription
+    def test_admin_of_an_unentitled_org_returns_403(self, client, user):
+        org = _make_unentitled_org(can_invite_organizations=False, slug="unentitled-org")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_returns_401(self, client, eligible_org):
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_401_UNAUTHORIZED)
+
+    def test_disallowed_content_type_returns_400(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        payload = {**VALID_PAYLOAD, "file_type": "image/svg+xml"}
+        response = client.post(UPLOAD_PARAMS_URL, data=payload, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_oversized_file_returns_400(self, client, user, eligible_org, eligible_org_admin):
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        payload = {
+            **VALID_PAYLOAD,
+            "file_size": settings.BRANDING_LOGO_MAX_SIZE_BYTES + 1,
+        }
+        response = client.post(UPLOAD_PARAMS_URL, data=payload, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_multi_org_admin_without_header_returns_400(self, client):
+        """Proves TenantScopedViewMixin is actually wired: a multi-org admin
+        omitting X-Organization-Id gets 400, not a silent fallback to the
+        oldest membership."""
+        user = baker.make(User)
+        org_a = baker.make(Organization, can_invite_organizations=False, slug="multi-a")
+        org_b = baker.make(Organization, can_invite_organizations=False, slug="multi-b")
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org_a,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+        baker.make(
+            OrganizationMembership,
+            user=user,
+            organization=org_b,
+            role=OrganizationRole.ADMIN,
+            is_active=True,
+        )
+
+        client.force_authenticate(user)
+        client.credentials()
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_400_BAD_REQUEST)

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -43,15 +43,14 @@ from organizations.branding_logo import (
     branding_diff_state,
     compute_logo_etag,
     guess_logo_content_type,
+    sign_branding_logo_upload,
 )
 from organizations.exceptions import (
-    BrandingEntitlementRequiredError,
+    BrandingLogoUploadRejectedError,
     DuplicateInvitationError,
     InvalidInvitationTokenError,
     InvitationNotFoundError,
     NoServiceAccountConfiguredError,
-    OrganizationHasParentBrandingError,
-    OrganizationSlugRequiredForBrandingError,
     UserAlreadyHasMembershipError,
 )
 from organizations.filtersets import (
@@ -68,10 +67,12 @@ from organizations.models import (
     resolve_branding_for_display,
 )
 from organizations.permissions import (
+    BRANDING_GATE_EXCEPTIONS,
     BrandingWriteGateReason,
     IsOrganizationAdmin,
     OrganizationInvitationPermission,
     OrganizationManagementPermission,
+    check_branding_read_eligibility,
     evaluate_branding_write_gate,
 )
 from organizations.serializers import (
@@ -79,6 +80,8 @@ from organizations.serializers import (
     CurrentMembershipSerializer,
     GoogleServiceAccountWriteSerializer,
     MyMembershipSerializer,
+    OrganizationBrandingLogoUploadParamsRequestSerializer,
+    OrganizationBrandingLogoUploadParamsSerializer,
     OrganizationBrandingSerializer,
     OrganizationInvitationSerializer,
     OrganizationMembershipSerializer,
@@ -1046,11 +1049,9 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         super().__init__(*args, **kwargs)
         self.audit_service = audit_service
 
-    _GATE_EXCEPTIONS: ClassVar[dict[BrandingWriteGateReason, type[PermissionDenied]]] = {
-        BrandingWriteGateReason.HAS_PARENT: OrganizationHasParentBrandingError,
-        BrandingWriteGateReason.NOT_ENTITLED: BrandingEntitlementRequiredError,
-        BrandingWriteGateReason.NO_SLUG: OrganizationSlugRequiredForBrandingError,
-    }
+    _GATE_EXCEPTIONS: ClassVar[dict[BrandingWriteGateReason, type[PermissionDenied]]] = (
+        BRANDING_GATE_EXCEPTIONS
+    )
 
     def _check_branding_write_gate(self) -> None:
         """Verify the acting org passes the full write gate (parentless,
@@ -1074,21 +1075,16 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
         """Verify the acting org passes the two-condition branding
         **eligibility** gate (parentless, entitled) used for GET.
 
-        Reuses ``evaluate_branding_write_gate`` to derive the failure reason
-        so the parent/entitlement 403 bodies stay byte-for-byte identical to
-        the write gate's, but treats ``NO_SLUG`` as admitted here -- a
-        slug-less eligible org must still be able to see the branding page
-        (see the class docstring). A no-op when the gate admits the org."""
+        Delegates to ``organizations.permissions.check_branding_read_eligibility``,
+        shared with ``OrganizationBrandingLogoUploadParamsView`` -- see that
+        function's docstring for why ``NO_SLUG`` is admitted here."""
         user = self.request.user
         if not user.is_authenticated:
             raise PermissionDenied("No active organization membership.")
         membership = get_active_organization_membership(user)
         if membership is None:
             raise PermissionDenied("No active organization membership.")
-        reason = evaluate_branding_write_gate(membership.organization)
-        if reason in (BrandingWriteGateReason.OK, BrandingWriteGateReason.NO_SLUG):
-            return
-        raise self._GATE_EXCEPTIONS[reason]()
+        check_branding_read_eligibility(membership.organization)
 
     def _get_branding_or_404(self):
         """Get the acting org's branding, or raise 404 if not set."""
@@ -1245,6 +1241,60 @@ class OrganizationBrandingView(TenantScopedViewMixin, views.APIView):
             subject=subject,
             diff=diff,
         )
+
+
+@extend_schema(tags=["Branding"])
+class OrganizationBrandingLogoUploadParamsView(TenantScopedViewMixin, views.APIView):
+    """Signs a ``branding_logos`` S3 upload for the acting organization's admin.
+
+    The shipped ``django-s3direct`` signing view (``POST
+    /s3direct/get_upload_params/``) is a plain Django view authenticated only
+    by session cookie -- it never reaches DRF's ``JWTAuthentication``, so the
+    JWT-only frontend SPA gets ``AnonymousUser`` there and is refused
+    unconditionally. This view is the REST sibling of the GraphQL
+    ``create_branding_logo_upload`` mutation (``public_api.mutations.Mutation``),
+    reusing the same ``sign_branding_logo_upload`` signing helper so the S3
+    key/credential logic has one implementation.
+
+    Gated on the two-condition branding **eligibility** check
+    (``organizations.permissions.check_branding_read_eligibility`` -- parentless
+    AND entitled), not the three-condition write gate: the frontend uploads a
+    logo on file-picker change, before the slug/branding PUT on form submit, so
+    requiring a slug here would refuse an upload the write gate itself never
+    sees. Matches ``OrganizationBrandingView.get``'s read gate.
+    """
+
+    permission_classes = (IsOrganizationAdmin,)
+
+    @extend_schema(
+        summary="Sign a branding logo upload",
+        request=OrganizationBrandingLogoUploadParamsRequestSerializer,
+        responses={
+            200: OrganizationBrandingLogoUploadParamsSerializer,
+            400: OpenApiResponse(description="Disallowed content type or file size"),
+            403: OpenApiResponse(
+                description="Organization has a parent or lacks the entitlement; or not an admin"
+            ),
+        },
+    )
+    def post(self, request, *args, **kwargs):
+        membership = get_active_organization_membership(request.user)
+        if membership is None:
+            raise PermissionDenied("No active organization membership.")
+        check_branding_read_eligibility(membership.organization)
+
+        request_serializer = OrganizationBrandingLogoUploadParamsRequestSerializer(
+            data=request.data
+        )
+        request_serializer.is_valid(raise_exception=True)
+
+        try:
+            payload = sign_branding_logo_upload(**request_serializer.validated_data)
+        except BrandingLogoUploadRejectedError as e:
+            raise ValidationError(str(e)) from e
+
+        serializer = OrganizationBrandingLogoUploadParamsSerializer(payload)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 @extend_schema(tags=["Branding"])

--- a/schema.yml
+++ b/schema.yml
@@ -3694,6 +3694,68 @@ paths:
             slug; or not an admin
         '404':
           description: Branding not yet configured
+  /branding/logo-upload-params/:
+    post:
+      operationId: branding_logo_upload_params_create
+      description: |-
+        Signs a ``branding_logos`` S3 upload for the acting organization's admin.
+
+        The shipped ``django-s3direct`` signing view (``POST
+        /s3direct/get_upload_params/``) is a plain Django view authenticated only
+        by session cookie -- it never reaches DRF's ``JWTAuthentication``, so the
+        JWT-only frontend SPA gets ``AnonymousUser`` there and is refused
+        unconditionally. This view is the REST sibling of the GraphQL
+        ``create_branding_logo_upload`` mutation (``public_api.mutations.Mutation``),
+        reusing the same ``sign_branding_logo_upload`` signing helper so the S3
+        key/credential logic has one implementation.
+
+        Gated on the two-condition branding **eligibility** check
+        (``organizations.permissions.check_branding_read_eligibility`` -- parentless
+        AND entitled), not the three-condition write gate: the frontend uploads a
+        logo on file-picker change, before the slug/branding PUT on form submit, so
+        requiring a slug here would refuse an upload the write gate itself never
+        sees. Matches ``OrganizationBrandingView.get``'s read gate.
+      summary: Sign a branding logo upload
+      parameters:
+      - in: header
+        name: X-Organization-Id
+        schema:
+          type: string
+        description: Selects the active organization for this request. Optional for
+          callers that belong to exactly one active organization — the single membership
+          is resolved implicitly. **Required** when the caller has two or more active
+          memberships; omitting it in that case returns **400**. If the header names
+          an organization the caller is not an active member of, the server returns
+          **403**.
+      tags:
+      - Branding
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationBrandingLogoUploadParamsRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OrganizationBrandingLogoUploadParamsRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/OrganizationBrandingLogoUploadParamsRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationBrandingLogoUploadParams'
+          description: ''
+        '400':
+          description: Disallowed content type or file size
+        '403':
+          description: Organization has a parent or lacks the entitlement; or not
+            an admin
   /branding/logo/{org_slug}/:
     get:
       operationId: branding_logo_retrieve
@@ -15146,6 +15208,57 @@ components:
           maxLength: 200
       required:
       - app_name
+    OrganizationBrandingLogoUploadParams:
+      type: object
+      description: |-
+        Response body for ``OrganizationBrandingLogoUploadParamsView`` — the same
+        shape ``organizations.branding_logo.sign_branding_logo_upload`` and the
+        GraphQL ``create_branding_logo_upload`` mutation return.
+      properties:
+        object_key:
+          type: string
+        access_key_id:
+          type: string
+          nullable: true
+        session_token:
+          type: string
+          nullable: true
+        region:
+          type: string
+          nullable: true
+        bucket:
+          type: string
+          nullable: true
+        endpoint:
+          type: string
+          nullable: true
+        acl:
+          type: string
+      required:
+      - access_key_id
+      - acl
+      - bucket
+      - endpoint
+      - object_key
+      - region
+      - session_token
+    OrganizationBrandingLogoUploadParamsRequest:
+      type: object
+      description: |-
+        Request body for ``OrganizationBrandingLogoUploadParamsView``. Mirrors
+        ``users.serializers.ProfilePictureUploadParamsRequestSerializer``.
+      properties:
+        file_name:
+          type: string
+        file_type:
+          type: string
+        file_size:
+          type: integer
+          minimum: 1
+      required:
+      - file_name
+      - file_size
+      - file_type
     OrganizationBrief:
       type: object
       description: |-


### PR DESCRIPTION
## Summary
- The Organization Auth-Area Branding feature's logo upload always 403'd from the frontend SPA: the shipped `django-s3direct` signing view (`POST /s3direct/get_upload_params/`) is a plain Django view authenticated only by session cookie, never reachable by DRF's `JWTAuthentication` — so the JWT-only SPA always hit it as `AnonymousUser`.
- Adds `OrganizationBrandingLogoUploadParamsView` (`POST /branding/logo-upload-params/`), the REST sibling of the existing GraphQL `create_branding_logo_upload` mutation, reusing `organizations.branding_logo.sign_branding_logo_upload` for the actual signing.
- Gated on the two-condition branding **eligibility** check (parentless + entitled), not the three-condition write gate — the SPA uploads a logo on file-picker change, before the slug/branding PUT on form submit. Factored the shared eligibility check into `organizations.permissions.check_branding_read_eligibility`, reused by both this view and `OrganizationBrandingView.get`.
- Regenerated `schema.yml`.

See `.vinta-ai-workflows/handoffs/2026-08-06-branding-logo-upload-403.md` and `ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_SPEC.md` / `ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md` for full context.

## Test plan
- [x] New tests in `organizations/tests/test_branding_logo_upload_params.py`: happy path, no-slug-org still admitted, non-admin/parented-org/unentitled-org 403s, unauthenticated 401, bad content-type/oversized-file 400s, multi-org-admin-without-header 400 (proves `TenantScopedViewMixin` is wired).
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` clean on touched files.
- [x] `makemigrations --check` — no changes needed (no model change).
- [x] Full test suite green on a fresh database (4869 passed).
- [ ] Manual check against a running stack with a real JWT (left to reviewer/QA, or the frontend agent once wired up).