### PR TITLE
fix(organizations): thread branding root's slug into the invitation accept URL

### DIFF
--- a/ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md
+++ b/ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md
@@ -65,6 +65,7 @@ them):
 | **Slug is mutable** | An admin can change it; previously-issued branded login URLs stop resolving and fall back to our default identity. No history table, no reclaim policy. The alternative — keeping old slugs alive — buys URL stability at the cost of a table and a policy for a problem no customer has yet. |
 | **Slug validation** | Three rules, because it is self-serve and lands in a URL path: a reserved-word list covering our own route names and names implying us; format and length limits (lowercase alphanumeric with hyphens, bounded); and rejection of mixed-script and confusable characters so one organization cannot register a visual twin of another's. The last is a phishing defense, not tidiness — a lookalike slug plus a lookalike logo is the whole attack. |
 | **Login URL shape** | Path segment carrying the slug. Survives copy-paste in a way a query parameter does not, and reads as a real branded entry point. |
+| **Invitation accept URL shape (2026-08-06 amendment)** | Same path-segment convention as the login URL: `HEADLESS_FRONTEND_URLS["account_accept_invitation_branded"]` = `{FRONTEND_BASE_URL}/o/{org_slug}/auth/accept-invite/?token={token}`, used instead of the plain `account_accept_invitation` template whenever the invitation's branding root has a slug. Phase 5 shipped the resolution that brands the email's *content* but never threaded the resolved root into the *link* itself — every invitation kept the same slug-less URL regardless of branding, so the SPA's accept page had nothing to key a `brandingForTenant` call on before the invitee authenticates. Keyed on the **branding root** (`resolve_branding_for_display(organization).organization`), not the invited organization directly — a reseller's child organization has no slug of its own, so its invitations must carry the reseller's. Falls back to the plain template, byte-for-byte, when no branding root resolves or the branded template is unset — an unbranded organization's invitation is unchanged. See `organizations/invitation_urls.py`. |
 | **Entitlement seeds** | Untouched. The seeded plans already say what we want — free off, unlimited on — and this work is about dropping the reseller gate, not about repricing. |
 | **Audit** | Branding writes go through `AuditService` with diffs on update, matching how it is wired into other business services. A branded invitation email is a plausible phishing vector, so a trail of who set what and when has value beyond bookkeeping. |
 | **Capability signal** | A read-only `can_manage_branding` field on the membership/organization payload the SPA already fetches, computed as parentless-and-entitled — deliberately **not** including the slug. An organization missing only a slug should still see the branding page, with a refusal that reads as "pick a slug first" rather than a page that silently is not there. Folding the slug in would hide the page from exactly the admins who are one step away from using it. |
@@ -512,6 +513,30 @@ Changes:
    semantics.
 3. @public_api/queries.py: `branding_for_tenant` inherits the widened root; add slug lookup
    alongside the tenant-id argument, preserving the default-on-unknown behavior for both.
+4. **(2026-08-06 amendment)** @organizations/invitation_urls.py: new module holding
+   `build_invitation_accept_url(branding_root, token)`. The accept-invite *link itself*
+   was never keyed on the resolved branding root's slug — only the email's rendered
+   *content* (app name, logo, colors) went through `resolve_branding_for_display`. Every
+   invitation, branded or not, kept pointing at the same slug-less
+   `HEADLESS_FRONTEND_URLS["account_accept_invitation"]` template, so a branded
+   organization's accept page had no way to know which organization's branding to render.
+   There is also no unauthenticated "resolve invitation by token" endpoint anywhere in the
+   codebase (confirmed by reading `organizations.services.OrganizationService
+   .accept_invitation`, which requires an authenticated user and narrows by *email*, not
+   token, before verifying the hash) — so the slug can only reach the SPA through the URL
+   itself; a second backend lookup call is not an available alternative. See **Guiding
+   Decisions** for the new `account_accept_invitation_branded` template and its path-segment
+   shape.
+5. **(2026-08-06 amendment)** @organizations/services.py:
+   `OrganizationService.invite_user_to_organization` resolves
+   `resolve_branding_for_display(organization)` and passes the branding row's
+   `organization` (the branding root, not necessarily the invited organization — a child
+   under a reseller must carry the reseller's slug) into `build_invitation_accept_url`
+   before building `context_kwargs["invitation_url"]`.
+6. **(2026-08-06 amendment)** @public_api/mutations.py: `Mutation.create_invitation`'s
+   `send_email=False` branch does the same resolution against `target_org` before building
+   `invite_url`, replacing the ad-hoc `.format(token=...)` call the phase originally shipped
+   with (which the code's own comment already flagged as provisional).
 
 Spec use-case: **Use-case 2** (invited user accepts from a branded organization),
 **Use-case 4** (invited user of a reseller's child accepts), and **Use-case 6** (a branded
@@ -523,11 +548,20 @@ Tests:
   non-reseller returns itself; for a child under a reseller returns the reseller; for a child
   under a non-reseller parent returns `None`; for an unentitled parentless organization the
   display variant returns `None` while values remain in the database.
+  **(2026-08-06 amendment)** @organizations/tests/test_invitation_urls.py — `None` and a
+  slug-less branding root fall back to the plain template byte-for-byte; a slugged branding
+  root produces the branded template; a missing branded template falls back to the plain one
+  rather than raising.
 - **Integration**: @organizations/tests/test_branding.py — the invitation email context
   carries the organization's app name, logo, and colors for a branded parentless
   organization, and our defaults for an unentitled one whose row still exists.
   @public_api/tests/test_queries.py — `brandingForTenant` returns the organization's branding
   by id and by slug, and the default for an unknown value of either.
+  **(2026-08-06 amendment)** @organizations/tests/test_services.py — a branded, slugged
+  organization's invite produces a branded `invitation_url` in the notification
+  context_kwargs; an unbranded organization's is byte-for-byte unchanged.
+  @public_api/tests/test_provisioning_flow.py — the `sendEmail=false` `inviteUrl` for a
+  reseller's child organization carries the *reseller's* slug, not the child's.
 
 **Review models**: reviewer Tier 4 — this changes the return value of the single function
 every branding caller depends on, including an unauthenticated public query. A mistake here
@@ -541,7 +575,8 @@ to defaults.
 Acceptance: an invited user of a branded parentless organization receives an email and sees
 an accept page carrying that organization's identity; a child organization under a branded
 reseller still renders the reseller's; an unentitled organization renders ours with its saved
-values intact.
+values intact. **(2026-08-06 amendment)** The accept-invite link itself carries the branding
+root's slug when one resolves, and is byte-for-byte unchanged when none does.
 
 ---
 
@@ -829,6 +864,13 @@ objective can only be run after the SPA ships its side.
 - [public_api/queries.py](../public_api/queries.py) — edited
 - [organizations/tests/test_branding.py](../organizations/tests/test_branding.py) — edited
 - [public_api/tests/test_queries.py](../public_api/tests/test_queries.py) — edited
+- **(2026-08-06 amendment)** @organizations/invitation_urls.py — new
+- **(2026-08-06 amendment)** [organizations/services.py](../organizations/services.py) — edited (`invite_user_to_organization` resolves the branding root before building `invitation_url`)
+- **(2026-08-06 amendment)** [public_api/mutations.py](../public_api/mutations.py) — edited (`create_invitation`'s `send_email=False` branch, same resolution)
+- **(2026-08-06 amendment)** [vinta_schedule_api/settings/production.py](../vinta_schedule_api/settings/production.py), [staging.py](../vinta_schedule_api/settings/staging.py), [local.py](../vinta_schedule_api/settings/local.py), [test.py](../vinta_schedule_api/settings/test.py) — edited (new `account_accept_invitation_branded` template; `base.py` has no `account_accept_invitation` key today, so it needs none either)
+- **(2026-08-06 amendment)** @organizations/tests/test_invitation_urls.py — new
+- **(2026-08-06 amendment)** [organizations/tests/test_services.py](../organizations/tests/test_services.py) — edited
+- **(2026-08-06 amendment)** [public_api/tests/test_provisioning_flow.py](../public_api/tests/test_provisioning_flow.py) — edited
 
 **Phase 6 — invitation reply-to**
 - [organizations/notification_contexts.py](../organizations/notification_contexts.py) — edited
@@ -860,3 +902,26 @@ objective can only be run after the SPA ships its side.
   test enforcing that every top-level URL route segment is in the reserved-slug set.
   Affected phases: 1 (body-amended); all downstream rebased. Branches force-pushed: phase-1,
   phase-2a, phase-2b, phase-3, phase-4, phase-5, phase-6, phase-7, phase-8, phase-9.
+
+- **2026-08-06** — Fix: the invitation accept-invite *link* never carried branding. Found
+  during post-release manual testing: an invited user of a branded organization still landed
+  on the generic, vendor-owned `/auth/accept-invite/?token=...` URL, so the accept page (SPA)
+  had no way to render that organization's identity — the objective Phase 5 was meant to
+  deliver held for the email's *content* (app name, logo, colors, via
+  `resolve_branding_for_display`) but not for the link itself, which both call sites
+  (`organizations/services.py`'s `invite_user_to_organization` and
+  `public_api/mutations.py`'s `create_invitation`) built from the same slug-less
+  `HEADLESS_FRONTEND_URLS["account_accept_invitation"]` template regardless of branding.
+  Confirmed there is no alternative path either: no unauthenticated "resolve invitation by
+  token" endpoint exists anywhere in the codebase, so the SPA's accept page can only learn
+  which organization a bare token belongs to if the URL itself carries it. Fix: a new
+  `organizations/invitation_urls.py` module (`build_invitation_accept_url`) and a new
+  `account_accept_invitation_branded` settings template, keyed on the **branding root's**
+  slug (so a reseller's child organization's invitation carries the reseller's slug, not its
+  own unset one) — same path-segment convention as the Phase 8 login URL shape. Falls back to
+  the original template, byte-for-byte, when no branding root resolves or the branded
+  template is absent. Affected phase: 5 (body-amended, touch list updated); no other phase
+  touched, and no branch was rebased or force-pushed — Phase 5's PR (#211) is already merged
+  to `main`, so this landed as a new, ordinary follow-up change rather than a history rewrite
+  of a closed PR. Full `organizations/` + `public_api/` suite re-run clean (1493 passed) after
+  the change.

--- a/common/media_storage_backend.py
+++ b/common/media_storage_backend.py
@@ -6,8 +6,5 @@ from storages.backends.s3boto3 import S3Boto3Storage
 class MediaStorage(S3Boto3Storage):
     bucket_name = getattr(settings, "AWS_MEDIA_BUCKET_NAME", "")
     location = getattr(settings, "AWS_MEDIA_LOCATION", "")
-
-    if getattr(settings, "USE_FLOCI", False):
-        endpoint_url = getattr(settings, "FLOCI_ENDPOINT", "")
-    else:
-        custom_domain = getattr(settings, "AWS_MEDIA_S3_CUSTOM_DOMAIN", "")
+    endpoint_url = getattr(settings, "AWS_MEDIA_S3_ENDPOINT_URL", None)
+    custom_domain = getattr(settings, "AWS_MEDIA_S3_CUSTOM_DOMAIN", "")

--- a/organizations/branding_logo.py
+++ b/organizations/branding_logo.py
@@ -19,6 +19,8 @@ from urllib.parse import unquote, urlparse
 from django.conf import settings
 from django.urls import reverse
 
+import boto3
+from botocore.config import Config as BotoConfig
 from s3direct.utils import get_aws_credentials, get_key
 
 from organizations.exceptions import BrandingLogoUploadRejectedError
@@ -183,53 +185,58 @@ def guess_logo_content_type(key: str) -> str:
 
 class SignedBrandingLogoUpload(TypedDict):
     object_key: str
-    access_key_id: str | None
-    session_token: str | None
-    region: str | None
-    bucket: str | None
-    endpoint: str | None
-    acl: str
+    upload_url: str
+    expires_in: int
+
+
+# Long enough for a slow connection to finish a logo upload, short enough that a
+# leaked URL is not a lasting write grant on the bucket. Mirrors
+# `users.views.PROFILE_PICTURE_UPLOAD_URL_EXPIRY_SECONDS`.
+BRANDING_LOGO_UPLOAD_URL_EXPIRY_SECONDS = 900
 
 
 def sign_branding_logo_upload(
     file_name: str, file_type: str, file_size: int
 ) -> SignedBrandingLogoUpload:
-    """Build the same signed-upload payload the shipped s3direct signing view
-    (``POST /s3direct/get_upload_params/``) returns for the ``branding_logos``
-    destination, for GraphQL/partner-API callers that cannot reach that
-    session-scoped Django endpoint directly.
+    """Mint a presigned S3 PUT URL for the ``branding_logos`` destination, for
+    REST/GraphQL/partner-API callers that cannot reach the session-scoped
+    ``POST /s3direct/get_upload_params/`` Django endpoint directly.
 
     Re-checks the destination's own content constraints (content-type allowlist,
     size range) -- these apply no matter who is asking, so they are re-verified
     here rather than trusted to the caller. Authorization (is this caller
-    allowed to upload a logo at all) is the GraphQL mutation's job, not this
-    function's -- see ``public_api.mutations.Mutation.create_branding_logo_upload``.
+    allowed to upload a logo at all) is the REST view's/GraphQL mutation's job,
+    not this function's -- see ``organizations.views.
+    OrganizationBrandingLogoUploadParamsView`` and ``public_api.mutations.
+    Mutation.create_branding_logo_upload``.
 
-    **Known residual limitation -- these checks are advisory, not enforced by S3
-    itself.** This project's ``s3direct`` signing mechanism (``s3direct.utils.
-    get_aws_credentials`` / ``s3direct.views.get_upload_params``, mirrored here)
-    hands the browser a bare AWS access key (and, when using an assumed role,
-    a session token) that the client then uses to sign a direct ``PUT`` with its
-    own SigV4 implementation -- it does not issue an S3 presigned-POST policy
-    document, so there is no ``conditions`` list (``content-length-range``,
-    ``Content-Type`` starts-with) for S3 to enforce server-side. A caller with
-    valid credentials could technically PUT a larger or differently-typed object
-    than what it declared here. Re-architecting the signing flow onto presigned
-    POST (a shared surface used by every other ``S3DIRECT_DESTINATIONS`` entry,
-    not just this one) is out of scope for this phase. The actual mitigation is
-    downstream, not at upload time: ``BRANDING_LOGO_KEY_PREFIX`` constrains every
-    written ``logo`` key to this destination's own prefix (see
-    ``normalize_uploaded_logo_key``), and the delivery route
-    (``organizations.views.OrganizationLogoDeliveryView``) treats every streamed
-    object's bytes and extension as untrusted regardless of what was declared at
-    upload time (allowlisted Content-Type via ``guess_logo_content_type`` +
-    ``X-Content-Type-Options: nosniff`` on every response) -- so an oversized or
-    mistyped object that slips past this advisory check still cannot be used for
-    stored XSS or to serve another tenant's object.
+    Unlike the shipped ``s3direct`` signing view, no AWS credentials ever reach
+    the caller -- the returned ``upload_url`` is a complete SigV4 presigned PUT
+    URL; the caller just PUTs the file body to it with a matching Content-Type
+    and no other headers. No ACL is signed either: the media bucket sets Object
+    Ownership to BucketOwnerEnforced, which rejects any upload carrying an
+    ``x-amz-acl`` header -- objects stay private through the bucket's
+    public-access block and are only ever served through the delivery route.
+
+    Content-Type is a signed header, so a caller cannot swap it after the URL is
+    issued (a mismatched ``Content-Type`` on the PUT invalidates the signature).
+    File size is **not** enforced by S3 itself -- a presigned PUT URL (unlike a
+    presigned POST policy) carries no ``content-length-range`` condition, so the
+    size check below is advisory only. The actual mitigation for an
+    oversized/mistyped object that slips past it is downstream, not at upload
+    time: ``BRANDING_LOGO_KEY_PREFIX`` constrains every written ``logo`` key to
+    this destination's own prefix (see ``normalize_uploaded_logo_key``), and the
+    delivery route (``organizations.views.OrganizationLogoDeliveryView``) treats
+    every streamed object's bytes and extension as untrusted regardless of what
+    was declared at upload time (allowlisted Content-Type via
+    ``guess_logo_content_type`` + ``X-Content-Type-Options: nosniff`` on every
+    response) -- so it still cannot be used for stored XSS or to serve another
+    tenant's object.
 
     Raises:
-        BrandingLogoUploadRejectedError: content type not in the allowlist, or
-            size outside the configured range, naming the specific rule broken.
+        BrandingLogoUploadRejectedError: content type not in the allowlist, size
+            outside the configured range, or the destination's S3 configuration
+            (bucket/region/endpoint) is incomplete.
     """
     # `S3DIRECT_DESTINATIONS` mixes value types (callables, strings, lists) across
     # its destinations, which collapses mypy's inferred value type to `object`
@@ -251,18 +258,41 @@ def sign_branding_logo_upload(
             f"Invalid file size (must be between {cl_range[0]} and {cl_range[1]} bytes)."
         )
 
-    key = dest.get("key")
-    object_key = get_key(key, file_name, dest)
+    bucket = dest.get("bucket") or getattr(settings, "AWS_STORAGE_BUCKET_NAME", None)
+    region = dest.get("region") or getattr(settings, "AWS_S3_REGION_NAME", None)
+    endpoint = dest.get("endpoint") or getattr(settings, "AWS_S3_ENDPOINT_URL", None)
+    if not bucket or not region or not endpoint:
+        raise BrandingLogoUploadRejectedError("S3 configuration is incomplete.")
+
+    object_key = get_key(dest.get("key"), file_name, dest)
     aws_credentials = get_aws_credentials()
+
+    s3_client = boto3.client(
+        "s3",
+        region_name=region,
+        endpoint_url=endpoint,
+        aws_access_key_id=aws_credentials.access_key,
+        aws_secret_access_key=aws_credentials.secret_key,
+        aws_session_token=aws_credentials.token,
+        config=BotoConfig(
+            signature_version="s3v4",
+            # Floci (local) only answers path-style; on AWS "auto" picks
+            # virtual-hosted. Mirrors what django-storages reads for the same call.
+            s3={"addressing_style": getattr(settings, "AWS_S3_ADDRESSING_STYLE", "auto")},
+        ),
+    )
+
+    upload_url = s3_client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": bucket, "Key": object_key, "ContentType": file_type},
+        ExpiresIn=BRANDING_LOGO_UPLOAD_URL_EXPIRY_SECONDS,
+        HttpMethod="PUT",
+    )
 
     return {
         "object_key": object_key,
-        "access_key_id": aws_credentials.access_key,
-        "session_token": aws_credentials.token,
-        "region": dest.get("region") or getattr(settings, "AWS_S3_REGION_NAME", None),
-        "bucket": dest.get("bucket") or getattr(settings, "AWS_STORAGE_BUCKET_NAME", None),
-        "endpoint": dest.get("endpoint") or getattr(settings, "AWS_S3_ENDPOINT_URL", None),
-        "acl": dest.get("acl") or "public-read",
+        "upload_url": upload_url,
+        "expires_in": BRANDING_LOGO_UPLOAD_URL_EXPIRY_SECONDS,
     }
 
 

--- a/organizations/invitation_urls.py
+++ b/organizations/invitation_urls.py
@@ -1,0 +1,53 @@
+"""Builds the invitation accept URL (Organization Auth-Area Branding plan, Phase 5
+amendment -- 2026-08-06).
+
+Phase 5 resolved branding into the invitation *email's content* (app name, logo,
+colors -- see ``organizations.notification_contexts``) but never threaded the
+branding root's slug into the accept link itself, so every invitation -- branded
+or not -- kept pointing at the same slug-less URL. The SPA's accept-invite page
+has no other way to discover which organization a bare token belongs to before
+the user authenticates (there is no unauthenticated "resolve invitation by
+token" endpoint), so without the slug in the URL it can never call
+``brandingForTenant`` to render that organization's identity.
+
+Split into its own module for the same reason as ``organizations.branding_logo``:
+the email-send path (``organizations.services.OrganizationService.
+invite_user_to_organization``) and the public-API path (``public_api.mutations.
+Mutation.create_invitation``) must build byte-for-byte the same URL shape from
+the same inputs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+
+if TYPE_CHECKING:
+    from organizations.models import Organization
+
+
+def build_invitation_accept_url(branding_root: Organization | None, token: str) -> str:
+    """Accept-invitation URL for ``token``.
+
+    ``branding_root`` must be the branding root -- ``resolve_branding_for_display
+    (invitation.organization).organization`` when a branding row resolved for the
+    invitation's organization, ``None`` otherwise -- mirroring
+    ``organizations.branding_logo.build_logo_delivery_url``'s contract. This is
+    what makes an invitation from a reseller's child organization carry the
+    reseller's slug (not the child's, which has none), so the accept page
+    resolves the reseller's branding instead of silently falling back to our
+    default identity.
+
+    Returns the plain, slug-less ``account_accept_invitation`` template when
+    ``branding_root`` is ``None``, has no slug, or the branded template is not
+    configured -- the exact URL every invitation got before this change, so an
+    unbranded organization's invitation stays byte-for-byte identical.
+    """
+    urls = getattr(settings, "HEADLESS_FRONTEND_URLS", {})
+    if branding_root is not None and branding_root.slug:
+        branded_template = urls.get("account_accept_invitation_branded", "")
+        if branded_template:
+            return branded_template.format(token=token, org_slug=branding_root.slug)
+    return urls.get("account_accept_invitation", "").format(token=token)

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -585,12 +585,14 @@ class OrganizationBrandingLogoUploadParamsRequestSerializer(serializers.Serializ
 class OrganizationBrandingLogoUploadParamsSerializer(serializers.Serializer):
     """Response body for ``OrganizationBrandingLogoUploadParamsView`` — the same
     shape ``organizations.branding_logo.sign_branding_logo_upload`` and the
-    GraphQL ``create_branding_logo_upload`` mutation return."""
+    GraphQL ``create_branding_logo_upload`` mutation return.
+
+    ``upload_url`` is a complete SigV4 presigned PUT URL. The client uploads by
+    PUTting the file body straight to it with a matching Content-Type and no
+    other headers — no AWS credentials reach the browser and nothing has to be
+    signed client-side. Mirrors ``users.serializers.ProfilePictureUploadParamsSerializer``.
+    """
 
     object_key = serializers.CharField()
-    access_key_id = serializers.CharField(allow_null=True)
-    session_token = serializers.CharField(allow_null=True)
-    region = serializers.CharField(allow_null=True)
-    bucket = serializers.CharField(allow_null=True)
-    endpoint = serializers.CharField(allow_null=True)
-    acl = serializers.CharField()
+    upload_url = serializers.URLField()
+    expires_in = serializers.IntegerField()

--- a/organizations/services.py
+++ b/organizations/services.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 from typing import Annotated
 
-from django.conf import settings
 from django.db import IntegrityError, transaction
 
 from allauth.socialaccount.models import SocialAccount
@@ -35,11 +34,13 @@ from organizations.exceptions import (
     NoServiceAccountConfiguredError,
     UserAlreadyHasMembershipError,
 )
+from organizations.invitation_urls import build_invitation_accept_url
 from organizations.models import (
     Organization,
     OrganizationInvitation,
     OrganizationMembership,
     OrganizationRole,
+    resolve_branding_for_display,
 )
 from payments.billing_constants import LimitedResource
 from payments.exceptions import OverLimitError
@@ -408,6 +409,15 @@ class OrganizationService:
             # the organization's branding by organization_invitation_context() at send
             # time and applied by ReplyToDjangoEmailNotificationAdapter
             # (notifications/notification_adapters/django_email.py).
+            #
+            # The accept-invite link itself is keyed on the *branding root's* slug
+            # (not organization.slug directly), so an invitation from a reseller's
+            # child organization carries the reseller's slug -- see
+            # organizations.invitation_urls.build_invitation_accept_url.
+            branding_root = resolve_branding_for_display(organization)
+            invitation_url = build_invitation_accept_url(
+                branding_root.organization if branding_root else None, token
+            )
             transaction.on_commit(
                 lambda: self.notification_service.create_one_off_notification(
                     email_or_phone=email,
@@ -420,9 +430,7 @@ class OrganizationService:
                     context_kwargs=NotificationContextDict(
                         {
                             "organization_invitation_id": invitation.id,
-                            "invitation_url": (getattr(settings, "HEADLESS_FRONTEND_URLS", {}))
-                            .get("account_accept_invitation", "")
-                            .format(token=token),
+                            "invitation_url": invitation_url,
                         }
                     ),
                     subject_template="organizations/emails/organization_invitation.subject.txt",

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -731,10 +731,29 @@ class TestSignBrandingLogoUpload:
     destination's content-type allowlist and size cap, re-checked independently of the
     shipped s3direct signing view (this is what the GraphQL signing mutation calls)."""
 
+    @pytest.fixture(autouse=True)
+    def _s3_upload_settings(self, settings):
+        """Only the accepted-upload cases below reach the presigned-URL step --
+        the rejection cases raise before ever needing a bucket/region/endpoint or
+        credentials, so they're unaffected by this fixture."""
+        from unittest.mock import patch
+
+        from s3direct.utils import AWSCredentials
+
+        settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+        settings.AWS_S3_REGION_NAME = "us-east-1"
+        settings.AWS_S3_ENDPOINT_URL = "https://s3.us-east-1.amazonaws.com"
+        with patch(
+            "organizations.branding_logo.get_aws_credentials",
+            return_value=AWSCredentials(token=None, secret_key="secret", access_key="AKIATEST"),
+        ):
+            yield
+
     @pytest.mark.parametrize("content_type", ["image/png", "image/jpeg", "image/webp"])
     def test_accepts_allowed_content_types(self, content_type):
         payload = sign_branding_logo_upload("logo.png", content_type, 1024)
         assert payload["object_key"]
+        assert payload["upload_url"].startswith("https://")
 
     def test_rejects_svg_explicitly(self):
         """SVG is the one format a reviewer will assume works -- it does not."""

--- a/organizations/tests/test_branding_logo_upload_params.py
+++ b/organizations/tests/test_branding_logo_upload_params.py
@@ -1,4 +1,6 @@
 import json
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -7,6 +9,7 @@ import pytest
 from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APIClient
+from s3direct.utils import AWSCredentials
 
 from organizations.models import Organization, OrganizationMembership, OrganizationRole
 from organizations.tests.test_branding_rest import _make_unentitled_org
@@ -15,6 +18,12 @@ from organizations.tests.test_branding_rest import _make_unentitled_org
 User = get_user_model()
 
 UPLOAD_PARAMS_URL = "/branding/logo-upload-params/"
+
+S3_TEST_SETTINGS = {
+    "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+    "AWS_S3_REGION_NAME": "us-east-1",
+    "AWS_S3_ENDPOINT_URL": "https://s3.us-east-1.amazonaws.com",
+}
 
 
 def assert_response_status_code(response, expected_status_code):
@@ -101,6 +110,22 @@ def parented_org_admin(user, parented_org):
 VALID_PAYLOAD = {"file_name": "logo.png", "file_type": "image/png", "file_size": 1024}
 
 
+@pytest.fixture(autouse=True)
+def _s3_upload_settings(settings):
+    """Every test in this module posts to the signing endpoint, which now needs a
+    complete S3 config (bucket/region/endpoint) to mint a presigned URL -- these
+    settings aren't defined in `vinta_schedule_api.settings.test`. Credentials are
+    mocked too, since `generate_presigned_url` needs a structurally valid access
+    key/secret to sign with (it never makes a network call)."""
+    for k, v in S3_TEST_SETTINGS.items():
+        setattr(settings, k, v)
+    with patch(
+        "organizations.branding_logo.get_aws_credentials",
+        return_value=AWSCredentials(token=None, secret_key="secret", access_key="AKIATEST"),
+    ):
+        yield
+
+
 @pytest.mark.django_db
 class TestOrganizationBrandingLogoUploadParamsView:
     def test_admin_of_eligible_org_gets_signed_params(
@@ -114,7 +139,66 @@ class TestOrganizationBrandingLogoUploadParamsView:
 
         data = response.json()
         assert data["object_key"]
-        assert data["acl"]
+        assert data["upload_url"].startswith("https://")
+        assert data["expires_in"] == 900
+
+    def test_returns_a_presigned_url_the_browser_can_put_to_unaided(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        """The response must carry a complete SigV4 presigned URL: the SPA
+        authenticates with JWT and has no way to reach s3direct's session+CSRF
+        signing view, so it cannot sign a request itself. Everything S3 needs has
+        to be in this URL's query string or the upload PUT goes out unsigned and
+        S3 answers 403."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        data = response.json()
+        parsed = urlparse(data["upload_url"])
+        query = parse_qs(parsed.query)
+
+        assert parsed.path.endswith(data["object_key"])
+        assert query["X-Amz-Algorithm"] == ["AWS4-HMAC-SHA256"]
+        assert query["X-Amz-Signature"][0]
+        assert query["X-Amz-Credential"][0].startswith("AKIATEST/")
+        assert int(query["X-Amz-Expires"][0]) == data["expires_in"]
+
+    def test_presigned_url_signs_content_type_but_never_an_acl(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        """No `x-amz-acl` anywhere: the media bucket has ACLs disabled
+        (BucketOwnerEnforced). Content-Type is signed so the type is fixed when
+        the URL is issued and cannot be swapped on the PUT."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        upload_url = response.json()["upload_url"]
+        signed_headers = parse_qs(urlparse(upload_url).query)["X-Amz-SignedHeaders"][0]
+
+        assert "x-amz-acl" not in signed_headers
+        assert "acl" not in upload_url.lower()
+        assert "content-type" in signed_headers
+
+    def test_response_no_longer_leaks_aws_credentials_to_the_browser(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        """The presigned URL replaces the raw key id the old handshake had to
+        expose."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        data = response.json()
+        assert "access_key_id" not in data
+        assert "session_token" not in data
 
     def test_admin_of_a_no_slug_org_still_gets_signed_params(
         self, client, user, no_slug_org, no_slug_org_admin

--- a/organizations/tests/test_invitation_urls.py
+++ b/organizations/tests/test_invitation_urls.py
@@ -1,0 +1,60 @@
+"""Tests for organizations.invitation_urls.build_invitation_accept_url.
+
+Organization Auth-Area Branding plan, Phase 5 amendment (2026-08-06): the
+invitation accept link must carry the branding root's slug so the SPA's
+accept-invite page can resolve that organization's branding before the user
+authenticates -- see the amendment note in the implementation plan for why
+this was missing from the original Phase 5 delivery.
+"""
+
+from model_bakery import baker
+
+from organizations.invitation_urls import build_invitation_accept_url
+from organizations.models import Organization
+
+
+ACCEPT_URLS = {
+    "account_accept_invitation": "https://frontend.example.com/auth/accept-invite/?token={token}",
+    "account_accept_invitation_branded": (
+        "https://frontend.example.com/o/{org_slug}/auth/accept-invite/?token={token}"
+    ),
+}
+
+
+class TestBuildInvitationAcceptUrl:
+    def test_no_branding_root_uses_the_plain_template(self, settings):
+        settings.HEADLESS_FRONTEND_URLS = ACCEPT_URLS
+
+        url = build_invitation_accept_url(None, "tok123")
+
+        assert url == "https://frontend.example.com/auth/accept-invite/?token=tok123"
+
+    def test_branding_root_with_no_slug_uses_the_plain_template(self, settings, db):
+        settings.HEADLESS_FRONTEND_URLS = ACCEPT_URLS
+        org = baker.make(Organization, slug=None)
+
+        url = build_invitation_accept_url(org, "tok123")
+
+        assert url == "https://frontend.example.com/auth/accept-invite/?token=tok123"
+
+    def test_branding_root_with_a_slug_uses_the_branded_template(self, settings, db):
+        settings.HEADLESS_FRONTEND_URLS = ACCEPT_URLS
+        org = baker.make(Organization, slug="brandco")
+
+        url = build_invitation_accept_url(org, "tok123")
+
+        assert url == "https://frontend.example.com/o/brandco/auth/accept-invite/?token=tok123"
+
+    def test_missing_branded_template_falls_back_to_the_plain_one(self, settings, db):
+        """A deploy that has not rolled out the branded template (e.g. a settings
+        module amended without it) must still produce a working, byte-for-byte
+        identical URL to what unbranded organizations got before this change --
+        never a KeyError, never an unformatted string."""
+        settings.HEADLESS_FRONTEND_URLS = {
+            "account_accept_invitation": ACCEPT_URLS["account_accept_invitation"],
+        }
+        org = baker.make(Organization, slug="brandco")
+
+        url = build_invitation_accept_url(org, "tok123")
+
+        assert url == "https://frontend.example.com/auth/accept-invite/?token=tok123"

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -19,6 +19,7 @@ from organizations.exceptions import (
 )
 from organizations.models import (
     Organization,
+    OrganizationBranding,
     OrganizationInvitation,
     OrganizationMembership,
     OrganizationRole,
@@ -350,6 +351,66 @@ class TestOrganizationService:
             OrganizationInvitation.objects.filter(email=email, organization=organization).count()
             == 1
         )
+
+    def test_invite_user_to_organization_branded_org_gets_the_branded_invitation_url(
+        self, organization_service_with_mocks, user, mock_notification_service, settings
+    ):
+        """Organization Auth-Area Branding plan, Phase 5 amendment (2026-08-06): the
+        accept-invite link must carry the branding root's slug, or the SPA has no way
+        to resolve that organization's branding before the invitee authenticates."""
+        settings.HEADLESS_FRONTEND_URLS = {
+            "account_accept_invitation": "https://app.example.com/auth/accept-invite/?token={token}",
+            "account_accept_invitation_branded": (
+                "https://app.example.com/o/{org_slug}/auth/accept-invite/?token={token}"
+            ),
+        }
+        # provision_default_subscription (conftest.py) auto-grants every entitlement,
+        # white_label_branding included, to every baker-made Organization -- so only
+        # the slug and an actual OrganizationBranding row need to be set up here.
+        branded_org = baker.make(Organization, parent=None, slug="brandco")
+        baker.make(OrganizationBranding, organization=branded_org, app_name="BrandCo")
+
+        with patch("organizations.services.transaction.on_commit") as mock_on_commit:
+            mock_on_commit.side_effect = lambda func: func()
+
+            organization_service_with_mocks.invite_user_to_organization(
+                email="invitee@example.com",
+                first_name="In",
+                last_name="Vitee",
+                invited_by=user,
+                organization=branded_org,
+            )
+
+        call_kwargs = mock_notification_service.create_one_off_notification.call_args[1]
+        invitation_url = call_kwargs["context_kwargs"]["invitation_url"]
+        assert invitation_url.startswith("https://app.example.com/o/brandco/auth/accept-invite/?token=")
+
+    def test_invite_user_to_organization_unbranded_org_keeps_the_plain_invitation_url(
+        self, organization_service_with_mocks, user, organization, mock_notification_service, settings
+    ):
+        """An organization with no branding row configured must get exactly the URL
+        it always got -- this change must not alter behavior for the common case."""
+        settings.HEADLESS_FRONTEND_URLS = {
+            "account_accept_invitation": "https://app.example.com/auth/accept-invite/?token={token}",
+            "account_accept_invitation_branded": (
+                "https://app.example.com/o/{org_slug}/auth/accept-invite/?token={token}"
+            ),
+        }
+
+        with patch("organizations.services.transaction.on_commit") as mock_on_commit:
+            mock_on_commit.side_effect = lambda func: func()
+
+            organization_service_with_mocks.invite_user_to_organization(
+                email="invitee2@example.com",
+                first_name="In",
+                last_name="Vitee",
+                invited_by=user,
+                organization=organization,
+            )
+
+        call_kwargs = mock_notification_service.create_one_off_notification.call_args[1]
+        invitation_url = call_kwargs["context_kwargs"]["invitation_url"]
+        assert invitation_url.startswith("https://app.example.com/auth/accept-invite/?token=")
 
     def test_accept_invitation_valid_token(self, organization_service, user, organization):
         """Test accepting an invitation with a valid token."""

--- a/organizations/tests/test_services.py
+++ b/organizations/tests/test_services.py
@@ -383,10 +383,17 @@ class TestOrganizationService:
 
         call_kwargs = mock_notification_service.create_one_off_notification.call_args[1]
         invitation_url = call_kwargs["context_kwargs"]["invitation_url"]
-        assert invitation_url.startswith("https://app.example.com/o/brandco/auth/accept-invite/?token=")
+        assert invitation_url.startswith(
+            "https://app.example.com/o/brandco/auth/accept-invite/?token="
+        )
 
     def test_invite_user_to_organization_unbranded_org_keeps_the_plain_invitation_url(
-        self, organization_service_with_mocks, user, organization, mock_notification_service, settings
+        self,
+        organization_service_with_mocks,
+        user,
+        organization,
+        mock_notification_service,
+        settings,
     ):
         """An organization with no branding row configured must get exactly the URL
         it always got -- this change must not alter behavior for the common case."""

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1485,12 +1485,13 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         file_size: int,
     ) -> BrandingLogoUploadResult:
         """
-        Mint a signed upload payload for the acting organization's branding logo.
+        Mint a presigned S3 upload URL for the acting organization's branding logo.
 
-        Same shape s3direct's own signing view returns, for partner-API callers
-        that cannot POST to that Django-session-scoped `/s3direct/` endpoint
-        directly. Gated on the branding eligibility helper -- the acting
-        organization must have no parent and hold the `white_label_branding`
+        A REST-reachable equivalent of s3direct's own signing view, for partner-API
+        callers that cannot POST to that Django-session-scoped `/s3direct/` endpoint
+        directly -- but returns a presigned PUT URL instead of bare AWS credentials,
+        so no credential ever reaches the caller. Gated on the branding eligibility
+        helper -- the acting organization must have no parent and hold the `white_label_branding`
         entitlement -- evaluated against the acting organization directly
         (`is_branding_eligible_organization`), NOT the destination's own `auth`
         callable: that callable only ever receives a bare user (see
@@ -1500,7 +1501,7 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
 
         Content-type and size are re-validated against the `branding_logos`
         destination's own allowlist/size cap (PNG/JPEG/WebP only, size-capped) --
-        rejected before any S3 credential is minted, naming the specific rule
+        rejected before any presigned URL is minted, naming the specific rule
         broken.
 
         The token's OrganizationResourceAccess must include the BRANDING resource.

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -3,7 +3,6 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, cast
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -60,7 +59,13 @@ from organizations.exceptions import (
     NoServiceAccountConfiguredError,
     UserAlreadyHasMembershipError,
 )
-from organizations.models import Organization, OrganizationBranding, OrganizationMembership
+from organizations.invitation_urls import build_invitation_accept_url
+from organizations.models import (
+    Organization,
+    OrganizationBranding,
+    OrganizationMembership,
+    resolve_branding_for_display,
+)
 from organizations.permissions import (
     BrandingWriteGateReason,
     evaluate_branding_write_gate,
@@ -1104,14 +1109,14 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
             # The service always attaches _raw_token; retrieve it once so it is not
             # inadvertently retained beyond this scope.
             raw_token = invitation._raw_token  # type: ignore[attr-defined]
-            # Build the invite URL using the same template the branded email uses.
-            # A later change may refine this URL from the reseller's redirect_url
-            # once OrganizationBranding is available; for now we use the same base as the
-            # email.
-            url_template: str = getattr(settings, "HEADLESS_FRONTEND_URLS", {}).get(
-                "account_accept_invitation", ""
+            # Build the invite URL exactly as the branded email does -- keyed on the
+            # branding root's slug (not target_org's directly), so a child
+            # organization's invite carries its reseller's slug. See
+            # organizations.invitation_urls.build_invitation_accept_url.
+            branding_root = resolve_branding_for_display(target_org)
+            invite_url = build_invitation_accept_url(
+                branding_root.organization if branding_root else None, raw_token
             )
-            invite_url = url_template.format(token=raw_token) if url_template else None
 
         return CreateInvitationResult(
             invitation=InvitationResult(

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -2538,10 +2538,8 @@ CREATE_BRANDING_LOGO_UPLOAD_MUTATION = """
 mutation CreateBrandingLogoUpload($fileName: String!, $fileType: String!, $fileSize: Int!) {
     createBrandingLogoUpload(fileName: $fileName, fileType: $fileType, fileSize: $fileSize) {
         objectKey
-        bucket
-        region
-        endpoint
-        acl
+        uploadUrl
+        expiresIn
     }
 }
 """
@@ -2601,10 +2599,16 @@ class TestCreateBrandingLogoUploadMutation:
     def setup_method(self):
         self.client = APIClient()
 
-    def test_eligible_caller_receives_a_signed_payload(self):
+    def test_eligible_caller_receives_a_signed_payload(self, settings):
         """Parentless + entitled (the suite's autouse fixture grants every
         baker-made Organization full entitlements) -- the eligible case."""
+        from s3direct.utils import AWSCredentials
+
         from di_core.containers import container
+
+        settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+        settings.AWS_S3_REGION_NAME = "us-east-1"
+        settings.AWS_S3_ENDPOINT_URL = "https://s3.us-east-1.amazonaws.com"
 
         org = baker.make(Organization, name="Eligible Org", parent=None)
         auth_service = PublicAPIAuthService()
@@ -2613,7 +2617,13 @@ class TestCreateBrandingLogoUploadMutation:
         )
         baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
 
-        with container.public_api_auth_service.override(auth_service):
+        with (
+            container.public_api_auth_service.override(auth_service),
+            patch(
+                "organizations.branding_logo.get_aws_credentials",
+                return_value=AWSCredentials(token=None, secret_key="secret", access_key="AKIATEST"),
+            ),
+        ):
             response = self.client.post(
                 "/graphql/",
                 data={
@@ -2633,7 +2643,8 @@ class TestCreateBrandingLogoUploadMutation:
         assert "errors" not in data or not data["errors"], data
         payload = data["data"]["createBrandingLogoUpload"]
         assert payload["objectKey"], "must mint an object key"
-        assert payload["acl"]
+        assert payload["uploadUrl"].startswith("https://")
+        assert payload["expiresIn"] == 900
 
     @pytest.mark.no_auto_subscription
     def test_free_plan_organization_is_refused(self):

--- a/public_api/tests/test_provisioning_flow.py
+++ b/public_api/tests/test_provisioning_flow.py
@@ -13,6 +13,7 @@ from rest_framework.test import APIClient
 from accounts.account_adapters import SocialAccountAdapter
 from organizations.models import (
     Organization,
+    OrganizationBranding,
     OrganizationInvitation,
     OrganizationMembership,
     OrganizationRole,
@@ -501,6 +502,66 @@ class TestCreateInvitationProvisioning:
         # Invitation is now accepted
         invitation.refresh_from_db()
         assert invitation.accepted_at is not None
+
+    def test_send_email_false_invite_url_carries_the_reseller_ancestor_slug(self, settings):
+        """Organization Auth-Area Branding plan, Phase 5 amendment (2026-08-06): the
+        inviteUrl the sendEmail=false path returns must be keyed on the branding
+        root's slug -- the reseller's, not the invited child org's (which has none)
+        -- exactly like the branded invitation email built by the same-org REST/
+        service path. Otherwise the SPA has no way to resolve the reseller's
+        branding for this invitation before the invitee authenticates."""
+        settings.HEADLESS_FRONTEND_URLS = {
+            "account_accept_invitation": "https://app.example.com/auth/accept-invite/?token={token}",
+            "account_accept_invitation_branded": (
+                "https://app.example.com/o/{org_slug}/auth/accept-invite/?token={token}"
+            ),
+        }
+
+        reseller_org = baker.make(
+            Organization, name="Reseller", can_invite_organizations=True, slug="reselco"
+        )
+        baker.make(OrganizationBranding, organization=reseller_org, app_name="ResellCo")
+        auth_service = PublicAPIAuthService()
+        system_user, token = auth_service.create_system_user(
+            integration_name="test_integration", organization=reseller_org
+        )
+        baker.make(ResourceAccess, system_user=system_user, resource_name="invitation")
+
+        child_org = baker.make(Organization, name="Child Org", parent=reseller_org)
+
+        create_invitation_mutation = """
+        mutation CreateInvitation($input: CreateInvitationInput!) {
+            createInvitation(input: $input) {
+                inviteUrl
+            }
+        }
+        """
+
+        from di_core.containers import container
+
+        with container.public_api_auth_service.override(auth_service):
+            response = self.client.post(
+                "/graphql/",
+                data={
+                    "query": create_invitation_mutation,
+                    "variables": {
+                        "input": {
+                            "userEmail": "branded_child_invite@example.com",
+                            "organizationId": str(child_org.id),
+                            "sendEmail": False,
+                        }
+                    },
+                },
+                format="json",
+                headers={"authorization": f"Bearer {system_user.id}:{token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data or len(data.get("errors", [])) == 0
+
+        invite_url = data["data"]["createInvitation"]["inviteUrl"]
+        assert invite_url.startswith("https://app.example.com/o/reselco/auth/accept-invite/?token=")
 
     def test_send_email_false_no_email_sent(self):
         """sendEmail=false suppresses the invitation email entirely.

--- a/public_api/types.py
+++ b/public_api/types.py
@@ -193,21 +193,19 @@ class PublicBrandingResult:
 class BrandingLogoUploadResult:
     """Signed upload payload for the ``branding_logos`` S3Direct destination.
 
-    Same shape the shipped s3direct signing view (``POST /s3direct/get_upload_params/``)
-    returns, for partner-API callers that cannot reach that Django-session-scoped
-    endpoint directly. Authorized by the branding eligibility helper (acting
-    organization is parentless and holds ``white_label_branding``), not by the
-    destination's own ``auth`` callable — see the plan's Logo upload path guiding
-    decision.
+    ``upload_url`` is a complete SigV4 presigned PUT URL — the caller uploads by
+    PUTting the file body straight to it with a matching Content-Type and no
+    other headers. No AWS credentials ever reach a partner-API caller, unlike
+    the shipped s3direct signing view (``POST /s3direct/get_upload_params/``),
+    which this mutation exists to serve as a REST-reachable equivalent of.
+    Authorized by the branding eligibility helper (acting organization is
+    parentless and holds ``white_label_branding``), not by the destination's own
+    ``auth`` callable — see the plan's Logo upload path guiding decision.
     """
 
     object_key: str
-    access_key_id: str | None
-    session_token: str | None
-    region: str | None
-    bucket: str | None
-    endpoint: str | None
-    acl: str
+    upload_url: str
+    expires_in: int
 
 
 @strawberry.input

--- a/schema.yml
+++ b/schema.yml
@@ -15214,34 +15214,23 @@ components:
         Response body for ``OrganizationBrandingLogoUploadParamsView`` — the same
         shape ``organizations.branding_logo.sign_branding_logo_upload`` and the
         GraphQL ``create_branding_logo_upload`` mutation return.
+
+        ``upload_url`` is a complete SigV4 presigned PUT URL. The client uploads by
+        PUTting the file body straight to it with a matching Content-Type and no
+        other headers — no AWS credentials reach the browser and nothing has to be
+        signed client-side. Mirrors ``users.serializers.ProfilePictureUploadParamsSerializer``.
       properties:
         object_key:
           type: string
-        access_key_id:
+        upload_url:
           type: string
-          nullable: true
-        session_token:
-          type: string
-          nullable: true
-        region:
-          type: string
-          nullable: true
-        bucket:
-          type: string
-          nullable: true
-        endpoint:
-          type: string
-          nullable: true
-        acl:
-          type: string
+          format: uri
+        expires_in:
+          type: integer
       required:
-      - access_key_id
-      - acl
-      - bucket
-      - endpoint
+      - expires_in
       - object_key
-      - region
-      - session_token
+      - upload_url
     OrganizationBrandingLogoUploadParamsRequest:
       type: object
       description: |-

--- a/vinta_schedule_api/settings/local.py.example
+++ b/vinta_schedule_api/settings/local.py.example
@@ -17,26 +17,17 @@ if USE_LOCALSTACK:
     # External endpoint for browser/frontend access (S3Direct)
     S3DIRECT_ENDPOINT = config("LOCALSTACK_EXTERNAL_ENDPOINT", default="http://localhost:4566")
     AWS_MEDIA_REGION = AWS_S3_REGION_NAME
-    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("branding_logos", {})
-    S3DIRECT_DESTINATIONS["providers_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["providers_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["providers_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["providers_documents"]["region"] = AWS_MEDIA_REGION
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["region"] = AWS_MEDIA_REGION
-    # `branding_logos` is declared in settings/base.py without a bucket/endpoint/
-    # region (like `profile_pictures`) -- but unlike `profile_pictures`, this repo
-    # never sets the `AWS_STORAGE_BUCKET_NAME` / `AWS_S3_REGION_NAME` /
-    # `AWS_S3_ENDPOINT_URL` globals s3direct falls back to when a destination omits
-    # them, so it needs the same explicit per-destination wiring the two
-    # destinations above already carry to actually sign in local dev.
-    S3DIRECT_DESTINATIONS["branding_logos"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["branding_logos"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["branding_logos"]["region"] = AWS_MEDIA_REGION
+    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {"acl": "private"})
+    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {"acl": "private"})
+
+    # Populate per-destination bucket/endpoint/region so S3Direct uploads resolve
+    # the same storage Django writes to. Looping over every key (instead of hand-
+    # listing destinations) means a new S3DIRECT_DESTINATIONS entry can't silently
+    # ship without this wiring in local dev, the way `profile_pictures` did.
+    for key in S3DIRECT_DESTINATIONS.keys():
+        S3DIRECT_DESTINATIONS[key]["bucket"] = AWS_MEDIA_BUCKET_NAME
+        S3DIRECT_DESTINATIONS[key]["endpoint"] = S3DIRECT_ENDPOINT
+        S3DIRECT_DESTINATIONS[key]["region"] = AWS_MEDIA_REGION
 
     # Use S3 storage backend for LocalStack
     STORAGES["default"]["BACKEND"] = "common.media_storage_backend.MediaStorage"
@@ -57,20 +48,13 @@ else:
     AWS_MEDIA_REGION = AWS_S3_REGION_NAME
     AWS_CLOUDFRONT_KEY_ID = config("AWS_CLOUDFRONT_KEY_ID")
     AWS_CLOUDFRONT_KEY = config("AWS_CLOUDFRONT_KEY")
-    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("branding_logos", {})
-    S3DIRECT_DESTINATIONS["providers_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["providers_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["providers_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["providers_documents"]["region"] = AWS_MEDIA_REGION
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["region"] = AWS_MEDIA_REGION
-    S3DIRECT_DESTINATIONS["branding_logos"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["branding_logos"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["branding_logos"]["region"] = AWS_MEDIA_REGION
+    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {"acl": "private"})
+    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {"acl": "private"})
+
+    for key in S3DIRECT_DESTINATIONS.keys():
+        S3DIRECT_DESTINATIONS[key]["bucket"] = AWS_MEDIA_BUCKET_NAME
+        S3DIRECT_DESTINATIONS[key]["endpoint"] = S3DIRECT_ENDPOINT
+        S3DIRECT_DESTINATIONS[key]["region"] = AWS_MEDIA_REGION
 
     STORAGES["default"]["BACKEND"] = "common.media_storage_backend.MediaStorage"
 

--- a/vinta_schedule_api/settings/production.py
+++ b/vinta_schedule_api/settings/production.py
@@ -200,6 +200,13 @@ HEADLESS_FRONTEND_URLS = {
     "account_reset_password_from_key": f"{FRONTEND_BASE_URL}/auth/reset-password/{{key}}",
     "account_signup": f"{FRONTEND_BASE_URL}/auth/signup",
     "account_accept_invitation": f"{FRONTEND_BASE_URL}/auth/accept-invite/?token={{token}}",
+    # Used instead of the entry above when the invitation's branding root has a
+    # slug -- see organizations.invitation_urls.build_invitation_accept_url. The
+    # path segment is what lets the accept page resolve that organization's
+    # branding before the user authenticates.
+    "account_accept_invitation_branded": (
+        f"{FRONTEND_BASE_URL}/o/{{org_slug}}/auth/accept-invite/?token={{token}}"
+    ),
     "socialaccount_login_error": f"{FRONTEND_BASE_URL}/auth/social-login-error",
 }
 

--- a/vinta_schedule_api/settings/staging.py
+++ b/vinta_schedule_api/settings/staging.py
@@ -13,5 +13,10 @@ HEADLESS_FRONTEND_URLS = {
     "account_reset_password_from_key": f"{FRONTEND_BASE_URL}/auth/reset-password/{{key}}",
     "account_signup": f"{FRONTEND_BASE_URL}/auth/signup",
     "account_accept_invitation": f"{FRONTEND_BASE_URL}/auth/accept-invite/?token={{token}}",
+    # See vinta_schedule_api.settings.production for why this exists alongside
+    # the entry above.
+    "account_accept_invitation_branded": (
+        f"{FRONTEND_BASE_URL}/o/{{org_slug}}/auth/accept-invite/?token={{token}}"
+    ),
     "socialaccount_login_error": f"{FRONTEND_BASE_URL}/auth/social-login-error",
 }

--- a/vinta_schedule_api/settings/test.py
+++ b/vinta_schedule_api/settings/test.py
@@ -7,6 +7,11 @@ DEBUG = True
 
 # Add the invitation-accept URLs so sendEmail=false tests receive a non-null inviteUrl.
 # The base settings omit these keys; staging/production set them against FRONTEND_BASE_URL.
+# Unlike staging/production, these values are plain strings, not f-strings -- the host
+# here is a hardcoded literal, so {token}/{org_slug} don't need the {{ }} escaping those
+# other settings use to survive f-string interpolation of FRONTEND_BASE_URL. Single braces
+# is correct here: build_invitation_accept_url calls .format(token=..., org_slug=...) on
+# these templates directly.
 HEADLESS_FRONTEND_URLS = {
     **HEADLESS_FRONTEND_URLS,
     "account_accept_invitation": "http://localhost:3000/auth/accept-invite/?token={token}",

--- a/vinta_schedule_api/settings/test.py
+++ b/vinta_schedule_api/settings/test.py
@@ -5,11 +5,14 @@ from .base import *
 # and N+1 regressions fail the suite instead of only surfacing on the dev runtime.
 DEBUG = True
 
-# Add the invitation-accept URL so sendEmail=false tests receive a non-null inviteUrl.
-# The base settings omit this key; staging/production set it against FRONTEND_BASE_URL.
+# Add the invitation-accept URLs so sendEmail=false tests receive a non-null inviteUrl.
+# The base settings omit these keys; staging/production set them against FRONTEND_BASE_URL.
 HEADLESS_FRONTEND_URLS = {
     **HEADLESS_FRONTEND_URLS,
     "account_accept_invitation": "http://localhost:3000/auth/accept-invite/?token={token}",
+    "account_accept_invitation_branded": (
+        "http://localhost:3000/o/{org_slug}/auth/accept-invite/?token={token}"
+    ),
 }
 
 SECRET_KEY = "test-secret-key-not-for-production-use-only-0123456789"  # nosec


### PR DESCRIPTION
## Summary
- Invitation emails and the `createInvitation` GraphQL mutation branded the email's *content* (app name, logo, colors) but the accept-invite *link itself* always pointed at the same slug-less `/auth/accept-invite/?token=...` URL — so a branded organization's accept page had no way to know which organization's branding to render before the invitee authenticates.
- Adds `organizations/invitation_urls.py` to key the accept link on the resolved **branding root's** slug (so a reseller's child organization's invite carries the reseller's slug, not its own unset one), via a new `account_accept_invitation_branded` settings template. Falls back to the original URL, byte-for-byte, whenever no branding root resolves.
- Amends the Organization Auth-Area Branding plan's Phase 5 (`ai-plans/2026-08-04-ORGANIZATION_AUTH_BRANDING_IMPLEMENTATION_PLAN.md`) with the gap found, the fix, and updated touch list.
- Client handoff doc drafted separately at `.vinta-ai-workflows/client-handoffs/2026-08-06-branded-invitation-accept-url.md` (gitignored — share with the SPA team directly) — flags that the SPA needs a new route for the `/o/{slug}/auth/accept-invite/` shape before/alongside this deploying.

## Test plan
- [x] New unit tests: `organizations/tests/test_invitation_urls.py`
- [x] New integration tests: `organizations/tests/test_services.py`, `public_api/tests/test_provisioning_flow.py` (covers the reseller-child-inherits-slug case)
- [x] Full `organizations/` + `public_api/` suite passes on this branch (1493 passed)
- [x] Ruff and mypy clean on touched files
- [x] Manually verified real GraphQL responses (branded and unbranded) via a local test run