### PR TITLE
fix(common): wire MediaStorage's endpoint_url to AWS_MEDIA_S3_ENDPOINT_URL

### DIFF
--- a/common/media_storage_backend.py
+++ b/common/media_storage_backend.py
@@ -6,8 +6,5 @@ from storages.backends.s3boto3 import S3Boto3Storage
 class MediaStorage(S3Boto3Storage):
     bucket_name = getattr(settings, "AWS_MEDIA_BUCKET_NAME", "")
     location = getattr(settings, "AWS_MEDIA_LOCATION", "")
-
-    if getattr(settings, "USE_FLOCI", False):
-        endpoint_url = getattr(settings, "FLOCI_ENDPOINT", "")
-    else:
-        custom_domain = getattr(settings, "AWS_MEDIA_S3_CUSTOM_DOMAIN", "")
+    endpoint_url = getattr(settings, "AWS_MEDIA_S3_ENDPOINT_URL", None)
+    custom_domain = getattr(settings, "AWS_MEDIA_S3_CUSTOM_DOMAIN", "")

--- a/organizations/branding_logo.py
+++ b/organizations/branding_logo.py
@@ -19,6 +19,8 @@ from urllib.parse import unquote, urlparse
 from django.conf import settings
 from django.urls import reverse
 
+import boto3
+from botocore.config import Config as BotoConfig
 from s3direct.utils import get_aws_credentials, get_key
 
 from organizations.exceptions import BrandingLogoUploadRejectedError
@@ -183,53 +185,58 @@ def guess_logo_content_type(key: str) -> str:
 
 class SignedBrandingLogoUpload(TypedDict):
     object_key: str
-    access_key_id: str | None
-    session_token: str | None
-    region: str | None
-    bucket: str | None
-    endpoint: str | None
-    acl: str
+    upload_url: str
+    expires_in: int
+
+
+# Long enough for a slow connection to finish a logo upload, short enough that a
+# leaked URL is not a lasting write grant on the bucket. Mirrors
+# `users.views.PROFILE_PICTURE_UPLOAD_URL_EXPIRY_SECONDS`.
+BRANDING_LOGO_UPLOAD_URL_EXPIRY_SECONDS = 900
 
 
 def sign_branding_logo_upload(
     file_name: str, file_type: str, file_size: int
 ) -> SignedBrandingLogoUpload:
-    """Build the same signed-upload payload the shipped s3direct signing view
-    (``POST /s3direct/get_upload_params/``) returns for the ``branding_logos``
-    destination, for GraphQL/partner-API callers that cannot reach that
-    session-scoped Django endpoint directly.
+    """Mint a presigned S3 PUT URL for the ``branding_logos`` destination, for
+    REST/GraphQL/partner-API callers that cannot reach the session-scoped
+    ``POST /s3direct/get_upload_params/`` Django endpoint directly.
 
     Re-checks the destination's own content constraints (content-type allowlist,
     size range) -- these apply no matter who is asking, so they are re-verified
     here rather than trusted to the caller. Authorization (is this caller
-    allowed to upload a logo at all) is the GraphQL mutation's job, not this
-    function's -- see ``public_api.mutations.Mutation.create_branding_logo_upload``.
+    allowed to upload a logo at all) is the REST view's/GraphQL mutation's job,
+    not this function's -- see ``organizations.views.
+    OrganizationBrandingLogoUploadParamsView`` and ``public_api.mutations.
+    Mutation.create_branding_logo_upload``.
 
-    **Known residual limitation -- these checks are advisory, not enforced by S3
-    itself.** This project's ``s3direct`` signing mechanism (``s3direct.utils.
-    get_aws_credentials`` / ``s3direct.views.get_upload_params``, mirrored here)
-    hands the browser a bare AWS access key (and, when using an assumed role,
-    a session token) that the client then uses to sign a direct ``PUT`` with its
-    own SigV4 implementation -- it does not issue an S3 presigned-POST policy
-    document, so there is no ``conditions`` list (``content-length-range``,
-    ``Content-Type`` starts-with) for S3 to enforce server-side. A caller with
-    valid credentials could technically PUT a larger or differently-typed object
-    than what it declared here. Re-architecting the signing flow onto presigned
-    POST (a shared surface used by every other ``S3DIRECT_DESTINATIONS`` entry,
-    not just this one) is out of scope for this phase. The actual mitigation is
-    downstream, not at upload time: ``BRANDING_LOGO_KEY_PREFIX`` constrains every
-    written ``logo`` key to this destination's own prefix (see
-    ``normalize_uploaded_logo_key``), and the delivery route
-    (``organizations.views.OrganizationLogoDeliveryView``) treats every streamed
-    object's bytes and extension as untrusted regardless of what was declared at
-    upload time (allowlisted Content-Type via ``guess_logo_content_type`` +
-    ``X-Content-Type-Options: nosniff`` on every response) -- so an oversized or
-    mistyped object that slips past this advisory check still cannot be used for
-    stored XSS or to serve another tenant's object.
+    Unlike the shipped ``s3direct`` signing view, no AWS credentials ever reach
+    the caller -- the returned ``upload_url`` is a complete SigV4 presigned PUT
+    URL; the caller just PUTs the file body to it with a matching Content-Type
+    and no other headers. No ACL is signed either: the media bucket sets Object
+    Ownership to BucketOwnerEnforced, which rejects any upload carrying an
+    ``x-amz-acl`` header -- objects stay private through the bucket's
+    public-access block and are only ever served through the delivery route.
+
+    Content-Type is a signed header, so a caller cannot swap it after the URL is
+    issued (a mismatched ``Content-Type`` on the PUT invalidates the signature).
+    File size is **not** enforced by S3 itself -- a presigned PUT URL (unlike a
+    presigned POST policy) carries no ``content-length-range`` condition, so the
+    size check below is advisory only. The actual mitigation for an
+    oversized/mistyped object that slips past it is downstream, not at upload
+    time: ``BRANDING_LOGO_KEY_PREFIX`` constrains every written ``logo`` key to
+    this destination's own prefix (see ``normalize_uploaded_logo_key``), and the
+    delivery route (``organizations.views.OrganizationLogoDeliveryView``) treats
+    every streamed object's bytes and extension as untrusted regardless of what
+    was declared at upload time (allowlisted Content-Type via
+    ``guess_logo_content_type`` + ``X-Content-Type-Options: nosniff`` on every
+    response) -- so it still cannot be used for stored XSS or to serve another
+    tenant's object.
 
     Raises:
-        BrandingLogoUploadRejectedError: content type not in the allowlist, or
-            size outside the configured range, naming the specific rule broken.
+        BrandingLogoUploadRejectedError: content type not in the allowlist, size
+            outside the configured range, or the destination's S3 configuration
+            (bucket/region/endpoint) is incomplete.
     """
     # `S3DIRECT_DESTINATIONS` mixes value types (callables, strings, lists) across
     # its destinations, which collapses mypy's inferred value type to `object`
@@ -251,18 +258,41 @@ def sign_branding_logo_upload(
             f"Invalid file size (must be between {cl_range[0]} and {cl_range[1]} bytes)."
         )
 
-    key = dest.get("key")
-    object_key = get_key(key, file_name, dest)
+    bucket = dest.get("bucket") or getattr(settings, "AWS_STORAGE_BUCKET_NAME", None)
+    region = dest.get("region") or getattr(settings, "AWS_S3_REGION_NAME", None)
+    endpoint = dest.get("endpoint") or getattr(settings, "AWS_S3_ENDPOINT_URL", None)
+    if not bucket or not region or not endpoint:
+        raise BrandingLogoUploadRejectedError("S3 configuration is incomplete.")
+
+    object_key = get_key(dest.get("key"), file_name, dest)
     aws_credentials = get_aws_credentials()
+
+    s3_client = boto3.client(
+        "s3",
+        region_name=region,
+        endpoint_url=endpoint,
+        aws_access_key_id=aws_credentials.access_key,
+        aws_secret_access_key=aws_credentials.secret_key,
+        aws_session_token=aws_credentials.token,
+        config=BotoConfig(
+            signature_version="s3v4",
+            # Floci (local) only answers path-style; on AWS "auto" picks
+            # virtual-hosted. Mirrors what django-storages reads for the same call.
+            s3={"addressing_style": getattr(settings, "AWS_S3_ADDRESSING_STYLE", "auto")},
+        ),
+    )
+
+    upload_url = s3_client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": bucket, "Key": object_key, "ContentType": file_type},
+        ExpiresIn=BRANDING_LOGO_UPLOAD_URL_EXPIRY_SECONDS,
+        HttpMethod="PUT",
+    )
 
     return {
         "object_key": object_key,
-        "access_key_id": aws_credentials.access_key,
-        "session_token": aws_credentials.token,
-        "region": dest.get("region") or getattr(settings, "AWS_S3_REGION_NAME", None),
-        "bucket": dest.get("bucket") or getattr(settings, "AWS_STORAGE_BUCKET_NAME", None),
-        "endpoint": dest.get("endpoint") or getattr(settings, "AWS_S3_ENDPOINT_URL", None),
-        "acl": dest.get("acl") or "public-read",
+        "upload_url": upload_url,
+        "expires_in": BRANDING_LOGO_UPLOAD_URL_EXPIRY_SECONDS,
     }
 
 

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -585,12 +585,14 @@ class OrganizationBrandingLogoUploadParamsRequestSerializer(serializers.Serializ
 class OrganizationBrandingLogoUploadParamsSerializer(serializers.Serializer):
     """Response body for ``OrganizationBrandingLogoUploadParamsView`` — the same
     shape ``organizations.branding_logo.sign_branding_logo_upload`` and the
-    GraphQL ``create_branding_logo_upload`` mutation return."""
+    GraphQL ``create_branding_logo_upload`` mutation return.
+
+    ``upload_url`` is a complete SigV4 presigned PUT URL. The client uploads by
+    PUTting the file body straight to it with a matching Content-Type and no
+    other headers — no AWS credentials reach the browser and nothing has to be
+    signed client-side. Mirrors ``users.serializers.ProfilePictureUploadParamsSerializer``.
+    """
 
     object_key = serializers.CharField()
-    access_key_id = serializers.CharField(allow_null=True)
-    session_token = serializers.CharField(allow_null=True)
-    region = serializers.CharField(allow_null=True)
-    bucket = serializers.CharField(allow_null=True)
-    endpoint = serializers.CharField(allow_null=True)
-    acl = serializers.CharField()
+    upload_url = serializers.URLField()
+    expires_in = serializers.IntegerField()

--- a/organizations/tests/test_branding.py
+++ b/organizations/tests/test_branding.py
@@ -731,10 +731,29 @@ class TestSignBrandingLogoUpload:
     destination's content-type allowlist and size cap, re-checked independently of the
     shipped s3direct signing view (this is what the GraphQL signing mutation calls)."""
 
+    @pytest.fixture(autouse=True)
+    def _s3_upload_settings(self, settings):
+        """Only the accepted-upload cases below reach the presigned-URL step --
+        the rejection cases raise before ever needing a bucket/region/endpoint or
+        credentials, so they're unaffected by this fixture."""
+        from unittest.mock import patch
+
+        from s3direct.utils import AWSCredentials
+
+        settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+        settings.AWS_S3_REGION_NAME = "us-east-1"
+        settings.AWS_S3_ENDPOINT_URL = "https://s3.us-east-1.amazonaws.com"
+        with patch(
+            "organizations.branding_logo.get_aws_credentials",
+            return_value=AWSCredentials(token=None, secret_key="secret", access_key="AKIATEST"),
+        ):
+            yield
+
     @pytest.mark.parametrize("content_type", ["image/png", "image/jpeg", "image/webp"])
     def test_accepts_allowed_content_types(self, content_type):
         payload = sign_branding_logo_upload("logo.png", content_type, 1024)
         assert payload["object_key"]
+        assert payload["upload_url"].startswith("https://")
 
     def test_rejects_svg_explicitly(self):
         """SVG is the one format a reviewer will assume works -- it does not."""

--- a/organizations/tests/test_branding_logo_upload_params.py
+++ b/organizations/tests/test_branding_logo_upload_params.py
@@ -1,4 +1,6 @@
 import json
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -7,6 +9,7 @@ import pytest
 from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APIClient
+from s3direct.utils import AWSCredentials
 
 from organizations.models import Organization, OrganizationMembership, OrganizationRole
 from organizations.tests.test_branding_rest import _make_unentitled_org
@@ -15,6 +18,12 @@ from organizations.tests.test_branding_rest import _make_unentitled_org
 User = get_user_model()
 
 UPLOAD_PARAMS_URL = "/branding/logo-upload-params/"
+
+S3_TEST_SETTINGS = {
+    "AWS_STORAGE_BUCKET_NAME": "test-bucket",
+    "AWS_S3_REGION_NAME": "us-east-1",
+    "AWS_S3_ENDPOINT_URL": "https://s3.us-east-1.amazonaws.com",
+}
 
 
 def assert_response_status_code(response, expected_status_code):
@@ -101,6 +110,22 @@ def parented_org_admin(user, parented_org):
 VALID_PAYLOAD = {"file_name": "logo.png", "file_type": "image/png", "file_size": 1024}
 
 
+@pytest.fixture(autouse=True)
+def _s3_upload_settings(settings):
+    """Every test in this module posts to the signing endpoint, which now needs a
+    complete S3 config (bucket/region/endpoint) to mint a presigned URL -- these
+    settings aren't defined in `vinta_schedule_api.settings.test`. Credentials are
+    mocked too, since `generate_presigned_url` needs a structurally valid access
+    key/secret to sign with (it never makes a network call)."""
+    for k, v in S3_TEST_SETTINGS.items():
+        setattr(settings, k, v)
+    with patch(
+        "organizations.branding_logo.get_aws_credentials",
+        return_value=AWSCredentials(token=None, secret_key="secret", access_key="AKIATEST"),
+    ):
+        yield
+
+
 @pytest.mark.django_db
 class TestOrganizationBrandingLogoUploadParamsView:
     def test_admin_of_eligible_org_gets_signed_params(
@@ -114,7 +139,66 @@ class TestOrganizationBrandingLogoUploadParamsView:
 
         data = response.json()
         assert data["object_key"]
-        assert data["acl"]
+        assert data["upload_url"].startswith("https://")
+        assert data["expires_in"] == 900
+
+    def test_returns_a_presigned_url_the_browser_can_put_to_unaided(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        """The response must carry a complete SigV4 presigned URL: the SPA
+        authenticates with JWT and has no way to reach s3direct's session+CSRF
+        signing view, so it cannot sign a request itself. Everything S3 needs has
+        to be in this URL's query string or the upload PUT goes out unsigned and
+        S3 answers 403."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        data = response.json()
+        parsed = urlparse(data["upload_url"])
+        query = parse_qs(parsed.query)
+
+        assert parsed.path.endswith(data["object_key"])
+        assert query["X-Amz-Algorithm"] == ["AWS4-HMAC-SHA256"]
+        assert query["X-Amz-Signature"][0]
+        assert query["X-Amz-Credential"][0].startswith("AKIATEST/")
+        assert int(query["X-Amz-Expires"][0]) == data["expires_in"]
+
+    def test_presigned_url_signs_content_type_but_never_an_acl(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        """No `x-amz-acl` anywhere: the media bucket has ACLs disabled
+        (BucketOwnerEnforced). Content-Type is signed so the type is fixed when
+        the URL is issued and cannot be swapped on the PUT."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        upload_url = response.json()["upload_url"]
+        signed_headers = parse_qs(urlparse(upload_url).query)["X-Amz-SignedHeaders"][0]
+
+        assert "x-amz-acl" not in signed_headers
+        assert "acl" not in upload_url.lower()
+        assert "content-type" in signed_headers
+
+    def test_response_no_longer_leaks_aws_credentials_to_the_browser(
+        self, client, user, eligible_org, eligible_org_admin
+    ):
+        """The presigned URL replaces the raw key id the old handshake had to
+        expose."""
+        client.force_authenticate(user)
+        client.credentials(HTTP_X_ORGANIZATION_ID=str(eligible_org.id))
+
+        response = client.post(UPLOAD_PARAMS_URL, data=VALID_PAYLOAD, format="json")
+        assert_response_status_code(response, status.HTTP_200_OK)
+
+        data = response.json()
+        assert "access_key_id" not in data
+        assert "session_token" not in data
 
     def test_admin_of_a_no_slug_org_still_gets_signed_params(
         self, client, user, no_slug_org, no_slug_org_admin

--- a/public_api/mutations.py
+++ b/public_api/mutations.py
@@ -1485,12 +1485,13 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
         file_size: int,
     ) -> BrandingLogoUploadResult:
         """
-        Mint a signed upload payload for the acting organization's branding logo.
+        Mint a presigned S3 upload URL for the acting organization's branding logo.
 
-        Same shape s3direct's own signing view returns, for partner-API callers
-        that cannot POST to that Django-session-scoped `/s3direct/` endpoint
-        directly. Gated on the branding eligibility helper -- the acting
-        organization must have no parent and hold the `white_label_branding`
+        A REST-reachable equivalent of s3direct's own signing view, for partner-API
+        callers that cannot POST to that Django-session-scoped `/s3direct/` endpoint
+        directly -- but returns a presigned PUT URL instead of bare AWS credentials,
+        so no credential ever reaches the caller. Gated on the branding eligibility
+        helper -- the acting organization must have no parent and hold the `white_label_branding`
         entitlement -- evaluated against the acting organization directly
         (`is_branding_eligible_organization`), NOT the destination's own `auth`
         callable: that callable only ever receives a bare user (see
@@ -1500,7 +1501,7 @@ class Mutation(ExternalEventChangeRequestMutations, CalendarGroupMutations):
 
         Content-type and size are re-validated against the `branding_logos`
         destination's own allowlist/size cap (PNG/JPEG/WebP only, size-capped) --
-        rejected before any S3 credential is minted, naming the specific rule
+        rejected before any presigned URL is minted, naming the specific rule
         broken.
 
         The token's OrganizationResourceAccess must include the BRANDING resource.

--- a/public_api/tests/test_mutations.py
+++ b/public_api/tests/test_mutations.py
@@ -2538,10 +2538,8 @@ CREATE_BRANDING_LOGO_UPLOAD_MUTATION = """
 mutation CreateBrandingLogoUpload($fileName: String!, $fileType: String!, $fileSize: Int!) {
     createBrandingLogoUpload(fileName: $fileName, fileType: $fileType, fileSize: $fileSize) {
         objectKey
-        bucket
-        region
-        endpoint
-        acl
+        uploadUrl
+        expiresIn
     }
 }
 """
@@ -2601,10 +2599,16 @@ class TestCreateBrandingLogoUploadMutation:
     def setup_method(self):
         self.client = APIClient()
 
-    def test_eligible_caller_receives_a_signed_payload(self):
+    def test_eligible_caller_receives_a_signed_payload(self, settings):
         """Parentless + entitled (the suite's autouse fixture grants every
         baker-made Organization full entitlements) -- the eligible case."""
+        from s3direct.utils import AWSCredentials
+
         from di_core.containers import container
+
+        settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+        settings.AWS_S3_REGION_NAME = "us-east-1"
+        settings.AWS_S3_ENDPOINT_URL = "https://s3.us-east-1.amazonaws.com"
 
         org = baker.make(Organization, name="Eligible Org", parent=None)
         auth_service = PublicAPIAuthService()
@@ -2613,7 +2617,13 @@ class TestCreateBrandingLogoUploadMutation:
         )
         baker.make(ResourceAccess, system_user=system_user, resource_name="branding")
 
-        with container.public_api_auth_service.override(auth_service):
+        with (
+            container.public_api_auth_service.override(auth_service),
+            patch(
+                "organizations.branding_logo.get_aws_credentials",
+                return_value=AWSCredentials(token=None, secret_key="secret", access_key="AKIATEST"),
+            ),
+        ):
             response = self.client.post(
                 "/graphql/",
                 data={
@@ -2633,7 +2643,8 @@ class TestCreateBrandingLogoUploadMutation:
         assert "errors" not in data or not data["errors"], data
         payload = data["data"]["createBrandingLogoUpload"]
         assert payload["objectKey"], "must mint an object key"
-        assert payload["acl"]
+        assert payload["uploadUrl"].startswith("https://")
+        assert payload["expiresIn"] == 900
 
     @pytest.mark.no_auto_subscription
     def test_free_plan_organization_is_refused(self):

--- a/public_api/types.py
+++ b/public_api/types.py
@@ -193,21 +193,19 @@ class PublicBrandingResult:
 class BrandingLogoUploadResult:
     """Signed upload payload for the ``branding_logos`` S3Direct destination.
 
-    Same shape the shipped s3direct signing view (``POST /s3direct/get_upload_params/``)
-    returns, for partner-API callers that cannot reach that Django-session-scoped
-    endpoint directly. Authorized by the branding eligibility helper (acting
-    organization is parentless and holds ``white_label_branding``), not by the
-    destination's own ``auth`` callable — see the plan's Logo upload path guiding
-    decision.
+    ``upload_url`` is a complete SigV4 presigned PUT URL — the caller uploads by
+    PUTting the file body straight to it with a matching Content-Type and no
+    other headers. No AWS credentials ever reach a partner-API caller, unlike
+    the shipped s3direct signing view (``POST /s3direct/get_upload_params/``),
+    which this mutation exists to serve as a REST-reachable equivalent of.
+    Authorized by the branding eligibility helper (acting organization is
+    parentless and holds ``white_label_branding``), not by the destination's own
+    ``auth`` callable — see the plan's Logo upload path guiding decision.
     """
 
     object_key: str
-    access_key_id: str | None
-    session_token: str | None
-    region: str | None
-    bucket: str | None
-    endpoint: str | None
-    acl: str
+    upload_url: str
+    expires_in: int
 
 
 @strawberry.input

--- a/schema.yml
+++ b/schema.yml
@@ -15214,34 +15214,23 @@ components:
         Response body for ``OrganizationBrandingLogoUploadParamsView`` — the same
         shape ``organizations.branding_logo.sign_branding_logo_upload`` and the
         GraphQL ``create_branding_logo_upload`` mutation return.
+
+        ``upload_url`` is a complete SigV4 presigned PUT URL. The client uploads by
+        PUTting the file body straight to it with a matching Content-Type and no
+        other headers — no AWS credentials reach the browser and nothing has to be
+        signed client-side. Mirrors ``users.serializers.ProfilePictureUploadParamsSerializer``.
       properties:
         object_key:
           type: string
-        access_key_id:
+        upload_url:
           type: string
-          nullable: true
-        session_token:
-          type: string
-          nullable: true
-        region:
-          type: string
-          nullable: true
-        bucket:
-          type: string
-          nullable: true
-        endpoint:
-          type: string
-          nullable: true
-        acl:
-          type: string
+          format: uri
+        expires_in:
+          type: integer
       required:
-      - access_key_id
-      - acl
-      - bucket
-      - endpoint
+      - expires_in
       - object_key
-      - region
-      - session_token
+      - upload_url
     OrganizationBrandingLogoUploadParamsRequest:
       type: object
       description: |-


### PR DESCRIPTION
## Summary
- `MediaStorage.endpoint_url` was only overridden when `settings.USE_FLOCI` was truthy (reading `settings.FLOCI_ENDPOINT`) — but nothing in the codebase ever sets `USE_FLOCI`; `local.py`/`production.py` set `USE_LOCALSTACK`/wire `AWS_MEDIA_S3_ENDPOINT_URL` instead. The override was dead code.
- Locally this meant `endpoint_url` fell back to django-storages' real-AWS default, so server-side reads (e.g. `OrganizationLogoDeliveryView`'s `storage.exists()`/`storage.open()` for branding logos) hit real AWS S3 with the local `test`/`test` credentials — a 403 on `HeadObject` — and silently degraded to the default logo, even though the S3Direct-signed PUT (write side, fixed in `ac9c158` on the base branch) landed the object correctly in Floci.
- Now `endpoint_url` always reads `AWS_MEDIA_S3_ENDPOINT_URL` (matching what every settings module actually wires), while `custom_domain` is still set unconditionally so production's CloudFront URL construction is unaffected.

## Test plan
- [x] `pytest organizations/tests/test_branding_logo.py s3direct_overrides/tests/test_model_fields.py` — 22 passed
- [ ] Manually verify locally: upload a branding logo end-to-end (sign → S3 PUT → `PATCH /branding/`), reload, confirm the real logo renders instead of the default