### PR TITLE
fix(settings): wire bucket/endpoint/region for every local S3Direct destination

### DIFF
--- a/vinta_schedule_api/settings/local.py.example
+++ b/vinta_schedule_api/settings/local.py.example
@@ -17,26 +17,17 @@ if USE_LOCALSTACK:
     # External endpoint for browser/frontend access (S3Direct)
     S3DIRECT_ENDPOINT = config("LOCALSTACK_EXTERNAL_ENDPOINT", default="http://localhost:4566")
     AWS_MEDIA_REGION = AWS_S3_REGION_NAME
-    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("branding_logos", {})
-    S3DIRECT_DESTINATIONS["providers_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["providers_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["providers_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["providers_documents"]["region"] = AWS_MEDIA_REGION
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["region"] = AWS_MEDIA_REGION
-    # `branding_logos` is declared in settings/base.py without a bucket/endpoint/
-    # region (like `profile_pictures`) -- but unlike `profile_pictures`, this repo
-    # never sets the `AWS_STORAGE_BUCKET_NAME` / `AWS_S3_REGION_NAME` /
-    # `AWS_S3_ENDPOINT_URL` globals s3direct falls back to when a destination omits
-    # them, so it needs the same explicit per-destination wiring the two
-    # destinations above already carry to actually sign in local dev.
-    S3DIRECT_DESTINATIONS["branding_logos"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["branding_logos"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["branding_logos"]["region"] = AWS_MEDIA_REGION
+    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {"acl": "private"})
+    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {"acl": "private"})
+
+    # Populate per-destination bucket/endpoint/region so S3Direct uploads resolve
+    # the same storage Django writes to. Looping over every key (instead of hand-
+    # listing destinations) means a new S3DIRECT_DESTINATIONS entry can't silently
+    # ship without this wiring in local dev, the way `profile_pictures` did.
+    for key in S3DIRECT_DESTINATIONS.keys():
+        S3DIRECT_DESTINATIONS[key]["bucket"] = AWS_MEDIA_BUCKET_NAME
+        S3DIRECT_DESTINATIONS[key]["endpoint"] = S3DIRECT_ENDPOINT
+        S3DIRECT_DESTINATIONS[key]["region"] = AWS_MEDIA_REGION
 
     # Use S3 storage backend for LocalStack
     STORAGES["default"]["BACKEND"] = "common.media_storage_backend.MediaStorage"
@@ -57,20 +48,13 @@ else:
     AWS_MEDIA_REGION = AWS_S3_REGION_NAME
     AWS_CLOUDFRONT_KEY_ID = config("AWS_CLOUDFRONT_KEY_ID")
     AWS_CLOUDFRONT_KEY = config("AWS_CLOUDFRONT_KEY")
-    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {})
-    S3DIRECT_DESTINATIONS.setdefault("branding_logos", {})
-    S3DIRECT_DESTINATIONS["providers_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["providers_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["providers_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["providers_documents"]["region"] = AWS_MEDIA_REGION
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["acl"] = "private"
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["healthcare_entities_documents"]["region"] = AWS_MEDIA_REGION
-    S3DIRECT_DESTINATIONS["branding_logos"]["bucket"] = AWS_MEDIA_BUCKET_NAME
-    S3DIRECT_DESTINATIONS["branding_logos"]["endpoint"] = S3DIRECT_ENDPOINT
-    S3DIRECT_DESTINATIONS["branding_logos"]["region"] = AWS_MEDIA_REGION
+    S3DIRECT_DESTINATIONS.setdefault("providers_documents", {"acl": "private"})
+    S3DIRECT_DESTINATIONS.setdefault("healthcare_entities_documents", {"acl": "private"})
+
+    for key in S3DIRECT_DESTINATIONS.keys():
+        S3DIRECT_DESTINATIONS[key]["bucket"] = AWS_MEDIA_BUCKET_NAME
+        S3DIRECT_DESTINATIONS[key]["endpoint"] = S3DIRECT_ENDPOINT
+        S3DIRECT_DESTINATIONS[key]["region"] = AWS_MEDIA_REGION
 
     STORAGES["default"]["BACKEND"] = "common.media_storage_backend.MediaStorage"
 


### PR DESCRIPTION
## Summary
- `POST /profile/me/profile-picture-upload-params/` always returned 400 "S3 configuration is incomplete." in local dev because `S3DIRECT_DESTINATIONS["profile_pictures"]` never got an explicit `endpoint`, and the view's fallback (`settings.AWS_S3_ENDPOINT_URL`) is not a setting that exists anywhere in this codebase — the real name is `S3DIRECT_ENDPOINT`.
- `local.py.example` hand-listed `bucket`/`endpoint`/`region` for `providers_documents`, `healthcare_entities_documents`, and `branding_logos`, but never for `profile_pictures` (declared in `base.py` without those keys, same as `branding_logos` was before it got manually wired). `production.py` avoids this class of bug entirely by looping over every key in `S3DIRECT_DESTINATIONS`.
- This PR replaces the hand-listed local wiring with the same generic loop `production.py` uses, in both branches of `local.py.example` (LocalStack and real-AWS-in-local). `profile_pictures` and `branding_logos` now get `bucket`/`endpoint`/`region` automatically, and any future destination added to `base.py` gets this wiring for free.

## Test plan
- [ ] `docker compose up`, restart the API so it re-reads `local.py` from the (regenerated) example
- [ ] `POST /profile/me/profile-picture-upload-params/` returns 200 with real bucket/endpoint/region instead of 400
- [ ] Confirm `providers_documents`/`healthcare_entities_documents`/`branding_logos` destinations still resolve correctly (unchanged behavior, same values, now via the loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)